### PR TITLE
fix(recv): dispatch a resent message once

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -179,6 +179,13 @@ pub struct CacheConfig {
     /// the same id does not surface a second notification. Default: 5m TTL,
     /// 1000 entries.
     pub undecryptable_dispatched: CacheEntryConfig,
+    /// Dispatch-once gate for a decrypted message: a sender whose outbox
+    /// retries resends the same id re-encrypted, which the ratchet cannot see
+    /// as a duplicate. Default: 5m TTL, 1000 entries. The TTL covers the
+    /// observed resend window (production logs: median 12s between attempts,
+    /// p90 189s, longest plausible resend 285s) and the capacity ~3.6x the
+    /// busiest 5-minute burst measured (278 messages). Capacity 0 disables it.
+    pub dispatched_messages: CacheEntryConfig,
     /// PDO pending requests (time_to_live). Default: 30s TTL, 200 entries.
     pub pdo_pending_requests: CacheEntryConfig,
     /// Messages already covered by a placeholder-resend PDO request
@@ -280,6 +287,7 @@ impl std::fmt::Debug for CacheConfig {
             .field("recent_messages", &self.recent_messages)
             .field("message_retry_counts", &self.message_retry_counts)
             .field("undecryptable_dispatched", &self.undecryptable_dispatched)
+            .field("dispatched_messages", &self.dispatched_messages)
             .field("pdo_pending_requests", &self.pdo_pending_requests)
             .field("pdo_requested", &self.pdo_requested)
             .field("sender_key_devices_cache", &self.sender_key_devices_cache)
@@ -341,6 +349,7 @@ impl Default for CacheConfig {
             // 5m TTL expired between reconnects so the count never reached the cap.
             message_retry_counts: CacheEntryConfig::new(one_hour, 500),
             undecryptable_dispatched: CacheEntryConfig::new(five_min, 1_000),
+            dispatched_messages: CacheEntryConfig::new(five_min, 1_000),
             pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 200),
             pdo_requested: CacheEntryConfig::new(Some(Duration::from_secs(24 * 3600)), 512),
             sender_key_devices_cache: CacheEntryConfig::new(one_hour, 500),

--- a/src/client.rs
+++ b/src/client.rs
@@ -432,6 +432,8 @@ pub struct MemoryReport {
     pub dm_devices_memo: CollectionStats,
     pub message_retry_counts: u64,
     pub undecryptable_dispatched: u64,
+    /// Entries in the dispatch-once gate for decrypted messages.
+    pub dispatched_messages: u64,
     pub pdo_pending_requests: u64,
     pub pdo_requested: u64,
     /// Queued/running history-sync tasks and their logical compressed-payload
@@ -662,6 +664,7 @@ impl std::fmt::Display for MemoryReport {
             "  undec_dispatched:       {}",
             self.undecryptable_dispatched
         )?;
+        writeln!(f, "  dispatched_messages:    {}", self.dispatched_messages)?;
         writeln!(f, "  pdo_pending_requests:   {}", self.pdo_pending_requests)?;
         writeln!(f, "  pdo_requested:          {}", self.pdo_requested)?;
         writeln!(f, "--- Capacity-only caches ---")?;
@@ -1421,6 +1424,16 @@ pub struct Client {
     /// duplicate event. Mirrors WA Web's DB-level placeholder uniqueness
     /// in `WAWebMessageProcessPlaceholder`.
     pub(crate) undecryptable_dispatched: Cache<wacore::types::message::SenderMessageId, ()>,
+
+    /// Dispatch-once gate for a decrypted message. A sender retrying its own
+    /// outbox resends one id as fresh ciphertext on a new ratchet iteration,
+    /// which decrypts as new traffic, so only message identity can collapse it.
+    pub(crate) dispatched_messages: Cache<wacore::types::message::SenderMessageId, ()>,
+
+    /// Lifetime count of resent messages this gate kept from reaching
+    /// consumers. Client-level, so it survives reconnects: the sender's retry
+    /// window does not end because our socket did.
+    pub(crate) duplicate_dispatch_suppressed: AtomicU64,
 
     pub enable_auto_reconnect: Arc<AtomicBool>,
     /// Set by [`Client::pause`] and cleared by [`Client::resume`]: the run loop

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -290,6 +290,8 @@ impl Client {
         let mut snapshot = self.stats.snapshot();
         snapshot.reconnect_errors = self.auto_reconnect_errors.load(Ordering::Relaxed);
         snapshot.resends_throttled = self.resend_rate_limiter.throttled_total();
+        snapshot.messages_suppressed_duplicate =
+            self.duplicate_dispatch_suppressed.load(Ordering::Relaxed);
         snapshot
     }
 
@@ -425,6 +427,7 @@ impl Client {
             dm_devices_memo,
             message_retry_counts: self.message_retry_counts.entry_count(),
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
+            dispatched_messages: self.dispatched_messages.entry_count(),
             pdo_pending_requests: self.pdo_pending_requests.entry_count(),
             pdo_requested: self.pdo_requested.entry_count(),
             history_sync_tasks,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -476,6 +476,9 @@ impl Client {
 
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),
 
+            dispatched_messages: cache_config.dispatched_messages.build_with_ttl(),
+            duplicate_dispatch_suppressed: AtomicU64::new(0),
+
             offline_sync_metrics: Arc::new(OfflineSyncMetrics {
                 active: AtomicBool::new(false),
                 total_messages: AtomicUsize::new(0),

--- a/src/features/message_edit.rs
+++ b/src/features/message_edit.rs
@@ -347,6 +347,19 @@ impl<'a> SecretEncrypted<'a> {
     }
 }
 
+/// Whether the message carries a secret-encrypted addon envelope at all,
+/// regardless of whether that envelope is well formed.
+///
+/// [`extract_secret_encrypted`] answers "can this be opened", which is the
+/// wrong question for anything deciding that the consumer did not get real
+/// content: it returns `None` both for a plain message and for a tagged
+/// envelope that is malformed, and those two must not be treated alike.
+pub fn carries_secret_encrypted(msg: &wa::Message) -> bool {
+    msg.secret_encrypted_message.as_option().is_some()
+        || msg.enc_reaction_message.as_option().is_some()
+        || msg.enc_comment_message.as_option().is_some()
+}
+
 /// Extract any supported `secret_encrypted_message` envelope (EVENT_EDIT,
 /// MESSAGE_EDIT, POLL_EDIT, POLL_ADD_OPTION) from a received message.
 ///

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -732,16 +732,34 @@ impl Client {
         /// receive path while it holds the processing permit. Giving up keeps
         /// everything, which is the safe direction.
         const MAX_COMPARED_PER_ID: usize = 8;
-        type Seen = std::collections::HashMap<
-            wacore::types::message::SenderMessageId,
-            Vec<(Arc<MessageInfo>, Arc<waproto::whatsapp::Message>)>,
-        >;
+        /// A kept payload, with its wire form filled in only if some later
+        /// item in the batch turns out to share its identity.
+        struct Kept {
+            info: Arc<MessageInfo>,
+            message: Arc<waproto::whatsapp::Message>,
+            encoded: Option<Vec<u8>>,
+        }
+        /// Compare the wire form rather than the decoded proto. `wa::Message`
+        /// derives `PartialEq`, but nothing else calls it, so one `==` here
+        /// makes the whole message tree's comparison code live and costs
+        /// ~236 KiB of binary. Encoding is already instantiated for the commit
+        /// path's durable write, so this adds no code and one memcmp.
+        fn wire(msg: &waproto::whatsapp::Message) -> Vec<u8> {
+            let mut buf = Vec::with_capacity(waproto::codec::message_encoded_len(msg));
+            waproto::codec::message_encode_into(msg, &mut buf);
+            buf
+        }
+        type Seen = std::collections::HashMap<wacore::types::message::SenderMessageId, Vec<Kept>>;
         fn keep(seen: &mut Seen, item: &InboundMessage) -> bool {
             let kept = seen.entry(Client::dispatch_key(&item.info)).or_default();
             if kept.len() >= MAX_COMPARED_PER_ID {
                 return true;
             }
-            if kept.iter().any(|(info, m)| {
+            // Encoded lazily and at most once per side, so a batch whose
+            // identities are all distinct (every live batch, and almost every
+            // drained one) never encodes anything here.
+            let mut candidate: Option<Vec<u8>> = None;
+            for k in kept.iter_mut() {
                 // Never collapse two dispatches of one stanza. They share the
                 // `MessageInfo` the stanza was parsed into, which the msmsg
                 // loop hands to every bot-reply part, so equal parts are not a
@@ -749,12 +767,23 @@ impl Client {
                 // separate stanzas always allocate separate infos, so this
                 // never exempts a genuine resend, while a part whose info was
                 // copied on write falls through to the content compare.
-                !Arc::ptr_eq(info, &item.info)
-                    && (Arc::ptr_eq(m, &item.message) || **m == *item.message)
-            }) {
-                return false;
+                if Arc::ptr_eq(&k.info, &item.info) {
+                    continue;
+                }
+                if Arc::ptr_eq(&k.message, &item.message) {
+                    return false;
+                }
+                let candidate = candidate.get_or_insert_with(|| wire(&item.message));
+                let existing = k.encoded.get_or_insert_with(|| wire(&k.message));
+                if *existing == *candidate {
+                    return false;
+                }
             }
-            kept.push((Arc::clone(&item.info), Arc::clone(&item.message)));
+            kept.push(Kept {
+                info: Arc::clone(&item.info),
+                message: Arc::clone(&item.message),
+                encoded: candidate,
+            });
             true
         }
         let mut seen = Seen::with_capacity(items.len());

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -883,6 +883,13 @@ impl Client {
         if is_drain {
             self.flush_offline_receipts();
         }
+        // Claim the ids here, at the one place a batch becomes observable, so
+        // the drain path claims too. Marking at the call site instead would
+        // miss a deferred batch: its dispatch happens here, later, and a resend
+        // after the drain would then find no claim.
+        for item in items.iter() {
+            self.mark_message_dispatched(&item.info).await;
+        }
         self.core.event_bus.dispatch(Event::Messages(
             MessageBatch::builder()
                 .messages(items)

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -766,7 +766,11 @@ impl Client {
         // acked from `arrived`; only what the hook and the consumer see is
         // reduced to one copy.
         let arrived = Arc::clone(&items);
-        let items = Self::dedup_batch_by_message(items);
+        let items = if self.dispatch_gate_enabled() {
+            Self::dedup_batch_by_message(items)
+        } else {
+            items
+        };
         let mut reinsert = ReinsertGuard {
             batcher: &self.inbound_commit_batch,
             items: is_drain.then(|| Arc::clone(&items)),
@@ -913,9 +917,7 @@ impl Client {
         if is_drain {
             self.flush_offline_receipts();
         }
-        for item in items.iter() {
-            self.mark_message_dispatched(&item.info).await;
-        }
+        let dispatched = Arc::clone(&items);
         self.core.event_bus.dispatch(Event::Messages(
             MessageBatch::builder()
                 .messages(items)
@@ -923,6 +925,14 @@ impl Client {
                 .hook_committed(hook_committed)
                 .build(),
         ));
+        // Claimed after the dispatch, never between the acks and it: this is the
+        // one suspension point in that span, and a teardown cancelling it there
+        // would leave the batch acked with its event never sent, which for a
+        // consumer without a hook is a lost message. Cancelled here instead, the
+        // claim is simply missing and a resend dispatches twice.
+        for item in dispatched.iter() {
+            self.mark_message_dispatched(&item.info).await;
+        }
         true
     }
 }

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -708,7 +708,7 @@ impl Client {
     ///
     /// Returns the input untouched when there is nothing to drop, which is
     /// every live batch (they hold one message) and almost every drained one.
-    fn dedup_batch_by_message(items: Arc<[InboundMessage]>) -> Arc<[InboundMessage]> {
+    fn dedup_batch_by_message(&self, items: Arc<[InboundMessage]>) -> Arc<[InboundMessage]> {
         if items.len() < 2 {
             return items;
         }
@@ -720,11 +720,20 @@ impl Client {
             return items;
         }
         seen.clear();
-        items
+        let kept: Arc<[InboundMessage]> = items
             .iter()
             .filter(|item| seen.insert(Self::dispatch_key(&item.info)))
             .cloned()
-            .collect()
+            .collect();
+        // Counted like any other suppression: what this drops never reaches a
+        // consumer, so leaving it out would make the metric disagree with what
+        // the consumer saw for exactly the deliveries it exists to explain.
+        for _ in 0..(items.len() - kept.len()) {
+            self.duplicate_dispatch_suppressed
+                .fetch_add(1, Ordering::Relaxed);
+            wacore::telemetry::recv("duplicate_resend");
+        }
+        kept
     }
 
     /// Commit one batch: durable buffer → Signal flush → hook → clear buffer →
@@ -767,7 +776,7 @@ impl Client {
         // reduced to one copy.
         let arrived = Arc::clone(&items);
         let items = if self.dispatch_gate_enabled() {
-            Self::dedup_batch_by_message(items)
+            self.dedup_batch_by_message(items)
         } else {
             items
         };

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -723,19 +723,38 @@ impl Client {
         if items.len() < 2 {
             return items;
         }
+        /// Distinct payloads compared per identity before the collapse gives
+        /// up on it. A resend repeats one message, so a real duplicate is
+        /// found against the first or second entry; an identity accumulating
+        /// more than this is not the pattern this function exists for, and
+        /// without a bound a participant could reuse one id across a full
+        /// 400-message drain batch and force ~80k structural compares on the
+        /// receive path while it holds the processing permit. Giving up keeps
+        /// everything, which is the safe direction.
+        const MAX_COMPARED_PER_ID: usize = 8;
         type Seen = std::collections::HashMap<
             wacore::types::message::SenderMessageId,
-            Vec<Arc<waproto::whatsapp::Message>>,
+            Vec<(Arc<MessageInfo>, Arc<waproto::whatsapp::Message>)>,
         >;
         fn keep(seen: &mut Seen, item: &InboundMessage) -> bool {
             let kept = seen.entry(Client::dispatch_key(&item.info)).or_default();
-            if kept
-                .iter()
-                .any(|m| Arc::ptr_eq(m, &item.message) || **m == *item.message)
-            {
+            if kept.len() >= MAX_COMPARED_PER_ID {
+                return true;
+            }
+            if kept.iter().any(|(info, m)| {
+                // Never collapse two dispatches of one stanza. They share the
+                // `MessageInfo` the stanza was parsed into, which the msmsg
+                // loop hands to every bot-reply part, so equal parts are not a
+                // repeat of each other. Best-effort by construction: two
+                // separate stanzas always allocate separate infos, so this
+                // never exempts a genuine resend, while a part whose info was
+                // copied on write falls through to the content compare.
+                !Arc::ptr_eq(info, &item.info)
+                    && (Arc::ptr_eq(m, &item.message) || **m == *item.message)
+            }) {
                 return false;
             }
-            kept.push(Arc::clone(&item.message));
+            kept.push((Arc::clone(&item.info), Arc::clone(&item.message)));
             true
         }
         let mut seen = Seen::with_capacity(items.len());
@@ -993,12 +1012,15 @@ impl Client {
         for item in dispatched.iter() {
             // An unresolved secret envelope is a placeholder in the same sense
             // as an UndecryptableMessage: what reached the consumer is not the
-            // content. Claiming it would suppress the resend that arrives once
+            // content. Presence, not extractability: a malformed envelope is
+            // just as unreadable to a consumer as an unopenable one, and
+            // `extract_secret_encrypted` returns `None` for both a plain
+            // message and a malformed envelope. Claiming it would suppress the resend that arrives once
             // the parent secret is known, so leave it unclaimed and take the
             // duplicate instead. The batch collapse keeps such a resend for a
             // related reason: it compares content, and the envelope is not the
             // content.
-            if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
+            if crate::features::message_edit::carries_secret_encrypted(&item.message) {
                 continue;
             }
             self.mark_message_dispatched(&item.info).await;

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -709,26 +709,36 @@ impl Client {
     /// Returns the input untouched when there is nothing to drop, which is
     /// every live batch (they hold one message) and almost every drained one.
     ///
-    /// An item still carrying an unresolved secret envelope is never collapsed,
-    /// in either direction. One batch can hold the envelope and, after the
-    /// parent secret arrived mid-drain, a retry of the same id that resolved to
-    /// the inner message; keeping the first would drop the only copy the
-    /// consumer can read, and both were acked. Whether the envelope comes first
-    /// or second, letting it through costs a duplicate and keeps the content.
+    /// A repeat is identity *and* content: a resend re-encrypts the same
+    /// message, so the decoded protos are equal. Identity alone is not enough,
+    /// because one stanza id can carry several genuinely different payloads
+    /// that share an `info`. The msmsg loop in `handle_incoming_message`
+    /// dispatches every bot-reply part under one id, and a drain batch can hold
+    /// an unresolved secret envelope beside the retry that resolved to the
+    /// inner message; collapsing on identity alone would drop those and ack
+    /// them, losing content with nothing left to redeliver it. Comparing the
+    /// message keeps them and costs a structural compare only where identities
+    /// actually collide, which is the rare case this whole function exists for.
     fn dedup_batch_by_message(&self, items: Arc<[InboundMessage]>) -> Arc<[InboundMessage]> {
         if items.len() < 2 {
             return items;
         }
-        fn keep(
-            seen: &mut std::collections::HashSet<wacore::types::message::SenderMessageId>,
-            item: &InboundMessage,
-        ) -> bool {
-            if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
-                return true;
+        type Seen = std::collections::HashMap<
+            wacore::types::message::SenderMessageId,
+            Vec<Arc<waproto::whatsapp::Message>>,
+        >;
+        fn keep(seen: &mut Seen, item: &InboundMessage) -> bool {
+            let kept = seen.entry(Client::dispatch_key(&item.info)).or_default();
+            if kept
+                .iter()
+                .any(|m| Arc::ptr_eq(m, &item.message) || **m == *item.message)
+            {
+                return false;
             }
-            seen.insert(Client::dispatch_key(&item.info))
+            kept.push(Arc::clone(&item.message));
+            true
         }
-        let mut seen = std::collections::HashSet::with_capacity(items.len());
+        let mut seen = Seen::with_capacity(items.len());
         if items.iter().all(|item| keep(&mut seen, item)) {
             return items;
         }
@@ -985,8 +995,9 @@ impl Client {
             // as an UndecryptableMessage: what reached the consumer is not the
             // content. Claiming it would suppress the resend that arrives once
             // the parent secret is known, so leave it unclaimed and take the
-            // duplicate instead. `dedup_batch_by_message` exempts the same
-            // items for the same reason.
+            // duplicate instead. The batch collapse keeps such a resend for a
+            // related reason: it compares content, and the envelope is not the
+            // content.
             if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
                 continue;
             }

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -883,15 +883,43 @@ impl Client {
             }
             hook_committed = true;
 
-            let delete_keys: Vec<PendingInboundKey<'_>> = items
-                .iter()
-                .zip(&keys)
-                .map(|(item, (chat, sender))| PendingInboundKey {
-                    chat,
-                    sender,
-                    id: &item.info.id,
-                })
-                .collect();
+            // Cleared for every stanza that arrived, not just the ones kept: a
+            // pending row is keyed on the sender exactly as that delivery spelled
+            // it, while the collapse folds spellings together. Deleting only the
+            // kept spelling would leave a row that a later resend replays as an
+            // already committed message. Deleting a row that is not there is a
+            // no-op, so the superset is free.
+            let arrived_keys: Vec<(String, String)>;
+            let delete_keys: Vec<PendingInboundKey<'_>> = if arrived.len() == items.len() {
+                items
+                    .iter()
+                    .zip(&keys)
+                    .map(|(item, (chat, sender))| PendingInboundKey {
+                        chat,
+                        sender,
+                        id: &item.info.id,
+                    })
+                    .collect()
+            } else {
+                arrived_keys = arrived
+                    .iter()
+                    .map(|m| {
+                        (
+                            m.info.source.chat.to_string(),
+                            m.info.source.sender.to_string(),
+                        )
+                    })
+                    .collect();
+                arrived
+                    .iter()
+                    .zip(&arrived_keys)
+                    .map(|(item, (chat, sender))| PendingInboundKey {
+                        chat,
+                        sender,
+                        id: &item.info.id,
+                    })
+                    .collect()
+            };
             if let Err(e) = backend.delete_pending_inbound_batch(&delete_keys).await {
                 // Leftover rows replay as duplicates; the idempotent hook
                 // re-commits and the replay path clears them.
@@ -940,6 +968,14 @@ impl Client {
         // consumer without a hook is a lost message. Cancelled here instead, the
         // claim is simply missing and a resend dispatches twice.
         for item in dispatched.iter() {
+            // An unresolved secret envelope is a placeholder in the same sense
+            // as an UndecryptableMessage: what reached the consumer is not the
+            // content. Claiming it would suppress the resend that arrives once
+            // the parent secret is known, so leave it unclaimed and take the
+            // duplicate instead.
+            if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
+                continue;
+            }
             self.mark_message_dispatched(&item.info).await;
         }
         true

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -708,21 +708,34 @@ impl Client {
     ///
     /// Returns the input untouched when there is nothing to drop, which is
     /// every live batch (they hold one message) and almost every drained one.
+    ///
+    /// An item still carrying an unresolved secret envelope is never collapsed,
+    /// in either direction. One batch can hold the envelope and, after the
+    /// parent secret arrived mid-drain, a retry of the same id that resolved to
+    /// the inner message; keeping the first would drop the only copy the
+    /// consumer can read, and both were acked. Whether the envelope comes first
+    /// or second, letting it through costs a duplicate and keeps the content.
     fn dedup_batch_by_message(&self, items: Arc<[InboundMessage]>) -> Arc<[InboundMessage]> {
         if items.len() < 2 {
             return items;
         }
+        fn keep(
+            seen: &mut std::collections::HashSet<wacore::types::message::SenderMessageId>,
+            item: &InboundMessage,
+        ) -> bool {
+            if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
+                return true;
+            }
+            seen.insert(Client::dispatch_key(&item.info))
+        }
         let mut seen = std::collections::HashSet::with_capacity(items.len());
-        if items
-            .iter()
-            .all(|item| seen.insert(Self::dispatch_key(&item.info)))
-        {
+        if items.iter().all(|item| keep(&mut seen, item)) {
             return items;
         }
         seen.clear();
         let kept: Arc<[InboundMessage]> = items
             .iter()
-            .filter(|item| seen.insert(Self::dispatch_key(&item.info)))
+            .filter(|item| keep(&mut seen, item))
             .cloned()
             .collect();
         // Counted like any other suppression: what this drops never reaches a
@@ -972,7 +985,8 @@ impl Client {
             // as an UndecryptableMessage: what reached the consumer is not the
             // content. Claiming it would suppress the resend that arrives once
             // the parent secret is known, so leave it unclaimed and take the
-            // duplicate instead.
+            // duplicate instead. `dedup_batch_by_message` exempts the same
+            // items for the same reason.
             if crate::features::message_edit::extract_secret_encrypted(&item.message).is_some() {
                 continue;
             }

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -704,6 +704,29 @@ impl Client {
         .await
     }
 
+    /// Collapse deliveries of one message inside a batch, keeping the first.
+    ///
+    /// Returns the input untouched when there is nothing to drop, which is
+    /// every live batch (they hold one message) and almost every drained one.
+    fn dedup_batch_by_message(items: Arc<[InboundMessage]>) -> Arc<[InboundMessage]> {
+        if items.len() < 2 {
+            return items;
+        }
+        let mut seen = std::collections::HashSet::with_capacity(items.len());
+        if items
+            .iter()
+            .all(|item| seen.insert(Self::dispatch_key(&item.info)))
+        {
+            return items;
+        }
+        seen.clear();
+        items
+            .iter()
+            .filter(|item| seen.insert(Self::dispatch_key(&item.info)))
+            .cloned()
+            .collect()
+    }
+
     /// Commit one batch: durable buffer → Signal flush → hook → clear buffer →
     /// acks → event. Nothing is acked or observable before it is durable (WA
     /// Web's `createSnapshot` ordering); acks precede the event dispatch so a
@@ -737,6 +760,13 @@ impl Client {
             debug_assert!(commit_ticket.is_none());
             return true;
         }
+        // A drain can accumulate two deliveries of one message before the batch
+        // commits: both read the gate before either claim landed, so the
+        // collapse has to happen here too. Every stanza that arrived is still
+        // acked from `arrived`; only what the hook and the consumer see is
+        // reduced to one copy.
+        let arrived = Arc::clone(&items);
+        let items = Self::dedup_batch_by_message(items);
         let mut reinsert = ReinsertGuard {
             batcher: &self.inbound_commit_batch,
             items: is_drain.then(|| Arc::clone(&items)),
@@ -870,7 +900,7 @@ impl Client {
         // synchronously, so a handler that panics or blocks must not be able
         // to suppress acks for messages the consumer already owns — the
         // pre-batch at-most-once path acked before dispatching too.
-        for item in items.iter() {
+        for item in arrived.iter() {
             self.ack_received_message(&item.info);
         }
         // WA Web `createSnapshot` sends `sendAggregateOfflineReceipts` per
@@ -883,10 +913,6 @@ impl Client {
         if is_drain {
             self.flush_offline_receipts();
         }
-        // Claim the ids here, at the one place a batch becomes observable, so
-        // the drain path claims too. Marking at the call site instead would
-        // miss a deferred batch: its dispatch happens here, later, and a resend
-        // after the drain would then find no claim.
         for item in items.iter() {
             self.mark_message_dispatched(&item.info).await;
         }

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -21,13 +21,10 @@ impl Client {
     /// stanza the server replays), so identity is the only thing left that says
     /// the two deliveries are one message.
     ///
-    /// Read here and written by [`Self::mark_message_dispatched`] after the
-    /// dispatch is durable; the read-then-write is safe because `chat_lanes`
-    /// serializes incoming processing per chat, and both deliveries of one
-    /// message are in one chat.
-    ///
-    /// Keyed on the wire spelling of the sender, deliberately unresolved, for
-    /// the reasons [`Self::dispatch_undecryptable_event`] states at length.
+    /// Read here and written by [`Self::mark_message_dispatched`] once the
+    /// batch carrying the message becomes observable. The read-then-write is
+    /// safe because `chat_lanes` serializes incoming processing per chat, and
+    /// both deliveries of one message are in one chat.
     pub(crate) async fn message_already_dispatched(&self, info: &Arc<MessageInfo>) -> bool {
         self.dispatched_messages
             .get(&Self::dispatch_key(info))
@@ -35,31 +32,35 @@ impl Client {
             .is_some()
     }
 
-    /// Claim a message id once its dispatch is durable.
+    /// Claim a message id, called where a committed batch is dispatched.
     ///
-    /// Only `Durable` claims it. A deferred commit (the offline drain) may
-    /// still fail, and a claim taken on one that does would let the redelivery
-    /// be suppressed and acked with nothing ever handed to a consumer, losing
-    /// the message instead of duplicating it. The cost is that a resend
-    /// arriving mid-drain still dispatches twice; drains carry the server's
-    /// byte-identical replays, which the ratchet rejects on its own.
-    pub(crate) async fn mark_message_dispatched(
-        &self,
-        info: &Arc<MessageInfo>,
-        state: &InboundCommitState,
-    ) {
-        if matches!(state, InboundCommitState::Durable) {
-            self.dispatched_messages
-                .insert(Self::dispatch_key(info), ())
-                .await;
-        }
+    /// Placing it there rather than at the call site is what makes the offline
+    /// drain claim as well: a deferred batch dispatches later, and a claim
+    /// taken before that could be taken for a batch that never commits, which
+    /// would suppress and ack the redelivery with nothing ever handed to a
+    /// consumer, losing the message instead of duplicating it.
+    pub(crate) async fn mark_message_dispatched(&self, info: &Arc<MessageInfo>) {
+        self.dispatched_messages
+            .insert(Self::dispatch_key(info), ())
+            .await;
     }
 
+    /// The message's identity: chat, id, and the sender without its device.
+    ///
+    /// Dropping the device matches WA Web, whose `MsgKey` for a group message
+    /// takes `participant: asUserWidOrThrow(author)`, a device-less wid. It
+    /// also has to: the server sends `skmsg` with a bare participant and
+    /// `pkmsg` with a device-qualified one, so a resend bundling a rotated
+    /// SKDM would otherwise be spelled differently from the delivery it
+    /// repeats and slip past the gate.
+    ///
+    /// The PN/LID namespace stays as it arrived, deliberately unresolved, for
+    /// the reasons [`Self::dispatch_undecryptable_event`] states at length.
     fn dispatch_key(info: &Arc<MessageInfo>) -> wacore::types::message::SenderMessageId {
         wacore::types::message::SenderMessageId::new(
             info.source.chat.clone(),
             info.id.clone(),
-            info.source.sender.clone(),
+            info.source.sender.to_non_ad(),
         )
     }
 

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -13,6 +13,56 @@ fn delivery_receipt_burst_warning(
 }
 
 impl Client {
+    /// Has this message already been dispatched to consumers?
+    ///
+    /// A sender whose network is bad re-runs its own outbox: same message id,
+    /// fresh ciphertext on a new ratchet iteration. Neither ratchet can call
+    /// that a duplicate (`DuplicatedMessage` covers only the byte-identical
+    /// stanza the server replays), so identity is the only thing left that says
+    /// the two deliveries are one message.
+    ///
+    /// Read here and written by [`Self::mark_message_dispatched`] after the
+    /// dispatch is durable; the read-then-write is safe because `chat_lanes`
+    /// serializes incoming processing per chat, and both deliveries of one
+    /// message are in one chat.
+    ///
+    /// Keyed on the wire spelling of the sender, deliberately unresolved, for
+    /// the reasons [`Self::dispatch_undecryptable_event`] states at length.
+    pub(crate) async fn message_already_dispatched(&self, info: &Arc<MessageInfo>) -> bool {
+        self.dispatched_messages
+            .get(&Self::dispatch_key(info))
+            .await
+            .is_some()
+    }
+
+    /// Claim a message id once its dispatch is durable.
+    ///
+    /// Only `Durable` claims it. A deferred commit (the offline drain) may
+    /// still fail, and a claim taken on one that does would let the redelivery
+    /// be suppressed and acked with nothing ever handed to a consumer, losing
+    /// the message instead of duplicating it. The cost is that a resend
+    /// arriving mid-drain still dispatches twice; drains carry the server's
+    /// byte-identical replays, which the ratchet rejects on its own.
+    pub(crate) async fn mark_message_dispatched(
+        &self,
+        info: &Arc<MessageInfo>,
+        state: &InboundCommitState,
+    ) {
+        if matches!(state, InboundCommitState::Durable) {
+            self.dispatched_messages
+                .insert(Self::dispatch_key(info), ())
+                .await;
+        }
+    }
+
+    fn dispatch_key(info: &Arc<MessageInfo>) -> wacore::types::message::SenderMessageId {
+        wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        )
+    }
+
     /// Dispatches a successfully parsed message to the event bus and sends a delivery receipt.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.dispatch", level = "debug", skip_all, fields(chat = %info.source.chat.observe(), sender = %info.source.sender.observe(), msg_id = %info.id)))]
     pub(crate) async fn dispatch_parsed_message(

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -62,7 +62,7 @@ impl Client {
     ///
     /// The PN/LID namespace stays as it arrived, deliberately unresolved, for
     /// the reasons [`Self::dispatch_undecryptable_event`] states at length.
-    fn dispatch_key(info: &Arc<MessageInfo>) -> wacore::types::message::SenderMessageId {
+    pub(crate) fn dispatch_key(info: &Arc<MessageInfo>) -> wacore::types::message::SenderMessageId {
         wacore::types::message::SenderMessageId::new(
             info.source.chat.clone(),
             info.id.clone(),

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -22,9 +22,15 @@ impl Client {
     /// the two deliveries are one message.
     ///
     /// Read here and written by [`Self::mark_message_dispatched`] once the
-    /// batch carrying the message becomes observable. The read-then-write is
-    /// safe because `chat_lanes` serializes incoming processing per chat, and
-    /// both deliveries of one message are in one chat.
+    /// batch carrying the message becomes observable. Those are two points in
+    /// time, so this cannot be an atomic `get_with` the way the sibling
+    /// `undecryptable_dispatched` gate is: claiming at the check would claim
+    /// for a commit that may still fail. `chat_lanes` serializes incoming
+    /// processing per chat and so closes the window for ordinary traffic, but
+    /// two workers for one chat can coexist after a lane eviction. The race
+    /// they leave is a second dispatch of one message, which is the behaviour
+    /// this gate improves on rather than a regression, and it is the safe
+    /// direction: the alternative loses the message.
     pub(crate) async fn message_already_dispatched(&self, info: &Arc<MessageInfo>) -> bool {
         self.dispatched_messages
             .get(&Self::dispatch_key(info))

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -38,6 +38,13 @@ impl Client {
             .is_some()
     }
 
+    /// Whether the dispatch-once gate is on. Capacity 0 is its documented off
+    /// switch, and it has to turn off the batch collapse too, or the switch
+    /// would restore the old behaviour for live traffic only.
+    pub(crate) fn dispatch_gate_enabled(&self) -> bool {
+        self.dispatched_messages.configured_capacity() != Some(0)
+    }
+
     /// Claim a message id, called where a committed batch is dispatched.
     ///
     /// Placing it there rather than at the call site is what makes the offline

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -33,8 +33,10 @@ impl Client {
     /// (no ack) so a transient storage error cannot drop a message that still
     /// needs its hook to commit.
     ///
-    /// Returns `true` when a buffered copy was replayed, which dispatches the
-    /// message again: a caller counting suppressions must not count that one.
+    /// Returns `true` when a buffered copy was replayed *and* its commit will
+    /// dispatch it, which hands the message to consumers again: a caller
+    /// counting suppressions must not count that one. A replay whose commit
+    /// failed returns `false`, because nothing reached a consumer.
     pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) -> bool {
         if self.inbound_durability_hook().is_some() {
             let backend = self.persistence_manager.backend();
@@ -43,15 +45,22 @@ impl Client {
             match backend.get_pending_inbound(&chat, &sender, &info.id).await {
                 Ok(Some(bytes)) => match waproto::codec::message_decode(&bytes) {
                     Ok(msg) => {
-                        self.commit_or_batch_inbound(
-                            InboundMessage::builder()
-                                .message(Arc::new(msg))
-                                .info(Arc::clone(info))
-                                .build(),
-                            false,
-                        )
-                        .await;
-                        return true;
+                        // Only a replay that will actually reach the consumer
+                        // counts as one. `Deferred` still does, later, when its
+                        // batch commits; `Failed` dispatched nothing, so the
+                        // caller must count that resend as a suppression or the
+                        // message reaches no one and nothing records it.
+                        return !matches!(
+                            self.commit_or_batch_inbound(
+                                InboundMessage::builder()
+                                    .message(Arc::new(msg))
+                                    .info(Arc::clone(info))
+                                    .build(),
+                                false,
+                            )
+                            .await,
+                            InboundCommitState::Failed
+                        );
                     }
                     Err(e) => {
                         // Corrupt row (our own serialization): it can never be

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -32,7 +32,10 @@ impl Client {
     /// a genuine duplicate (no buffered copy). A read failure fails closed
     /// (no ack) so a transient storage error cannot drop a message that still
     /// needs its hook to commit.
-    pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) {
+    ///
+    /// Returns `true` when a buffered copy was replayed, which dispatches the
+    /// message again: a caller counting suppressions must not count that one.
+    pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) -> bool {
         if self.inbound_durability_hook().is_some() {
             let backend = self.persistence_manager.backend();
             let chat = info.source.chat.to_string();
@@ -48,6 +51,7 @@ impl Client {
                             false,
                         )
                         .await;
+                        return true;
                     }
                     Err(e) => {
                         // Corrupt row (our own serialization): it can never be
@@ -74,6 +78,7 @@ impl Client {
         } else {
             self.ack_received_message(info);
         }
+        false
     }
 }
 

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1873,10 +1873,31 @@ impl Client {
                 skdm_only: true,
                 ..Default::default()
             })
+        } else if self.message_already_dispatched(info).await {
+            // The sender resent a message we already handed to consumers. Ack
+            // it the way the ratchet-level duplicate is acked, so a registered
+            // durability hook still gets its replay instead of a bare ack; the
+            // key share (if any) was scheduled by the delivery that dispatched.
+            // status is acked by the should_ack gate.
+            self.duplicate_dispatch_suppressed
+                .fetch_add(1, Ordering::Relaxed);
+            wacore::telemetry::recv("duplicate_resend");
+            log::debug!(
+                "[msg:{}] already dispatched for this sender; suppressing the resend's event",
+                info.id
+            );
+            if !info.source.chat.is_status_broadcast() {
+                self.ack_or_replay_to_hook(info).await;
+            }
+            Ok(PlaintextHandleOutcome {
+                dispatched: true,
+                ..Default::default()
+            })
         } else {
             let commit_state = self
                 .dispatch_parsed_message(msg, info, app_state_key_share_job.is_some())
                 .await;
+            self.mark_message_dispatched(info, &commit_state).await;
             if let Some((requester, request)) = app_state_key_share_job {
                 match commit_state {
                     InboundCommitState::Durable => {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1876,8 +1876,7 @@ impl Client {
         } else if self.message_already_dispatched(info).await {
             // The sender resent a message we already handed to consumers. Ack
             // it the way the ratchet-level duplicate is acked, so a registered
-            // durability hook still gets its replay instead of a bare ack; the
-            // key share (if any) was scheduled by the delivery that dispatched.
+            // durability hook still gets its replay instead of a bare ack.
             // status is acked by the should_ack gate. A hook whose buffered copy
             // survived replays instead of being acked, which dispatches the
             // message again: that is the documented at-least-once shape, not a
@@ -1892,6 +1891,14 @@ impl Client {
                     "[msg:{}] already dispatched for this sender; suppressing the resend's event",
                     info.id
                 );
+            }
+            // The event is a duplicate; the key share is not. Our phone asking
+            // again is what it does when it did not get the keys, so the first
+            // delivery's send having been scheduled is no reason to skip this
+            // one. Sending them twice costs a stanza; not sending them leaves
+            // the requester without app-state keys until it changes request id.
+            if let Some((requester, request)) = app_state_key_share_job {
+                self.schedule_app_state_sync_key_share(requester, request, None);
             }
             Ok(PlaintextHandleOutcome {
                 dispatched: true,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1897,7 +1897,6 @@ impl Client {
             let commit_state = self
                 .dispatch_parsed_message(msg, info, app_state_key_share_job.is_some())
                 .await;
-            self.mark_message_dispatched(info, &commit_state).await;
             if let Some((requester, request)) = app_state_key_share_job {
                 match commit_state {
                     InboundCommitState::Durable => {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1878,16 +1878,20 @@ impl Client {
             // it the way the ratchet-level duplicate is acked, so a registered
             // durability hook still gets its replay instead of a bare ack; the
             // key share (if any) was scheduled by the delivery that dispatched.
-            // status is acked by the should_ack gate.
-            self.duplicate_dispatch_suppressed
-                .fetch_add(1, Ordering::Relaxed);
-            wacore::telemetry::recv("duplicate_resend");
-            log::debug!(
-                "[msg:{}] already dispatched for this sender; suppressing the resend's event",
-                info.id
-            );
-            if !info.source.chat.is_status_broadcast() {
-                self.ack_or_replay_to_hook(info).await;
+            // status is acked by the should_ack gate. A hook whose buffered copy
+            // survived replays instead of being acked, which dispatches the
+            // message again: that is the documented at-least-once shape, not a
+            // suppression, so it is not counted as one.
+            let replayed =
+                !info.source.chat.is_status_broadcast() && self.ack_or_replay_to_hook(info).await;
+            if !replayed {
+                self.duplicate_dispatch_suppressed
+                    .fetch_add(1, Ordering::Relaxed);
+                wacore::telemetry::recv("duplicate_resend");
+                log::debug!(
+                    "[msg:{}] already dispatched for this sender; suppressing the resend's event",
+                    info.id
+                );
             }
             Ok(PlaintextHandleOutcome {
                 dispatched: true,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1874,6 +1874,14 @@ impl Client {
                 ..Default::default()
             })
         } else if self.message_already_dispatched(info).await {
+            // The event is a duplicate; the message secret it carries may not
+            // be. Capture is write-behind and can drop an entry when its
+            // backend is down, and this branch skips `dispatch_parsed_message`,
+            // which is the only other caller: without this the resend is the
+            // second chance we would have thrown away, and every later
+            // encrypted edit, reaction or comment on that parent stays
+            // unopenable. It is a no-op for a message carrying no secret.
+            self.maybe_capture_inbound_msg_secret(&msg, info).await;
             // The sender resent a message we already handed to consumers. Ack
             // it the way the ratchet-level duplicate is acked, so a registered
             // durability hook still gets its replay instead of a bare ack.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15650,7 +15650,6 @@ async fn an_unresolved_secret_envelope_is_not_claimed() {
             }),
             enc_payload: Some(vec![9; 16]),
             enc_iv: Some(vec![7; 12]),
-            ..Default::default()
         }),
         ..Default::default()
     };
@@ -15674,6 +15673,67 @@ async fn an_unresolved_secret_envelope_is_not_claimed() {
         dispatch_count(&drain_message_events(&rx), id),
         2,
         "the resend must still reach the consumer: the first delivery handed it an envelope it could not open"
+    );
+}
+
+/// A drain batch can hold an unresolved envelope and, once the parent secret
+/// arrived mid-drain, a retry of the same id that resolved to the inner
+/// message. Collapsing them would drop the only copy the consumer can read.
+#[tokio::test]
+async fn a_batch_keeps_the_resolved_copy_of_an_unresolved_envelope() {
+    use wacore::messages::MessageUtils;
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("envelope_then_resolved").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "ENC_THEN_PLAIN";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    let envelope = wa::Message {
+        enc_reaction_message: buffa::MessageField::some(wa::message::EncReactionMessage {
+            target_message_key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("TARGET".into()),
+                remote_jid: Some(peer.to_string()),
+                from_me: Some(false),
+                ..Default::default()
+            }),
+            enc_payload: Some(vec![9; 16]),
+            enc_iv: Some(vec![7; 12]),
+        }),
+        ..Default::default()
+    };
+    // What the retry looks like once the secret is known: the inner message,
+    // under the same id the envelope carried.
+    let resolved = wa::Message {
+        conversation: Some("the reaction we could finally read".into()),
+        ..Default::default()
+    };
+
+    client.inbound_commit_batch.reset();
+    for payload in [
+        MessageUtils::encode_and_pad(&envelope),
+        MessageUtils::encode_and_pad(&resolved),
+    ] {
+        client
+            .handle_decrypted_plaintext("msg", payload, 2, 0, Default::default(), &info)
+            .await
+            .expect("handle the delivery");
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "the resolved copy must survive the collapse: the envelope is not the content"
     );
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15462,6 +15462,77 @@ async fn two_resends_inside_one_deferred_batch_dispatch_once() {
         1,
         "one message must not reach the consumer twice inside a single batch"
     );
+    assert_eq!(
+        client.stats().messages_suppressed_duplicate,
+        1,
+        "what the batch collapse drops is a suppression like any other, and has to be counted as one"
+    );
+}
+
+/// A resent `app_state_sync_key_request` is our phone saying it still has no
+/// keys. Suppressing the duplicate event must not suppress the recovery.
+#[tokio::test]
+async fn suppressed_key_request_resend_still_schedules_the_share() {
+    use wacore::messages::MessageUtils;
+
+    let (client, transport) = capturing_client("key_request_resend").await;
+    let requester_str = "5511000000001:33@s.whatsapp.net";
+    let requester: Jid = requester_str.parse().expect("requester jid");
+    let mut peer = AlicePeer::new(requester_str).await;
+    let (bundle, own_jid) = bobs_prekey_bundle(&client).await;
+    let own_address = own_jid.to_protocol_address();
+    peer.install_bob_session(&own_address, &bundle).await;
+    let establishing = peer.encrypt_text(&own_address, "establish session").await;
+    let (decrypted, _, _, session_present) =
+        submit_and_check_session(&client, &requester, &establishing).await;
+    assert!(decrypted && session_present, "precondition: peer session");
+    client.flush_signal_cache().await.expect("flush session");
+
+    let request = wa::Message {
+        protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
+            r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyRequest),
+            app_state_sync_key_request: buffa::MessageField::some(
+                wa::message::AppStateSyncKeyRequest {
+                    key_ids: vec![wa::message::AppStateSyncKeyId {
+                        key_id: Some(vec![1, 2, 3, 4]),
+                    }],
+                },
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let mut info = create_test_message_info(requester_str, "AKR_RESEND", requester_str);
+    info.source.is_from_me = true;
+    let info = Arc::new(info);
+
+    let plaintext = || MessageUtils::encode_and_pad(&request);
+    client
+        .handle_decrypted_plaintext("msg", plaintext(), 2, 0, Default::default(), &info)
+        .await
+        .expect("handle key request");
+    crate::test_utils::poll_until("the first key share", || {
+        message_count_to_after(&transport.sent(), 0, requester_str) == 1
+    })
+    .await;
+    let after_first = transport.sent().len();
+
+    // Same request again, re-encrypted: the event is a duplicate, the phone's
+    // need for the keys is not.
+    client
+        .handle_decrypted_plaintext("msg", plaintext(), 2, 0, Default::default(), &info)
+        .await
+        .expect("handle resent key request");
+
+    crate::test_utils::poll_until("the key share for the resent request", || {
+        has_message_to_after(&transport.sent(), after_first, requester_str)
+    })
+    .await;
+    assert_eq!(
+        client.stats().messages_suppressed_duplicate,
+        1,
+        "the resend's consumer event is still suppressed"
+    );
 }
 
 /// The server spells `participant` bare on an skmsg and device-qualified on the

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5681,6 +5681,16 @@ async fn capturing_client(
     Arc<Client>,
     Arc<crate::transport::mock::CapturingMockTransport>,
 ) {
+    capturing_client_with_cache_config(test_id, crate::cache_config::CacheConfig::default()).await
+}
+
+async fn capturing_client_with_cache_config(
+    test_id: &str,
+    cache_config: crate::cache_config::CacheConfig,
+) -> (
+    Arc<Client>,
+    Arc<crate::transport::mock::CapturingMockTransport>,
+) {
     use crate::socket::NoiseSocket;
     use crate::store::SqliteStore;
     use crate::store::persistence_manager::PersistenceManager;
@@ -5710,12 +5720,13 @@ async fn capturing_client(
     );
     let factory = CapturingMockTransportFactory::new();
     let transport = factory.transport();
-    let (client, _sync_rx) = Client::new(
+    let (client, _sync_rx) = Client::new_with_cache_config(
         Arc::new(crate::runtime_impl::TokioRuntime),
         pm,
         Arc::new(factory),
         Arc::new(MockHttpClient),
         None,
+        cache_config,
     )
     .await;
 
@@ -14953,5 +14964,497 @@ async fn a_namespace_switch_mid_flight_is_seen_as_a_second_message() {
         switched,
         "an unresolved key cannot tell this from a new sender, and the duplicate \
          placeholder is the cost this design accepts"
+    );
+}
+
+// --- Resent-message dispatch gate --------------------------------------
+//
+// A sender whose network is bad re-runs its own outbox: same message id, fresh
+// ciphertext at a new sender-key iteration. The ratchet cannot see that as a
+// duplicate, so only message identity can.
+
+/// A group participant whose sender key the client already holds, as a real
+/// first message would have left it.
+async fn joined_group_sender(client: &Arc<Client>, jid_str: &str, group: &Jid) -> AlicePeer {
+    let mut peer = AlicePeer::new(jid_str).await;
+    let skdm = peer.create_group_skdm(group).await;
+    let axolotl = skdm
+        .axolotl_sender_key_distribution_message
+        .expect("skdm bytes");
+    client
+        .handle_sender_key_distribution_message(group, &peer.jid, "SKDM_INSTALL", &axolotl)
+        .await;
+    peer
+}
+
+fn group_skmsg_stanza(
+    group: &Jid,
+    sender: &Jid,
+    id: &str,
+    ciphertext: Vec<u8>,
+) -> Arc<OwnedNodeRef> {
+    let enc = NodeBuilder::new("enc")
+        .attr("type", "skmsg")
+        .attr("v", "2")
+        .bytes(ciphertext)
+        .build();
+    node_to_arc(
+        NodeBuilder::new("message")
+            .attr("from", group.clone())
+            .attr("participant", sender.clone())
+            .attr("id", id)
+            .attr("t", wacore::time::now_secs().to_string())
+            .attr("type", "text")
+            .attr(
+                "addressing_mode",
+                crate::types::message::AddressingMode::Lid.as_str(),
+            )
+            .children(vec![enc])
+            .build(),
+    )
+}
+
+async fn encrypt_group_text(peer: &mut AlicePeer, group: &Jid, text: &str) -> Vec<u8> {
+    use wacore::messages::MessageUtils;
+
+    let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+        conversation: Some(text.to_string()),
+        ..Default::default()
+    });
+    peer.encrypt_group_message(group, &plaintext).await
+}
+
+/// The production bug: the sender re-encrypts and resends under one id, so both
+/// deliveries decrypt cleanly and the consumer sees one message twice.
+#[tokio::test]
+async fn resent_group_message_dispatches_once() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, transport) = capturing_client("resend_dispatch_once").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000001@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    let id = "RESEND_ONCE";
+    let first = encrypt_group_text(&mut alice, &group, "ping").await;
+    let second = encrypt_group_text(&mut alice, &group, "ping").await;
+    assert_ne!(
+        first, second,
+        "a resend is fresh ciphertext, not the same bytes"
+    );
+
+    for ciphertext in [first, second] {
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, ciphertext))
+            .await;
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        message_events_for_id(&rx, id),
+        (1, 1),
+        "one logical message must reach the consumer once, however often the sender resends it"
+    );
+    assert_eq!(
+        delivery_receipts_for(&transport.sent(), id),
+        2,
+        "every delivery still gets its receipt: WA Web sends one after each decryption"
+    );
+    assert_eq!(
+        client.stats().messages_suppressed_duplicate,
+        1,
+        "the suppression is counted, so a report of a missing message can be told from this fix"
+    );
+}
+
+/// The reason the key carries the sender: two participants of one group picked
+/// the same id (seen in production, 116s apart), and folding them together
+/// would drop the second one's message.
+#[tokio::test]
+async fn same_id_from_two_participants_dispatches_twice() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_two_participants").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000002@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+    let mut bob = joined_group_sender(&client, "100000000000002:12@lid", &group).await;
+
+    let id = "SHARED_ID";
+    let from_alice = encrypt_group_text(&mut alice, &group, "from alice").await;
+    let from_bob = encrypt_group_text(&mut bob, &group, "from bob").await;
+
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, from_alice))
+        .await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &bob.jid, id, from_bob))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        message_events_for_id(&rx, id),
+        (2, 2),
+        "an id is the sending client's to choose; two senders sharing one is two messages"
+    );
+}
+
+/// Drain the event channel into `(id, conversation)` pairs so one test can
+/// count dispatches for more than one message id.
+fn drain_message_events(rx: &async_channel::Receiver<Arc<Event>>) -> Vec<(String, Option<String>)> {
+    let mut seen = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        for m in event.messages() {
+            seen.push((m.info.id.to_string(), m.message.conversation.clone()));
+        }
+    }
+    seen
+}
+
+fn dispatch_count(seen: &[(String, Option<String>)], id: &str) -> usize {
+    seen.iter().filter(|(seen_id, _)| seen_id == id).count()
+}
+
+fn gate_disabled_config() -> crate::cache_config::CacheConfig {
+    let mut config = crate::cache_config::CacheConfig::default();
+    config.dispatched_messages.capacity = 0;
+    config
+}
+
+/// The server replaying the identical stanza is a different failure mode, and
+/// the persisted ratchet already rejects it. Run it with the new gate off so
+/// the assertion can only be satisfied by `DuplicatedMessage`.
+#[tokio::test]
+async fn byte_identical_redelivery_is_still_rejected_by_the_ratchet() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) =
+        capturing_client_with_cache_config("redelivery_ratchet", gate_disabled_config()).await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000003@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    let id = "REDELIVERED";
+    let ciphertext = encrypt_group_text(&mut alice, &group, "ping").await;
+    for _ in 0..2 {
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(
+                &group,
+                &alice.jid,
+                id,
+                ciphertext.clone(),
+            ))
+            .await;
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "the persisted ratchet rejects a byte-identical replay without help from the gate"
+    );
+    assert_eq!(
+        client.stats().messages_suppressed_duplicate,
+        0,
+        "a ratchet-level duplicate is not counted as a suppressed resend"
+    );
+}
+
+/// Capacity 0 is the off switch (`PortableCache` short-circuits the insert), and
+/// turning it off must restore the pre-fix behaviour exactly.
+#[tokio::test]
+async fn zero_capacity_disables_the_gate() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) =
+        capturing_client_with_cache_config("gate_disabled", gate_disabled_config()).await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000004@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    let id = "GATE_OFF";
+    for _ in 0..2 {
+        let ciphertext = encrypt_group_text(&mut alice, &group, "ping").await;
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, ciphertext))
+            .await;
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "capacity 0 must leave the resend dispatching twice, as it did before the gate"
+    );
+}
+
+/// Nothing was dispatched on the delivery that failed to decrypt, so the key is
+/// not in the cache and the resend must come through.
+#[tokio::test]
+async fn resend_after_our_own_decrypt_failure_dispatches() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_after_failure").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000005@g.us".parse().expect("group");
+    // Sender key deliberately not installed yet: the first delivery fails with
+    // NoSenderKey, exactly as it does before an SKDM arrives.
+    let mut alice = AlicePeer::new("100000000000001:75@lid").await;
+    let skdm = alice.create_group_skdm(&group).await;
+
+    let id = "RESEND_AFTER_FAILURE";
+    let failed = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, failed))
+        .await;
+
+    client
+        .handle_sender_key_distribution_message(
+            &group,
+            &alice.jid,
+            "SKDM_LATE",
+            &skdm
+                .axolotl_sender_key_distribution_message
+                .expect("skdm bytes"),
+        )
+        .await;
+
+    let resent = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, resent))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "a resend after our own decrypt failure is the first dispatch, not a duplicate"
+    );
+}
+
+/// Suppressing the event must not suppress the session `<enc>` the resend
+/// carries: dropping the SKDM would turn one duplicate into a run of
+/// NoSenderKey failures on everything after it.
+#[tokio::test]
+async fn suppressed_resend_still_installs_the_sender_key_it_carries() {
+    use wacore::messages::MessageUtils;
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_with_skdm").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000006@g.us".parse().expect("group");
+    let sender_jid = "100000000000001:75@lid";
+    let mut alice = joined_group_sender(&client, sender_jid, &group).await;
+
+    let id = "RESEND_WITH_SKDM";
+    let first = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, first))
+        .await;
+
+    // The sender rotated its sender key before retrying, so the resend carries
+    // a pkmsg with the new SKDM alongside the skmsg.
+    let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+    let bob_addr = bob_jid.to_protocol_address();
+    let mut rotated = AlicePeer::new(sender_jid).await;
+    rotated.install_bob_session(&bob_addr, &bundle).await;
+    let skdm = rotated.create_group_skdm(&group).await;
+    let session_ct = rotated
+        .encrypt(
+            &bob_addr,
+            &MessageUtils::encode_and_pad(&wa::Message {
+                sender_key_distribution_message: buffa::MessageField::some(skdm),
+                ..Default::default()
+            }),
+        )
+        .await;
+    let CiphertextMessage::PreKeySignalMessage(pkmsg) = &session_ct else {
+        panic!("expected a pkmsg");
+    };
+    let resent = encrypt_group_text(&mut rotated, &group, "ping").await;
+
+    let stanza = node_to_arc(
+        NodeBuilder::new("message")
+            .attr("from", group.clone())
+            .attr("participant", alice.jid.clone())
+            .attr("id", id)
+            .attr("t", wacore::time::now_secs().to_string())
+            .attr("type", "text")
+            .attr(
+                "addressing_mode",
+                crate::types::message::AddressingMode::Lid.as_str(),
+            )
+            .children(vec![
+                NodeBuilder::new("enc")
+                    .attr("type", "pkmsg")
+                    .attr("v", "2")
+                    .bytes(pkmsg.serialized().to_vec())
+                    .build(),
+                NodeBuilder::new("enc")
+                    .attr("type", "skmsg")
+                    .attr("v", "2")
+                    .bytes(resent)
+                    .build(),
+            ])
+            .build(),
+    );
+    client.clone().handle_incoming_message(stanza).await;
+
+    // The next message rides the rotated chain: it only decrypts if the
+    // suppressed resend still installed the key it carried.
+    let next_id = "AFTER_ROTATION";
+    let next = encrypt_group_text(&mut rotated, &group, "pong").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, next_id, next))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let seen = drain_message_events(&rx);
+    assert_eq!(
+        dispatch_count(&seen, id),
+        1,
+        "the resend's own event is suppressed"
+    );
+    assert_eq!(
+        dispatch_count(&seen, next_id),
+        1,
+        "the rotated sender key the suppressed resend carried must still be installed"
+    );
+}
+
+/// A commit that failed handed nothing to a consumer, so the claim must not be
+/// taken: suppressing the resend there would lose the message rather than
+/// deduplicate it.
+#[tokio::test]
+async fn resend_after_a_failed_commit_dispatches() {
+    use std::sync::atomic::Ordering;
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_after_failed_commit").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000008@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    let id = "COMMIT_FAILED";
+    client
+        .inbound_commit_batch
+        .fail_commits
+        .store(true, Ordering::Release);
+    let first = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, first))
+        .await;
+
+    client
+        .inbound_commit_batch
+        .fail_commits
+        .store(false, Ordering::Release);
+    let resent = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, resent))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "the resend is the first delivery the consumer actually gets"
+    );
+}
+
+/// With a hook registered and its first commit failed, the message is buffered
+/// and unacked. The suppression must replay that buffered copy instead of
+/// acking it away: a bare ack here would lose the message for the consumer
+/// while telling the server it was handled.
+#[tokio::test]
+async fn suppressed_resend_replays_to_a_durability_hook() {
+    use crate::types::durability_hook::InboundDurabilityHook;
+    use std::sync::atomic::AtomicUsize;
+    use wacore::types::events::{ChannelEventHandler, InboundMessage};
+
+    /// Fails the first commit (leaving a buffered, unacked copy) and succeeds
+    /// after, the way a consumer recovering from a transient storage error does.
+    struct FlakyHook {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl InboundDurabilityHook for FlakyHook {
+        async fn on_messages(
+            &self,
+            _client: Arc<Client>,
+            _batch: &[InboundMessage],
+        ) -> anyhow::Result<()> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(anyhow::anyhow!("commit failed"));
+            }
+            Ok(())
+        }
+    }
+
+    let (client, transport) = capturing_client("resend_hook_replay").await;
+    let hook = Arc::new(FlakyHook {
+        calls: AtomicUsize::new(0),
+    });
+    client
+        .inbound_durability_hook
+        .set(hook.clone() as Arc<dyn InboundDurabilityHook>)
+        .ok()
+        .expect("hook registers once");
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000007@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    let id = "HOOK_REPLAY";
+    for _ in 0..2 {
+        let ciphertext = encrypt_group_text(&mut alice, &group, "ping").await;
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, ciphertext))
+            .await;
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        hook.calls.load(Ordering::SeqCst),
+        2,
+        "the suppressed resend replays the buffered copy to the hook"
+    );
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "the replay is what delivers the message the failed commit owed the consumer"
+    );
+    assert_eq!(
+        delivery_receipts_for(&transport.sent(), id),
+        1,
+        "the ack follows the commit that finally succeeded, not the one that failed"
     );
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15201,6 +15201,45 @@ async fn zero_capacity_disables_the_gate() {
     );
 }
 
+/// The off switch has to reach the batch collapse too, or capacity 0 would
+/// restore the old behaviour for live traffic only.
+#[tokio::test]
+async fn zero_capacity_disables_the_batch_collapse() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) =
+        capturing_client_with_cache_config("gate_disabled_drain", gate_disabled_config()).await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000012@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    client.inbound_commit_batch.reset();
+
+    let id = "GATE_OFF_DRAIN";
+    for _ in 0..2 {
+        let ciphertext = encrypt_group_text(&mut alice, &group, "ping").await;
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, ciphertext))
+            .await;
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "capacity 0 must leave a drained batch carrying both deliveries, as it did before the gate"
+    );
+}
+
 /// Nothing was dispatched on the delivery that failed to decrypt, so the key is
 /// not in the cache and the resend must come through.
 #[tokio::test]

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15052,16 +15052,16 @@ async fn resent_group_message_dispatches_once() {
             .await;
     }
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Receipts leave through the delivery-receipt worker, so wait on the count
+    // rather than on a fixed delay.
+    crate::test_utils::poll_until("both delivery receipts", || {
+        delivery_receipts_for(&transport.sent(), id) == 2
+    })
+    .await;
     assert_eq!(
         message_events_for_id(&rx, id),
         (1, 1),
         "one logical message must reach the consumer once, however often the sender resends it"
-    );
-    assert_eq!(
-        delivery_receipts_for(&transport.sent(), id),
-        2,
-        "every delivery still gets its receipt: WA Web sends one after each decryption"
     );
     assert_eq!(
         client.stats().messages_suppressed_duplicate,
@@ -15521,7 +15521,10 @@ async fn suppressed_resend_replays_to_a_durability_hook() {
             .await;
     }
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    crate::test_utils::poll_until("the replayed commit's receipt", || {
+        delivery_receipts_for(&transport.sent(), id) == 1
+    })
+    .await;
     assert_eq!(
         hook.calls.load(Ordering::SeqCst),
         2,
@@ -15531,10 +15534,5 @@ async fn suppressed_resend_replays_to_a_durability_hook() {
         dispatch_count(&drain_message_events(&rx), id),
         1,
         "the replay is what delivers the message the failed commit owed the consumer"
-    );
-    assert_eq!(
-        delivery_receipts_for(&transport.sent(), id),
-        1,
-        "the ack follows the commit that finally succeeded, not the one that failed"
     );
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15676,6 +15676,235 @@ async fn an_unresolved_secret_envelope_is_not_claimed() {
     );
 }
 
+/// A replay whose commit fails dispatches nothing. Reporting it as a replay
+/// would skip the suppression counter, so a message that reached no consumer
+/// would leave no trace in the one number that exists to explain exactly that.
+#[tokio::test]
+async fn a_replay_that_fails_to_commit_counts_as_a_suppression() {
+    use crate::types::durability_hook::InboundDurabilityHook;
+    use wacore::messages::MessageUtils;
+    use wacore::types::events::InboundMessage;
+
+    struct SilentHook;
+
+    #[async_trait::async_trait]
+    impl InboundDurabilityHook for SilentHook {
+        async fn on_messages(
+            &self,
+            _client: Arc<Client>,
+            _batch: &[InboundMessage],
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    let (client, _transport) = capturing_client("failed_replay_counts").await;
+    client
+        .inbound_durability_hook
+        .set(Arc::new(SilentHook) as Arc<dyn InboundDurabilityHook>)
+        .ok()
+        .expect("hook registers once");
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "REPLAY_THAT_FAILS";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+    let msg = wa::Message {
+        conversation: Some("the copy still buffered".into()),
+        ..Default::default()
+    };
+
+    // The state the resend arrives into: the id was claimed by a delivery that
+    // dispatched, but its pending row outlived the commit that should have
+    // cleared it, so the replay path finds a buffered copy to re-commit.
+    client
+        .persistence_manager
+        .backend()
+        .store_pending_inbound(
+            &info.source.chat.to_string(),
+            &info.source.sender.to_string(),
+            id,
+            &{
+                let mut buf = Vec::new();
+                waproto::codec::message_encode_into(&msg, &mut buf);
+                buf
+            },
+        )
+        .await
+        .expect("buffer a copy");
+    client.mark_message_dispatched(&info).await;
+    client
+        .inbound_commit_batch
+        .fail_commits
+        .store(true, Ordering::Release);
+
+    client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&msg),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .expect("handle the resend");
+
+    assert_eq!(
+        client.stats().messages_suppressed_duplicate,
+        1,
+        "a replay whose commit failed reached no consumer, so it is a suppression"
+    );
+}
+
+/// `extract_secret_encrypted` returns `None` both for a plain message and for a
+/// tagged envelope that is malformed, so the claim must test for the envelope's
+/// presence: a malformed one is no more readable to a consumer than an
+/// unopenable one.
+#[tokio::test]
+async fn a_malformed_secret_envelope_is_not_claimed() {
+    use wacore::messages::MessageUtils;
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("malformed_envelope").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "MALFORMED_REACTION";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    // Tagged as an encrypted reaction, but the IV is not 12 bytes, so
+    // extraction rejects it while the consumer still gets only the envelope.
+    let malformed = wa::Message {
+        enc_reaction_message: buffa::MessageField::some(wa::message::EncReactionMessage {
+            target_message_key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("TARGET".into()),
+                remote_jid: Some(peer.to_string()),
+                from_me: Some(false),
+                ..Default::default()
+            }),
+            enc_payload: Some(vec![9; 16]),
+            enc_iv: Some(vec![7; 5]),
+        }),
+        ..Default::default()
+    };
+
+    for _ in 0..2 {
+        client
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(&malformed),
+                2,
+                0,
+                Default::default(),
+                &info,
+            )
+            .await
+            .expect("handle the envelope");
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "a malformed envelope must not claim the id its corrected resend needs"
+    );
+}
+
+/// Two dispatches of one stanza share its `MessageInfo`, which is what the
+/// msmsg loop hands every bot-reply part. Equal parts are not a repeat of each
+/// other, so identity plus content is not enough on its own.
+#[tokio::test]
+async fn two_identical_msmsg_parts_under_one_id_both_reach_the_consumer() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("msmsg_identical_parts").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "BOT_REPLY_SAME_TWICE";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    client.inbound_commit_batch.reset();
+    for _ in 0..2 {
+        client
+            .dispatch_parsed_message(
+                wa::Message {
+                    conversation: Some("the same bot reply twice".into()),
+                    ..Default::default()
+                },
+                &info,
+                false,
+            )
+            .await;
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "parts of one stanza are not repeats of each other, even when identical"
+    );
+}
+
+/// One participant reusing an id across a whole drain batch must not make the
+/// collapse compare every payload against every earlier one. Past the bound it
+/// gives up on that identity and keeps everything, which is the safe direction
+/// and is what this asserts: a repeat that arrives after the bound survives.
+#[tokio::test]
+async fn an_id_reused_past_the_bound_stops_being_collapsed() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("id_reuse_bound").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "REUSED_PAST_THE_BOUND";
+    let repeated = "the payload that comes back";
+
+    client.inbound_commit_batch.reset();
+    // Distinct stanzas (each its own info) all claiming one id: the first
+    // payload, then enough different ones to exhaust the bound, then the first
+    // payload again. Below the bound that last one would collapse into the
+    // first; past it the collapse has stopped looking at this identity.
+    let payloads = std::iter::once(repeated.to_string())
+        .chain((0..8).map(|n| format!("filler {n}")))
+        .chain(std::iter::once(repeated.to_string()));
+    for text in payloads {
+        client
+            .dispatch_parsed_message(
+                wa::Message {
+                    conversation: Some(text),
+                    ..Default::default()
+                },
+                &Arc::new(create_test_message_info(peer, id, peer)),
+                false,
+            )
+            .await;
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        10,
+        "past the bound the collapse gives up on an identity and keeps everything"
+    );
+}
+
 /// The msmsg loop dispatches every bot-reply part of one stanza under a single
 /// `info`, so a drain batch can hold several genuinely different payloads that
 /// share an identity. Collapsing them would ack every part and deliver one.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15535,6 +15535,148 @@ async fn suppressed_key_request_resend_still_schedules_the_share() {
     );
 }
 
+/// A pending row is keyed on the sender exactly as its delivery spelled it,
+/// while the collapse folds spellings together. Clearing only the kept spelling
+/// leaves a row that a later resend replays as an already committed message.
+#[tokio::test]
+async fn a_collapsed_batch_clears_every_arrived_pending_row() {
+    use crate::types::durability_hook::InboundDurabilityHook;
+    use wacore::types::events::{BatchOrigin, InboundMessage};
+
+    struct OkHook;
+
+    #[async_trait::async_trait]
+    impl InboundDurabilityHook for OkHook {
+        async fn on_messages(
+            &self,
+            _client: Arc<Client>,
+            _batch: &[InboundMessage],
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    let (client, _transport) = capturing_client("collapsed_pending_rows").await;
+    client
+        .inbound_durability_hook
+        .set(Arc::new(OkHook) as Arc<dyn InboundDurabilityHook>)
+        .ok()
+        .expect("hook registers once");
+
+    let chat: Jid = "120363000000000013@g.us".parse().expect("group");
+    let bare: Jid = "100000000000001@lid".parse().expect("bare sender");
+    let device: Jid = "100000000000001:75@lid".parse().expect("device sender");
+    let id = "COLLAPSED_ROWS";
+
+    let item = |sender: &Jid| {
+        let sender_str = sender.to_string();
+        let mut info = create_test_message_info(&sender_str, id, &sender_str);
+        info.source.chat = chat.clone();
+        info.source.sender = sender.clone();
+        InboundMessage::builder()
+            .message(Arc::new(wa::Message {
+                conversation: Some("ping".to_string()),
+                ..Default::default()
+            }))
+            .info(Arc::new(info))
+            .build()
+    };
+
+    // Both spellings buffered by earlier failed commits.
+    let backend = client.persistence_manager.backend();
+    for sender in [&bare, &device] {
+        backend
+            .store_pending_inbound_batch(&[crate::store::traits::PendingInboundRow {
+                chat: &chat.to_string(),
+                sender: &sender.to_string(),
+                id,
+                message: &waproto::codec::message_to_vec(&wa::Message {
+                    conversation: Some("ping".to_string()),
+                    ..Default::default()
+                }),
+            }])
+            .await
+            .expect("buffer the delivery");
+    }
+
+    assert!(
+        client
+            .commit_inbound_batch(
+                Arc::from(vec![item(&bare), item(&device)]),
+                BatchOrigin::Live,
+                None,
+            )
+            .await,
+        "the batch must commit"
+    );
+
+    for sender in [&bare, &device] {
+        assert!(
+            backend
+                .get_pending_inbound(&chat.to_string(), &sender.to_string(), id)
+                .await
+                .expect("read pending")
+                .is_none(),
+            "every arrived spelling's row must be cleared, not just the kept one"
+        );
+    }
+}
+
+/// An unresolved secret envelope is a placeholder: the consumer got a payload
+/// it cannot read. Claiming it would suppress the resend that arrives once the
+/// parent secret is known, so it must not be claimed.
+#[tokio::test]
+async fn an_unresolved_secret_envelope_is_not_claimed() {
+    use wacore::messages::MessageUtils;
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("unresolved_envelope").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "ENC_REACTION";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    // A reaction whose secret we do not hold: the envelope cannot be opened, so
+    // what reaches the consumer is the envelope itself.
+    let envelope = wa::Message {
+        enc_reaction_message: buffa::MessageField::some(wa::message::EncReactionMessage {
+            target_message_key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("TARGET".into()),
+                remote_jid: Some(peer.to_string()),
+                from_me: Some(false),
+                ..Default::default()
+            }),
+            enc_payload: Some(vec![9; 16]),
+            enc_iv: Some(vec![7; 12]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    for _ in 0..2 {
+        client
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(&envelope),
+                2,
+                0,
+                Default::default(),
+                &info,
+            )
+            .await
+            .expect("handle the envelope");
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "the resend must still reach the consumer: the first delivery handed it an envelope it could not open"
+    );
+}
+
 /// The server spells `participant` bare on an skmsg and device-qualified on the
 /// pkmsg that carries an SKDM, so the two deliveries of one message can differ.
 /// The key drops the device for exactly this reason.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15343,6 +15343,86 @@ async fn suppressed_resend_still_installs_the_sender_key_it_carries() {
     );
 }
 
+/// A batch deferred by the offline drain claims its ids when the batch itself
+/// commits, not before, so a resend arriving after the drain is still caught.
+#[tokio::test]
+async fn resend_after_a_deferred_batch_commits_is_suppressed() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_after_drain").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000009@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    // Back into drain mode: the first delivery joins the accumulating batch
+    // instead of committing on its own.
+    client.inbound_commit_batch.reset();
+
+    let id = "DRAIN_THEN_RESEND";
+    let first = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, first))
+        .await;
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    let resent = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, resent))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "a batch that committed has been handed to the consumer, so the resend is a duplicate"
+    );
+}
+
+/// The server spells `participant` bare on an skmsg and device-qualified on the
+/// pkmsg that carries an SKDM, so the two deliveries of one message can differ.
+/// The key drops the device for exactly this reason.
+#[tokio::test]
+async fn resend_with_a_device_qualified_participant_is_suppressed() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_device_spelling").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000010@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+    let bare = alice.jid.to_non_ad();
+
+    let id = "DEVICE_SPELLING";
+    let first = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &bare, id, first))
+        .await;
+
+    let resent = encrypt_group_text(&mut alice, &group, "ping").await;
+    client
+        .clone()
+        .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, resent))
+        .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "one message spelled two ways on the wire is still one message"
+    );
+}
+
 /// A commit that failed handed nothing to a consumer, so the claim must not be
 /// taken: suppressing the resend there would lose the message rather than
 /// deduplicate it.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15387,6 +15387,44 @@ async fn resend_after_a_deferred_batch_commits_is_suppressed() {
     );
 }
 
+/// Both deliveries can land in one drained batch: each checked the gate before
+/// either claim existed, so the batch itself has to collapse them.
+#[tokio::test]
+async fn two_resends_inside_one_deferred_batch_dispatch_once() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("resend_same_batch").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let group: Jid = "120363000000000011@g.us".parse().expect("group");
+    let mut alice = joined_group_sender(&client, "100000000000001:75@lid", &group).await;
+
+    client.inbound_commit_batch.reset();
+
+    let id = "SAME_BATCH_RESEND";
+    for _ in 0..2 {
+        let ciphertext = encrypt_group_text(&mut alice, &group, "ping").await;
+        client
+            .clone()
+            .handle_incoming_message(group_skmsg_stanza(&group, &alice.jid, id, ciphertext))
+            .await;
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        1,
+        "one message must not reach the consumer twice inside a single batch"
+    );
+}
+
 /// The server spells `participant` bare on an skmsg and device-qualified on the
 /// pkmsg that carries an SKDM, so the two deliveries of one message can differ.
 /// The key drops the device for exactly this reason.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15676,6 +15676,122 @@ async fn an_unresolved_secret_envelope_is_not_claimed() {
     );
 }
 
+/// The msmsg loop dispatches every bot-reply part of one stanza under a single
+/// `info`, so a drain batch can hold several genuinely different payloads that
+/// share an identity. Collapsing them would ack every part and deliver one.
+#[tokio::test]
+async fn two_msmsg_parts_under_one_id_both_reach_the_consumer() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let (client, _transport) = capturing_client("msmsg_parts_one_id").await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "BOT_REPLY_PARTS";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    client.inbound_commit_batch.reset();
+    // What `handle_msmsg_payload` does per part: one `dispatch_parsed_message`
+    // with the stanza's shared info and this part's own decrypted content.
+    for part in [
+        "first half of the bot reply",
+        "second half of the bot reply",
+    ] {
+        client
+            .dispatch_parsed_message(
+                wa::Message {
+                    conversation: Some(part.into()),
+                    ..Default::default()
+                },
+                &info,
+                false,
+            )
+            .await;
+    }
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the drained batch must commit"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        dispatch_count(&drain_message_events(&rx), id),
+        2,
+        "both bot-reply parts must reach the consumer: one stanza id, two different payloads"
+    );
+}
+
+/// Capture is write-behind and can lose an entry when its backend is down. A
+/// resend is the second chance, so suppressing its event must not also skip
+/// the capture, or every later encrypted addon on that parent stays unopenable.
+#[tokio::test]
+async fn a_suppressed_resend_still_captures_the_message_secret() {
+    use wacore::messages::MessageUtils;
+
+    let (client, _transport) = capturing_client("suppressed_secret_capture").await;
+
+    let peer = "5511000000002:11@s.whatsapp.net";
+    let id = "SECRET_PARENT";
+    let info = Arc::new(create_test_message_info(peer, id, peer));
+
+    let with_secret = |forwarded: bool| wa::Message {
+        extended_text_message: buffa::MessageField::some(wa::message::ExtendedTextMessage {
+            text: Some("parent of a later reaction".into()),
+            context_info: buffa::MessageField::some(wa::ContextInfo {
+                is_forwarded: Some(forwarded),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
+            message_secret: Some(vec![4; 32]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    // The first delivery dispatches and claims the id but stores no secret.
+    // Forwarding is the controllable stand-in here for any reason the capture
+    // did not land; the branch the resend then takes is the same either way.
+    client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&with_secret(true)),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .expect("handle the first delivery");
+    assert_eq!(
+        client.memory_report().await.msg_secret_buffer,
+        0,
+        "precondition: the first delivery stored no secret"
+    );
+
+    client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&with_secret(false)),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .expect("handle the resend");
+
+    assert_eq!(
+        client.memory_report().await.msg_secret_buffer,
+        1,
+        "the suppressed resend must still capture the secret it carries"
+    );
+}
+
 /// A drain batch can hold an unresolved envelope and, once the parent secret
 /// arrived mid-drain, a retry of the same id that resolved to the inner
 /// message. Collapsing them would drop the only copy the consumer can read.

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -597,6 +597,13 @@ where
         log::warn!("PortableCache::invalidate_all: could not acquire write lock after retries");
     }
 
+    /// The configured capacity, or `None` when unbounded. `Some(0)` is the
+    /// off switch: `insert` short-circuits, so the cache never holds anything
+    /// and a caller can skip work that only makes sense when it does.
+    pub fn configured_capacity(&self) -> Option<u64> {
+        self.max_capacity
+    }
+
     pub fn entry_count(&self) -> u64 {
         self.inner
             .try_read()

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -155,7 +155,8 @@ pub struct SessionStats {
 }
 
 /// Point-in-time copy of [`SessionStats`], plus client-level counters the
-/// client fills in ([`Self::reconnect_errors`], [`Self::resends_throttled`]).
+/// client fills in ([`Self::reconnect_errors`], [`Self::resends_throttled`],
+/// [`Self::messages_suppressed_duplicate`]).
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StatsSnapshot {
@@ -201,6 +202,10 @@ pub struct StatsSnapshot {
     /// Outbound resends dropped by the per-chat rate limiter. Surfaces storm
     /// chats.
     pub resends_throttled: u64,
+    /// Decrypted messages not dispatched because the same message had already
+    /// reached consumers: a sender resending one id as fresh ciphertext. This
+    /// is the number to check first when a consumer reports a missing message.
+    pub messages_suppressed_duplicate: u64,
     pub last_data_received_ms: u64,
 }
 
@@ -370,8 +375,8 @@ impl SessionStats {
     }
 
     /// Copy the session-level counters. Client-level fields
-    /// (`reconnect_errors`, `resends_throttled`) are left zero for the owner
-    /// to fill.
+    /// (`reconnect_errors`, `resends_throttled`,
+    /// `messages_suppressed_duplicate`) are left zero for the owner to fill.
     pub fn snapshot(&self) -> StatsSnapshot {
         StatsSnapshot {
             bytes_sent: self.bytes_sent.load(Ordering::Relaxed),
@@ -391,6 +396,7 @@ impl SessionStats {
             reconnects: self.reconnects.load(Ordering::Relaxed),
             reconnect_errors: 0,
             resends_throttled: 0,
+            messages_suppressed_duplicate: 0,
             last_data_received_ms: self.last_data_received_ms.load(Ordering::Relaxed),
         }
     }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -898,9 +898,14 @@ pub enum Event {
     /// `info.unavailable_request_id`) dispatch event-only.
     ///
     /// A sender retrying its own outbox resends one message re-encrypted, which
-    /// no ratchet can see as a duplicate. Those collapse to a single dispatch,
-    /// keyed by chat, id and sender, for as long as the `dispatched_messages`
-    /// window holds; `stats().messages_suppressed_duplicate` counts them.
+    /// no ratchet can see as a duplicate. Such a resend collapses to a single
+    /// dispatch, keyed by chat, id and sender, for as long as the
+    /// `dispatched_messages` window holds;
+    /// `stats().messages_suppressed_duplicate` counts them. The collapse covers
+    /// what arrives as a decrypted payload for this device, so a message
+    /// delivered in several `msmsg` parts under one stanza id is out of scope:
+    /// suppressing there could drop a part, and a lost part is worse than a
+    /// duplicate event.
     Messages(MessageBatch),
     Receipt(Receipt),
     /// The server `<ack>`-ed (or nack-ed) an outgoing stanza.

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -896,6 +896,11 @@ pub enum Event {
     /// messages (plaintext, acked on their own path, never redelivered) and
     /// PDO placeholder recoveries (identified by
     /// `info.unavailable_request_id`) dispatch event-only.
+    ///
+    /// A sender retrying its own outbox resends one message re-encrypted, which
+    /// no ratchet can see as a duplicate. Those collapse to a single dispatch,
+    /// keyed by chat, id and sender, for as long as the `dispatched_messages`
+    /// window holds; `stats().messages_suppressed_duplicate` counts them.
     Messages(MessageBatch),
     Receipt(Receipt),
     /// The server `<ack>`-ed (or nack-ed) an outgoing stanza.


### PR DESCRIPTION
## Summary

A consumer answered a single group message two or four times, intermittently and only for some senders. The cause is upstream of us: a sender whose network is bad re-runs its own outbox and resends the same message id, re-encrypted on a new sender-key iteration. `get_sender_key` (`wacore/libsignal/src/protocol/group_cipher.rs:157-172`) returns `DuplicatedMessage` only when the *same iteration* comes back, which covers the byte-identical stanza the server replays and nothing else, so every resend decrypted cleanly and became another `Event::Messages`. Nothing anywhere on `handle_decrypted_plaintext` → `dispatch_parsed_message` → `commit_or_batch_inbound` asked whether that message identity had already been delivered.

The fix is a dispatch-once gate keyed on `SenderMessageId { chat, id, sender }`, reusing the idiom the `UndecryptableMessage` gate already established in `src/message/retry.rs`. It reads immediately before `dispatch_parsed_message` and claims the id where a committed batch is dispatched, suppresses through the same `ack_or_replay_to_hook` the ratchet-level duplicate uses, and adds no durable storage.

## Reproduction

`resent_group_message_dispatches_once` is the reproducer, and it is the wire scenario rather than a stub: a real SKDM installs the sender key, the remote peer's own `MemSenderKeyStore` encrypts the same plaintext twice (two iterations of one chain, exactly what an outbox retry produces), both stanzas carry the same `id`, and both enter through the production path `Client::handle_incoming_message`. It asserts one `Event::Messages`, two delivery receipts (one per delivery), and one counted suppression.

Before the fix it fails on the dispatch count, not on compilation:

```
thread 'message::tests::resent_group_message_dispatches_once' panicked:
  left: (2, 2)
 right: (1, 1)
```

Reverting only the gate line (`} else if self.message_already_dispatched(info).await {` → `} else if false {`) reproduces that failure plus `suppressed_resend_still_installs_the_sender_key_it_carries` (`left: 2, right: 1`), while the other tests still pass.

Every test added in review was checked the same way, each time confirming that exactly the intended tests fail and nothing else moves: restoring the pre-review claim site and key fails `resend_after_a_deferred_batch_commits_is_suppressed` and `resend_with_a_device_qualified_participant_is_suppressed`; removing the batch collapse fails `two_resends_inside_one_deferred_batch_dispatch_once`; removing its capacity-0 guard fails `zero_capacity_disables_the_batch_collapse`; removing the collapse's suppression count and the key-share reschedule fails those two tests and nothing else; building `delete_keys` from the collapsed slice again fails `a_collapsed_batch_clears_every_arrived_pending_row`; removing the envelope guard on the claim fails `an_unresolved_secret_envelope_is_not_claimed`; collapsing on identity alone fails `two_msmsg_parts_under_one_id_both_reach_the_consumer` and `a_batch_keeps_the_resolved_copy_of_an_unresolved_envelope`; dropping the secret capture from the suppressed branch fails `a_suppressed_resend_still_captures_the_message_secret`; reverting the comparison bound, the same-stanza exemption, the replay's commit check and the presence-based envelope test fails exactly `an_id_reused_past_the_bound_stops_being_collapsed`, `two_identical_msmsg_parts_under_one_id_both_reach_the_consumer`, `a_replay_that_fails_to_commit_counts_as_a_suppression` and `a_malformed_secret_envelope_is_not_claimed`.

That discipline earned its keep. The first version of the envelope test drove `dispatch_parsed_message` directly, which never consults the gate, so it passed with the fix reverted: a green test that proved nothing. It was rewritten to go through `handle_decrypted_plaintext`, and only then did the revert fail it. A later bound test was vacuous the same way (distinct payloads never collapse, bound or no bound) and was rewritten to send a repeat *past* the bound, which is the behaviour the bound actually changes.

### Production numbers

Regenerated from the two logs (ids and JIDs redacted throughout; only counts and time deltas are quoted). Note the published one-liner undercounts, because its `from [^:]*` stops at the colon in a device-qualified JID; these numbers match on `\S+` instead.

| | bot A | bot B |
| --- | --- | --- |
| distinct group message ids decrypted | 3050 | 12857 |
| ids decrypted more than once | 31 (1.0%) | 42 (0.33%) |
| deliveries observed for one id | up to 3 | up to 6 |
| busiest 5-minute decrypt burst | 65 | 278 |

Repeated ids from the same sender have gaps of median 11.7s, p90 189s, and 285s for the longest plausible resend. Five of the repeated ids are duplicated in **both** logs, from two different bots, which places the resend at the sender and not in our client. Filtering one id shows the shape: successive arrivals with different `sts` and `t`, different ciphertext length, a successful decrypt each time, and one delivery receipt of ours per arrival. No `<retry>` of ours appears for any of them.

The same parse also turned up the case that decides the key: **two different participants of one group used the same 32-character id, 116 seconds apart**. A `(chat, id)` key with any TTL above two minutes would have swallowed the second participant's message.

## Protocol evidence

Both sources are at whatspec `waVersion` **2.3000.1045368834**, which is also the version pinned in `tools/whatspec-codegen/whatspec.lock.json` (rev `12dbeeb`), so the IR and the bundle agree here and no staleness caveat applies. The raw bundle referenced in the task as `docs/captured-js/` is not in this tree; whatspec commits bundle URLs and hashes rather than sources, so the bundle set was fetched from `generated/bundles.lock.json` and read directly.

### From the IR

- `generated/incoming/index.json`, `tag: "message"` (`incomingMsgParser`, `WAWebHandleMsgParser`): the official client reads `from`, `participant`, `t`, `type` and a repeated `<enc>` whose `type` is the `CiphertextType` enum (`skmsg`/`pkmsg`/`msg`/`msmsg`, `unknownValue: reject`) plus optional `count`, `decrypt-fail`, `state`, `session_type`. `count` (the per-`<enc>` retry count) and `t` exist on the wire but are read as message *metadata*, not as identity; identity is `MsgKey`, and the sibling `incomingMsgParserForAckOnly` reads exactly `type`, `offline`, `id`, `from`, `participant`, confirming which fields name a stanza. Nothing in the envelope makes a resend a different message.
- `generated/stanza/index.json`: **no** edit or revoke mixin writes `id`. `WASmaxOutMessagePublishAdminEditMixin` sets `edit="3"`, `WASmaxOutMessagePublishRevokeMixin` `edit="7"`, `WASmaxOutSpamMessageEditMixin` `edit="1"`, and so on; every one of them is attributes-only. Each message stanza's `id` comes from the sending record's own id (`msgRecord.data.id.id` in `WAWebSendMsgCreateFanoutStanza`, `WAWebSendMsgCreateDeviceStanza`, `WAWebBroadcastMessageRPC`, …). `generated/proto/WAProto.proto` puts the target in `ProtocolMessage.key` (a `MessageKey`), field 1. An edit, revoke, reaction or poll vote therefore carries its **own** stanza id and points at the target from inside the protobuf, so the gate cannot swallow one. Cross-checked against the logs: no repeated id there was an edit.
- `generated/stanza/index.json`, receipts: `WAWebSendDeliveryReceiptJob` (exported as `sendDeliveryReceiptsAfterDecryption`) carries `id`, `to`, `participant`, `recipient`, `type`, `class` and a `<list>` child. `type` and `class` are dynamic there, and our plain delivery receipt omits both; the `id`/`to`/`participant`/`recipient` set matches attribute for attribute. `generated/incoming/index.json`, `tag: "receipt"` (`WAWebHandleMsgReceiptParser`) reads `id`, `from`, `offline`, `type`, `participant`, `recipient`, `t` and friends. **Neither side has any attribute distinguishing a first delivery from a redelivery**, and the job's own name says it fires after each decryption, so one receipt per delivery is conformance, not noise.

### From the raw bundle (runtime logic the IR does not model)

- **`WAWebMsgProcessingApiUtils.messageInfoToKey` is what settles the key's shape.** For a group message it returns `new MsgKey({ remote: chat, fromMe: …, participant: asUserWidOrThrow(author), id: externalId })`: a **device-less** user wid. WA Web's own message identity is therefore `(chat, fromMe, id, bare author)`, which is what the gate now uses; keeping the device made our key narrower than the official one (see Design 3).
- `WAWebPendingMessageKey.createPendingMessageKey(msgKey, ts, encs)` returns `` `${msgKey}_${ts}_${encs.map(e => e.e2eType + ":" + e.retryCount).join(",")}` ``. It includes `ts`, and the resends in our logs carry a **different `t` per attempt**, so this key would not collapse the cases we see even if it were used for that.
- `WAWebMessageDedupUtils` is a plain `Map` of counts with `addPendingMessage` (returns the running count), `hasPendingMessage` and `maybeClearPendingMessages`, behind AB prop `web_pending_message_cache_enabled` (code 8353, `bool`, default `false`, altDefault `true`). In the captured set, the only cross-module caller is `maybeClearPendingMessages(count)` from the offline info-bulletin handler; **`hasPendingMessage` has no caller at all**. The count surfaces as `msgReceivedTimes`, used in exactly one place: `aggregateDeliveryReceipts` treats `msgReceivedTimes > 1` as `isInDB: true`, skipping the DB existence check for a `SIGNAL_OLD_COUNTER_ERROR` duplicate. So the cache is receipt bookkeeping and measurement, not a dispatch gate.
- The collapse a WA Web user actually sees happens a layer below, at `MsgKey` identity in the message store: the second arrival updates the same row instead of creating a message. We have no message store, so the collapse has to be at dispatch, and the key has to be message identity.
- `WAWebMsgProcessingDecryptionHandler`'s `canDecryptNext` / `E2EProcessResult` flow (which `should_process_skmsg_after_session` mirrors) is untouched by the chosen position: the gate sits after both passes, so nothing about pkmsg-then-skmsg ordering changes.

## Design

**1. Where the gate cuts.** At dispatch, in `handle_decrypted_plaintext` immediately before `dispatch_parsed_message`. Cutting before PASS 2 instead would save the duplicate's `group_decrypt` but leave the iteration unconsumed, and the next real message would then buffer that skipped key via `add_skipped_message_key` into the **persisted** sender key record: an entry on disk per duplicate, forever, to save 0.3% to 1.0% of receive CPU. Measured, the crypto being paid for is ~44 µs (`bench_group_recv`) on 0.3-1.0% of messages, i.e. under 0.5 µs per message amortised, against a persisted write per duplicate. There is also a correctness reason the pre-decrypt position cannot work as stated: the gate must fire only when a *dispatch* already happened, and before decrypting we cannot tell a resend of a delivered message from a resend of one that failed to decrypt.

**2. What replaces the dispatch.** `ack_or_replay_to_hook` (`src/message/durability.rs`), the same helper the `DuplicatedMessage` branch uses. A bare ack would lose the message for anyone with an `InboundDurabilityHook` whose earlier commit failed; the helper replays the buffered copy instead. Status broadcast is skipped exactly as in that branch, since the `should_ack` gate already acked it.

What is *not* suppressed is the recovery work the message carried, and there are two pieces of it. An `app_state_sync_key_request` gets its key share scheduled again, because our own phone repeating the request is what it does when the first share never arrived. And `maybe_capture_inbound_msg_secret` still runs, because `dispatch_parsed_message` is otherwise its only caller: capture is write-behind and can drop an entry when its backend is down, so the resend is the second chance, and without it every later encrypted edit, reaction or comment on that parent stays unopenable. Both are no-ops when the message carries neither. The rule is the same in both cases: the *event* is a duplicate, the recovery is not.

**3. What enters the cache, and its key.** Only a real dispatch, and only one that handed the consumer the actual content. Two exclusions, both the same rule: `UndecryptableMessage` placeholders never enter (if we dispatched a placeholder and the resend now decrypts, the real content has to arrive; `undecryptable_dispatched` stays a separate cache), and neither does a message carrying a secret-encrypted envelope, because what the consumer got was the envelope and not the edit, reaction or comment inside it. That second test is **presence, not extractability**: `extract_secret_encrypted` returns `None` both for a plain message and for a tagged envelope that is malformed (missing field, IV not 12 bytes), and a malformed envelope is no more readable to a consumer than an unopenable one, so `carries_secret_encrypted` asks only whether one of the three envelope fields is set.

The claim is taken in `commit_inbound_batch`, immediately **after** its `Event::Messages` dispatch. Two constraints pin it there. It has to be at the batch, because a batch deferred by the drain never claimed at the call site (so a resend after the drain dispatched twice), and a claim taken for a commit that then fails would suppress *and ack* the redelivery with nothing ever handed to a consumer - the existing `app_state_key_share_waits_outside_the_offline_message_lane` test caught that. And it has to be after the dispatch rather than before it, because the claim's cache write is an `await` and this function can be cancelled by a bounded teardown flush: between the acks and the event, a cancellation would leave the batch acked with its event never sent, which for a consumer without a hook is a lost message. After the dispatch, a cancellation merely loses the claim and a later resend dispatches twice.

Because the read and the claim are at two points in time, a drain can accumulate both deliveries of one message before either claim exists, so the batch itself also collapses on the way out, keeping the first of each and counting what it drops as a suppression. The collapse changes only what the hook and the consumer see: everything that describes what *arrived* still runs over the pre-collapse slice, both the acks and the pending-inbound cleanup. That second half matters as much as the first, because the identities that collapse can be spelled differently on the wire (bare vs device-qualified participant); clearing only the surviving spelling's row would leave a stale row for a later resend to replay as an already-committed message. Live batches hold one message and return untouched without allocating, and a batch with nothing to collapse keeps borrowing the keys it already built.

**A repeat is identity *and* content, from a *different stanza*, and only up to a bound.** Each of those three qualifiers is there because identity alone loses real content:

- *Content*, because one stanza id can carry several genuinely different payloads. The msmsg loop in `handle_incoming_message` dispatches every bot-reply part under one `info`, and a drain batch can hold an unresolved envelope beside the retry that resolved to the inner message. A resend re-encrypts the *same* message, so its wire form is identical; those are not. The comparison is on the **encoded bytes**, through the `waproto::codec` entry points this file already calls for the byte cap and the durable write, and never on the decoded proto: `wa::Message` derives `PartialEq` but nothing else calls it, so a single `==` makes the whole message tree's equality code live and costs 236 KiB of binary, over the per-PR size budget. Encoding is lazy and at most once per side, so a batch whose identities are all distinct never encodes anything for this.
- *Different stanza*, because two parts of one stanza are not repeats of each other even when their payloads are equal. Every part is handed the same `Arc<MessageInfo>`, and two separate stanzas always allocate separate infos, so `Arc::ptr_eq` on the info is an exact "same stanza" test that can never exempt a genuine resend. It is best-effort in the other direction: `dispatch_parsed_message` may `Arc::make_mut` the info, and a part whose info was copied on write falls back to the content compare. What that residue can cost is the multiplicity of an identical repeat, never content the consumer did not otherwise get; per-addon identity is the complete fix and is a recorded follow-up.
- *A bound*, because comparing every payload against every earlier one sharing an identity is quadratic, and a participant chooses its own stanza ids: reusing one across a full 400-message drain batch would otherwise force tens of thousands of comparisons on the path holding the processing permit. Past eight distinct payloads for one identity the collapse gives up on it and keeps everything. That is also the more honest statement of intent, since a resend repeats *one* message and is found against the first or second entry; anything past that is not the pattern this exists for. Giving up errs toward a duplicate.

The key drops the sender's device (`to_non_ad`) and keeps the PN/LID namespace exactly as it arrived. Dropping the device matches `messageInfoToKey` above, and it has to: the server sends `skmsg` with a bare participant and `pkmsg` with a device-qualified one, so a resend bundling a rotated SKDM would otherwise be spelled differently from the delivery it repeats and slip past.

The check and the claim cannot be an atomic `get_with` the way the sibling gate is, for the reasons above. `chat_lanes` serializes incoming processing per chat and closes the window for ordinary traffic, but two workers for one chat can coexist after a lane eviction; the race they leave is a second dispatch of one message, which is the behaviour this gate improves on rather than a regression, and it errs in the safe direction. This is stated in the code rather than implied.

**4. Persistence: none.** The two duplicate modes are disjoint. A byte-identical redelivery survives a restart (it comes from the server's offline queue) and is already rejected by the **persisted** ratchet as `DuplicatedMessage`. A re-encrypted resend is live and short-lived: median 11.7s between attempts, 285s for the longest plausible one. So the new gate only has to cover a short in-memory window, and the durable cost is zero. Declared gap: a sender still retrying **across a restart of ours** escapes the gate and dispatches twice. `PortableCache` is runtime-agnostic and compiles for wasm32, so the bridge target is unaffected.

**5. Sizing.** `CacheConfig::dispatched_messages`, default `CacheEntryConfig::new(five_min, 1_000)`, on by default. The 5-minute TTL comes from the measured resend window, not from a round number: of the 56 same-sender gaps between deliveries in the logs, 54 are under 300s, and the two that are not carry 41-character ids from a namespace that never reaches this gate. Lengthening it would catch nothing more and only widen the id-collision exposure the 116s cross-sender case illustrates (the sender is in the key, so that case is safe regardless). Capacity 1000 is ~3.6x the busiest 5-minute burst measured (278) and ~14x the p99 (72). `max_capacity == Some(0)` short-circuits the insert (`src/portable_cache.rs`), so capacity 0 is both the off switch and a cheap early-out, as `recent_messages` already uses. The batch collapse honours the same switch, or capacity 0 would restore the old behaviour for live traffic only.

**6. Observability.** `stats().messages_suppressed_duplicate` counts suppressions for the client's lifetime (client-level, not session-level: the sender's retry window does not end because our socket did), `memory_report().dispatched_messages` reports the cache occupancy next to its neighbours, `wacore::telemetry::recv("duplicate_resend")` labels the metrics facade, and the suppressed path logs at `debug` with the message id. Without these, the next "a message disappeared" report could not be told apart from this fix, which is why the counter is careful in both directions: it counts what the batch collapse drops (that reaches no consumer at all), and it skips a replay that reached the consumer — but only one that actually did. `ack_or_replay_to_hook` reports a replay from what its commit returned, so a replay whose commit *failed* dispatched nothing and is counted as the suppression it is; `Deferred` still counts as a replay, because its batch dispatches later. Received minus suppressed is what consumers saw. The `Event::Messages` doc comment, which is the stability policy for that payload, states the collapse and its limits too.

**7. Scope.** The gate covers everything reaching `handle_decrypted_plaintext`: group (skmsg), 1:1 (msg/pkmsg) and status. Newsletters are excluded and unreachable from here anyway; they branch off in `classify_incoming_message` into `handle_newsletter_message` and reach `dispatch_parsed_message` through its own early return, never entering the commit pipeline. Status broadcast keeps its own ack gate, which the suppressed path respects.

The msmsg bot-reply dispatch (`src/message/msg_secret.rs`) does not consult the gate, and that is a decision rather than an oversight: an msmsg delivery is an addon under a bot stanza, and nothing in the logs or in whatspec establishes that one stanza id carries at most one dispatchable addon. If a bot streams several parts under one id, a `(chat, id, sender)` gate would drop every part after the first, which is the failure this gate is built to avoid. Gating there needs the addon's identity, not the message's, so it is listed as a follow-up. Those parts *do* reach the batch, which is why the collapse carries the content and same-stanza qualifiers in Design 3.

## Benchmarks &amp; Cost

`cargo bench -p wacore --bench send_receive_benchmark`, medians, same machine, baseline measured with the change stashed:

| bench | before | after |
| --- | --- | --- |
| `bench_group_recv` | 48.22 µs | 44.44 µs |
| `bench_dm_recv` | 134.9 µs | 131.1 µs |
| `bench_dm_recv_steady` | 4.291 µs | 3.945 µs |
| `bench_group_send_10` | 38.36 µs | 33.44 µs |
| `bench_group_send_skdm_256` | 1.425 ms | 1.468 ms |

The spread is noise in both directions on a loaded machine, which is the expected result: `wacore` has no behavioural change (its diff is two fields on `StatsSnapshot` and a doc comment), and the gate lives in the `whatsapp-rust` crate. `sender_key_derivation_benchmark` was not run: the chosen position does not touch the group ratchet.

Marginal cost of the gate, measured with a temporary divan target (not part of this PR), 1000-operation batches inside one `block_on` so runtime entry does not dominate, release profile, medians:

| operation | per message |
| --- | --- |
| key construction alone (two `Jid` clones + the id) | 23.0 ns |
| gate hit (a suppressed resend) | 206.7 ns |
| miss + insert (every dispatched message) | 517.5 ns |

So ~0.52 µs on the receive path per dispatched message: ~1.2% of the group-receive benchmark's 44 µs, ~13% of the isolated steady-state DM Signal decrypt (3.9 µs, which is only the crypto and not the surrounding pipeline). `to_non_ad()` replaces a `Jid` clone in the key, so it does not change these figures materially.

The batch collapse costs one hash per item on batches larger than one, i.e. drains only; a live commit takes an early return. Message comparison runs only where identities collide, encodes each side at most once, and is bounded at eight distinct payloads per identity, so its worst case over a full batch is linear with a small constant rather than quadratic. The envelope check on the claim path is three `as_option()` reads on an already-decoded message, with no decode and no allocation.

Memory. `size_of::<SenderMessageId>() == 88` (`Jid` 32 x2 + `MessageId` 24). `MessageId`'s `CompactString` inlines up to 24 bytes; in the logs 61% of ids are 32 characters and spill to the heap (~32 bytes), while the 22-character (31%) and 20-character (8.5%) forms stay inline. At the default capacity that is 1000 x (88 B key + up to ~32 B heap id + the map's per-entry overhead), on the order of **0.15-0.20 MB worst case** for a client saturating the cache, next to an identically shaped `undecryptable_dispatched`.

Binary size is **+10.25 KiB stripped (+0.10%)** and **+9.31 KiB `.text` (+0.11%)**, inside the per-PR budget (64 KiB / 32 KiB), with `.text waproto` unchanged at 0 and no new dependency (Cargo.lock crate count 468 before and after). That last part took a correction worth recording: an earlier revision compared the decoded protos with `==`, which made `wa::Message`'s derived `PartialEq` live across the whole message tree and cost **+236 KiB stripped**, most of it attributed to waproto even though no waproto file is touched. Comparing the encoded bytes through `waproto::codec` — whose `#[inline(never)]` wrappers exist precisely to keep that tree from being instantiated in calling crates, and both of which this file already called — put it back: locally measured `.text` 8,828,982 → 8,636,982 and stripped 10,978,328 → 10,746,776.

**Not covered by any benchmark:** the inbound dispatch pipeline in the `whatsapp-rust` crate (protobuf decode, commit batching, ack and receipt emission) has no bench target, so the gate's share of the *whole* inbound cost is stated as a marginal figure against a `wacore` decrypt baseline rather than measured end to end. `benches/client_group_send.rs` is send-only by construction.

## Audit

Every `event_bus.dispatch` in `src/message/` and `src/handlers/`, asked the same question: is the effect idempotent under message identity, or does it fire per wire delivery?

| site | verdict |
| --- | --- |
| `src/message/dispatch.rs` (`Event::Messages`, newsletter) | Correct. Plaintext, server-identified, never re-encrypted by the sender and never in the commit pipeline. |
| `src/message/commit_batch.rs` (`Event::Messages`) | Now covered, and it is where the claim and the batch collapse happen. |
| `src/message/receive.rs` and `src/message/msg_secret.rs` (`Event::DecryptedPayload`) | Correct **by design**, stated here so nobody "fixes" it later: the event is pre-decode and per `<enc>`, and its whole point is to hand a consumer bytes this build may not be able to decode. Its identity is `(message, enc_index)`, not the message. A resend is a genuinely different payload. |
| `src/message/retry.rs` (`Event::EncDecryptFailed`) | Correct. Same shape: a per-`<enc>`, per-attempt diagnostic. Collapsing it would hide a sender whose every attempt fails. |
| `src/message/retry.rs` (`Event::UndecryptableMessage`) | Already gated, by the precedent this change follows. |
| Delivery receipt (`ack_received_message`) | Correct as-is, and resolved against the IR rather than by taste: `WAWebSendDeliveryReceiptJob` is `sendDeliveryReceiptsAfterDecryption`, and neither the send shape nor `WAWebHandleMsgReceiptParser` carries anything separating a first delivery from a repeat. One receipt per delivery is what the official client does. Both the suppressed path and the collapsed batch keep sending it per delivery. |
| `src/handlers/**` (`DirtyState`, `OfflineSyncPreview`, contact/group/newsletter/mex notifications, `IdentityChange`, `IncomingCall`, `Presence`) | Correct. None is keyed on message identity; notifications and calls have their own ids and their own idempotency. |

## Investigado e correto

- **A single stanza never dispatches twice today.** The one shape that could is a stanza whose session `<enc>` and group `<enc>` both yield dispatchable plaintext; in practice the pkmsg is SKDM-only (`is_sender_key_distribution_only` returns before dispatch) and the skmsg carries the content, so exactly one dispatch happens. No such case appears in the logs.
- **One stanza id *can* dispatch several different payloads**, which is a different thing and is why the collapse carries the content and same-stanza qualifiers: the msmsg loop dispatches every bot-reply part under one `info`. Covered by `two_msmsg_parts_under_one_id_both_reach_the_consumer` and `two_identical_msmsg_parts_under_one_id_both_reach_the_consumer`.
- **Edits, revokes, reactions and poll votes cannot be swallowed.** Established from whatspec, not assumed: no edit or revoke mixin writes `id`, every message stanza's `id` comes from the sender's own record, and the target lives in `ProtocolMessage.key`. Cross-checked against the logs. The secret-encrypted form of those addons is covered separately, by never claiming an envelope the consumer could not read (malformed included) and by the collapse comparing content.
- **A resend after a retry receipt of ours passes the gate.** We never dispatch on an attempt that failed to decrypt, so no key was claimed. Covered by `resend_after_our_own_decrypt_failure_dispatches`.
- **A resend after a failed commit passes the gate.** Covered by `resend_after_a_failed_commit_dispatches`.
- **`messages_received` still counts every decrypted message that entered the pipeline**, including ones later suppressed. That is what it already meant for every other path that decrypts without reaching a consumer, so redefining it here would change an existing counter for reasons unrelated to this gate. The suppression counter is the one that reconciles the two.
- **`MemoryReport::dispatched_messages` is a bare entry count, not `CollectionStats`**, so it does not contribute to `total_estimated_bytes()`. That matches every neighbour of the same shape (`message_retry_counts`, `undecryptable_dispatched`, `pdo_pending_requests`, `pdo_requested`), and `undecryptable_dispatched` in particular holds the identical key type at the identical capacity. Promoting only the new one would make the report inconsistent; changing the convention belongs to the whole group at once.
- **The long-gap "duplicates" are not resends.** Two repeated ids in bot B's log (116s and ~17h apart) turn out to be different senders in the same chat reusing one id, and two more (~91 min apart) carry 41-character ids from a different id namespace. They are the argument for keeping the sender in the key, not for widening the TTL.
- **Semver Checks (informational) is red, and not from this PR.** Every failing item is a `waproto::` path (`EncryptMessageOutput::message_key` and `AIRichResponseContentItemMetadata` fields removed, new variants on exhaustive generated enums, `sync_action_data_to_vec` arity), i.e. pre-existing drift between the last published 0.7.0 and the regenerated protobuf. This PR touches no waproto file, and the job's own summary says it does not block. Worth knowing when reading that job: it aborts at the first failing crate (`Finished [97s] waproto`, exit 100) and never reaches `whatsapp-rust`, so its silence about this crate is not evidence of anything — see the `CacheConfig` caveat below.
- **Follow-ups, deliberately not fixed here.** All are paths that dispatch outside the commit pipeline or under an identity this gate does not model, and in each case claiming there would trade a duplicate for a possible loss - the wrong direction for this gate:
  - **History-sync notifications.** A resend carrying a `history_sync_notification` enqueues a second `MajorSyncTask` and dispatches a second `Event::HistorySync`, since `handle_history_sync` runs above the gate. This cache records that a message batch committed, not that a history chunk was processed, and the download happens later and can fail. A resend here is our own phone retrying a chunk, so suppressing it after a failed download loses that history permanently.
  - **PDO placeholder recovery.** `src/pdo.rs` dispatches the recovered message's `Event::Messages` directly, bypassing the commit batcher, so it never claims an identity and a resent PDO response re-dispatches it. Claiming it there would suppress a *later normal delivery* of the same message - the delivery that goes through the durability hook, while PDO recovery is deliberately event-only.
  - **Per-addon identity for msmsg.** Beyond the gate itself, this is also the complete fix for the residue noted in Design 3: an `InboundMessage` cannot carry the addon index without widening a frozen event payload, so the same-stanza exemption is exact where it fires and falls back to content comparison where the info was copied on write.
  - Separately, **our delivery receipt omits `type` and `class`** (dynamic in `WAWebSendDeliveryReceiptJob`) and the `<list>` child - a conformance question for the receipt format, which this PR is scoped out of.

## Changes

- `src/message/dispatch.rs`: `message_already_dispatched` / `mark_message_dispatched` / `dispatch_key` / `dispatch_gate_enabled`, keyed on `SenderMessageId` with the sender's device dropped.
- `src/message/commit_batch.rs`: the claim, taken just after a committed batch's event goes out so the ack-to-dispatch span keeps no suspension point, and skipped for a message carrying a secret envelope; the collapse of repeats inside a batch, on identity and encoded content, from different stanzas, bounded per identity, counted as suppressions. Acks and pending-inbound cleanup both still run over every stanza that arrived.
- `src/message/receive.rs`: the gate branch in `handle_decrypted_plaintext`, suppressing through `ack_or_replay_to_hook`, still scheduling any app-state key share the message asked for and still capturing any message secret it carries, and reporting `dispatched: true` so the caller's ack state machine is unchanged.
- `src/message/durability.rs`: `ack_or_replay_to_hook` now reports whether a buffered copy was replayed *and* will dispatch, from what its commit returned, so the suppression counter skips only a replay that reached the consumer.
- `src/features/message_edit.rs`: `carries_secret_encrypted`, presence without shape validation, for callers deciding that the consumer did not get real content.
- `src/cache_config.rs`: `dispatched_messages`, 5m TTL / 1000 entries, in `Debug` next to its neighbours. Capacity 0 disables both the gate and the batch collapse.
- `src/portable_cache.rs`: `configured_capacity()`, so the off switch can be honoured outside the cache.
- `src/client.rs`, `src/client/lifecycle.rs`, `src/client/accessors.rs`: the cache, the `duplicate_dispatch_suppressed` counter, and both readouts.
- `wacore/src/stats.rs`: `StatsSnapshot::messages_suppressed_duplicate`, filled client-side like `resends_throttled`.
- `wacore/src/types/events.rs`: a paragraph on `Event::Messages` recording the collapse and what it does not cover, since that doc comment is the payload's stability policy.
- `src/message/tests.rs`: twenty-two tests (below), plus `capturing_client_with_cache_config` so a test can build a client with the gate turned off.

**One API caveat, corrected from an earlier version of this description.** `MemoryReport` and `StatsSnapshot` are `#[non_exhaustive]`, so their new fields are additive. `CacheConfig` is **not**: it carries nine `pub` fields, no private field and no `#[non_exhaustive]`, so adding `dispatched_messages` does break a downstream exhaustive struct literal or full destructure, and the field's `Default` only helps callers that already write `..Default::default()` (which is the idiom the struct's own doc example uses). Marking the struct `#[non_exhaustive]` is itself a breaking change and a wider one, so it belongs in its own change and is the maintainer's call: either this field lands as an ordinary minor break at 0.x alongside its nine siblings, which is what this PR does, or the struct gets `#[non_exhaustive]` first as a deliberate one-time break that prevents every future one. That review thread is left open on purpose.

Tests added: `resent_group_message_dispatches_once`, `same_id_from_two_participants_dispatches_twice`, `byte_identical_redelivery_is_still_rejected_by_the_ratchet` (run with the gate at capacity 0, so only the ratchet can satisfy it), `zero_capacity_disables_the_gate`, `zero_capacity_disables_the_batch_collapse`, `resend_after_our_own_decrypt_failure_dispatches`, `resend_after_a_deferred_batch_commits_is_suppressed`, `two_resends_inside_one_deferred_batch_dispatch_once`, `resend_with_a_device_qualified_participant_is_suppressed`, `resend_after_a_failed_commit_dispatches`, `suppressed_key_request_resend_still_schedules_the_share`, `a_suppressed_resend_still_captures_the_message_secret`, `suppressed_resend_still_installs_the_sender_key_it_carries`, `suppressed_resend_replays_to_a_durability_hook`, `a_replay_that_fails_to_commit_counts_as_a_suppression`, `a_collapsed_batch_clears_every_arrived_pending_row`, `an_unresolved_secret_envelope_is_not_claimed`, `a_malformed_secret_envelope_is_not_claimed`, `a_batch_keeps_the_resolved_copy_of_an_unresolved_envelope`, `two_msmsg_parts_under_one_id_both_reach_the_consumer`, `two_identical_msmsg_parts_under_one_id_both_reach_the_consumer`, `an_id_reused_past_the_bound_stops_being_collapsed`.

No existing test needed adapting. `app_state_key_share_waits_outside_the_offline_message_lane` failed against the first version of the gate and drove where the claim is taken; it passes unmodified.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib            # 1776 passed, 1 ignored
cargo test -p whatsapp-rust --lib message::  # 280 passed, 1 ignored
cargo test -p wacore --lib                   # 1485 passed, 1 ignored
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
cargo clippy -p whatsapp-rust --all-features --all-targets -- -D warnings
cargo bench -p wacore --bench send_receive_benchmark    # baseline and after
python3 scripts/ci/measure_binary_size.py               # for the size figures above
```

Rest of the matrix left to CI (workspace clippy, feature matrix, wasm32, Miri, e2e, doctests), green on the current head apart from the pre-existing Semver Checks failure explained above.