### PR TITLE
perf(core): shrink the long-lived caches — group mappings, device records, archived sessions

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -142,10 +142,20 @@ Walks every internal collection and returns entry counts plus estimated
 retained bytes (`MemoryReport`, per-collection `CollectionStats`). Byte
 figures come from the `wacore::stats::HeapSize` trait:
 
-- Signal records use their protobuf encoded size (`SessionRecord::
-  estimated_size`, buffa `compute_size` — no encode buffer allocated).
+- Signal records walk their live structures (`SessionRecord::estimated_size`,
+  `SenderKeyRecord::estimated_size`) — struct sizes, `Vec` capacities and the
+  bytes each field points at. Not the protobuf-encoded size, which is what
+  these reported until it was found to understate a session carrying skipped
+  message keys by roughly 5x: the encoded form omits both the `Option` slots a
+  seed-only `MessageKey` leaves empty and the `Vec` capacity behind the
+  backlog. Size computation only — no encode buffer is allocated.
 - Collections sum key/payload capacities (`GroupInfo`, `DeviceListRecord`,
-  `LidPnEntry`, `ResolvedGroupDevices`, ...).
+  `LidPnEntry`, `ResolvedGroupDevices`, ...). Hash-backed ones go through
+  `wacore::stats::hash_table_bytes`, which converts a `capacity()` into the
+  buckets hashbrown actually owns: it rounds to a power of two and keeps an
+  eighth free, so `capacity() * size_of::<(K, V)>()` under-counts by up to a
+  half. `wacore/tests/hash_table_bytes_matches_the_allocator.rs` checks that
+  conversion against a counting `GlobalAlloc`.
 - Store-backed caches (Redis etc.) report `bytes: 0` — their entries are not
   process memory.
 - In-flight history sync reports queued/running task count, retained compressed

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -150,12 +150,19 @@ figures come from the `wacore::stats::HeapSize` trait:
   seed-only `MessageKey` leaves empty and the `Vec` capacity behind the
   backlog. Size computation only — no encode buffer is allocated.
 - Collections sum key/payload capacities (`GroupInfo`, `DeviceListRecord`,
-  `LidPnEntry`, `ResolvedGroupDevices`, ...). Hash-backed ones go through
-  `wacore::stats::hash_table_bytes`, which converts a `capacity()` into the
-  buckets hashbrown actually owns: it rounds to a power of two and keeps an
-  eighth free, so `capacity() * size_of::<(K, V)>()` under-counts by up to a
-  half. `wacore/tests/hash_table_bytes_matches_the_allocator.rs` checks that
-  conversion against a counting `GlobalAlloc`.
+  `LidPnEntry`, `ResolvedGroupDevices`, ...). Where a report charges for a hash
+  table's slots it should go through `wacore::stats::hash_table_bytes`, which
+  converts a `capacity()` into the buckets hashbrown actually owns: it rounds to
+  a power of two and keeps an eighth free, so `capacity() * size_of::<(K, V)>()`
+  under-counts by up to a half. The device-list memos
+  (`GroupDevicesMemo`/`DmDevicesMemo`) and the sender-key device cache use it;
+  `SignalStoreCache::memory_stats` does **not** — it sums key and payload bytes
+  and does not charge for its tables' slots at all, so its figures are a floor.
+  `wacore/tests/hash_table_bytes_matches_the_allocator.rs` checks the conversion
+  against a counting `GlobalAlloc`. After removals the figure is a lower bound
+  rather than exact: hashbrown leaves tombstones that consume growth slots
+  without shrinking the bucket array, so `capacity()` can read below the
+  canonical capacity for the buckets really held.
 - Store-backed caches (Redis etc.) report `bytes: 0` — their entries are not
   process memory.
 - In-flight history sync reports queued/running task count, retained compressed

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -318,9 +318,10 @@ async fn send_once(client: &Arc<Client>, group: &Jid) {
         .expect("offline group send must reach the sink");
 }
 
-async fn seed_registry(client: &Arc<Client>, user: &str, devices: &[u32]) {
+async fn seed_registry(client: &Arc<Client>, user: &str, devices: &[u16]) {
+    let user: Arc<str> = Arc::from(user);
     let record = DeviceListRecord {
-        user: user.into(),
+        user: Arc::clone(&user),
         devices: devices
             .iter()
             .map(|id| DeviceInfo::new(*id, None))
@@ -331,7 +332,7 @@ async fn seed_registry(client: &Arc<Client>, user: &str, devices: &[u32]) {
     };
     client
         .device_registry_cache
-        .promote(user.to_string(), Arc::new(record))
+        .promote(user, Arc::new(record))
         .await;
 }
 

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -664,13 +664,12 @@ impl Client {
 
     /// WA Web: `isFromKnownDevice(author)` — local check only, no network.
     pub(crate) async fn is_from_known_device(&self, sender: &Jid) -> bool {
-        let device_id = sender.device as u32;
-        self.has_device(&sender.user, device_id).await
+        self.has_device(&sender.user, sender.device).await
     }
 
     /// Check if a device exists for a user.
     /// Returns true for device_id 0 (primary device always exists).
-    pub(crate) async fn has_device(&self, user: &str, device_id: u32) -> bool {
+    pub(crate) async fn has_device(&self, user: &str, device_id: u16) -> bool {
         if device_id == 0 {
             return true;
         }
@@ -680,7 +679,7 @@ impl Client {
 
         for key in lookup.all_keys() {
             if let Some(record) = self.device_registry_cache.get(key).await {
-                return record.devices.iter().any(|d| d.device_id == device_id);
+                return record.devices.iter().any(|d| d.device_id() == device_id);
             }
         }
 
@@ -688,11 +687,11 @@ impl Client {
         for key in lookup.all_keys() {
             match backend.get_devices(key).await {
                 Ok(Some(record)) => {
-                    let has_device = record.devices.iter().any(|d| d.device_id == device_id);
+                    let has_device = record.devices.iter().any(|d| d.device_id() == device_id);
                     // Cache under the record's actual stored key, not our guessed one,
                     // to keep the cache and backend consistent.
                     self.device_registry_cache
-                        .promote(record.user.clone(), Arc::new(record))
+                        .promote(Arc::clone(&record.user), Arc::new(record))
                         .await;
                     return has_device;
                 }
@@ -732,26 +731,25 @@ impl Client {
     ) -> Result<()> {
         use anyhow::Context;
 
-        let original_user = record.user.clone();
+        let original_user = Arc::clone(&record.user);
         let lookup = self.resolve_lookup_keys(&original_user).await;
-        let canonical_key = lookup.canonical_key().to_string();
-        record.user.clone_from(&canonical_key); // More efficient: reuses allocation
+        // One allocation for the canonical name: the record carries it and
+        // the cache is keyed by it, and both hold the same `Arc`.
+        let canonical_key: Arc<str> = Arc::from(lookup.canonical_key());
+        record.user = Arc::clone(&canonical_key);
 
         // Clone record for cache before moving to backend
         let record_for_cache = record.clone();
 
-        // Use canonical_key directly as cache key (no extra clone)
         // Record every lookup alias, not just canonical+original: a LID-keyed
         // update must also touch the mapped PN, or a PN-addressed group's memo
         // (whose member set only knows the PN side) would re-stamp stale.
         self.device_registry_cache
             .insert(
                 guard,
-                canonical_key.clone(),
+                Arc::clone(&canonical_key),
                 Arc::new(record_for_cache),
-                lookup
-                    .all_keys()
-                    .chain(std::iter::once(original_user.as_str())),
+                lookup.all_keys().chain(std::iter::once(&*original_user)),
             )
             .await;
 
@@ -761,7 +759,7 @@ impl Client {
             .await
             .context("Failed to update device list in backend")?;
 
-        if canonical_key != original_user {
+        if *canonical_key != *original_user {
             // Invalidate before + after delete so a concurrent reader that
             // resurrects the cache from the about-to-be-deleted DB row still
             // gets cleared. Run the second invalidate unconditionally: even
@@ -815,28 +813,26 @@ impl Client {
         }
 
         let mut prepared = Vec::with_capacity(records.len());
-        let mut to_delete: Vec<String> = Vec::new();
+        let mut to_delete: Vec<Arc<str>> = Vec::new();
 
         for mut record in records {
-            let original_user = record.user.clone();
+            let original_user = Arc::clone(&record.user);
             let lookup = self.resolve_lookup_keys(&original_user).await;
-            let canonical_key = lookup.canonical_key().to_string();
-            record.user.clone_from(&canonical_key);
+            let canonical_key: Arc<str> = Arc::from(lookup.canonical_key());
+            record.user = Arc::clone(&canonical_key);
 
             let record_for_cache = record.clone();
             // Same alias rule as update_device_list: record every lookup key.
             self.device_registry_cache
                 .insert(
                     guard,
-                    canonical_key.clone(),
+                    Arc::clone(&canonical_key),
                     Arc::new(record_for_cache),
-                    lookup
-                        .all_keys()
-                        .chain(std::iter::once(original_user.as_str())),
+                    lookup.all_keys().chain(std::iter::once(&*original_user)),
                 )
                 .await;
 
-            if canonical_key != original_user {
+            if *canonical_key != *original_user {
                 to_delete.push(original_user);
             }
             prepared.push(record);
@@ -958,7 +954,16 @@ impl Client {
         key_index_info: Option<&wacore::stanza::devices::KeyIndexInfo>,
     ) {
         let guard = self.device_topology.lock_registry().await;
-        let device_id = device.device_id();
+        // The notification carries the id as a `u32`; a registry device id is
+        // a `u16`, as it is on the wire, so anything wider names a device that
+        // cannot exist rather than one to add.
+        let Ok(device_id) = u16::try_from(device.device_id()) else {
+            warn!(
+                "patch_device_add: device_id {} exceeds u16 — ignoring",
+                device.device_id()
+            );
+            return;
+        };
         let is_hosted = wacore_binary::JidExt::is_hosted(&device.jid);
 
         let Some(mut record) = self.load_device_record(user).await else {
@@ -982,11 +987,13 @@ impl Client {
                     );
                     self.clear_device_record(user, device.jid.server.as_str(), &record)
                         .await;
-                    record.devices.retain(|device| device.device_id == 0);
+                    record.edit_devices(|devices| devices.retain(|device| device.device_id() == 0));
                 } else {
                     // Filter stale devices by valid_indexes. A raw_id reset already
                     // removed every companion while preserving primary metadata.
-                    wacore::adv::retain_devices_by_key_index(&mut record.devices, &decoded);
+                    record.edit_devices(|devices| {
+                        wacore::adv::retain_devices_by_key_index(devices, &decoded)
+                    });
                 }
                 record.raw_id = Some(decoded.raw_id);
 
@@ -1018,10 +1025,10 @@ impl Client {
         // `None` to match how device 0 is recorded everywhere else. Hosting belongs
         // to each device-list entry, so the companion notification cannot classify
         // the primary.
-        if !record.devices.iter().any(|d| d.device_id == 0) {
-            record
-                .devices
-                .push(wacore::store::traits::DeviceInfo::new(0, None));
+        if !record.devices.iter().any(|d| d.device_id() == 0) {
+            record.edit_devices(|devices| {
+                devices.push(wacore::store::traits::DeviceInfo::new(0, None))
+            });
         }
 
         // New devices are picked up automatically by `resolve_skdm_targets`:
@@ -1037,21 +1044,22 @@ impl Client {
     fn append_or_refresh_device(
         &self,
         record: &mut wacore::store::traits::DeviceListRecord,
-        device_id: u32,
+        device_id: u16,
         key_index: Option<u32>,
         is_hosted: bool,
     ) {
-        match record
-            .devices
-            .iter_mut()
-            .find(|device| device.device_id == device_id)
-        {
-            Some(device) => device.is_hosted = is_hosted,
-            None => record.devices.push(
-                wacore::store::traits::DeviceInfo::new(device_id, key_index)
-                    .with_hosting(is_hosted),
-            ),
-        }
+        record.edit_devices(|devices| {
+            match devices
+                .iter_mut()
+                .find(|device| device.device_id() == device_id)
+            {
+                Some(device) => *device = device.with_hosting(is_hosted),
+                None => devices.push(
+                    wacore::store::traits::DeviceInfo::new(device_id, key_index)
+                        .with_hosting(is_hosted),
+                ),
+            }
+        });
     }
 
     /// Delete Signal sessions for specific device IDs in every user namespace,
@@ -1093,8 +1101,8 @@ impl Client {
         let non_primary_ids: Vec<u16> = record
             .devices
             .iter()
-            .filter(|d| d.device_id != 0)
-            .map(|d| d.device_id as u16)
+            .map(|d| d.device_id())
+            .filter(|id| *id != 0)
             .collect();
         info!(
             "Clearing device record for user {user}: removing {} non-primary device(s) due to raw_id change",
@@ -1125,36 +1133,28 @@ impl Client {
         if device_id == 0 {
             return;
         }
+        // A registry device id is a `u16`, as it is on the wire and as the
+        // JID-keyed structures (Signal sessions, sender_key_devices) store it,
+        // so a wider id names no device the registry could be holding. This
+        // used to remove it from the record and then skip the session cleanup;
+        // there is now nothing to remove.
+        let Ok(device_id) = u16::try_from(device_id) else {
+            warn!("patch_device_remove: device_id {device_id} > u16::MAX — nothing to remove");
+            return;
+        };
         let guard = self.device_topology.lock_registry().await;
         if let Some(mut record) = self.load_device_record(user).await {
             let before = record.devices.len();
-            record.devices.retain(|d| d.device_id != device_id);
+            record.edit_devices(|devices| devices.retain(|d| d.device_id() != device_id));
             if record.devices.len() != before {
-                // JID-keyed structures (Signal sessions, sender_key_devices)
-                // store device as u16. A blind cast for ids > u16::MAX would
-                // truncate to a different value and cleanup the wrong device.
-                let Ok(device_id_u16) = u16::try_from(device_id) else {
-                    warn!(
-                        "patch_device_remove: device_id {device_id} > u16::MAX — skipping \
-                         session/SKDM cleanup but still persisting registry removal"
-                    );
-                    if let Err(e) = self.update_device_list_guarded(record, &guard).await {
-                        warn!("patch_device_remove: failed to persist: {e}");
-                    }
-                    return;
-                };
-
-                if device_id_u16 != 0 {
-                    self.delete_sessions_for_devices(user, &[device_id_u16])
-                        .await;
-                }
+                self.delete_sessions_for_devices(user, &[device_id]).await;
                 // WA Web's `updateGroupParticipantsInTransaction` deletes the
                 // device JID from each affected group's senderKey Map. Skip
                 // the registry update on failure: a half-applied state where
                 // `resolve_devices` says "gone" but the tracker still vouches
                 // `has_key=true` would silently skip SKDM redistribution.
                 if let Err(e) = self
-                    .delete_sender_key_rows_for_device(user, device_id_u16)
+                    .delete_sender_key_rows_for_device(user, device_id)
                     .await
                 {
                     warn!(
@@ -1229,13 +1229,20 @@ impl Client {
         device: &wacore::stanza::devices::DeviceElement,
     ) {
         let guard = self.device_topology.lock_registry().await;
-        let device_id = device.device_id();
+        let Ok(device_id) = u16::try_from(device.device_id()) else {
+            return;
+        };
 
-        if let Some(mut record) = self.load_device_record(user).await
-            && let Some(d) = record.devices.iter_mut().find(|d| d.device_id == device_id)
-        {
-            d.key_index = device.key_index;
-            if let Err(e) = self.update_device_list_guarded(record, &guard).await {
+        if let Some(mut record) = self.load_device_record(user).await {
+            let mut updated = false;
+            record.edit_devices(|devices| {
+                if let Some(d) = devices.iter_mut().find(|d| d.device_id() == device_id) {
+                    *d = wacore::store::traits::DeviceInfo::new(device_id, device.key_index)
+                        .with_hosting(d.is_hosted());
+                    updated = true;
+                }
+            });
+            if updated && let Err(e) = self.update_device_list_guarded(record, &guard).await {
                 warn!("patch_device_update: failed to persist: {e}");
             }
         }
@@ -1315,7 +1322,7 @@ impl Client {
                         continue;
                     }
                     self.device_registry_cache
-                        .promote(record.user.clone(), Arc::new(record))
+                        .promote(Arc::clone(&record.user), Arc::new(record))
                         .await;
                     return Some(devices);
                 }
@@ -1337,19 +1344,13 @@ impl Client {
         record: &wacore::store::traits::DeviceListRecord,
     ) -> Vec<Jid> {
         let base = query_jid.to_non_ad();
-        let mut devices = Vec::with_capacity(record.devices.len());
-        for device in &record.devices {
-            match u16::try_from(device.device_id) {
-                Ok(device_id) => {
-                    devices.push(base.with_device_hosting(device_id, device.is_hosted));
-                }
-                Err(_) => warn!(
-                    "reconstruct_device_jids: device_id {} exceeds u16; skipping",
-                    device.device_id
-                ),
-            }
-        }
-        devices
+        // No range check: a registry device id is a `u16`, the width the JID
+        // itself carries, so the conversion this used to guard cannot fail.
+        record
+            .devices
+            .iter()
+            .map(|device| base.with_device_hosting(device.device_id(), device.is_hosted()))
+            .collect()
     }
 
     /// Migrate device registry entries from PN key to LID key.
@@ -1374,7 +1375,7 @@ impl Client {
                     record.devices.len()
                 );
 
-                record.user = lid.to_string();
+                record.user = Arc::from(lid);
 
                 if let Err(e) = backend.update_device_list(record.clone()).await {
                     // The backend row may have changed even on error, so the
@@ -1386,7 +1387,12 @@ impl Client {
                 }
 
                 self.device_registry_cache
-                    .insert(&guard, lid.to_string(), Arc::new(record), [lid, pn])
+                    .insert(
+                        &guard,
+                        Arc::clone(&record.user),
+                        Arc::new(record),
+                        [lid, pn],
+                    )
                     .await;
 
                 // Drop the PN-keyed row in both cache and DB. Invalidate
@@ -1426,7 +1432,7 @@ mod tests {
         client.lid_pn_cache.add(&entry).await;
     }
 
-    async fn setup_device_record(client: &Arc<Client>, user: &str, device_ids: &[u32]) {
+    async fn setup_device_record(client: &Arc<Client>, user: &str, device_ids: &[u16]) {
         let record = wacore::store::traits::DeviceListRecord {
             user: user.into(),
             devices: device_ids
@@ -1728,7 +1734,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: pn.into(),
-                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1749,10 +1755,11 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: lid.into(),
-                devices: vec![
+                devices: [
                     wacore::store::traits::DeviceInfo::new(0, None),
                     wacore::store::traits::DeviceInfo::new(11, None),
-                ],
+                ]
+                .into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1783,7 +1790,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: "5511999990003".into(),
-                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1799,7 +1806,7 @@ mod tests {
         client
             .update_device_lists(vec![wacore::store::traits::DeviceListRecord {
                 user: "5511999990004".into(),
-                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1833,7 +1840,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: "5511999990005".into(),
-                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2080,9 +2087,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.devices.len(), 2);
-        assert!(updated.devices.iter().any(|d| d.device_id == 3));
-        let dev3 = updated.devices.iter().find(|d| d.device_id == 3).unwrap();
-        assert_eq!(dev3.key_index, Some(5));
+        assert!(updated.devices.iter().any(|d| d.device_id() == 3));
+        let dev3 = updated.devices.iter().find(|d| d.device_id() == 3).unwrap();
+        assert_eq!(dev3.key_index(), Some(5));
     }
 
     #[tokio::test]
@@ -2102,15 +2109,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            updated.devices.iter().filter(|d| d.device_id == 3).count(),
+            updated
+                .devices
+                .iter()
+                .filter(|d| d.device_id() == 3)
+                .count(),
             1
         );
-        assert!(updated.devices.iter().any(|d| d.device_id == 0));
+        assert!(updated.devices.iter().any(|d| d.device_id() == 0));
         assert!(
             updated
                 .devices
                 .iter()
-                .any(|d| d.device_id == 3 && d.is_hosted)
+                .any(|d| d.device_id() == 3 && d.is_hosted())
         );
         assert_eq!(updated.devices.len(), 2);
     }
@@ -2146,7 +2157,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.devices.len(), 1);
-        assert_eq!(updated.devices[0].device_id, 0);
+        assert_eq!(updated.devices[0].device_id(), 0);
     }
 
     #[tokio::test]
@@ -2243,18 +2254,19 @@ mod tests {
 
         // Pre-populate registry cache
         let record = wacore::store::traits::DeviceListRecord {
-            user: "15551234567".to_string(),
-            devices: vec![
+            user: "15551234567".into(),
+            devices: [
                 wacore::store::traits::DeviceInfo::new(0, None),
                 wacore::store::traits::DeviceInfo::new(3, Some(1)),
-            ],
+            ]
+            .into(),
             timestamp: 1000,
             phash: None,
             raw_id: None,
         };
         client
             .device_registry_cache
-            .raw_insert_for_tests("15551234567".to_string(), Arc::new(record))
+            .raw_insert_for_tests("15551234567".into(), Arc::new(record))
             .await;
 
         // Patch: update device 3 key_index to 5
@@ -2266,8 +2278,8 @@ mod tests {
             .get("15551234567")
             .await
             .unwrap();
-        let dev3 = updated.devices.iter().find(|d| d.device_id == 3).unwrap();
-        assert_eq!(dev3.key_index, Some(5));
+        let dev3 = updated.devices.iter().find(|d| d.device_id() == 3).unwrap();
+        assert_eq!(dev3.key_index(), Some(5));
     }
 
     #[tokio::test]
@@ -2287,8 +2299,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.devices.len(), 2);
-        let dev3 = updated.devices.iter().find(|d| d.device_id == 3).unwrap();
-        assert_eq!(dev3.key_index, Some(2));
+        let dev3 = updated.devices.iter().find(|d| d.device_id() == 3).unwrap();
+        assert_eq!(dev3.key_index(), Some(2));
     }
 
     #[tokio::test]
@@ -2309,13 +2321,13 @@ mod tests {
             updated
                 .devices
                 .iter()
-                .any(|device| device.device_id == 3 && device.is_hosted)
+                .any(|device| device.device_id() == 3 && device.is_hosted())
         );
         assert!(
             updated
                 .devices
                 .iter()
-                .any(|device| device.device_id == 0 && !device.is_hosted)
+                .any(|device| device.device_id() == 0 && !device.is_hosted())
         );
     }
 
@@ -2346,7 +2358,7 @@ mod tests {
 
     fn record_with_raw_id(
         user: &str,
-        device_ids: &[u32],
+        device_ids: &[u16],
         raw_id: u32,
     ) -> wacore::store::traits::DeviceListRecord {
         wacore::store::traits::DeviceListRecord {
@@ -2369,7 +2381,7 @@ mod tests {
         client
             .device_registry_cache
             .raw_insert_for_tests(
-                "15551234567".to_string(),
+                "15551234567".into(),
                 Arc::new(record_with_raw_id("15551234567", &[0, 5], 1)),
             )
             .await;
@@ -2394,7 +2406,7 @@ mod tests {
             updated
                 .devices
                 .iter()
-                .any(|device| device.device_id == 5 && device.is_hosted)
+                .any(|device| device.device_id() == 5 && device.is_hosted())
         );
     }
 
@@ -2405,16 +2417,17 @@ mod tests {
         let client = create_test_client().await;
 
         let mut record = record_with_raw_id("15551234567", &[0, 5], 1);
-        record
-            .devices
-            .iter_mut()
-            .find(|device| device.device_id == 0)
-            .unwrap()
-            .is_hosted = true;
+        record.edit_devices(|devices| {
+            let primary = devices
+                .iter_mut()
+                .find(|device| device.device_id() == 0)
+                .unwrap();
+            *primary = primary.with_hosting(true);
+        });
 
         client
             .device_registry_cache
-            .raw_insert_for_tests("15551234567".to_string(), Arc::new(record))
+            .raw_insert_for_tests("15551234567".into(), Arc::new(record))
             .await;
 
         // New raw_id (2) != stored (1) → clear + rebuild. Notified device 19 has a
@@ -2437,7 +2450,7 @@ mod tests {
         let dev0 = updated
             .devices
             .iter()
-            .find(|d| d.device_id == 0)
+            .find(|d| d.device_id() == 0)
             .unwrap_or_else(|| {
                 panic!(
                     "primary (device 0) must survive a raw_id mismatch clear, got {:?}",
@@ -2446,11 +2459,11 @@ mod tests {
             });
         // The existing primary metadata is retained; it is not reconstructed from
         // the incoming companion's namespace.
-        assert_eq!(dev0.key_index, None);
-        assert!(dev0.is_hosted);
-        assert!(updated.devices.iter().any(|d| d.device_id == 19));
+        assert_eq!(dev0.key_index(), None);
+        assert!(dev0.is_hosted());
+        assert!(updated.devices.iter().any(|d| d.device_id() == 19));
         // Stale companion from the old identity is dropped by the clear.
-        assert!(!updated.devices.iter().any(|d| d.device_id == 5));
+        assert!(!updated.devices.iter().any(|d| d.device_id() == 5));
     }
 
     // Same mismatch but the notified device's key index is rejected, so the
@@ -2463,7 +2476,7 @@ mod tests {
         client
             .device_registry_cache
             .raw_insert_for_tests(
-                "15551234567".to_string(),
+                "15551234567".into(),
                 Arc::new(record_with_raw_id("15551234567", &[0, 5], 1)),
             )
             .await;
@@ -2491,8 +2504,8 @@ mod tests {
             "expected only the primary, got {:?}",
             updated.devices
         );
-        assert_eq!(updated.devices[0].device_id, 0);
-        assert_eq!(updated.devices[0].key_index, None);
+        assert_eq!(updated.devices[0].device_id(), 0);
+        assert_eq!(updated.devices[0].key_index(), None);
     }
 
     #[tokio::test]
@@ -2505,8 +2518,8 @@ mod tests {
 
         // Store device list under PN in backend
         let record = DeviceListRecord {
-            user: pn.to_string(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))],
+            user: pn.into(),
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2584,14 +2597,15 @@ mod tests {
         assert_eq!(devices[0].user, lid, "device JID user should be the LID");
     }
 
+    /// `reconstruct_device_jids` used to skip persisted ids too wide for a
+    /// JID's `u16` device field. A registry device id is now a `u16` itself,
+    /// so there is no such record to skip; what rejects a blob claiming one is
+    /// `DeviceInfo`'s deserializer, covered in `wacore::store::traits`.
     #[test]
-    fn reconstruct_device_jids_skips_unrepresentable_persisted_ids() {
+    fn reconstruct_device_jids_carries_hosting_through() {
         let record = wacore::store::traits::DeviceListRecord {
             user: "13135550100".into(),
-            devices: vec![
-                wacore::store::traits::DeviceInfo::new(7, None).with_hosting(true),
-                wacore::store::traits::DeviceInfo::new(u32::from(u16::MAX) + 1, None),
-            ],
+            devices: [wacore::store::traits::DeviceInfo::new(7, None).with_hosting(true)].into(),
             timestamp: 0,
             phash: None,
             raw_id: None,
@@ -2633,7 +2647,7 @@ mod tests {
         // Seed backend DB directly (bypassing the in-process cache)
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![DeviceInfo::new(0, None)],
+            devices: [DeviceInfo::new(0, None)].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2666,7 +2680,7 @@ mod tests {
             .unwrap()
             .expect("record should still exist in DB");
         assert_eq!(updated.devices.len(), 2);
-        assert!(updated.devices.iter().any(|d| d.device_id == 3));
+        assert!(updated.devices.iter().any(|d| d.device_id() == 3));
 
         // Cache should be warm now too
         assert!(
@@ -2686,7 +2700,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))],
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2716,7 +2730,7 @@ mod tests {
             .unwrap()
             .expect("record should still exist");
         assert_eq!(updated.devices.len(), 1);
-        assert_eq!(updated.devices[0].device_id, 0);
+        assert_eq!(updated.devices[0].device_id(), 0);
     }
 
     // ── Sender key device cache: post-fix behavior ──────────────────────
@@ -2761,7 +2775,7 @@ mod tests {
         // Pre-populate device registry with device 0 AND device 3
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))],
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2854,8 +2868,8 @@ mod tests {
         // Legacy state: DB row stored under PN (mapping wasn't known yet).
         backend
             .update_device_list(DeviceListRecord {
-                user: pn.to_string(),
-                devices: vec![DeviceInfo::new(5, None)],
+                user: pn.into(),
+                devices: [DeviceInfo::new(5, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2869,8 +2883,8 @@ mod tests {
         // now resolves to LID because the mapping is known.
         client
             .update_device_list(DeviceListRecord {
-                user: pn.to_string(),
-                devices: vec![DeviceInfo::new(7, None)],
+                user: pn.into(),
+                devices: [DeviceInfo::new(7, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2884,7 +2898,7 @@ mod tests {
         );
         let lid_row = backend.get_devices(lid).await.unwrap();
         assert!(lid_row.is_some(), "new LID-keyed DB row must exist");
-        assert_eq!(lid_row.unwrap().devices[0].device_id, 7);
+        assert_eq!(lid_row.unwrap().devices[0].device_id(), 7);
     }
 
     /// U2 — `migrate_device_registry_on_lid_discovery` deletes the PN-keyed DB
@@ -2901,8 +2915,8 @@ mod tests {
 
         backend
             .update_device_list(DeviceListRecord {
-                user: pn.to_string(),
-                devices: vec![DeviceInfo::new(0, None)],
+                user: pn.into(),
+                devices: [DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2942,8 +2956,8 @@ mod tests {
         for user in [pn, lid] {
             backend
                 .update_device_list(DeviceListRecord {
-                    user: user.to_string(),
-                    devices: vec![DeviceInfo::new(1, None)],
+                    user: user.into(),
+                    devices: [DeviceInfo::new(1, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
@@ -2997,8 +3011,8 @@ mod tests {
         let backend = client.persistence_manager.backend();
 
         let legacy = DeviceListRecord {
-            user: pn.to_string(),
-            devices: vec![DeviceInfo::new(9, None)],
+            user: pn.into(),
+            devices: [DeviceInfo::new(9, None)].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -3015,8 +3029,8 @@ mod tests {
 
         client
             .update_device_list(DeviceListRecord {
-                user: pn.to_string(),
-                devices: vec![DeviceInfo::new(10, None)],
+                user: pn.into(),
+                devices: [DeviceInfo::new(10, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -3108,12 +3122,12 @@ mod tests {
 
         let record = client.device_registry_cache.get(user).await.unwrap();
         assert!(
-            record.devices.iter().any(|d| d.device_id == 0),
+            record.devices.iter().any(|d| d.device_id() == 0),
             "remove for the primary must be ignored, got {:?}",
             record.devices
         );
         // The companion is untouched too — the remove is a full no-op.
-        assert!(record.devices.iter().any(|d| d.device_id == 5));
+        assert!(record.devices.iter().any(|d| d.device_id() == 5));
     }
 
     #[tokio::test]
@@ -3488,7 +3502,7 @@ mod tests {
             .await
             .expect("a hash-only <update> must not drop the device registry");
         assert!(
-            record.devices.iter().any(|d| d.device_id == 65),
+            record.devices.iter().any(|d| d.device_id() == 65),
             "companion devices must survive a hash-only <update>"
         );
     }
@@ -3587,7 +3601,7 @@ mod tests {
 
     /// Seed a device record straight into the registry cache WITHOUT recording a
     /// topology change, so a memo that is really hitting must serve it stale.
-    async fn setup_hosted_device_record(client: &Arc<Client>, user: &str, devices: &[(u32, bool)]) {
+    async fn setup_hosted_device_record(client: &Arc<Client>, user: &str, devices: &[(u16, bool)]) {
         let record = wacore::store::traits::DeviceListRecord {
             user: user.into(),
             devices: devices
@@ -3608,7 +3622,7 @@ mod tests {
 
     /// Publish a device record through the real write path, which records the
     /// topology change every invalidation rule depends on.
-    async fn publish_device_record(client: &Arc<Client>, user: &str, device_ids: &[u32]) {
+    async fn publish_device_record(client: &Arc<Client>, user: &str, device_ids: &[u16]) {
         let record = wacore::store::traits::DeviceListRecord {
             user: user.into(),
             devices: device_ids

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -34,7 +34,10 @@ impl wacore::stats::HeapSize for GroupDevicesMemo {
         // The Weak keeps only the GroupInfo allocation header alive; the memo
         // does not retain its payload.
         self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-            + self.members.capacity() * size_of::<wacore_binary::CompactString>()
+            + wacore::stats::hash_table_bytes(
+                self.members.capacity(),
+                size_of::<wacore_binary::CompactString>(),
+            )
             + self.devices.heap_bytes()
     }
 }
@@ -64,7 +67,10 @@ impl wacore::stats::HeapSize for DmDevicesMemo {
         self.own_pn.heap_bytes()
             + self.own_lid.as_ref().map_or(0, |lid| lid.heap_bytes())
             + self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-            + self.members.capacity() * size_of::<wacore_binary::CompactString>()
+            + wacore::stats::hash_table_bytes(
+                self.members.capacity(),
+                size_of::<wacore_binary::CompactString>(),
+            )
             + self.devices.heap_bytes()
     }
 }

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -139,13 +139,16 @@ impl DeviceTopology {
 /// non-recording [`promote`](Self::promote) (whose data is by definition what
 /// the DB fallback already answered).
 pub(crate) struct DeviceRegistryCache {
-    cache: crate::cache_store::TypedCache<String, Arc<wacore::store::traits::DeviceListRecord>>,
+    cache: crate::cache_store::TypedCache<Arc<str>, Arc<wacore::store::traits::DeviceListRecord>>,
     topology: Arc<DeviceTopology>,
 }
 
 impl DeviceRegistryCache {
     pub(crate) fn new(
-        cache: crate::cache_store::TypedCache<String, Arc<wacore::store::traits::DeviceListRecord>>,
+        cache: crate::cache_store::TypedCache<
+            Arc<str>,
+            Arc<wacore::store::traits::DeviceListRecord>,
+        >,
         topology: Arc<DeviceTopology>,
     ) -> Self {
         Self { cache, topology }
@@ -164,7 +167,7 @@ impl DeviceRegistryCache {
     pub(crate) async fn insert<'a>(
         &self,
         guard: &DeviceRegistryMutationGuard<'_>,
-        key: String,
+        key: Arc<str>,
         record: Arc<wacore::store::traits::DeviceListRecord>,
         touched: impl IntoIterator<Item = &'a str>,
     ) {
@@ -181,7 +184,7 @@ impl DeviceRegistryCache {
     /// answer is unchanged, so no topology change is recorded.
     pub(crate) async fn promote(
         &self,
-        key: String,
+        key: Arc<str>,
         record: Arc<wacore::store::traits::DeviceListRecord>,
     ) {
         self.cache.insert(key, record).await;
@@ -191,9 +194,9 @@ impl DeviceRegistryCache {
     /// when backed by a custom store (entries live outside this process).
     pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
         use wacore::stats::HeapSize;
-        self.cache
-            .memory_stats(|k, v| k.capacity() + v.heap_bytes())
-            .await
+        // The key is the record's own `user` string, one allocation shared
+        // between them, so only `heap_bytes` counts it.
+        self.cache.memory_stats(|_k, v| v.heap_bytes()).await
     }
 
     /// Test-only passthrough for cache maintenance flushes.
@@ -208,7 +211,7 @@ impl DeviceRegistryCache {
     #[cfg(test)]
     pub(crate) async fn raw_insert_for_tests(
         &self,
-        key: String,
+        key: Arc<str>,
         record: Arc<wacore::store::traits::DeviceListRecord>,
     ) {
         self.cache.insert(key, record).await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -2345,8 +2345,8 @@ mod tests {
         // from "migration never called".
         backend
             .update_device_list(DeviceListRecord {
-                user: pn.to_string(),
-                devices: vec![DeviceInfo::new(3, None)],
+                user: pn.into(),
+                devices: [DeviceInfo::new(3, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2388,7 +2388,7 @@ mod tests {
             "migration must delete the old PN-keyed device row"
         );
         let lid_row = backend.get_devices(lid).await.unwrap().unwrap();
-        assert_eq!(lid_row.devices[0].device_id, 3);
+        assert_eq!(lid_row.devices[0].device_id(), 3);
         // And the mapping resolves from both directions.
         assert_eq!(
             client

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1299,8 +1299,8 @@ mod tests {
         let recipient = Jid::new("15550002000", Server::Pn);
         client
             .update_device_list(DeviceListRecord {
-                user: recipient.user.to_string(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(1, None)],
+                user: recipient.user.as_str().into(),
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(1, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -633,16 +633,15 @@ pub(crate) async fn handle_account_sync_devices(
     // Build DeviceListRecord for storage
     // Note: update_device_list() will automatically store under LID if mapping is known
     let device_list = DeviceListRecord {
-        user: from_jid.user.to_string(),
+        user: Arc::from(from_jid.user.as_str()),
         devices: devices
             .iter()
             .map(|d| {
-                DeviceInfo::new(d.jid.device as u32, d.key_index)
-                    .with_hosting(JidExt::is_hosted(&d.jid))
+                DeviceInfo::new(d.jid.device, d.key_index).with_hosting(JidExt::is_hosted(&d.jid))
             })
             .collect(),
         timestamp,
-        phash: dhash,
+        phash: dhash.map(Box::<str>::from),
         raw_id: existing_raw_id,
     };
 

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -1097,7 +1097,7 @@ mod tests {
         // Pre-populate device registry so clear_device_record has something to clear
         let record = wacore::store::traits::DeviceListRecord {
             user: "5511999999999".into(),
-            devices: vec![wacore::store::traits::DeviceInfo::new(1, None)],
+            devices: [wacore::store::traits::DeviceInfo::new(1, None)].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: Some(42),
@@ -1411,7 +1411,7 @@ mod tests {
                 "5511666666666".into(),
                 Arc::new(wacore::store::traits::DeviceListRecord {
                     user: "5511666666666".into(),
-                    devices: vec![wacore::store::traits::DeviceInfo::new(1, None)],
+                    devices: [wacore::store::traits::DeviceInfo::new(1, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: Some(1),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -522,7 +522,7 @@ impl Client {
         // list for this user, so refresh it (rate-limited, dedup'd) to learn the
         // device for the next send. Done before the message-cache lookup so an
         // evicted retry still triggers it.
-        let sender_device_id = info.requester.device() as u32;
+        let sender_device_id = info.requester.device();
         let device_known = self
             .has_device(&info.requester.user, sender_device_id)
             .await;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3177,14 +3177,14 @@ mod tests {
             {
                 let record = DeviceListRecord {
                     user: user.into(),
-                    devices: vec![DeviceInfo::new(0, None)],
+                    devices: [DeviceInfo::new(0, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
                 };
                 client
                     .device_registry_cache
-                    .raw_insert_for_tests(user.to_string(), Arc::new(record))
+                    .raw_insert_for_tests(Arc::from(user), Arc::new(record))
                     .await;
             }
 
@@ -3278,17 +3278,14 @@ mod tests {
             // through the mapping.
             let record = DeviceListRecord {
                 user: own.user.as_str().into(),
-                devices: vec![
-                    DeviceInfo::new(0, None),
-                    DeviceInfo::new(u32::from(device_id), None),
-                ],
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(device_id, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
             };
             self.client
                 .device_registry_cache
-                .raw_insert_for_tests(own.user.to_string(), Arc::new(record))
+                .raw_insert_for_tests(Arc::from(own.user.as_str()), Arc::new(record))
                 .await;
             let companion = self.own_sending.with_device(device_id);
             crate::test_utils::seed_peer_session(&self.client, &companion).await;
@@ -3846,10 +3843,10 @@ mod tests {
             client
                 .device_registry_cache
                 .raw_insert_for_tests(
-                    user.to_string(),
+                    user.into(),
                     Arc::new(DeviceListRecord {
                         user: user.into(),
-                        devices: vec![DeviceInfo::new(0, None)],
+                        devices: [DeviceInfo::new(0, None)].into(),
                         timestamp: wacore::time::now_secs(),
                         phash: None,
                         raw_id: None,
@@ -4734,7 +4731,7 @@ mod tests {
         for user in &participant_users {
             let record = DeviceListRecord {
                 user: (*user).into(),
-                devices: vec![DeviceInfo::new(0, None)],
+                devices: [DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -6511,14 +6508,14 @@ mod tests {
         // blocking on a network device-list fetch (which would time out with
         // no socket).
         for user in [
-            peer_lid.user.to_string(),
-            peer_pn.user.to_string(),
-            own_pn.user.to_string(),
+            Arc::from(peer_lid.user.as_str()),
+            Arc::from(peer_pn.user.as_str()),
+            Arc::<str>::from(own_pn.user.as_str()),
         ] {
             client
                 .update_device_list(wacore::store::traits::DeviceListRecord {
                     user,
-                    devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                    devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
@@ -7455,7 +7452,7 @@ mod clock_budget_tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: user.into(),
-                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
+                devices: [wacore::store::traits::DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -9,6 +9,7 @@ use portable_atomic::AtomicU64;
 
 use crate::cache::Cache;
 use crate::cache_config::CacheEntryConfig;
+use wacore::stats::hash_table_bytes;
 use wacore_binary::Jid;
 
 /// Pre-parsed, pre-indexed sender key device map for one group.
@@ -179,16 +180,25 @@ impl SenderKeyDeviceCache {
 
     /// Approximate entry count plus estimated retained bytes.
     pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
-        // Slot allocations use capacity() (outer and inner maps alike);
-        // per-entry heap is summed by iteration.
+        // Table allocations go through `hash_table_bytes` (outer and inner
+        // maps alike), which accounts for the buckets hashbrown really owns
+        // rather than the entries that fit in them; per-entry heap is summed
+        // by iteration.
         self.inner
             .memory_stats(|k, v| {
                 k.capacity()
-                    + v.devices.capacity() * size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>()
+                    + hash_table_bytes(
+                        v.devices.capacity(),
+                        size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>(),
+                    )
                     + v.devices
                         .iter()
                         .map(|(user, by_device)| {
-                            user.len() + by_device.capacity() * size_of::<(u16, AtomicBool)>()
+                            user.len()
+                                + hash_table_bytes(
+                                    by_device.capacity(),
+                                    size_of::<(u16, AtomicBool)>(),
+                                )
                         })
                         .sum::<usize>()
             })

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -688,7 +688,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "5551230000".into(),
-            devices: [].into(),
+            devices: Box::default(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -748,7 +748,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: "1111111111@s.whatsapp.net".parse().unwrap(),
-                devices: [UsyncDevice::new(0, None)].into(),
+                devices: vec![UsyncDevice::new(0, None)],
                 phash: Some("2:a".into()),
                 key_index_bytes: None,
             }],
@@ -787,11 +787,10 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: [
+                devices: vec![
                     UsyncDevice::new(0, None),
                     UsyncDevice::new(7, Some(3)).with_hosting(true),
-                ]
-                .into(),
+                ],
                 phash: Some("2:hosted".into()),
                 key_index_bytes: None,
             }],
@@ -840,7 +839,7 @@ mod tests {
         let stale_response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: [UsyncDevice::new(0, None)].into(),
+                devices: vec![UsyncDevice::new(0, None)],
                 phash: Some("1:stale".into()),
                 key_index_bytes: None,
             }],
@@ -975,7 +974,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: refreshed,
-                devices: [UsyncDevice::new(0, None)].into(),
+                devices: vec![UsyncDevice::new(0, None)],
                 phash: None,
                 key_index_bytes: None,
             }],
@@ -1011,7 +1010,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: refreshed,
-                devices: [UsyncDevice::new(0, None)].into(),
+                devices: vec![UsyncDevice::new(0, None)],
                 phash: None,
                 key_index_bytes: None,
             }],
@@ -1055,7 +1054,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: "3333333333@s.whatsapp.net".parse().unwrap(),
-                devices: [].into(),
+                devices: vec![],
                 phash: Some("3:empty".into()),
                 key_index_bytes: None,
             }],
@@ -1107,7 +1106,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: [UsyncDevice::new(7, Some(3))].into(),
+                devices: vec![UsyncDevice::new(7, Some(3))],
                 phash: Some("2:incomplete".into()),
                 key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
             }],
@@ -1156,7 +1155,7 @@ mod tests {
                     user: identity_changed.clone(),
                     // A primary device survives key-index filtering, so this
                     // first user schedules a valid identity replacement.
-                    devices: [UsyncDevice::new(0, None)].into(),
+                    devices: vec![UsyncDevice::new(0, None)],
                     phash: Some("1:changed".into()),
                     key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
                 },
@@ -1164,7 +1163,7 @@ mod tests {
                     user: invalid,
                     // The second user makes the authoritative response invalid
                     // only after key-index projection.
-                    devices: [UsyncDevice::new(7, Some(3))].into(),
+                    devices: vec![UsyncDevice::new(7, Some(3))],
                     phash: Some("1:invalid".into()),
                     key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
                 },
@@ -1209,7 +1208,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: [UsyncDevice::new(7, Some(3))].into(),
+                devices: vec![UsyncDevice::new(7, Some(3))],
                 phash: Some("1:changed".into()),
                 key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
             }],

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -337,11 +337,11 @@ impl Client {
                             record
                                 .devices
                                 .iter()
-                                .find(|cached| cached.device_id == d.device as u32)
-                                .and_then(|cached| cached.key_index)
+                                .find(|cached| cached.device_id() == d.device)
+                                .and_then(|cached| cached.key_index())
                         })
                     });
-                    wacore::store::traits::DeviceInfo::new(d.device as u32, key_index)
+                    wacore::store::traits::DeviceInfo::new(d.device, key_index)
                         .with_hosting(d.is_hosted)
                 })
                 .collect();
@@ -386,14 +386,14 @@ impl Client {
             // Convert filtered DeviceInfo list back to JIDs for return
             let user_jid = &user_list.user;
             for d in &devices {
-                fetched_devices.push(user_jid.with_device_hosting(d.device_id as u16, d.is_hosted));
+                fetched_devices.push(user_jid.with_device_hosting(d.device_id(), d.is_hosted()));
             }
 
             device_records.push(wacore::store::traits::DeviceListRecord {
-                user: user_list.user.user.to_string(),
-                devices,
+                user: std::sync::Arc::from(user_list.user.user.as_str()),
+                devices: devices.into_boxed_slice(),
                 timestamp: wacore::time::now_secs(),
-                phash: user_list.phash.clone(),
+                phash: user_list.phash.clone().map(Box::<str>::from),
                 raw_id,
             });
         }
@@ -453,7 +453,7 @@ impl Client {
             if let Some(record) = self.load_device_record(&bare.user).await
                 && let Some(phash) = record.phash
             {
-                hashes.insert(bare.clone(), (phash, record.timestamp));
+                hashes.insert(bare.clone(), (String::from(phash), record.timestamp));
             }
             jids.push(bare);
         }
@@ -571,7 +571,7 @@ mod tests {
         // Insert a device record into the registry (simulates prior usync/notification)
         let record = DeviceListRecord {
             user: "1234567890".into(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(10))],
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(3, Some(10))].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -593,7 +593,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: "12025550102".into(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(8, None)],
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(8, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -633,7 +633,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "100000012345678".into(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))],
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -656,7 +656,7 @@ mod tests {
         // Insert into backend DB via update_device_list
         let record = DeviceListRecord {
             user: "9876543210".into(),
-            devices: vec![DeviceInfo::new(5, None)],
+            devices: [DeviceInfo::new(5, None)].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -688,7 +688,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "5551230000".into(),
-            devices: vec![],
+            devices: [].into(),
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -736,9 +736,9 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: "2222222222".into(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(7, None)],
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(7, None)].into(),
                 timestamp: wacore::time::now_secs(),
-                phash: Some("2:oldB".to_string()),
+                phash: Some("2:oldB".into()),
                 raw_id: None,
             })
             .await
@@ -748,8 +748,8 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: "1111111111@s.whatsapp.net".parse().unwrap(),
-                devices: vec![UsyncDevice::new(0, None)],
-                phash: Some("2:a".to_string()),
+                devices: [UsyncDevice::new(0, None)].into(),
+                phash: Some("2:a".into()),
                 key_index_bytes: None,
             }],
             lid_mappings: vec![],
@@ -787,11 +787,12 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: vec![
+                devices: [
                     UsyncDevice::new(0, None),
                     UsyncDevice::new(7, Some(3)).with_hosting(true),
-                ],
-                phash: Some("2:hosted".to_string()),
+                ]
+                .into(),
+                phash: Some("2:hosted".into()),
                 key_index_bytes: None,
             }],
             lid_mappings: Vec::new(),
@@ -826,10 +827,10 @@ mod tests {
         let user = Jid::pn("12025550102");
         client
             .update_device_list(DeviceListRecord {
-                user: user.user.to_string(),
-                devices: vec![DeviceInfo::new(0, None)],
+                user: user.user.as_str().into(),
+                devices: [DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
-                phash: Some("1:before".to_string()),
+                phash: Some("1:before".into()),
                 raw_id: None,
             })
             .await
@@ -839,8 +840,8 @@ mod tests {
         let stale_response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: vec![UsyncDevice::new(0, None)],
-                phash: Some("1:stale".to_string()),
+                devices: [UsyncDevice::new(0, None)].into(),
+                phash: Some("1:stale".into()),
                 key_index_bytes: None,
             }],
             lid_mappings: Vec::new(),
@@ -962,8 +963,8 @@ mod tests {
         let refresh_started_at = client.device_topology.current();
         client
             .update_device_list(DeviceListRecord {
-                user: "12025550105".to_string(),
-                devices: vec![DeviceInfo::new(0, None)],
+                user: "12025550105".into(),
+                devices: [DeviceInfo::new(0, None)].into(),
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -974,7 +975,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: refreshed,
-                devices: vec![UsyncDevice::new(0, None)],
+                devices: [UsyncDevice::new(0, None)].into(),
                 phash: None,
                 key_index_bytes: None,
             }],
@@ -1010,7 +1011,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: refreshed,
-                devices: vec![UsyncDevice::new(0, None)],
+                devices: [UsyncDevice::new(0, None)].into(),
                 phash: None,
                 key_index_bytes: None,
             }],
@@ -1042,9 +1043,9 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: "3333333333".into(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(4, None)],
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(4, None)].into(),
                 timestamp: wacore::time::now_secs(),
-                phash: Some("3:old".to_string()),
+                phash: Some("3:old".into()),
                 raw_id: None,
             })
             .await
@@ -1054,8 +1055,8 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: "3333333333@s.whatsapp.net".parse().unwrap(),
-                devices: vec![],
-                phash: Some("3:empty".to_string()),
+                devices: [].into(),
+                phash: Some("3:empty".into()),
                 key_index_bytes: None,
             }],
             lid_mappings: vec![],
@@ -1091,10 +1092,10 @@ mod tests {
         let user = Jid::pn("4444444444");
         client
             .update_device_list(DeviceListRecord {
-                user: user.user.to_string(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))],
+                user: user.user.as_str().into(),
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))].into(),
                 timestamp: wacore::time::now_secs(),
-                phash: Some("2:previous".to_string()),
+                phash: Some("2:previous".into()),
                 raw_id: Some(1),
             })
             .await
@@ -1106,8 +1107,8 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: vec![UsyncDevice::new(7, Some(3))],
-                phash: Some("2:incomplete".to_string()),
+                devices: [UsyncDevice::new(7, Some(3))].into(),
+                phash: Some("2:incomplete".into()),
                 key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
             }],
             lid_mappings: Vec::new(),
@@ -1138,10 +1139,10 @@ mod tests {
         for (user, raw_id) in [(&identity_changed, 2), (&invalid, 1)] {
             client
                 .update_device_list(DeviceListRecord {
-                    user: user.user.to_string(),
-                    devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))],
+                    user: user.user.as_str().into(),
+                    devices: [DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))].into(),
                     timestamp: wacore::time::now_secs(),
-                    phash: Some("2:previous".to_string()),
+                    phash: Some("2:previous".into()),
                     raw_id: Some(raw_id),
                 })
                 .await
@@ -1155,16 +1156,16 @@ mod tests {
                     user: identity_changed.clone(),
                     // A primary device survives key-index filtering, so this
                     // first user schedules a valid identity replacement.
-                    devices: vec![UsyncDevice::new(0, None)],
-                    phash: Some("1:changed".to_string()),
+                    devices: [UsyncDevice::new(0, None)].into(),
+                    phash: Some("1:changed".into()),
                     key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
                 },
                 UserDeviceList {
                     user: invalid,
                     // The second user makes the authoritative response invalid
                     // only after key-index projection.
-                    devices: vec![UsyncDevice::new(7, Some(3))],
-                    phash: Some("1:invalid".to_string()),
+                    devices: [UsyncDevice::new(7, Some(3))].into(),
+                    phash: Some("1:invalid".into()),
                     key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
                 },
             ],
@@ -1195,10 +1196,10 @@ mod tests {
         let user = Jid::pn("4444444453");
         client
             .update_device_list(DeviceListRecord {
-                user: user.user.to_string(),
-                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))],
+                user: user.user.as_str().into(),
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(7, Some(3))].into(),
                 timestamp: wacore::time::now_secs(),
-                phash: Some("2:previous".to_string()),
+                phash: Some("2:previous".into()),
                 raw_id: Some(2),
             })
             .await
@@ -1208,8 +1209,8 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: user.clone(),
-                devices: vec![UsyncDevice::new(7, Some(3))],
-                phash: Some("1:changed".to_string()),
+                devices: [UsyncDevice::new(7, Some(3))].into(),
+                phash: Some("1:changed".into()),
                 key_index_bytes: Some(signed_key_index_bytes(Vec::new(), 10)),
             }],
             lid_mappings: Vec::new(),

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -7028,8 +7028,8 @@ mod tests {
         let update = rekey_update(&client, &recipients);
         let generation = register_group_update(&client, &update);
         let encrypted = wacore::send::EncryptForDevicesRaw {
-            devices: [wacore::send::EncryptedDevice {
-                device_jid: recipients[0].into().clone(),
+            devices: vec![wacore::send::EncryptedDevice {
+                device_jid: recipients[0].clone(),
                 enc_type: "msg",
                 is_prekey: false,
                 ciphertext: vec![7; 32],

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4250,8 +4250,8 @@ mod tests {
         for peer in [&peer_a, &peer_b] {
             client
                 .update_device_list(DeviceListRecord {
-                    user: peer.user.to_string(),
-                    devices: vec![DeviceInfo::new(0, None)],
+                    user: peer.user.as_str().into(),
+                    devices: [DeviceInfo::new(0, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
@@ -7028,8 +7028,8 @@ mod tests {
         let update = rekey_update(&client, &recipients);
         let generation = register_group_update(&client, &update);
         let encrypted = wacore::send::EncryptForDevicesRaw {
-            devices: vec![wacore::send::EncryptedDevice {
-                device_jid: recipients[0].clone(),
+            devices: [wacore::send::EncryptedDevice {
+                device_jid: recipients[0].into().clone(),
                 enc_type: "msg",
                 is_prekey: false,
                 ciphertext: vec![7; 32],
@@ -8410,8 +8410,8 @@ mod tests {
         for target in &targets {
             client
                 .update_device_list(DeviceListRecord {
-                    user: target.user.to_string(),
-                    devices: vec![DeviceInfo::new(0, None)],
+                    user: target.user.as_str().into(),
+                    devices: [DeviceInfo::new(0, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
@@ -8480,8 +8480,8 @@ mod tests {
         for target in &targets {
             client
                 .update_device_list(DeviceListRecord {
-                    user: target.user.to_string(),
-                    devices: vec![DeviceInfo::new(0, None)],
+                    user: target.user.as_str().into(),
+                    devices: [DeviceInfo::new(0, None)].into(),
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2997,10 +2997,10 @@ impl ProtocolStore for SqliteStore {
             let raw_id_i32 = record.raw_id.map(|r| r as i32);
             diesel::insert_into(device_registry::table)
                 .values((
-                    device_registry::user_id.eq(&record.user),
+                    device_registry::user_id.eq(record.user.as_ref()),
                     device_registry::devices_json.eq(&devices_json),
                     device_registry::timestamp.eq(record.timestamp as i32),
-                    device_registry::phash.eq(&record.phash),
+                    device_registry::phash.eq(record.phash.as_deref()),
                     device_registry::device_id.eq(device_id),
                     device_registry::updated_at.eq(now),
                     device_registry::raw_id.eq(raw_id_i32),
@@ -3010,7 +3010,7 @@ impl ProtocolStore for SqliteStore {
                 .set((
                     device_registry::devices_json.eq(&devices_json),
                     device_registry::timestamp.eq(record.timestamp as i32),
-                    device_registry::phash.eq(&record.phash),
+                    device_registry::phash.eq(record.phash.as_deref()),
                     device_registry::updated_at.eq(now),
                     device_registry::raw_id.eq(raw_id_i32),
                 ))
@@ -3047,10 +3047,10 @@ impl ProtocolStore for SqliteStore {
                 let devices_json = serde_json::to_string(&r.devices)
                     .map_err(|e| StoreError::Serialization(Box::new(e)))?;
                 Ok(PreparedRow {
-                    user: r.user,
+                    user: r.user.to_string(),
                     devices_json,
                     timestamp: r.timestamp as i32,
-                    phash: r.phash,
+                    phash: r.phash.map(String::from),
                     raw_id: r.raw_id.map(|v| v as i32),
                 })
             })
@@ -3119,13 +3119,13 @@ impl ProtocolStore for SqliteStore {
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
             match row {
                 Some((user, devices_json, timestamp, phash, raw_id)) => {
-                    let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
+                    let devices: Box<[DeviceInfo]> = serde_json::from_str(&devices_json)
                         .map_err(|e| StoreError::Serialization(Box::new(e)))?;
                     Ok(Some(DeviceListRecord {
-                        user,
+                        user: Arc::from(user),
                         devices,
                         timestamp: timestamp as i64,
-                        phash,
+                        phash: phash.map(Box::<str>::from),
                         raw_id: raw_id.map(|r| r as u32),
                     }))
                 }
@@ -4529,10 +4529,10 @@ mod tests {
         let store = create_test_store().await;
 
         let record = DeviceListRecord {
-            user: "1234567890".to_string(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(1, Some(42))],
+            user: "1234567890".into(),
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(1, Some(42))].into(),
             timestamp: 1234567890,
-            phash: Some("2:abcdef".to_string()),
+            phash: Some("2:abcdef".into()),
             raw_id: None,
         };
 
@@ -4545,9 +4545,9 @@ mod tests {
 
         assert_eq!(loaded.user, "1234567890");
         assert_eq!(loaded.devices.len(), 2);
-        assert_eq!(loaded.devices[0].device_id, 0);
-        assert_eq!(loaded.devices[1].device_id, 1);
-        assert_eq!(loaded.devices[1].key_index, Some(42));
+        assert_eq!(loaded.devices[0].device_id(), 0);
+        assert_eq!(loaded.devices[1].device_id(), 1);
+        assert_eq!(loaded.devices[1].key_index(), Some(42));
         assert_eq!(loaded.phash, Some("2:abcdef".to_string()));
     }
 
@@ -4556,10 +4556,10 @@ mod tests {
         let store = create_test_store().await;
 
         let record1 = DeviceListRecord {
-            user: "1234567890".to_string(),
-            devices: vec![DeviceInfo::new(0, None)],
+            user: "1234567890".into(),
+            devices: [DeviceInfo::new(0, None)].into(),
             timestamp: 1000,
-            phash: Some("2:old".to_string()),
+            phash: Some("2:old".into()),
             raw_id: None,
         };
         store
@@ -4568,10 +4568,10 @@ mod tests {
             .expect("save1 failed");
 
         let record2 = DeviceListRecord {
-            user: "1234567890".to_string(),
-            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(2, None)],
+            user: "1234567890".into(),
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(2, None)].into(),
             timestamp: 2000,
-            phash: Some("2:new".to_string()),
+            phash: Some("2:new".into()),
             raw_id: None,
         };
         store
@@ -6123,7 +6123,7 @@ mod read_routing_tests {
 
         store
             .update_device_list(DeviceListRecord {
-                user: "559990000001".to_string(),
+                user: "559990000001".into(),
                 devices: Vec::new(),
                 timestamp: 5,
                 phash: None,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4543,12 +4543,12 @@ mod tests {
             .expect("get failed")
             .expect("record should exist");
 
-        assert_eq!(loaded.user, "1234567890");
+        assert_eq!(&*loaded.user, "1234567890");
         assert_eq!(loaded.devices.len(), 2);
         assert_eq!(loaded.devices[0].device_id(), 0);
         assert_eq!(loaded.devices[1].device_id(), 1);
         assert_eq!(loaded.devices[1].key_index(), Some(42));
-        assert_eq!(loaded.phash, Some("2:abcdef".to_string()));
+        assert_eq!(loaded.phash.as_deref(), Some("2:abcdef"));
     }
 
     #[tokio::test]
@@ -4586,7 +4586,7 @@ mod tests {
             .expect("record should exist");
 
         assert_eq!(loaded.devices.len(), 2);
-        assert_eq!(loaded.phash, Some("2:new".to_string()));
+        assert_eq!(loaded.phash.as_deref(), Some("2:new"));
     }
 
     #[tokio::test]
@@ -6124,7 +6124,7 @@ mod read_routing_tests {
         store
             .update_device_list(DeviceListRecord {
                 user: "559990000001".into(),
-                devices: Vec::new(),
+                devices: Box::default(),
                 timestamp: 5,
                 phash: None,
                 raw_id: None,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2987,7 +2987,7 @@ impl ProtocolStore for SqliteStore {
     async fn update_device_list(&self, record: DeviceListRecord) -> Result<()> {
         let pool = self.pool.clone();
         let device_id = self.device_id;
-        let devices_json = serde_json::to_string(&record.devices)
+        let devices_json = serde_json::to_string(&*record.devices)
             .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         let now = wacore::time::now_secs() as i32;
         tokio::task::spawn_blocking(move || -> Result<()> {
@@ -3044,7 +3044,7 @@ impl ProtocolStore for SqliteStore {
         let prepared: Vec<PreparedRow> = records
             .into_iter()
             .map(|r| {
-                let devices_json = serde_json::to_string(&r.devices)
+                let devices_json = serde_json::to_string(&*r.devices)
                     .map_err(|e| StoreError::Serialization(Box::new(e)))?;
                 Ok(PreparedRow {
                     user: r.user.to_string(),
@@ -3119,11 +3119,14 @@ impl ProtocolStore for SqliteStore {
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
             match row {
                 Some((user, devices_json, timestamp, phash, raw_id)) => {
-                    let devices: Box<[DeviceInfo]> = serde_json::from_str(&devices_json)
+                    // Decoded as a `Vec` and converted, so this reuses the
+                    // `Vec<DeviceInfo>` codec the crate already instantiates
+                    // rather than stamping a second one for `Box<[_]>`.
+                    let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
                         .map_err(|e| StoreError::Serialization(Box::new(e)))?;
                     Ok(Some(DeviceListRecord {
                         user: Arc::from(user),
-                        devices,
+                        devices: devices.into_boxed_slice(),
                         timestamp: timestamp as i64,
                         phash: phash.map(Box::<str>::from),
                         raw_id: raw_id.map(|r| r as u32),

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -160,6 +160,10 @@ name = "media_benchmark"
 harness = false
 
 [[bench]]
+name = "retained_memory_benchmark"
+harness = false
+
+[[bench]]
 name = "voip_benchmark"
 harness = false
 # Only `voip-mlow` here on purpose: cargo SILENTLY SKIPS a bench target whose required features are

--- a/wacore/benches/retained_memory_benchmark.rs
+++ b/wacore/benches/retained_memory_benchmark.rs
@@ -1,0 +1,91 @@
+//! Long-lived per-entry structures, on the shapes that actually accumulate.
+//!
+//! These are the collections a connected client keeps resident for hours: the
+//! group snapshot behind every group send, and the device-registry record
+//! behind every recipient. Their *size* is pinned by the retained-bytes tests
+//! next to each type; what is measured here is the cost of the layouts those
+//! tests buy — a sorted slice searched with `binary_search` has to stay at
+//! least as fast as the `HashMap` it replaced on the read path, which is where
+//! a group send spends one lookup per participant.
+
+use divan::black_box;
+use std::collections::HashMap;
+use wacore::client::context::GroupInfo;
+use wacore::types::message::AddressingMode;
+use wacore_binary::CompactString;
+use wacore_binary::jid::{Jid, Server};
+
+fn main() {
+    divan::main();
+}
+
+/// A LID group of `n` members, every member carrying a phone-number mapping —
+/// the worst case for the mapping structures and the shape a community group
+/// actually has.
+fn lid_group(n: usize) -> (Vec<Jid>, HashMap<CompactString, Jid>) {
+    let mut participants = Vec::with_capacity(n);
+    let mut lid_to_pn = HashMap::with_capacity(n);
+    for i in 0..n {
+        let lid_user = CompactString::from(format!("1000000{i:08}"));
+        let pn_user = CompactString::from(format!("5511{i:09}"));
+        participants.push(Jid::new(lid_user.clone(), Server::Lid));
+        lid_to_pn.insert(lid_user, Jid::new(pn_user, Server::Pn));
+    }
+    (participants, lid_to_pn)
+}
+
+/// Building the snapshot: paid once per group-metadata fetch, and the cost the
+/// sorted layout front-loads in exchange for the read path below.
+#[divan::bench(args = [64, 256, 1024])]
+fn group_info_build(bencher: divan::Bencher, n: usize) {
+    let (participants, lid_to_pn) = lid_group(n);
+    bencher
+        .with_inputs(|| (participants.clone(), lid_to_pn.clone()))
+        .bench_values(|(participants, lid_to_pn)| {
+            GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn)
+        });
+}
+
+/// One forward lookup per participant: what `resolve_group_devices` does on
+/// every group send before it can query devices.
+#[divan::bench(args = [64, 256, 1024])]
+fn group_info_lookup_forward(bencher: divan::Bencher, n: usize) {
+    let (participants, lid_to_pn) = lid_group(n);
+    let users: Vec<CompactString> = participants.iter().map(|j| j.user.clone()).collect();
+    let info = GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn);
+    bencher.bench(|| {
+        for user in &users {
+            black_box(info.phone_jid_for_lid_user(user));
+        }
+    });
+}
+
+/// One reverse lookup per participant: the direction that used to cost a whole
+/// second `HashMap` and now costs a `u32` index.
+#[divan::bench(args = [64, 256, 1024])]
+fn group_info_lookup_reverse(bencher: divan::Bencher, n: usize) {
+    let (participants, lid_to_pn) = lid_group(n);
+    let phone_users: Vec<CompactString> = lid_to_pn.values().map(|j| j.user.clone()).collect();
+    let info = GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn);
+    bencher.bench(|| {
+        for user in &phone_users {
+            black_box(info.lid_user_for_phone_user(user));
+        }
+    });
+}
+
+/// A participant-add notification on a warm group: the write path, which the
+/// sorted layout makes a rebuild rather than n hash insertions.
+#[divan::bench(args = [64, 256, 1024])]
+fn group_info_add_participants(bencher: divan::Bencher, n: usize) {
+    let (participants, lid_to_pn) = lid_group(n);
+    let info = GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn);
+    let new_lid = Jid::lid("100000099999999");
+    let new_pn = Jid::pn("5511999999999");
+    bencher
+        .with_inputs(|| info.clone())
+        .bench_values(|mut info| {
+            info.add_participants([(&new_lid, Some(&new_pn))]);
+            info
+        });
+}

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -5,7 +5,7 @@
 
 use std::collections::VecDeque;
 
-use buffa::{Message, MessageField};
+use buffa::MessageField;
 
 use hmac::{HmacReset, KeyInit, Mac};
 use sha2::Sha256;
@@ -945,28 +945,63 @@ impl SenderKeyRecord {
         Ok(buf)
     }
 
-    /// Estimated in-memory footprint proxy: encoded size of each state's
-    /// structure plus the out-of-order message-key backlog (held outside the
-    /// protobuf in memory). Size computation only — nothing is cloned or
-    /// encoded. Used by per-session memory reports.
+    /// Retained in-memory bytes of every state this record holds.
+    ///
+    /// Walks the live structures rather than asking for their protobuf-encoded
+    /// size, which is what this used to report — the encoded form omits the
+    /// `Option` slots and `Vec` capacity that memory actually pays for. Size
+    /// computation only: nothing is cloned or encoded.
     pub fn estimated_size(&self) -> usize {
-        let mut cache = buffa::SizeCache::new();
-        self.states
-            .iter()
-            .map(|s| {
-                s.state.compute_size(&mut cache) as usize
-                    + s.message_keys.len() * size_of::<StoredMessageKey>()
-                    + s.sender_chain.map_or(0, |_| size_of::<SenderChainKey>())
-            })
-            .sum()
+        self.states.capacity() * size_of::<SenderKeyState>()
+            + self
+                .states
+                .iter()
+                .map(|s| {
+                    state_structure_retained_bytes(&s.state)
+                        + s.message_keys.capacity() * size_of::<StoredMessageKey>()
+                        + s.sender_chain.map_or(0, |_| size_of::<SenderChainKey>())
+                })
+                .sum::<usize>()
     }
+}
+
+/// Retained bytes of one sender-key state structure, including everything it
+/// points at.
+///
+/// The skipped-key backlog is not walked here: this record keeps it in
+/// [`StoredMessageKey`] (36 bytes, seed inline) rather than in the protobuf's
+/// `SenderMessageKey`, and `estimated_size` counts it there.
+fn state_structure_retained_bytes(state: &SenderKeyStateStructure) -> usize {
+    fn bytes_field(field: &Option<bytes::Bytes>) -> usize {
+        field.as_ref().map_or(0, |b| b.len())
+    }
+
+    size_of::<SenderKeyStateStructure>()
+        + state.sender_chain_key.as_option().map_or(0, |chain| {
+            size_of::<sender_key_state_structure::SenderChainKey>() + bytes_field(&chain.seed)
+        })
+        + state.sender_signing_key.as_option().map_or(0, |signing| {
+            size_of::<sender_key_state_structure::SenderSigningKey>()
+                + bytes_field(&signing.public)
+                + bytes_field(&signing.private)
+        })
+        + state.sender_message_keys.capacity()
+            * size_of::<sender_key_state_structure::SenderMessageKey>()
+        + state
+            .sender_message_keys
+            .iter()
+            .map(|key| bytes_field(&key.seed))
+            .sum::<usize>()
 }
 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    // The protobuf encode helpers are only needed to build fixtures here; the
+    // module itself no longer encodes anything.
     use crate::protocol::KeyPair;
+    use buffa::Message;
 
     /// An injected derivation has to be indistinguishable from the one the
     /// state would have produced, or the API trades correctness for speed.

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -951,42 +951,54 @@ impl SenderKeyRecord {
     /// size, which is what this used to report — the encoded form omits the
     /// `Option` slots and `Vec` capacity that memory actually pays for. Size
     /// computation only: nothing is cloned or encoded.
+    ///
+    /// Each container's inline slots are charged once, here, and the walker
+    /// below adds only what hangs off them. `sender_chain` and `state` live
+    /// inline in `SenderKeyState`, so they are already inside the capacity
+    /// term; adding their `size_of` again would make the figure grow faster
+    /// than the memory it describes.
+    ///
+    /// Not counted: the lazily built signing/verifying key memos. They are
+    /// fixed-size, shared behind an `Arc` between every clone of a state, and
+    /// bounded by the number of cached states the report already lists as
+    /// entries — so charging them per owner would over-count sharing to
+    /// describe a constant.
     pub fn estimated_size(&self) -> usize {
-        self.states.capacity() * size_of::<SenderKeyState>()
+        size_of::<Self>()
+            + self.states.capacity() * size_of::<SenderKeyState>()
             + self
                 .states
                 .iter()
                 .map(|s| {
-                    state_structure_retained_bytes(&s.state)
+                    state_structure_pointed_bytes(&s.state)
+                        // The `Arc` owns a `Vec` header plus its buffer.
+                        + size_of::<Vec<StoredMessageKey>>()
                         + s.message_keys.capacity() * size_of::<StoredMessageKey>()
-                        + s.sender_chain.map_or(0, |_| size_of::<SenderChainKey>())
                 })
                 .sum::<usize>()
     }
 }
 
-/// Retained bytes of one sender-key state structure, including everything it
-/// points at.
+/// Heap bytes one sender-key state structure points at, excluding the
+/// `SenderKeyStateStructure` itself — it lives inline in `SenderKeyState`.
 ///
 /// The skipped-key backlog is not walked here: this record keeps it in
 /// [`StoredMessageKey`] (36 bytes, seed inline) rather than in the protobuf's
 /// `SenderMessageKey`, and `estimated_size` counts it there.
-fn state_structure_retained_bytes(state: &SenderKeyStateStructure) -> usize {
+fn state_structure_pointed_bytes(state: &SenderKeyStateStructure) -> usize {
     fn bytes_field(field: &Option<bytes::Bytes>) -> usize {
         field.as_ref().map_or(0, |b| b.len())
     }
 
-    size_of::<SenderKeyStateStructure>()
-        + state.sender_chain_key.as_option().map_or(0, |chain| {
-            size_of::<sender_key_state_structure::SenderChainKey>() + bytes_field(&chain.seed)
-        })
-        + state.sender_signing_key.as_option().map_or(0, |signing| {
-            size_of::<sender_key_state_structure::SenderSigningKey>()
-                + bytes_field(&signing.public)
-                + bytes_field(&signing.private)
-        })
-        + state.sender_message_keys.capacity()
-            * size_of::<sender_key_state_structure::SenderMessageKey>()
+    // `MessageField` is an `Option<Box<T>>`, so a set one owns its `T`.
+    state.sender_chain_key.as_option().map_or(0, |chain| {
+        size_of::<sender_key_state_structure::SenderChainKey>() + bytes_field(&chain.seed)
+    }) + state.sender_signing_key.as_option().map_or(0, |signing| {
+        size_of::<sender_key_state_structure::SenderSigningKey>()
+            + bytes_field(&signing.public)
+            + bytes_field(&signing.private)
+    }) + state.sender_message_keys.capacity()
+        * size_of::<sender_key_state_structure::SenderMessageKey>()
         + state
             .sender_message_keys
             .iter()

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -776,9 +776,15 @@ fn vec_field_retained(field: &Option<Vec<u8>>) -> usize {
     field.as_ref().map_or(0, Vec::capacity)
 }
 
-fn chain_retained_bytes(chain: &session_structure::Chain) -> usize {
-    size_of::<session_structure::Chain>()
-        + vec_field_retained(&chain.sender_ratchet_key)
+/// Heap bytes a chain points at, **excluding the `Chain` itself**.
+///
+/// Every one of these walkers follows that rule: whoever owns the value counts
+/// its inline size once — a `Vec` element through the buffer's capacity, a
+/// `MessageField` through the `Box` it always is — and the walker adds only
+/// what hangs off it. Counting `size_of::<Chain>()` here as well is how a
+/// report starts growing faster than the memory it describes.
+fn chain_pointed_bytes(chain: &session_structure::Chain) -> usize {
+    vec_field_retained(&chain.sender_ratchet_key)
         + vec_field_retained(&chain.sender_ratchet_key_private)
         + chain.chain_key.as_option().map_or(0, |key| {
             size_of::<session_structure::chain::ChainKey>() + bytes_field_retained(&key.key)
@@ -798,35 +804,36 @@ fn chain_retained_bytes(chain: &session_structure::Chain) -> usize {
             .sum::<usize>()
 }
 
-/// Retained bytes of one session state, including everything it points at.
-fn session_retained_bytes(session: &SessionStructure) -> usize {
-    size_of::<SessionStructure>()
-        + vec_field_retained(&session.local_identity_public)
+/// Heap bytes one session state points at, excluding the `SessionStructure`
+/// itself.
+fn session_pointed_bytes(session: &SessionStructure) -> usize {
+    vec_field_retained(&session.local_identity_public)
         + vec_field_retained(&session.remote_identity_public)
         + vec_field_retained(&session.root_key)
         + vec_field_retained(&session.alice_base_key)
+        // `MessageField` is an `Option<Box<T>>`, so a set one owns a `T` on the
+        // heap; a `Vec` element does not, and is covered by the capacity term.
         + session
             .sender_chain
             .as_option()
-            .map_or(0, chain_retained_bytes)
+            .map_or(0, |chain| {
+                size_of::<session_structure::Chain>() + chain_pointed_bytes(chain)
+            })
         + session.receiver_chains.capacity() * size_of::<session_structure::Chain>()
         + session
             .receiver_chains
             .iter()
-            .map(chain_retained_bytes)
+            .map(chain_pointed_bytes)
             .sum::<usize>()
-        + session
-            .pending_key_exchange
-            .as_option()
-            .map_or(0, |pending| {
-                size_of::<session_structure::PendingKeyExchange>()
-                    + vec_field_retained(&pending.local_base_key)
-                    + vec_field_retained(&pending.local_base_key_private)
-                    + vec_field_retained(&pending.local_ratchet_key)
-                    + vec_field_retained(&pending.local_ratchet_key_private)
-                    + vec_field_retained(&pending.local_identity_key)
-                    + vec_field_retained(&pending.local_identity_key_private)
-            })
+        + session.pending_key_exchange.as_option().map_or(0, |pending| {
+            size_of::<session_structure::PendingKeyExchange>()
+                + vec_field_retained(&pending.local_base_key)
+                + vec_field_retained(&pending.local_base_key_private)
+                + vec_field_retained(&pending.local_ratchet_key)
+                + vec_field_retained(&pending.local_ratchet_key_private)
+                + vec_field_retained(&pending.local_identity_key)
+                + vec_field_retained(&pending.local_identity_key_private)
+        })
         + session.pending_pre_key.as_option().map_or(0, |pending| {
             size_of::<session_structure::PendingPreKey>()
                 + vec_field_retained(&pending.base_key)
@@ -1463,21 +1470,25 @@ impl SessionRecord {
     /// therefore reported at roughly a fifth of what it costs — the wrong
     /// direction for the one structure whose growth these reports exist to
     /// catch. Size computation only: nothing is cloned or encoded.
+    ///
+    /// Each container's inline slots are charged once, by whoever owns them;
+    /// the walkers above add only what hangs off those slots.
     pub fn estimated_size(&self) -> usize {
         let current = self
             .current_session
             .as_ref()
-            .map(|s| session_retained_bytes(&s.session))
+            .map(|s| session_pointed_bytes(&s.session))
             .unwrap_or(0);
-        // Archived states are held as their encoding, so this is what they
-        // cost — the point of keeping them that way.
-        let previous: usize = self
-            .previous_sessions
-            .iter()
-            .map(|archived| archived.as_bytes().len())
-            .sum::<usize>()
-            + self.previous_sessions.capacity() * size_of::<ArchivedSession>();
-        current + previous
+        // The `Arc` owns a `Vec` header plus its buffer; each archived state
+        // is its own boxed slice of encoded bytes.
+        let previous = size_of::<Vec<ArchivedSession>>()
+            + self.previous_sessions.capacity() * size_of::<ArchivedSession>()
+            + self
+                .previous_sessions
+                .iter()
+                .map(|archived| archived.as_bytes().len())
+                .sum::<usize>();
+        size_of::<Self>() + current + previous
     }
 
     pub fn remote_registration_id(&self) -> Result<u32, SignalProtocolError> {
@@ -1894,6 +1905,29 @@ mod tests {
         }
     }
 
+    /// Every walker charges only what hangs off a slot, and the owner charges
+    /// the slot — so adding a receiver chain must raise the figure by one
+    /// chain's worth, not two. This is the shape that made the previous
+    /// version report memory growing faster than it did.
+    #[test]
+    fn a_chain_is_charged_once_not_once_per_walker() {
+        let empty = make_cache_shape_session(1, 0, 0);
+        let mut with_one = empty.clone();
+        with_one.receiver_chains = vec![session_structure::Chain {
+            sender_ratchet_key: None,
+            sender_ratchet_key_private: None,
+            chain_key: MessageField::none(),
+            message_keys: Vec::new(),
+        }];
+
+        let delta = session_pointed_bytes(&with_one) - session_pointed_bytes(&empty);
+        assert_eq!(
+            delta,
+            with_one.receiver_chains.capacity() * size_of::<session_structure::Chain>(),
+            "a bare receiver chain costs its slot and nothing more"
+        );
+    }
+
     /// The archive is the deepest part of a record — up to
     /// `ARCHIVED_STATES_MAX_LENGTH` states, each with its own chains and
     /// skipped-key backlog — and the coldest: nothing reads one until a
@@ -1939,7 +1973,10 @@ mod tests {
             lease: CounterLease::default(),
         };
 
-        let parsed: usize = archived.iter().map(session_retained_bytes).sum();
+        let parsed: usize = archived
+            .iter()
+            .map(|session| size_of::<SessionStructure>() + session_pointed_bytes(session))
+            .sum();
         let held: usize = record
             .previous_sessions
             .iter()

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -752,7 +752,7 @@ const RESERVED_SENDER_CHAIN_INDEX_FIELD: u32 =
 #[derive(Clone)]
 pub struct SessionRecord {
     current_session: Option<SessionState>,
-    previous_sessions: Arc<Vec<SessionStructure>>,
+    previous_sessions: Arc<Vec<ArchivedSession>>,
     /// Durability lease over sender-chain counters, or the consumer's
     /// declaration that it persists before the wire and needs none. Any state
     /// entering service from a snapshot must fast-forward past a live lease
@@ -834,6 +834,90 @@ fn session_retained_bytes(session: &SessionStructure) -> usize {
         })
 }
 
+/// One archived session state, retained as the protobuf bytes it was
+/// persisted as rather than as a parsed [`SessionStructure`].
+///
+/// A record may hold up to [`consts::ARCHIVED_STATES_MAX_LENGTH`] of these,
+/// and a parsed state is far larger than its encoding: every absent `optional`
+/// field still occupies its slot, and a chain's skipped-key backlog costs a
+/// 136-byte `MessageKey` per key against ~36 bytes on the wire. They are also
+/// cold — nothing reads an archived state until a message arrives for a
+/// session that was replaced, which is the out-of-order and re-pair case, not
+/// the steady one. Keeping the bytes shrinks the resident record, makes
+/// serialization a copy instead of a re-encode, and makes loading a record
+/// stop deep-copying states it will probably never look at.
+///
+/// Load-time validation is deliberately unchanged: `deserialize` still decodes
+/// every archived state to reject a malformed record there, because deferring
+/// that rejection to a promotion would turn a quarantined row into an error
+/// that strands the address (`agent_docs/signal_durability.md`). The parsed
+/// tree is then dropped instead of retained.
+#[derive(Clone, PartialEq, Eq)]
+struct ArchivedSession(Box<[u8]>);
+
+impl ArchivedSession {
+    fn encode(session: &SessionStructure) -> Self {
+        Self(waproto::codec::session_structure_to_vec(session).into_boxed_slice())
+    }
+
+    fn decode(&self) -> Result<SessionStructure, InvalidSessionError> {
+        waproto::codec::session_structure_decode(&self.0)
+            .map_err(|_| InvalidSessionError("failed to decode archived session protobuf"))
+    }
+
+    /// Read just the two fields that identify a session, without building the
+    /// owned tree — this runs once per archived state on the promotion path.
+    fn view(&self) -> Result<waproto::whatsapp::SessionStructureView<'_>, InvalidSessionError> {
+        use buffa::view::MessageView as _;
+        waproto::whatsapp::SessionStructureView::decode_view(&self.0)
+            .map_err(|_| InvalidSessionError("failed to decode archived session protobuf"))
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// The raw bytes of each `previousSessions` element, in wire order, capped at
+/// `limit`.
+///
+/// A scan of the record's own top-level fields rather than anything the
+/// decoded view offers: `RepeatedView` hands back decoded element views, and
+/// what is wanted here is the untouched encoding of each element so a
+/// re-serialized record is byte-for-byte what was read. The record has already
+/// been decoded as a view by the caller, so malformed input is rejected there;
+/// this pass fails closed on the same shapes anyway.
+fn archived_session_slices(
+    mut bytes: &[u8],
+    limit: usize,
+) -> Result<Vec<&[u8]>, InvalidSessionError> {
+    use buffa::encoding::{Tag, WireType, decode_varint, skip_field};
+
+    const PREVIOUS_SESSIONS_FIELD: u32 = 2;
+    let err = || InvalidSessionError("failed to decode session record protobuf");
+
+    let mut out = Vec::new();
+    while !bytes.is_empty() {
+        let tag = Tag::decode(&mut bytes).map_err(|_| err())?;
+        if tag.field_number() == PREVIOUS_SESSIONS_FIELD
+            && tag.wire_type() == WireType::LengthDelimited
+        {
+            let len = usize::try_from(decode_varint(&mut bytes).map_err(|_| err())?)
+                .map_err(|_| err())?;
+            if bytes.len() < len {
+                return Err(err());
+            }
+            if out.len() < limit {
+                out.push(&bytes[..len]);
+            }
+            bytes = &bytes[len..];
+        } else {
+            skip_field(tag, &mut bytes).map_err(|_| err())?;
+        }
+    }
+    Ok(out)
+}
+
 impl SessionRecord {
     pub fn new_fresh() -> Self {
         Self {
@@ -866,7 +950,9 @@ impl SessionRecord {
             .previous_sessions
             .into_iter()
             .take(consts::ARCHIVED_STATES_MAX_LENGTH)
-            .map(session_structure_from_components)
+            .map(|components| {
+                session_structure_from_components(components).map(|s| ArchivedSession::encode(&s))
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
@@ -894,10 +980,11 @@ impl SessionRecord {
             .current_session
             .map(|state| session_components_from_structure(state.session))
             .transpose()?;
-        let previous_sessions = Arc::try_unwrap(self.previous_sessions)
-            .unwrap_or_else(|shared| shared.as_ref().clone())
-            .into_iter()
-            .map(|session| {
+        let previous_sessions = self
+            .previous_sessions
+            .iter()
+            .map(|archived| {
+                let session = archived.decode()?;
                 if reserved_sender_chain_index == 0 {
                     return session_components_from_structure(session);
                 }
@@ -951,10 +1038,16 @@ impl SessionRecord {
         if let Some(state) = self.current_session.as_mut() {
             state.fast_forward_sender_chain_or_drop(ceiling);
         }
-        for session in Arc::make_mut(&mut self.previous_sessions) {
-            let mut state = SessionState::from_session_structure(std::mem::take(session));
+        for archived in Arc::make_mut(&mut self.previous_sessions) {
+            // A corrupt archived state cannot be burned, and must not be left
+            // holding a lease the record is about to forget. Decoding fails
+            // closed here the same way promoting it would.
+            let Ok(session) = archived.decode() else {
+                continue;
+            };
+            let mut state = SessionState::from_session_structure(session);
             state.fast_forward_sender_chain_or_drop(ceiling);
-            *session = state.session;
+            *archived = ArchivedSession::encode(&state.session);
         }
         self.lease.waive();
     }
@@ -1029,14 +1122,23 @@ impl SessionRecord {
         let view = RecordStructureView::decode_view(bytes)
             .map_err(|_| InvalidSessionError("failed to decode session record protobuf"))?;
 
+        // Archived states are validated here exactly as before — the owned
+        // decode below is what rejects a malformed one, and dropping it would
+        // move that rejection to a later promotion, where an error strands the
+        // address instead of quarantining the row (see
+        // `agent_docs/signal_durability.md`). What changes is what is *kept*:
+        // their untouched encoding rather than the parsed tree, so a record
+        // holds a fraction of the bytes and re-serializes byte-for-byte.
         let limit = consts::ARCHIVED_STATES_MAX_LENGTH;
-        let previous_sessions: Vec<SessionStructure> = view
-            .previous_sessions
+        view.previous_sessions
             .iter()
             .take(limit)
-            .map(|sv| sv.to_owned_message())
-            .collect::<Result<_, _>>()
+            .try_for_each(|sv| sv.to_owned_message().map(drop))
             .map_err(|_| InvalidSessionError("failed to decode archived session protobuf"))?;
+        let previous_sessions: Vec<ArchivedSession> = archived_session_slices(bytes, limit)?
+            .into_iter()
+            .map(|raw| ArchivedSession(Box::from(raw)))
+            .collect();
 
         let local_fields = crate::protocol::local_field::decode_local_record_fields(
             bytes,
@@ -1131,11 +1233,14 @@ impl SessionRecord {
     /// The session is converted from SessionStructure to SessionState.
     pub fn take_previous_session(&mut self, index: usize) -> Option<SessionState> {
         if index < self.previous_sessions.len() {
-            Some(
-                Arc::make_mut(&mut self.previous_sessions)
-                    .remove(index)
-                    .into(),
-            )
+            let archived = Arc::make_mut(&mut self.previous_sessions).remove(index);
+            // Removed either way. A state that got past `deserialize` and
+            // still cannot be decoded is not promotable, and leaving it in
+            // place would have every later search trip over it again.
+            archived
+                .decode()
+                .ok()
+                .map(SessionState::from_session_structure)
         } else {
             None
         }
@@ -1151,11 +1256,12 @@ impl SessionRecord {
     /// the caller is expected to restore only what was taken.
     pub fn restore_previous_session(&mut self, index: usize, state: SessionState) {
         let structure: SessionStructure = state.into();
+        let archived = ArchivedSession::encode(&structure);
         let sessions = Arc::make_mut(&mut self.previous_sessions);
         if index <= sessions.len() {
-            sessions.insert(index, structure);
+            sessions.insert(index, archived);
         } else {
-            sessions.push(structure);
+            sessions.push(archived);
         }
     }
 
@@ -1164,7 +1270,7 @@ impl SessionRecord {
     ) -> impl ExactSizeIterator<Item = Result<SessionState, InvalidSessionError>> + '_ {
         self.previous_sessions
             .iter()
-            .map(|structure| Ok(structure.clone().into()))
+            .map(|archived| archived.decode().map(SessionState::from_session_structure))
     }
 
     /// Find the index of a previous session matching the given version and alice_base_key.
@@ -1177,9 +1283,11 @@ impl SessionRecord {
         version: u32,
         alice_base_key: &[u8],
     ) -> Result<Option<usize>, InvalidSessionError> {
-        for (i, session) in self.previous_sessions.iter().enumerate() {
-            // Check version directly from protobuf
-            let session_version = match session.session_version.unwrap_or(0) {
+        for (i, archived) in self.previous_sessions.iter().enumerate() {
+            // A view, not an owned decode: the search reads two scalar fields
+            // per candidate and only the winner is ever materialized.
+            let view = archived.view()?;
+            let session_version = match view.session_version.unwrap_or(0) {
                 0 => 2, // Default version
                 v => v,
             };
@@ -1188,8 +1296,7 @@ impl SessionRecord {
                 continue;
             }
 
-            // Check alice_base_key directly from protobuf
-            let session_base_key = session.alice_base_key.as_deref().unwrap_or(&[]);
+            let session_base_key = view.alice_base_key.unwrap_or(&[]);
             if alice_base_key.ct_eq(session_base_key).into() {
                 return Ok(Some(i));
             }
@@ -1239,7 +1346,7 @@ impl SessionRecord {
                 sessions.pop();
             }
             current_session.clear_unacknowledged_pre_key_message();
-            sessions.insert(0, current_session.session);
+            sessions.insert(0, ArchivedSession::encode(&current_session.session));
             true
         } else {
             false
@@ -1297,23 +1404,19 @@ impl SessionRecord {
             .map(|msg_len| 1 + varint_len(msg_len as u64) + msg_len)
             .unwrap_or(0);
 
-        // Sizing pass for the archived states. Their encoded lengths are needed
-        // twice (to reserve, then to write each length prefix), and a scratch
-        // `Vec` for them allocated on every flush. `previous_sessions` holds 0
-        // to 3 states in the common case, so the lengths land in a stack array
-        // and only a deep archive falls back to the heap.
-        const INLINE_PREVIOUS_LENS: usize = 8;
-        let mut inline_msg_lens = [0usize; INLINE_PREVIOUS_LENS];
-        let mut spilled_msg_lens: Vec<usize> = Vec::new();
-        let mut previous_len = 0usize;
-        for (i, session) in self.previous_sessions.iter().enumerate() {
-            let msg_len = session.compute_size(&mut cache) as usize;
-            previous_len += 1 + varint_len(msg_len as u64) + msg_len;
-            match inline_msg_lens.get_mut(i) {
-                Some(slot) => *slot = msg_len,
-                None => spilled_msg_lens.push(msg_len),
-            }
-        }
+        // Archived states are already encoded, so there is no sizing pass to
+        // run and no scratch array of lengths to carry: each contributes its
+        // own length, and writing it is a `extend_from_slice`. The stack array
+        // and heap spill this replaced existed only to avoid computing each
+        // length twice.
+        let previous_len: usize = self
+            .previous_sessions
+            .iter()
+            .map(|archived| {
+                let msg_len = archived.as_bytes().len();
+                1 + varint_len(msg_len as u64) + msg_len
+            })
+            .sum();
 
         let reserved = self.lease.ceiling();
         let incarnation = incarnation.filter(|_| reserved > 0);
@@ -1334,12 +1437,11 @@ impl SessionRecord {
         {
             write_len_delimited(1, &state.session, msg_len, &mut cache, buf);
         }
-        for (i, session) in self.previous_sessions.iter().enumerate() {
-            let msg_len = match inline_msg_lens.get(i) {
-                Some(msg_len) => *msg_len,
-                None => spilled_msg_lens[i - INLINE_PREVIOUS_LENS],
-            };
-            write_len_delimited(2, session, msg_len, &mut cache, buf);
+        for archived in self.previous_sessions.iter() {
+            let bytes = archived.as_bytes();
+            Tag::new(2, WireType::LengthDelimited).encode(buf);
+            encode_varint(bytes.len() as u64, buf);
+            buf.extend_from_slice(bytes);
         }
         if reserved > 0 {
             Tag::new(RESERVED_SENDER_CHAIN_INDEX_FIELD, WireType::Varint).encode(buf);
@@ -1367,12 +1469,14 @@ impl SessionRecord {
             .as_ref()
             .map(|s| session_retained_bytes(&s.session))
             .unwrap_or(0);
+        // Archived states are held as their encoding, so this is what they
+        // cost — the point of keeping them that way.
         let previous: usize = self
             .previous_sessions
             .iter()
-            .map(session_retained_bytes)
+            .map(|archived| archived.as_bytes().len())
             .sum::<usize>()
-            + self.previous_sessions.capacity() * size_of::<SessionStructure>();
+            + self.previous_sessions.capacity() * size_of::<ArchivedSession>();
         current + previous
     }
 
@@ -1787,6 +1891,79 @@ mod tests {
             sender_ratchet_key_private: Some(vec![seed.wrapping_add(1); 32]),
             chain_key: MessageField::some(chain_key),
             message_keys,
+        }
+    }
+
+    /// The archive is the deepest part of a record — up to
+    /// `ARCHIVED_STATES_MAX_LENGTH` states, each with its own chains and
+    /// skipped-key backlog — and the coldest: nothing reads one until a
+    /// message arrives for a session that was replaced. Held as bytes it
+    /// costs a fraction of the parsed tree, and the record still round-trips
+    /// byte-for-byte.
+    #[test]
+    fn archived_states_are_held_as_bytes_not_parsed_trees() {
+        // Seed-only message keys: the shape a session written by this code
+        // actually carries, and the one the parsed form is worst at — the
+        // three fields it leaves empty still occupy their `Option<Bytes>`
+        // slots in memory but cost nothing on the wire.
+        let archived: Vec<SessionStructure> = (0..8u8)
+            .map(|i| {
+                let mut session = make_cache_shape_session(i.wrapping_mul(7).wrapping_add(3), 0, 0);
+                session.receiver_chains = (0..3)
+                    .map(|c| session_structure::Chain {
+                        sender_ratchet_key: Some(vec![c as u8; 33]),
+                        sender_ratchet_key_private: Some(vec![c as u8; 32]),
+                        chain_key: MessageField::some(session_structure::chain::ChainKey {
+                            index: Some(c),
+                            key: Some(vec![c as u8; 32].into()),
+                        }),
+                        message_keys: (0..40)
+                            .map(|k| session_structure::chain::MessageKey {
+                                index: Some(k),
+                                cipher_key: None,
+                                mac_key: None,
+                                iv: None,
+                                seed: Some(vec![k as u8; 32].into()),
+                            })
+                            .collect(),
+                    })
+                    .collect();
+                session
+            })
+            .collect();
+        let record = SessionRecord {
+            current_session: Some(SessionState::from_session_structure(
+                make_cache_shape_session(1, 1, 2),
+            )),
+            previous_sessions: Arc::new(archived.iter().map(ArchivedSession::encode).collect()),
+            lease: CounterLease::default(),
+        };
+
+        let parsed: usize = archived.iter().map(session_retained_bytes).sum();
+        let held: usize = record
+            .previous_sessions
+            .iter()
+            .map(|a| a.as_bytes().len())
+            .sum();
+        assert!(
+            held * 3 < parsed,
+            "the archive should cost a fraction of its parsed form: {held} B held vs \
+             {parsed} B parsed"
+        );
+
+        // Nothing is lost: the record still serializes to the same bytes and
+        // every archived state still decodes to what went in.
+        let round_tripped = SessionRecord::deserialize(&record.serialize().expect("serialize"))
+            .expect("deserialize");
+        assert_eq!(round_tripped.previous_session_count(), archived.len());
+        for (i, original) in archived.iter().enumerate() {
+            assert_eq!(
+                &round_tripped.previous_sessions[i]
+                    .decode()
+                    .expect("archived state decodes"),
+                original,
+                "archived state {i} changed across the round trip"
+            );
         }
     }
 
@@ -2238,7 +2415,11 @@ mod tests {
             current_session: MessageField::some(
                 record.current_session.as_ref().unwrap().session.clone(),
             ),
-            previous_sessions: record.previous_sessions.as_ref().clone(),
+            previous_sessions: record
+                .previous_sessions
+                .iter()
+                .map(|archived| archived.decode().expect("archived state decodes"))
+                .collect(),
         }
         .encode_to_vec();
 
@@ -2259,7 +2440,12 @@ mod tests {
         ];
         let record = SessionRecord {
             current_session: Some(SessionState::from_session_structure(current.clone())),
-            previous_sessions: Arc::new(previous_sessions.clone()),
+            previous_sessions: Arc::new(
+                previous_sessions
+                    .iter()
+                    .map(ArchivedSession::encode)
+                    .collect(),
+            ),
             lease: CounterLease::default(),
         };
         let expected = waproto::whatsapp::RecordStructure {
@@ -2303,7 +2489,12 @@ mod tests {
 
         let record = SessionRecord {
             current_session: Some(SessionState::from_session_structure(current.clone())),
-            previous_sessions: Arc::new(previous_sessions.clone()),
+            previous_sessions: Arc::new(
+                previous_sessions
+                    .iter()
+                    .map(ArchivedSession::encode)
+                    .collect(),
+            ),
             lease: CounterLease::default(),
         };
         let expected = waproto::whatsapp::RecordStructure {
@@ -2329,7 +2520,8 @@ mod tests {
         for _ in 0..(consts::ARCHIVED_STATES_MAX_LENGTH + 10) {
             let key = KeyPair::generate(&mut rng()).public_key;
             let state = create_test_session_state(3, &key);
-            Arc::make_mut(&mut record.previous_sessions).push(state.session);
+            Arc::make_mut(&mut record.previous_sessions)
+                .push(ArchivedSession::encode(&state.session));
         }
 
         // Serialize

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -762,6 +762,78 @@ pub struct SessionRecord {
     lease: CounterLease,
 }
 
+/// Bytes one `Bytes` field holds beyond its inline representation.
+///
+/// `Bytes` may point into a shared buffer, in which case the slice is counted
+/// against whichever field names it. That over-counts a session decoded from
+/// one contiguous blob and under-counts nothing, which is the safe direction
+/// for a report that exists to catch growth.
+fn bytes_field_retained(field: &Option<bytes::Bytes>) -> usize {
+    field.as_ref().map_or(0, |b| b.len())
+}
+
+fn vec_field_retained(field: &Option<Vec<u8>>) -> usize {
+    field.as_ref().map_or(0, Vec::capacity)
+}
+
+fn chain_retained_bytes(chain: &session_structure::Chain) -> usize {
+    size_of::<session_structure::Chain>()
+        + vec_field_retained(&chain.sender_ratchet_key)
+        + vec_field_retained(&chain.sender_ratchet_key_private)
+        + chain.chain_key.as_option().map_or(0, |key| {
+            size_of::<session_structure::chain::ChainKey>() + bytes_field_retained(&key.key)
+        })
+        // The skipped-key backlog: capacity, not length, because the `Vec`
+        // keeps its allocation when keys are consumed or pruned.
+        + chain.message_keys.capacity() * size_of::<session_structure::chain::MessageKey>()
+        + chain
+            .message_keys
+            .iter()
+            .map(|key| {
+                bytes_field_retained(&key.cipher_key)
+                    + bytes_field_retained(&key.mac_key)
+                    + bytes_field_retained(&key.iv)
+                    + bytes_field_retained(&key.seed)
+            })
+            .sum::<usize>()
+}
+
+/// Retained bytes of one session state, including everything it points at.
+fn session_retained_bytes(session: &SessionStructure) -> usize {
+    size_of::<SessionStructure>()
+        + vec_field_retained(&session.local_identity_public)
+        + vec_field_retained(&session.remote_identity_public)
+        + vec_field_retained(&session.root_key)
+        + vec_field_retained(&session.alice_base_key)
+        + session
+            .sender_chain
+            .as_option()
+            .map_or(0, chain_retained_bytes)
+        + session.receiver_chains.capacity() * size_of::<session_structure::Chain>()
+        + session
+            .receiver_chains
+            .iter()
+            .map(chain_retained_bytes)
+            .sum::<usize>()
+        + session
+            .pending_key_exchange
+            .as_option()
+            .map_or(0, |pending| {
+                size_of::<session_structure::PendingKeyExchange>()
+                    + vec_field_retained(&pending.local_base_key)
+                    + vec_field_retained(&pending.local_base_key_private)
+                    + vec_field_retained(&pending.local_ratchet_key)
+                    + vec_field_retained(&pending.local_ratchet_key_private)
+                    + vec_field_retained(&pending.local_identity_key)
+                    + vec_field_retained(&pending.local_identity_key_private)
+            })
+        + session.pending_pre_key.as_option().map_or(0, |pending| {
+            size_of::<session_structure::PendingPreKey>()
+                + vec_field_retained(&pending.base_key)
+                + vec_field_retained(&pending.kyber_ciphertext)
+        })
+}
+
 impl SessionRecord {
     pub fn new_fresh() -> Self {
         Self {
@@ -1278,21 +1350,29 @@ impl SessionRecord {
         }
     }
 
-    /// Estimated in-memory footprint proxy: the protobuf-encoded size of the
-    /// current plus archived states. Size computation only — no encode buffer
-    /// is allocated. Used by per-session memory reports.
+    /// Retained in-memory bytes of the current plus archived states.
+    ///
+    /// Walks the live structures rather than asking for their protobuf-encoded
+    /// size, which is what this used to report. The two are far apart: a
+    /// skipped message key is 36 bytes on the wire but a 136-byte
+    /// `MessageKey` plus a 32-byte `Bytes` allocation in memory, because the
+    /// three fields a modern seed-only key leaves empty still occupy their
+    /// `Option<Bytes>` slots. A session with a backlog of skipped keys was
+    /// therefore reported at roughly a fifth of what it costs — the wrong
+    /// direction for the one structure whose growth these reports exist to
+    /// catch. Size computation only: nothing is cloned or encoded.
     pub fn estimated_size(&self) -> usize {
-        let mut cache = buffa::SizeCache::new();
         let current = self
             .current_session
             .as_ref()
-            .map(|s| s.session.compute_size(&mut cache) as usize)
+            .map(|s| session_retained_bytes(&s.session))
             .unwrap_or(0);
         let previous: usize = self
             .previous_sessions
             .iter()
-            .map(|s| s.compute_size(&mut cache) as usize)
-            .sum();
+            .map(session_retained_bytes)
+            .sum::<usize>()
+            + self.previous_sessions.capacity() * size_of::<SessionStructure>();
         current + previous
     }
 
@@ -1708,6 +1788,60 @@ mod tests {
             chain_key: MessageField::some(chain_key),
             message_keys,
         }
+    }
+
+    /// What these reports exist to catch is a receiver chain accumulating
+    /// skipped message keys — up to `MAX_MESSAGE_KEYS` of them per chain. That
+    /// only works if the figure is memory, not wire bytes: a modern seed-only
+    /// key is ~36 bytes encoded and 136 bytes of `MessageKey` plus a 32-byte
+    /// `Bytes` allocation in memory, because the three fields it leaves empty
+    /// still occupy their `Option<Bytes>` slots.
+    #[test]
+    fn skipped_message_keys_are_reported_at_their_in_memory_cost() {
+        const KEYS: usize = 500;
+
+        let message_keys: Vec<session_structure::chain::MessageKey> = (0..KEYS)
+            .map(|index| session_structure::chain::MessageKey {
+                index: Some(index as u32),
+                cipher_key: None,
+                mac_key: None,
+                iv: None,
+                seed: Some(vec![7u8; 32].into()),
+            })
+            .collect();
+        let chain = session_structure::Chain {
+            sender_ratchet_key: Some(vec![1u8; 33]),
+            sender_ratchet_key_private: Some(vec![2u8; 32]),
+            chain_key: MessageField::some(session_structure::chain::ChainKey {
+                index: Some(0),
+                key: Some(vec![3u8; 32].into()),
+            }),
+            message_keys,
+        };
+        let mut session = make_cache_shape_session(1, 0, 0);
+        session.receiver_chains = vec![chain];
+
+        let record = SessionRecord {
+            current_session: Some(SessionState::from_session_structure(session.clone())),
+            previous_sessions: Arc::new(Vec::new()),
+            lease: CounterLease::default(),
+        };
+
+        let reported = record.estimated_size();
+        let backlog = KEYS * size_of::<session_structure::chain::MessageKey>();
+        assert!(
+            reported >= backlog,
+            "a {KEYS}-key backlog occupies at least {backlog} B; reported {reported} B"
+        );
+
+        // And the figure this replaced: the encoded size, which is what the
+        // report used to hand back for the very same record.
+        let encoded = session.encode_to_vec().len();
+        assert!(
+            reported > encoded * 3,
+            "the in-memory figure ({reported} B) must be far above the encoded \
+             one ({encoded} B) for a seed-only backlog"
+        );
     }
 
     fn make_cache_shape_session(

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -862,13 +862,35 @@ fn session_pointed_bytes(session: &SessionStructure) -> usize {
 #[derive(Clone, PartialEq, Eq)]
 struct ArchivedSession(Box<[u8]>);
 
+/// Append `msg`'s encoding to `out`.
+///
+/// Direct buffa calls, on the same grounds as `serialize_into_inner` below:
+/// the session storage protos are encoded only inside this file, so this
+/// duplicates nothing — `serialize_into_inner` already instantiates
+/// `SessionStructure`'s encode tree here. A `waproto::codec` pin would add a
+/// second copy of that tree to `waproto`, which is the cost the rule exists to
+/// avoid, not to incur.
+#[allow(clippy::disallowed_methods)]
+fn encode_message(msg: &impl Message, out: &mut Vec<u8>) {
+    let mut cache = buffa::SizeCache::new();
+    let len = msg.compute_size(&mut cache) as usize;
+    out.reserve(len);
+    msg.write_to(&mut cache, out);
+}
+
 impl ArchivedSession {
     fn encode(session: &SessionStructure) -> Self {
-        Self(waproto::codec::session_structure_to_vec(session).into_boxed_slice())
+        let mut buf = Vec::new();
+        encode_message(session, &mut buf);
+        Self(buf.into_boxed_slice())
     }
 
+    /// Decode through the view, which `deserialize` already instantiates for
+    /// every archived state — an owned `Message::decode` would be a second
+    /// decode tree for the same type.
     fn decode(&self) -> Result<SessionStructure, InvalidSessionError> {
-        waproto::codec::session_structure_decode(&self.0)
+        self.view()?
+            .to_owned_message()
             .map_err(|_| InvalidSessionError("failed to decode archived session protobuf"))
     }
 

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -195,7 +195,7 @@ pub fn retain_devices_by_key_index(devices: &mut Vec<DeviceInfo>, decoded: &Deco
 }
 
 fn should_retain_device(device: &DeviceInfo, decoded: &DecodedKeyIndex) -> bool {
-    device.device_id == 0 || is_key_index_valid(device.key_index, decoded)
+    device.device_id() == 0 || is_key_index_valid(device.key_index(), decoded)
 }
 
 /// Check if a key_index is accepted by the decoded ADV list.
@@ -216,7 +216,7 @@ mod tests {
     use super::*;
     use buffa::Message;
 
-    fn dev(id: u32, key_index: Option<u32>) -> DeviceInfo {
+    fn dev(id: u16, key_index: Option<u32>) -> DeviceInfo {
         DeviceInfo::new(id, key_index)
     }
 
@@ -231,7 +231,7 @@ mod tests {
         };
         let result = filter_devices_by_key_index(&devices, &decoded);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].device_id, 0);
+        assert_eq!(result[0].device_id(), 0);
     }
 
     #[test]
@@ -245,9 +245,9 @@ mod tests {
         };
         let result = filter_devices_by_key_index(&devices, &decoded);
         assert_eq!(result.len(), 2); // device 0 + device 12
-        assert!(result.iter().any(|d| d.device_id == 0));
-        assert!(result.iter().any(|d| d.device_id == 12));
-        assert!(!result.iter().any(|d| d.device_id == 11));
+        assert!(result.iter().any(|d| d.device_id() == 0));
+        assert!(result.iter().any(|d| d.device_id() == 12));
+        assert!(!result.iter().any(|d| d.device_id() == 11));
     }
 
     #[test]
@@ -275,7 +275,7 @@ mod tests {
         };
         let result = filter_devices_by_key_index(&devices, &decoded);
         assert_eq!(result.len(), 1); // only primary device kept
-        assert_eq!(result[0].device_id, 0);
+        assert_eq!(result[0].device_id(), 0);
     }
 
     #[test]

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -6,13 +6,50 @@ use std::sync::Arc;
 use wacore_binary::CompactString;
 use wacore_binary::Jid;
 
-fn build_pn_to_lid_map(
-    lid_to_pn_map: &HashMap<CompactString, Jid>,
-) -> HashMap<CompactString, CompactString> {
-    lid_to_pn_map
-        .iter()
-        .map(|(lid_user, phone_jid)| (phone_jid.user.clone(), lid_user.clone()))
-        .collect()
+/// One LID→PN mapping. Kept as `(lid, phone jid)` rather than `(lid, phone
+/// user + server)` because `Jid` is 32 bytes and a `CompactString` plus a
+/// `Server` pads to the same 32: storing the whole JID costs nothing and lets
+/// [`GroupInfo::phone_jid_for_lid_user`] keep handing out a borrow. The server
+/// is not assumed to be `Pn` — a malformed response can map a LID to another
+/// LID, and callers such as `collect_stale_device_users` check for that.
+type LidPnPair = (CompactString, Jid);
+
+/// Order `lid_pn` by the PN user part, returning indices into it.
+///
+/// Duplicate PN users (two LIDs claiming one phone number) resolve to the
+/// last entry in LID order. The `HashMap` this replaced resolved them by
+/// iteration order, i.e. arbitrarily; any deterministic rule is an
+/// improvement, and this one is stable across rebuilds.
+fn build_pn_order(lid_pn: &[LidPnPair]) -> Box<[u32]> {
+    let mut order: Vec<u32> = (0..lid_pn.len() as u32).collect();
+    order.sort_unstable_by(|a, b| {
+        let (a, b) = (*a as usize, *b as usize);
+        lid_pn[a]
+            .1
+            .user
+            .cmp(&lid_pn[b].1.user)
+            .then_with(|| lid_pn[a].0.cmp(&lid_pn[b].0))
+    });
+    order.into_boxed_slice()
+}
+
+/// Sort by LID user and drop the `HashMap`'s excess capacity in one step.
+fn build_lid_pn(map: HashMap<CompactString, Jid>) -> Box<[LidPnPair]> {
+    let mut pairs: Vec<LidPnPair> = map.into_iter().collect();
+    pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    pairs.into_boxed_slice()
+}
+
+fn serialize_lid_pn<S: serde::Serializer>(
+    lid_pn: &[LidPnPair],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeMap;
+    let mut map = serializer.serialize_map(Some(lid_pn.len()))?;
+    for (lid_user, phone_jid) in lid_pn.iter() {
+        map.serialize_entry(lid_user, phone_jid)?;
+    }
+    map.end()
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -25,16 +62,24 @@ pub struct GroupInfo {
     /// predates the field, so the answer is unknown and callers must re-query.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_community_announce: Option<bool>,
-    /// Maps a LID user identifier (the `user` part of the LID JID) to the
-    /// corresponding phone-number JID. This is used for device queries since
-    /// LID usync requests may not work reliably.
-    lid_to_pn_map: HashMap<CompactString, Jid>,
-    /// Reverse index: phone user → LID user. Derived from `lid_to_pn_map`
-    /// (the LID jid is reconstructed on demand), so it is neither persisted
-    /// nor stores Jids — for a large LID group that halves the map bytes in
-    /// memory and in the serialized `group_metadata` blob.
+    /// LID→PN mappings, sorted by the LID user part, looked up by binary
+    /// search. Used for device queries, since LID usync requests may not work
+    /// reliably.
+    ///
+    /// A sorted slice rather than a `HashMap`: a 1024-member group needs 2048
+    /// hashbrown buckets, so roughly half the map's bytes were empty slots,
+    /// and the entries are read far more often than they are written (member
+    /// changes arrive on notifications; lookups run once per participant per
+    /// send). Serialized as the `lid_to_pn_map` object the previous layout
+    /// wrote, so the persisted `group_metadata` blob is unchanged.
+    #[serde(rename = "lid_to_pn_map", serialize_with = "serialize_lid_pn")]
+    lid_pn: Box<[LidPnPair]>,
+    /// Reverse index: indices into `lid_pn` ordered by the PN user part.
+    ///
+    /// Derived, so it is not persisted. Four bytes per mapping instead of the
+    /// 48 the reverse `HashMap` spent re-storing both identifier strings.
     #[serde(skip)]
-    pn_to_lid_map: HashMap<CompactString, CompactString>,
+    pn_order: Box<[u32]>,
 }
 
 /// Deserialization shadow: rebuilds the derived reverse index. Old blobs
@@ -69,8 +114,8 @@ impl GroupInfo {
             participants,
             addressing_mode,
             is_community_announce: None,
-            lid_to_pn_map: HashMap::new(),
-            pn_to_lid_map: HashMap::new(),
+            lid_pn: Box::default(),
+            pn_order: Box::default(),
         }
     }
 
@@ -80,52 +125,86 @@ impl GroupInfo {
         addressing_mode: AddressingMode,
         lid_to_pn_map: HashMap<CompactString, Jid>,
     ) -> Self {
-        let pn_to_lid_map = build_pn_to_lid_map(&lid_to_pn_map);
+        let lid_pn = build_lid_pn(lid_to_pn_map);
+        let pn_order = build_pn_order(&lid_pn);
 
         Self {
             participants,
             addressing_mode,
             is_community_announce: None,
-            lid_to_pn_map,
-            pn_to_lid_map,
+            lid_pn,
+            pn_order,
         }
     }
 
     /// Replace the current LID-to-phone mapping.
     pub fn set_lid_to_pn_map(&mut self, lid_to_pn_map: HashMap<CompactString, Jid>) {
-        self.pn_to_lid_map = build_pn_to_lid_map(&lid_to_pn_map);
-        self.lid_to_pn_map = lid_to_pn_map;
+        self.lid_pn = build_lid_pn(lid_to_pn_map);
+        self.pn_order = build_pn_order(&self.lid_pn);
+    }
+
+    /// Rebuild both slices from an edited pair list. The reverse index is
+    /// derived, so every write goes through here and no caller can leave the
+    /// two out of step.
+    fn store_pairs(&mut self, mut pairs: Vec<LidPnPair>) {
+        pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        self.lid_pn = pairs.into_boxed_slice();
+        self.pn_order = build_pn_order(&self.lid_pn);
+    }
+
+    /// Position of `lid_user` in the LID-sorted pair list.
+    fn lid_index(&self, lid_user: &str) -> Option<usize> {
+        self.lid_pn
+            .binary_search_by(|(lid, _)| lid.as_str().cmp(lid_user))
+            .ok()
+    }
+
+    /// Position in `lid_pn` of the mapping whose phone user is `phone_user`,
+    /// found through the reverse index.
+    fn pn_index(&self, phone_user: &str) -> Option<usize> {
+        self.pn_order
+            .binary_search_by(|slot| self.lid_pn[*slot as usize].1.user.as_str().cmp(phone_user))
+            .ok()
+            .map(|slot| self.pn_order[slot] as usize)
     }
 
     /// Look up the mapped phone-number JID for a given LID user identifier.
     pub fn phone_jid_for_lid_user(&self, lid_user: &str) -> Option<&Jid> {
-        self.lid_to_pn_map.get(lid_user)
+        self.lid_index(lid_user).map(|i| &self.lid_pn[i].1)
     }
 
     /// Look up the mapped LID user for a given phone number (user part).
     pub fn lid_user_for_phone_user(&self, phone_user: &str) -> Option<&CompactString> {
-        self.pn_to_lid_map.get(phone_user)
+        self.pn_index(phone_user).map(|i| &self.lid_pn[i].0)
     }
 
     /// Append participants that are not already present.
     ///
-    /// For LID-addressed groups, also updates the LID-to-PN and PN-to-LID maps
-    /// using the `phone_number` field from each participant.  Maps are updated
-    /// even for already-present participants so that a later call with
+    /// For LID-addressed groups, also updates the LID→PN mappings using the
+    /// `phone_number` field from each participant. Mappings are updated even
+    /// for already-present participants so that a later call with
     /// `Some(phone_number)` backfills a previous `None` entry.
     pub fn add_participants<'a, I>(&mut self, new: I)
     where
         I: IntoIterator<Item = (&'a Jid, Option<&'a Jid>)>,
     {
+        // The pair list is rebuilt once for the whole batch, not once per
+        // added member: sorting a 1024-entry slice per notification is
+        // cheaper than the n insertions it replaces, and a notification that
+        // maps nobody (the common PN-group case) never touches it at all.
+        let mut pairs: Option<Vec<LidPnPair>> = None;
         for (jid, phone_number) in new {
-            // Always backfill LID maps — a re-add with phone_number fills a
-            // previous None (e.g., client-initiated add followed by server
-            // notification that carries the phone number).
+            // Always backfill the LID mapping — a re-add with phone_number
+            // fills a previous None (e.g., client-initiated add followed by
+            // server notification that carries the phone number).
             if self.addressing_mode == AddressingMode::Lid
                 && let Some(pn) = phone_number
             {
-                self.pn_to_lid_map.insert(pn.user.clone(), jid.user.clone());
-                self.lid_to_pn_map.insert(jid.user.clone(), pn.clone());
+                let pairs = pairs.get_or_insert_with(|| self.lid_pn.to_vec());
+                match pairs.iter_mut().find(|(lid, _)| *lid == jid.user) {
+                    Some((_, mapped)) => *mapped = pn.clone(),
+                    None => pairs.push((jid.user.clone(), pn.clone())),
+                }
             }
 
             if self.participants.iter().any(|p| p.user == jid.user) {
@@ -133,22 +212,33 @@ impl GroupInfo {
             }
             self.participants.push(jid.clone());
         }
+        if let Some(pairs) = pairs {
+            self.store_pairs(pairs);
+        }
     }
 
     /// Remove participants whose user part is in `users_to_remove`.
     ///
-    /// Also cleans up the LID-to-PN and PN-to-LID maps.
+    /// Also drops the LID→PN mappings naming them, on either side.
     pub fn remove_participants(&mut self, users_to_remove: &[&str]) {
         self.participants
             .retain(|p| !users_to_remove.iter().any(|u| *u == p.user));
+        // Each name can be either side of a mapping, so both directions are
+        // resolved against the *current* slices before anything is dropped,
+        // then the survivors are rebuilt in one pass.
+        let mut drop_indices: Vec<usize> = Vec::new();
         for user in users_to_remove {
-            if let Some(pn_jid) = self.lid_to_pn_map.remove(*user) {
-                self.pn_to_lid_map.remove(&pn_jid.user);
+            drop_indices.extend(self.lid_index(user));
+            drop_indices.extend(self.pn_index(user));
+        }
+        if !drop_indices.is_empty() {
+            drop_indices.sort_unstable();
+            drop_indices.dedup();
+            let mut pairs = self.lid_pn.to_vec();
+            for index in drop_indices.into_iter().rev() {
+                pairs.remove(index);
             }
-            // Also try reverse: user might be a PN
-            if let Some(lid_user) = self.pn_to_lid_map.remove(*user) {
-                self.lid_to_pn_map.remove(&lid_user);
-            }
+            self.store_pairs(pairs);
         }
     }
 
@@ -172,19 +262,14 @@ impl crate::stats::HeapSize for GroupInfo {
                 .iter()
                 .map(|j| j.heap_bytes())
                 .sum::<usize>();
-        let lid_to_pn = self.lid_to_pn_map.capacity() * size_of::<(CompactString, Jid)>()
+        let lid_pn = self.lid_pn.len() * size_of::<LidPnPair>()
             + self
-                .lid_to_pn_map
+                .lid_pn
                 .iter()
                 .map(|(k, v)| k.heap_bytes() + v.heap_bytes())
                 .sum::<usize>();
-        let pn_to_lid = self.pn_to_lid_map.capacity() * size_of::<(CompactString, CompactString)>()
-            + self
-                .pn_to_lid_map
-                .iter()
-                .map(|(k, v)| k.heap_bytes() + v.heap_bytes())
-                .sum::<usize>();
-        participants + lid_to_pn + pn_to_lid
+        let pn_order = self.pn_order.len() * size_of::<u32>();
+        participants + lid_pn + pn_order
     }
 }
 
@@ -424,6 +509,145 @@ mod tests {
                 .phone_jid_for_lid_user("lid_bob")
                 .map(|j| j.user.as_str()),
             Some("bob_pn")
+        );
+    }
+
+    /// The sorted slices replace two `HashMap`s, so every edit path has to
+    /// leave both of them ordered and in step. This drives adds and removes
+    /// against a `HashMap` oracle and checks the invariants after each step.
+    #[test]
+    fn pair_slices_stay_consistent_with_a_map_oracle() {
+        let mut info = GroupInfo::new(Vec::new(), AddressingMode::Lid);
+        let mut oracle: HashMap<CompactString, Jid> = HashMap::new();
+
+        // A deterministic walk that mixes fresh adds, re-adds that remap an
+        // existing LID, removals by the LID side and removals by the PN side.
+        for round in 0..40u32 {
+            let lid_user = CompactString::from(format!("lid_{}", round % 13));
+            let pn_user = CompactString::from(format!("pn_{}", round % 7));
+            let lid_jid = Jid::lid(lid_user.clone());
+            let pn_jid = Jid::pn(pn_user.clone());
+
+            if round % 5 == 4 {
+                let victim = format!("lid_{}", round % 11);
+                info.remove_participants(&[victim.as_str()]);
+                if let Some(pn) = oracle.remove(victim.as_str()) {
+                    let _ = pn;
+                }
+                oracle.retain(|_, mapped| mapped.user != victim.as_str());
+            } else if round % 7 == 6 {
+                let victim = format!("pn_{}", round % 7);
+                info.remove_participants(&[victim.as_str()]);
+                oracle.retain(|lid, mapped| {
+                    lid.as_str() != victim.as_str() && mapped.user != victim.as_str()
+                });
+            } else {
+                info.add_participants([(&lid_jid, Some(&pn_jid))]);
+                oracle.insert(lid_user.clone(), pn_jid.clone());
+            }
+
+            assert!(
+                info.lid_pn.windows(2).all(|w| w[0].0 < w[1].0),
+                "lid_pn must stay sorted and unique by LID: {:?}",
+                info.lid_pn
+                    .iter()
+                    .map(|(l, _)| l.as_str())
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(info.pn_order.len(), info.lid_pn.len());
+            assert!(
+                info.pn_order
+                    .windows(2)
+                    .all(|w| info.lid_pn[w[0] as usize].1.user
+                        <= info.lid_pn[w[1] as usize].1.user),
+                "pn_order must stay ordered by the PN user"
+            );
+
+            assert_eq!(
+                info.lid_pn.len(),
+                oracle.len(),
+                "round {round}: entry count diverged from the oracle"
+            );
+            for (lid_user, phone_jid) in &oracle {
+                assert_eq!(
+                    info.phone_jid_for_lid_user(lid_user),
+                    Some(phone_jid),
+                    "round {round}: forward lookup diverged for {lid_user}"
+                );
+                // The reverse direction only promises *a* LID for a phone
+                // number; two LIDs claiming one PN is a server bug, not a
+                // shape this has to preserve. What it must never do is
+                // answer with a LID that is not mapped to that PN.
+                let reverse = info
+                    .lid_user_for_phone_user(&phone_jid.user)
+                    .expect("reverse lookup must find some LID");
+                assert_eq!(
+                    oracle.get(reverse).map(|j| &j.user),
+                    Some(&phone_jid.user),
+                    "round {round}: reverse lookup pointed at an unmapped LID"
+                );
+            }
+        }
+    }
+
+    /// `remove_participants` takes user parts without saying which namespace
+    /// they are in, so naming the phone side has to drop the mapping too.
+    #[test]
+    fn remove_by_phone_side_drops_the_mapping() {
+        let lid_to_pn = HashMap::from([(CompactString::from("lid_bob"), pn("bob_pn"))]);
+        let mut info =
+            GroupInfo::with_lid_to_pn_map(vec![lid("lid_bob")], AddressingMode::Lid, lid_to_pn);
+
+        info.remove_participants(&["bob_pn"]);
+
+        assert!(info.phone_jid_for_lid_user("lid_bob").is_none());
+        assert!(info.lid_user_for_phone_user("bob_pn").is_none());
+    }
+
+    /// A malformed response can map a LID to something that is not a phone
+    /// number. The pair keeps the whole JID rather than a user part plus an
+    /// assumed `Pn` server, so callers can still see what it really was.
+    #[test]
+    fn a_non_pn_mapping_survives_the_round_trip() {
+        let lid_to_pn = HashMap::from([(
+            CompactString::from("100000000000007"),
+            Jid::lid("100000000000099"),
+        )]);
+        let info = GroupInfo::with_lid_to_pn_map(Vec::new(), AddressingMode::Lid, lid_to_pn);
+
+        let mapped = info
+            .phone_jid_for_lid_user("100000000000007")
+            .expect("mapping present");
+        assert!(!mapped.is_pn());
+        assert_eq!(mapped.user.as_str(), "100000000000099");
+    }
+
+    /// The layout exists to bound what a resident group snapshot costs, so the
+    /// bound is asserted rather than left to a comment. A 1024-member LID
+    /// group holds, per participant: a 32-byte `Jid`, a 56-byte
+    /// `(CompactString, Jid)` pair and a 4-byte reverse index — 92 bytes, with
+    /// every identifier short enough to live inline in its `CompactString`.
+    /// The two `HashMap`s this replaced needed 2048 buckets for the same 1024
+    /// entries and spent 212 bytes per participant.
+    #[test]
+    fn retained_bytes_per_participant_stay_bounded() {
+        use crate::stats::HeapSize;
+
+        const N: usize = 1024;
+        let mut participants = Vec::with_capacity(N);
+        let mut lid_to_pn = HashMap::with_capacity(N);
+        for i in 0..N {
+            let lid_user = CompactString::from(format!("1000000{i:08}"));
+            let pn_user = CompactString::from(format!("5511{i:09}"));
+            participants.push(Jid::lid(lid_user.clone()));
+            lid_to_pn.insert(lid_user, Jid::pn(pn_user));
+        }
+        let info = GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn);
+
+        let per_participant = (size_of::<GroupInfo>() + info.heap_bytes()) / N;
+        assert!(
+            per_participant <= 92,
+            "a resident LID group must stay within 92 B/participant, got {per_participant}"
         );
     }
 }

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -49,10 +49,14 @@ fn ordered_indices(pairs: &[LidPnPair], by: OrderBy) -> Vec<u32> {
 /// order is computed over indices and applied here.
 fn sort_pairs(pairs: Vec<LidPnPair>) -> Box<[LidPnPair]> {
     let order = ordered_indices(&pairs, OrderBy::Lid);
-    let mut slots: Vec<Option<LidPnPair>> = pairs.into_iter().map(Some).collect();
+    // `mem::take` rather than wrapping each slot in an `Option`: a pair is
+    // `Default`, every index appears exactly once, and the alternative asks
+    // the binary to carry a second set of `Vec` codegen for
+    // `Option<LidPnPair>` to say the same thing.
+    let mut slots = pairs;
     order
         .into_iter()
-        .map(|i| slots[i as usize].take().expect("each index appears once"))
+        .map(|i| std::mem::take(&mut slots[i as usize]))
         .collect()
 }
 

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -14,30 +14,74 @@ use wacore_binary::Jid;
 /// LID, and callers such as `collect_stale_device_users` check for that.
 type LidPnPair = (CompactString, Jid);
 
+/// Which side of a pair an ordering keys on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OrderBy {
+    Lid,
+    Phone,
+}
+
+/// Indices `0..pairs.len()` ordered by one side of the pairs.
+///
+/// Both orderings go through this one function, and it sorts `u32` indices
+/// rather than the pairs themselves, so the binary carries a **single**
+/// `sort_unstable_by` instantiation for the whole module. That matters more
+/// than it looks: pdqsort monomorphizes per (element type, comparator type)
+/// and costs roughly 10 KiB of `.text` a copy, so the obvious spelling — a
+/// closure at each of the four call sites that needed an order — put ~40 KiB
+/// into the binary for ~40 lines of logic. The `by` branch inside the
+/// comparator is the price, paid on the build path only.
+fn ordered_indices(pairs: &[LidPnPair], by: OrderBy) -> Vec<u32> {
+    let mut order: Vec<u32> = (0..pairs.len() as u32).collect();
+    order.sort_unstable_by(|a, b| {
+        let (a, b) = (&pairs[*a as usize], &pairs[*b as usize]);
+        match by {
+            OrderBy::Lid => a.0.cmp(&b.0),
+            OrderBy::Phone => a.1.user.cmp(&b.1.user).then_with(|| a.0.cmp(&b.0)),
+        }
+    });
+    order
+}
+
+/// Put a pair list in LID order.
+///
+/// Permutes rather than sorts, for the reason in [`ordered_indices`]: the
+/// order is computed over indices and applied here.
+fn sort_pairs(pairs: Vec<LidPnPair>) -> Box<[LidPnPair]> {
+    let order = ordered_indices(&pairs, OrderBy::Lid);
+    let mut slots: Vec<Option<LidPnPair>> = pairs.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|i| slots[i as usize].take().expect("each index appears once"))
+        .collect()
+}
+
 /// Order `lid_pn` by the PN user part, returning indices into it.
 ///
-/// Duplicate PN users (two LIDs claiming one phone number) resolve to the
-/// last entry in LID order. The `HashMap` this replaced resolved them by
-/// iteration order, i.e. arbitrarily; any deterministic rule is an
-/// improvement, and this one is stable across rebuilds.
+/// **One slot per phone user.** The reverse `HashMap` this replaced was keyed
+/// by phone user and so could hold only one LID per number; keeping every
+/// duplicate here would answer reverse lookups differently from the map and
+/// make `remove_participants` drop mappings it used to leave alone. Two LIDs
+/// claiming one phone number is a server bug either way; the map resolved it
+/// by iteration order, i.e. arbitrarily, and this resolves it to the last LID
+/// in sort order — deterministic, and stable across rebuilds.
 fn build_pn_order(lid_pn: &[LidPnPair]) -> Box<[u32]> {
-    let mut order: Vec<u32> = (0..lid_pn.len() as u32).collect();
-    order.sort_unstable_by(|a, b| {
-        let (a, b) = (*a as usize, *b as usize);
-        lid_pn[a]
-            .1
-            .user
-            .cmp(&lid_pn[b].1.user)
-            .then_with(|| lid_pn[a].0.cmp(&lid_pn[b].0))
+    let mut order = ordered_indices(lid_pn, OrderBy::Phone);
+    // `dedup_by` keeps the first of each run; the winner is the last, so the
+    // comparison hands the later index to the entry that survives.
+    order.dedup_by(|later, earlier| {
+        let same = lid_pn[*later as usize].1.user == lid_pn[*earlier as usize].1.user;
+        if same {
+            *earlier = *later;
+        }
+        same
     });
     order.into_boxed_slice()
 }
 
 /// Sort by LID user and drop the `HashMap`'s excess capacity in one step.
 fn build_lid_pn(map: HashMap<CompactString, Jid>) -> Box<[LidPnPair]> {
-    let mut pairs: Vec<LidPnPair> = map.into_iter().collect();
-    pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-    pairs.into_boxed_slice()
+    sort_pairs(map.into_iter().collect())
 }
 
 fn serialize_lid_pn<S: serde::Serializer>(
@@ -146,9 +190,8 @@ impl GroupInfo {
     /// Rebuild both slices from an edited pair list. The reverse index is
     /// derived, so every write goes through here and no caller can leave the
     /// two out of step.
-    fn store_pairs(&mut self, mut pairs: Vec<LidPnPair>) {
-        pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-        self.lid_pn = pairs.into_boxed_slice();
+    fn store_pairs(&mut self, pairs: Vec<LidPnPair>) {
+        self.lid_pn = sort_pairs(pairs);
         self.pn_order = build_pn_order(&self.lid_pn);
     }
 
@@ -223,21 +266,19 @@ impl GroupInfo {
     pub fn remove_participants(&mut self, users_to_remove: &[&str]) {
         self.participants
             .retain(|p| !users_to_remove.iter().any(|u| *u == p.user));
-        // Each name can be either side of a mapping, so both directions are
-        // resolved against the *current* slices before anything is dropped,
-        // then the survivors are rebuilt in one pass.
-        let mut drop_indices: Vec<usize> = Vec::new();
-        for user in users_to_remove {
-            drop_indices.extend(self.lid_index(user));
-            drop_indices.extend(self.pn_index(user));
-        }
-        if !drop_indices.is_empty() {
-            drop_indices.sort_unstable();
-            drop_indices.dedup();
+        // Each name can be either side of a mapping. The phone side is
+        // resolved through the reverse index first, so a phone number shared
+        // by two LIDs drops exactly the one that index names — which is what
+        // removing it from the reverse `HashMap` used to do.
+        let doomed_lids: Vec<CompactString> = users_to_remove
+            .iter()
+            .filter_map(|user| self.pn_index(user).map(|i| self.lid_pn[i].0.clone()))
+            .collect();
+        if !doomed_lids.is_empty() || users_to_remove.iter().any(|u| self.lid_index(u).is_some()) {
             let mut pairs = self.lid_pn.to_vec();
-            for index in drop_indices.into_iter().rev() {
-                pairs.remove(index);
-            }
+            pairs.retain(|(lid, _)| {
+                !users_to_remove.contains(&lid.as_str()) && !doomed_lids.contains(lid)
+            });
             self.store_pairs(pairs);
         }
     }
@@ -524,7 +565,9 @@ mod tests {
         // existing LID, removals by the LID side and removals by the PN side.
         for round in 0..40u32 {
             let lid_user = CompactString::from(format!("lid_{}", round % 13));
-            let pn_user = CompactString::from(format!("pn_{}", round % 7));
+            // One phone number per LID: the duplicate case has its own test,
+            // and mixing it in here would only let the oracle drift.
+            let pn_user = CompactString::from(format!("pn_{}", round % 13));
             let lid_jid = Jid::lid(lid_user.clone());
             let pn_jid = Jid::pn(pn_user.clone());
 
@@ -536,7 +579,7 @@ mod tests {
                 }
                 oracle.retain(|_, mapped| mapped.user != victim.as_str());
             } else if round % 7 == 6 {
-                let victim = format!("pn_{}", round % 7);
+                let victim = format!("pn_{}", round % 11);
                 info.remove_participants(&[victim.as_str()]);
                 oracle.retain(|lid, mapped| {
                     lid.as_str() != victim.as_str() && mapped.user != victim.as_str()
@@ -554,12 +597,15 @@ mod tests {
                     .map(|(l, _)| l.as_str())
                     .collect::<Vec<_>>()
             );
-            assert_eq!(info.pn_order.len(), info.lid_pn.len());
+            assert_eq!(
+                info.pn_order.len(),
+                info.lid_pn.len(),
+                "with one phone number per LID the reverse index loses nothing"
+            );
             assert!(
                 info.pn_order
                     .windows(2)
-                    .all(|w| info.lid_pn[w[0] as usize].1.user
-                        <= info.lid_pn[w[1] as usize].1.user),
+                    .all(|w| info.lid_pn[w[0] as usize].1.user < info.lid_pn[w[1] as usize].1.user),
                 "pn_order must stay ordered by the PN user"
             );
 
@@ -620,6 +666,46 @@ mod tests {
             .expect("mapping present");
         assert!(!mapped.is_pn());
         assert_eq!(mapped.user.as_str(), "100000000000099");
+    }
+
+    /// Two LIDs claiming one phone number is a server bug, but it has to
+    /// resolve the same way every time. The reverse `HashMap` this replaced
+    /// was keyed by phone user, so it held one LID per number and resolved
+    /// collisions by iteration order — arbitrarily. The reverse index keeps
+    /// the same one-slot-per-number shape and picks the last LID in sort
+    /// order, which survives a rebuild.
+    #[test]
+    fn two_lids_claiming_one_phone_number_resolve_deterministically() {
+        let shared = pn("shared_pn");
+        let lid_to_pn = HashMap::from([
+            (CompactString::from("lid_aaa"), shared.clone()),
+            (CompactString::from("lid_zzz"), shared.clone()),
+        ]);
+        let mut info = GroupInfo::with_lid_to_pn_map(
+            vec![lid("lid_aaa"), lid("lid_zzz")],
+            AddressingMode::Lid,
+            lid_to_pn,
+        );
+
+        assert_eq!(info.pn_order.len(), 1, "one slot per phone number");
+        assert_eq!(
+            info.lid_user_for_phone_user("shared_pn")
+                .map(|u| u.as_str()),
+            Some("lid_zzz")
+        );
+
+        // Removing by the phone side drops the mapping that slot names and
+        // leaves the other alone, which is what removing the entry from the
+        // reverse map used to do.
+        info.remove_participants(&["shared_pn"]);
+        assert!(info.phone_jid_for_lid_user("lid_zzz").is_none());
+        assert!(info.phone_jid_for_lid_user("lid_aaa").is_some());
+        assert_eq!(
+            info.lid_user_for_phone_user("shared_pn")
+                .map(|u| u.as_str()),
+            Some("lid_aaa"),
+            "the survivor takes the slot on the rebuild"
+        );
     }
 
     /// The layout exists to bound what a resident group snapshot costs, so the

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -21,23 +21,75 @@ enum OrderBy {
     Phone,
 }
 
+/// Order `order` in place, `le` deciding whether the first index sorts at or
+/// before the second.
+///
+/// A hand-written bottom-up merge sort, not `sort_unstable_by`. pdqsort
+/// monomorphizes into thirteen specialized routines per (element type,
+/// comparator type) — `sort13_optimal`, `sort9_optimal`, `ipnsort`, two
+/// partition variants, a heapsort fallback and more — which a symbol-level
+/// diff of `wacore`'s release object measured at **15.6 KiB of `.text` for
+/// this single call site**, half of the crate's whole growth. Nothing here is
+/// hot enough to buy that: it runs once per group-metadata fetch and once per
+/// membership notification, over at most a few thousand `u32`s.
+///
+/// The comparator is a trait object rather than a generic parameter so this
+/// routine exists exactly once however many orderings are added later — the
+/// property the previous spelling had to get by funnelling every caller
+/// through one closure, now a guarantee of the signature.
+fn merge_sort_indices(order: &mut Vec<u32>, le: &dyn Fn(u32, u32) -> bool) {
+    let n = order.len();
+    if n < 2 {
+        return;
+    }
+    let mut src = std::mem::take(order);
+    let mut dst = vec![0u32; n];
+    let mut width = 1;
+    while width < n {
+        let mut start = 0;
+        while start < n {
+            let mid = (start + width).min(n);
+            let end = (start + 2 * width).min(n);
+            let (mut left, mut right, mut out) = (start, mid, start);
+            while left < mid && right < end {
+                if le(src[left], src[right]) {
+                    dst[out] = src[left];
+                    left += 1;
+                } else {
+                    dst[out] = src[right];
+                    right += 1;
+                }
+                out += 1;
+            }
+            // Exactly one run still has elements, and it fills the rest of
+            // this block.
+            let rest = if left < mid {
+                &src[left..mid]
+            } else {
+                &src[right..end]
+            };
+            dst[out..end].copy_from_slice(rest);
+            start = end;
+        }
+        std::mem::swap(&mut src, &mut dst);
+        width *= 2;
+    }
+    *order = src;
+}
+
 /// Indices `0..pairs.len()` ordered by one side of the pairs.
 ///
-/// Both orderings go through this one function, and it sorts `u32` indices
-/// rather than the pairs themselves, so the binary carries a **single**
-/// `sort_unstable_by` instantiation for the whole module. That matters more
-/// than it looks: pdqsort monomorphizes per (element type, comparator type)
-/// and costs roughly 10 KiB of `.text` a copy, so the obvious spelling — a
-/// closure at each of the four call sites that needed an order — put ~40 KiB
-/// into the binary for ~40 lines of logic. The `by` branch inside the
-/// comparator is the price, paid on the build path only.
+/// Sorts `u32` indices rather than the pairs themselves: the elements moved
+/// are 4 bytes instead of 56, and the permutation is what both callers want
+/// anyway. Ties keep input order, so a rebuild of the same input yields the
+/// same slice.
 fn ordered_indices(pairs: &[LidPnPair], by: OrderBy) -> Vec<u32> {
     let mut order: Vec<u32> = (0..pairs.len() as u32).collect();
-    order.sort_unstable_by(|a, b| {
-        let (a, b) = (&pairs[*a as usize], &pairs[*b as usize]);
+    merge_sort_indices(&mut order, &|a, b| {
+        let (a, b) = (&pairs[a as usize], &pairs[b as usize]);
         match by {
-            OrderBy::Lid => a.0.cmp(&b.0),
-            OrderBy::Phone => a.1.user.cmp(&b.1.user).then_with(|| a.0.cmp(&b.0)),
+            OrderBy::Lid => a.0 <= b.0,
+            OrderBy::Phone => a.1.user.cmp(&b.1.user).then_with(|| a.0.cmp(&b.0)).is_le(),
         }
     });
     order
@@ -555,6 +607,37 @@ mod tests {
                 .map(|j| j.user.as_str()),
             Some("bob_pn")
         );
+    }
+
+    /// A hand-written sort earns a direct test, not only the oracle below:
+    /// merge sorts fail at the block boundaries, on odd lengths, and on runs
+    /// of equal keys, and an ordering bug there would surface as a lookup
+    /// miss far from here.
+    #[test]
+    fn the_index_sort_orders_every_length_and_keeps_ties_in_input_order() {
+        for n in 0..=65usize {
+            // Keys deliberately collide in threes, so most lengths carry runs
+            // of equal elements across a merge boundary.
+            let keys: Vec<u32> = (0..n as u32).map(|i| (i * 7 % 13) / 3).collect();
+            let mut order: Vec<u32> = (0..n as u32).collect();
+            merge_sort_indices(&mut order, &|a, b| keys[a as usize] <= keys[b as usize]);
+
+            assert_eq!(order.len(), n, "length {n}: the permutation lost entries");
+            let mut seen = order.clone();
+            seen.sort_unstable();
+            assert_eq!(
+                seen,
+                (0..n as u32).collect::<Vec<_>>(),
+                "length {n}: not a permutation of the input indices"
+            );
+            for w in order.windows(2) {
+                let (a, b) = (w[0] as usize, w[1] as usize);
+                assert!(keys[a] <= keys[b], "length {n}: out of order at {a},{b}");
+                if keys[a] == keys[b] {
+                    assert!(a < b, "length {n}: a tie was reordered ({a} after {b})");
+                }
+            }
+        }
     }
 
     /// The sorted slices replace two `HashMap`s, so every edit path has to

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -407,9 +407,12 @@ impl SessionStats {
 /// Estimated heap bytes owned by a value, excluding `size_of::<Self>()` and
 /// allocator overhead.
 ///
-/// Implementations are honest approximations (protobuf-encoded size for
-/// Signal records, string/collection payload sums elsewhere): good for
-/// per-session attribution and growth tracking, not for byte-exact accounting.
+/// Implementations are honest approximations (string/collection payload sums,
+/// walked structure sizes for Signal records, [`hash_table_bytes`] for
+/// hash-backed collections): good for per-session attribution and growth
+/// tracking, not for byte-exact accounting. What they must not do is
+/// understate a structure that grows — a report that is quietest when memory
+/// is climbing is worse than none.
 pub trait HeapSize {
     fn heap_bytes(&self) -> usize;
 }
@@ -421,6 +424,37 @@ impl<T: HeapSize> HeapSize for Arc<T> {
     fn heap_bytes(&self) -> usize {
         size_of::<T>() + T::heap_bytes(self)
     }
+}
+
+/// Bytes a hash table of `capacity` usable entries actually allocates, for
+/// entries of `entry_size` bytes.
+///
+/// `HashMap::capacity()` is how many entries fit before the next resize, not
+/// how many buckets exist: hashbrown rounds the bucket count up to a power of
+/// two and keeps one eighth of it free, so a map holding 1024 entries owns
+/// 2048 buckets. Multiplying `capacity()` by the entry size — what these
+/// reports did before — therefore under-counts by an eighth at best and by
+/// nearly half right after a resize. Each bucket also carries one control
+/// byte.
+///
+/// This inverts hashbrown's own `capacity_to_buckets`, so it is exact for the
+/// bucket count. The fixed `Group::WIDTH` tail on the control array (16 bytes
+/// on x86-64) is not counted: it does not scale with the map, and counting it
+/// would attribute a constant to whichever collection happened to be empty.
+pub fn hash_table_bytes(capacity: usize, entry_size: usize) -> usize {
+    if capacity == 0 {
+        // An unused map allocates nothing at all.
+        return 0;
+    }
+    let buckets = if capacity < 8 {
+        if capacity < 4 { 4 } else { 8 }
+    } else {
+        // hashbrown's own `capacity_to_buckets`, floor division included.
+        (capacity.saturating_mul(8) / 7)
+            .checked_next_power_of_two()
+            .unwrap_or(capacity)
+    };
+    buckets.saturating_mul(entry_size.saturating_add(1))
 }
 
 impl HeapSize for Vec<u8> {

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -437,10 +437,18 @@ impl<T: HeapSize> HeapSize for Arc<T> {
 /// nearly half right after a resize. Each bucket also carries one control
 /// byte.
 ///
-/// This inverts hashbrown's own `capacity_to_buckets`, so it is exact for the
-/// bucket count. The fixed `Group::WIDTH` tail on the control array (16 bytes
-/// on x86-64) is not counted: it does not scale with the map, and counting it
-/// would attribute a constant to whichever collection happened to be empty.
+/// This inverts hashbrown's own `capacity_to_buckets`, so it is exact for a
+/// table that has only ever been inserted into. After removals it is a lower
+/// bound: hashbrown leaves a tombstone where a bucket's group has no empty
+/// slot, and a tombstone consumes a growth slot without shrinking the bucket
+/// array, so `capacity()` can read below the canonical capacity of the buckets
+/// really held. A floor is the right direction for these reports and is what
+/// the previous `capacity() * size_of::<(K, V)>()` failed at, by up to a half,
+/// on every table.
+///
+/// The fixed `Group::WIDTH` tail on the control array (16 bytes on x86-64) is
+/// not counted either: it does not scale with the map, and counting it would
+/// attribute a constant to whichever collection happened to be empty.
 pub fn hash_table_bytes(capacity: usize, entry_size: usize) -> usize {
     if capacity == 0 {
         // An unused map allocates nothing at all.

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -127,7 +127,8 @@ struct InMemoryState {
     /// Reverse index: phone_number -> lid
     pn_to_lid: HashMap<String, String>,
     base_keys: HashMap<BaseKeyKey, Vec<u8>>,
-    device_lists: HashMap<String, DeviceListRecord>,
+    /// Keyed by `Arc<str>`, shared with each record's own `user`.
+    device_lists: HashMap<Arc<str>, DeviceListRecord>,
     group_metadata: HashMap<String, Vec<u8>>,
     tc_tokens: HashMap<String, TcTokenEntry>,
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
@@ -773,7 +774,7 @@ impl ProtocolStore for InMemoryBackend {
             .lock()
             .await
             .device_lists
-            .insert(record.user.clone(), record);
+            .insert(Arc::clone(&record.user), record);
         Ok(())
     }
 
@@ -1265,11 +1266,11 @@ impl DeviceStore for InMemoryBackend {
             .capacity()
             + k.1.capacity()
             + v.capacity());
-        account!(state.device_lists, |k: &String, v: &DeviceListRecord| {
-            k.capacity()
-                + v.user.capacity()
-                + v.devices.capacity() * size_of::<DeviceInfo>()
-                + v.phash.as_ref().map_or(0, String::capacity)
+        // The key and the record's `user` are one allocation, counted once.
+        account!(state.device_lists, |_k: &Arc<str>, v: &DeviceListRecord| {
+            v.user.len()
+                + v.devices.len() * size_of::<DeviceInfo>()
+                + v.phash.as_ref().map_or(0, |p| p.len())
         });
         account!(state.group_metadata, |k: &String, v: &Vec<u8>| k.capacity()
             + v.capacity());

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1845,9 +1845,9 @@ impl SignalStoreCache {
     }
 
     /// Entry counts and estimated retained bytes for each store
-    /// (sessions, identities, sender_keys). Sizes use the records' encoded-size
-    /// proxy (see `SessionRecord::estimated_size`); on-demand only — walks the
-    /// caches under their locks.
+    /// (sessions, identities, sender_keys). Sizes walk the records' live
+    /// structures (see `SessionRecord::estimated_size`); on-demand only — walks
+    /// the caches under their locks.
     ///
     /// Session entry counts include negative (`Absent`) and checked-out slots
     /// — they occupy the map. Byte totals include the key length for every
@@ -1861,7 +1861,7 @@ impl SignalStoreCache {
     ) {
         use crate::stats::CollectionStats;
 
-        // Sizing a record walks its whole protobuf tree, and these mutexes
+        // Sizing a record walks its whole structure tree, and these mutexes
         // serialize the Signal encrypt/decrypt path — so only key lengths and
         // Arc refcount bumps happen under the locks; the estimated_size walks
         // run after each guard drops. Identities are raw bytes (len is free)

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -298,6 +298,54 @@ mod device_info_tests {
         assert_eq!(size_of::<super::DeviceListRecord>(), 64);
     }
 
+    /// The record now serializes through a shadow struct; the blob it writes
+    /// and reads has to stay exactly what the owned-field layout produced.
+    #[test]
+    fn a_device_list_record_keeps_its_persisted_shape() {
+        use super::DeviceListRecord;
+
+        let record = DeviceListRecord {
+            user: "5511999999999".into(),
+            devices: [DeviceInfo::new(0, None), DeviceInfo::new(2, Some(9))].into(),
+            timestamp: 1234,
+            phash: Some("2:abcdef".into()),
+            raw_id: Some(7),
+        };
+
+        let json = serde_json::to_value(record.clone()).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "user": "5511999999999",
+                "devices": [
+                    { "device_id": 0, "key_index": null, "is_hosted": false },
+                    { "device_id": 2, "key_index": 9, "is_hosted": false },
+                ],
+                "timestamp": 1234,
+                "phash": "2:abcdef",
+                "raw_id": 7,
+            })
+        );
+
+        let round: DeviceListRecord = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(&*round.user, "5511999999999");
+        assert_eq!(round.devices, record.devices);
+        assert_eq!(round.phash.as_deref(), Some("2:abcdef"));
+        assert_eq!(round.raw_id, Some(7));
+
+        // `raw_id` has always been optional, and a record without a phash
+        // writes an explicit null the way it always did.
+        let legacy: DeviceListRecord = serde_json::from_value(serde_json::json!({
+            "user": "5511888888888",
+            "devices": [],
+            "timestamp": 0,
+            "phash": null,
+        }))
+        .expect("deserialize legacy");
+        assert!(legacy.devices.is_empty());
+        assert_eq!(legacy.raw_id, None);
+    }
+
     /// A device id is a `u16` on the wire and in a `Jid`. A blob claiming a
     /// wider one is corrupt, and has to be rejected rather than truncated into
     /// a different device — which is what a plain `as u16` would have done.
@@ -394,7 +442,14 @@ mod msg_secret_entry_tests {
 }
 
 /// Device list record matching WhatsApp Web's DeviceListRecord structure.
+///
+/// Serialized through [`DeviceListRecordDe`], whose fields are the `String`,
+/// `Vec` and `Option<String>` the previous layout used. Deriving serde on the
+/// compact fields directly would stamp a second set of `Box<[T]>` and
+/// `Option<Box<str>>` codecs into every crate that persists a record, for a
+/// blob that is byte-for-byte the same either way.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "DeviceListRecordDe", into = "DeviceListRecordDe")]
 pub struct DeviceListRecord {
     /// The user part of the JID (phone number or LID)
     /// `Arc<str>`, so the registry cache can key the record by exactly this
@@ -418,6 +473,41 @@ pub struct DeviceListRecord {
     /// When this changes, all sessions and sender keys for the user must be cleared.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_id: Option<u32>,
+}
+
+/// Serialization shadow: the owned-collection shape the blobs carry.
+#[derive(Serialize, Deserialize)]
+struct DeviceListRecordDe {
+    user: String,
+    devices: Vec<DeviceInfo>,
+    timestamp: i64,
+    phash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    raw_id: Option<u32>,
+}
+
+impl From<DeviceListRecordDe> for DeviceListRecord {
+    fn from(d: DeviceListRecordDe) -> Self {
+        Self {
+            user: Arc::from(d.user),
+            devices: d.devices.into_boxed_slice(),
+            timestamp: d.timestamp,
+            phash: d.phash.map(String::into_boxed_str),
+            raw_id: d.raw_id,
+        }
+    }
+}
+
+impl From<DeviceListRecord> for DeviceListRecordDe {
+    fn from(d: DeviceListRecord) -> Self {
+        Self {
+            user: d.user.to_string(),
+            devices: d.devices.into_vec(),
+            timestamp: d.timestamp,
+            phash: d.phash.map(String::from),
+            raw_id: d.raw_id,
+        }
+    }
 }
 
 impl DeviceListRecord {

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -443,7 +443,7 @@ mod msg_secret_entry_tests {
 
 /// Device list record matching WhatsApp Web's DeviceListRecord structure.
 ///
-/// Serialized through [`DeviceListRecordDe`], whose fields are the `String`,
+/// Serialized through a private shadow struct whose fields are the `String`,
 /// `Vec` and `Option<String>` the previous layout used. Deriving serde on the
 /// compact fields directly would stamp a second set of `Box<[T]>` and
 /// `Option<Box<str>>` codecs into every crate that persists a record, for a

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -122,31 +122,196 @@ impl MsgSecretEntry {
 }
 
 /// Device information for registry tracking.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Packed into 8 bytes rather than the 16 the obvious three fields occupy: a
+/// `u32` device id, an `Option<u32>` key index and a `bool` carry 5 bytes of
+/// information and 11 bytes of alignment padding, and a device registry holds
+/// one of these per device per known contact. The device id is a `u16`
+/// because that is what it is on the wire — [`Jid::device`] has always been
+/// one — and the hosted flag and the key index's presence share one byte.
+///
+/// Serialized as the `{device_id, key_index, is_hosted}` object the previous
+/// layout wrote, so stored device-list blobs are unchanged in both directions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "DeviceInfoDe", into = "DeviceInfoDe")]
 pub struct DeviceInfo {
-    /// The device ID (0 = primary device, 1+ = companion devices)
-    pub device_id: u32,
-    /// The key index, if known
-    pub key_index: Option<u32>,
-    /// Whether the device uses the hosted PN/LID address space.
+    device_id: u16,
+    flags: u8,
+    /// Meaningful only when [`Self::HAS_KEY_INDEX`] is set.
+    key_index: u32,
+}
+
+/// Serialization shadow: the field-per-value shape the blobs carry.
+///
+/// `device_id` is a `u16` here too, so a corrupt blob claiming a device
+/// beyond the wire's range is rejected by serde with its own message instead
+/// of being silently truncated into a different device.
+#[derive(Serialize, Deserialize)]
+struct DeviceInfoDe {
+    device_id: u16,
+    key_index: Option<u32>,
     #[serde(default)]
-    pub is_hosted: bool,
+    is_hosted: bool,
+}
+
+impl From<DeviceInfoDe> for DeviceInfo {
+    fn from(d: DeviceInfoDe) -> Self {
+        Self::new(d.device_id, d.key_index).with_hosting(d.is_hosted)
+    }
+}
+
+impl From<DeviceInfo> for DeviceInfoDe {
+    fn from(d: DeviceInfo) -> Self {
+        Self {
+            device_id: d.device_id(),
+            key_index: d.key_index(),
+            is_hosted: d.is_hosted(),
+        }
+    }
 }
 
 impl DeviceInfo {
+    const IS_HOSTED: u8 = 1 << 0;
+    const HAS_KEY_INDEX: u8 = 1 << 1;
+
     /// Construct a regular device entry.
-    pub const fn new(device_id: u32, key_index: Option<u32>) -> Self {
+    pub const fn new(device_id: u16, key_index: Option<u32>) -> Self {
+        let (flags, key_index) = match key_index {
+            Some(index) => (Self::HAS_KEY_INDEX, index),
+            None => (0, 0),
+        };
         Self {
             device_id,
+            flags,
             key_index,
-            is_hosted: false,
         }
     }
 
     /// Apply the hosted bit reported by the device-list source.
     pub const fn with_hosting(mut self, is_hosted: bool) -> Self {
-        self.is_hosted = is_hosted;
+        if is_hosted {
+            self.flags |= Self::IS_HOSTED;
+        } else {
+            self.flags &= !Self::IS_HOSTED;
+        }
         self
+    }
+
+    /// The device ID (0 = primary device, 1+ = companion devices).
+    pub const fn device_id(&self) -> u16 {
+        self.device_id
+    }
+
+    /// The key index, if known.
+    pub const fn key_index(&self) -> Option<u32> {
+        if self.flags & Self::HAS_KEY_INDEX != 0 {
+            Some(self.key_index)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the device uses the hosted PN/LID address space.
+    pub const fn is_hosted(&self) -> bool {
+        self.flags & Self::IS_HOSTED != 0
+    }
+}
+
+#[cfg(test)]
+mod device_info_tests {
+    use super::DeviceInfo;
+
+    /// The packed layout is the whole point; a field added carelessly would
+    /// undo it silently.
+    #[test]
+    fn a_device_entry_is_eight_bytes() {
+        assert_eq!(size_of::<DeviceInfo>(), 8);
+    }
+
+    #[test]
+    fn accessors_round_trip_every_combination() {
+        for device_id in [0u16, 1, 7, u16::MAX] {
+            for key_index in [None, Some(0), Some(1), Some(u32::MAX)] {
+                for is_hosted in [false, true] {
+                    let info = DeviceInfo::new(device_id, key_index).with_hosting(is_hosted);
+                    assert_eq!(info.device_id(), device_id);
+                    assert_eq!(info.key_index(), key_index, "key_index {key_index:?}");
+                    assert_eq!(info.is_hosted(), is_hosted);
+                }
+            }
+        }
+    }
+
+    /// `key_index: Some(0)` and `None` share the same stored word, so only the
+    /// presence bit tells them apart — the case a sentinel value would break.
+    #[test]
+    fn a_zero_key_index_is_not_an_absent_one() {
+        assert_eq!(DeviceInfo::new(3, Some(0)).key_index(), Some(0));
+        assert_eq!(DeviceInfo::new(3, None).key_index(), None);
+    }
+
+    #[test]
+    fn hosted_flag_is_backward_compatible_with_persisted_json() {
+        let legacy: DeviceInfo = serde_json::from_str(r#"{"device_id":7,"key_index":3}"#).unwrap();
+        assert!(!legacy.is_hosted());
+
+        let hosted = DeviceInfo::new(7, Some(3)).with_hosting(true);
+        let roundtrip: DeviceInfo =
+            serde_json::from_str(&serde_json::to_string(&hosted).unwrap()).unwrap();
+        assert!(roundtrip.is_hosted());
+    }
+
+    /// Device-list blobs already on disk were written by the three-field
+    /// layout, and are read back by the packed one. Both directions have to
+    /// hold, including `is_hosted` absent from a blob predating that field.
+    #[test]
+    fn the_persisted_shape_is_unchanged() {
+        let info = DeviceInfo::new(3, Some(42)).with_hosting(true);
+        let json = serde_json::to_value(info).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({ "device_id": 3, "key_index": 42, "is_hosted": true })
+        );
+
+        let stored: DeviceInfo = serde_json::from_value(serde_json::json!({
+            "device_id": 5,
+            "key_index": null,
+            "is_hosted": false
+        }))
+        .expect("deserialize");
+        assert_eq!(stored, DeviceInfo::new(5, None));
+
+        // Predates `is_hosted`, which has always been `#[serde(default)]`.
+        let legacy: DeviceInfo =
+            serde_json::from_value(serde_json::json!({ "device_id": 9, "key_index": 4 }))
+                .expect("deserialize legacy");
+        assert_eq!(legacy, DeviceInfo::new(9, Some(4)));
+        assert!(!legacy.is_hosted());
+    }
+
+    /// The record is held per known contact for the life of a cache entry, so
+    /// its inline size is part of the budget: `Arc<str>` + `Box<[_]>` +
+    /// `Option<Box<str>>` rather than `String` + `Vec` + `Option<String>` is
+    /// what keeps it at 64 bytes instead of 88.
+    #[test]
+    fn a_device_list_record_is_sixty_four_bytes() {
+        assert_eq!(size_of::<super::DeviceListRecord>(), 64);
+    }
+
+    /// A device id is a `u16` on the wire and in a `Jid`. A blob claiming a
+    /// wider one is corrupt, and has to be rejected rather than truncated into
+    /// a different device — which is what a plain `as u16` would have done.
+    #[test]
+    fn a_device_id_beyond_the_wire_range_is_rejected() {
+        let err = serde_json::from_value::<DeviceInfo>(serde_json::json!({
+            "device_id": u32::from(u16::MAX) + 1,
+            "key_index": null
+        }))
+        .expect_err("a device id past u16 must not decode");
+        assert!(
+            err.to_string().contains("u16"),
+            "the error should name the range it violated: {err}"
+        );
     }
 }
 
@@ -228,44 +393,54 @@ mod msg_secret_entry_tests {
     }
 }
 
-#[cfg(test)]
-mod device_info_tests {
-    use super::DeviceInfo;
-
-    #[test]
-    fn hosted_flag_is_backward_compatible_with_persisted_json() {
-        let legacy: DeviceInfo = serde_json::from_str(r#"{"device_id":7,"key_index":3}"#).unwrap();
-        assert!(!legacy.is_hosted);
-
-        let hosted = DeviceInfo::new(7, Some(3)).with_hosting(true);
-        let roundtrip: DeviceInfo =
-            serde_json::from_str(&serde_json::to_string(&hosted).unwrap()).unwrap();
-        assert!(roundtrip.is_hosted);
-    }
-}
-
 /// Device list record matching WhatsApp Web's DeviceListRecord structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceListRecord {
     /// The user part of the JID (phone number or LID)
-    pub user: String,
-    /// List of known devices for this user
-    pub devices: Vec<DeviceInfo>,
+    /// `Arc<str>`, so the registry cache can key the record by exactly this
+    /// string instead of allocating a second copy of it: every write stores
+    /// the record under its own `user`, and the two used to be separate
+    /// `String` allocations of identical content.
+    pub user: Arc<str>,
+    /// List of known devices for this user.
+    ///
+    /// Boxed rather than a `Vec`: the list is built once and then read for the
+    /// life of the cache entry, so the capacity field is dead weight — and
+    /// worse, `retain_devices_by_key_index` shortens it without releasing the
+    /// capacity, leaving the dropped devices' slots resident. Mutations go
+    /// through [`DeviceListRecord::edit_devices`].
+    pub devices: Box<[DeviceInfo]>,
     /// Timestamp when this record was last updated
     pub timestamp: i64,
     /// Participant hash from usync, if available
-    pub phash: Option<String>,
+    pub phash: Option<Box<str>>,
     /// ADV raw_id from `ADVKeyIndexList` — used to detect identity changes.
     /// When this changes, all sessions and sender keys for the user must be cleared.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_id: Option<u32>,
 }
 
+impl DeviceListRecord {
+    /// Mutate the device list in place.
+    ///
+    /// The field is a `Box<[_]>`, so an edit moves through a `Vec` and back.
+    /// Every caller is a notification path (a device added, removed or
+    /// key-index filtered), never a send, and the round trip is what keeps a
+    /// filtered list from retaining the slots it dropped.
+    pub fn edit_devices(&mut self, edit: impl FnOnce(&mut Vec<DeviceInfo>)) {
+        let mut devices = std::mem::take(&mut self.devices).into_vec();
+        edit(&mut devices);
+        self.devices = devices.into_boxed_slice();
+    }
+}
+
 impl crate::stats::HeapSize for DeviceListRecord {
+    /// The `user` string is shared with the registry cache's key, so the
+    /// report must not also count it there.
     fn heap_bytes(&self) -> usize {
-        self.user.capacity()
-            + self.devices.capacity() * size_of::<DeviceInfo>()
-            + self.phash.as_ref().map_or(0, |p| p.capacity())
+        self.user.len()
+            + self.devices.len() * size_of::<DeviceInfo>()
+            + self.phash.as_ref().map_or(0, |p| p.len())
     }
 }
 

--- a/wacore/tests/hash_table_bytes_matches_the_allocator.rs
+++ b/wacore/tests/hash_table_bytes_matches_the_allocator.rs
@@ -1,0 +1,96 @@
+//! `wacore::stats::hash_table_bytes` claims to report what a hash table really
+//! allocates. That claim is only worth having if it is checked against the
+//! allocator rather than against another formula, so this test installs a
+//! counting `GlobalAlloc` and compares.
+//!
+//! Its own integration test, not a unit test: a global allocator applies to the
+//! whole binary, and the library's other tests must not run under one.
+//!
+//! One test function, not two: the counter is global, so a second test running
+//! on another harness thread would have its allocations land in this one's
+//! measurement.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use wacore::stats::hash_table_bytes;
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+// SAFETY: every method forwards to `System` unchanged; the counters are the
+// only added effect and touch no allocation state.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        LIVE.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        LIVE.fetch_add(new_size, Ordering::Relaxed);
+        LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// A 24-byte entry, the shape of the `(CompactString, u64)`-ish pairs these
+/// reports actually hold.
+type Entry = (u64, [u8; 16]);
+
+#[test]
+fn reported_bytes_match_what_the_table_allocates() {
+    // One throwaway table first: `RandomState` seeds a thread-local on first
+    // use, and that allocation would otherwise land on the first measurement.
+    drop(HashMap::<u64, [u8; 16]>::from_iter([(0, [0u8; 16])]));
+
+    // Sizes either side of hashbrown's small-table cases (4 and 8 buckets) and
+    // across several resize boundaries.
+    for entries in [1usize, 3, 4, 7, 8, 9, 100, 1000, 1024, 1792, 1793] {
+        let before = LIVE.load(Ordering::Relaxed);
+        // `with_capacity`, so the table is one allocation of the final size
+        // rather than a series of doublings whose freed intermediates the
+        // counter would have to net out.
+        let mut map: HashMap<u64, [u8; 16]> = HashMap::with_capacity(entries);
+        for i in 0..entries {
+            map.insert(i as u64, [0u8; 16]);
+        }
+        let allocated = LIVE.load(Ordering::Relaxed) - before;
+        let capacity = map.capacity();
+        drop(map);
+
+        let reported = hash_table_bytes(capacity, size_of::<Entry>());
+
+        // The control array carries a fixed `Group::WIDTH` tail (16 bytes on
+        // x86-64) that does not scale with the map, so the report is allowed
+        // to sit just under the true figure — but never over it, and never by
+        // a margin that grows with the entry count.
+        assert!(
+            reported <= allocated,
+            "{entries} entries: reported {reported} B over the real {allocated} B"
+        );
+        assert!(
+            allocated - reported <= 64,
+            "{entries} entries: reported {reported} B, real {allocated} B \u{2014} the \
+             gap must stay a fixed tail, not a per-entry error"
+        );
+
+        // And the bug this replaced: multiplying `capacity()` by the entry
+        // size misses both the free eighth hashbrown keeps and the control
+        // bytes, so it lands under the truth by more than that fixed tail.
+        let previous_formula = capacity * size_of::<Entry>();
+        assert!(
+            previous_formula < reported,
+            "{entries} entries: the corrected figure ({reported} B) must exceed \
+             the old one ({previous_formula} B)"
+        );
+    }
+}

--- a/wacore/tests/hash_table_bytes_matches_the_allocator.rs
+++ b/wacore/tests/hash_table_bytes_matches_the_allocator.rs
@@ -6,9 +6,10 @@
 //! Its own integration test, not a unit test: a global allocator applies to the
 //! whole binary, and the library's other tests must not run under one.
 //!
-//! One test function, not two: the counter is global, so a second test running
-//! on another harness thread would have its allocations land in this one's
-//! measurement.
+//! One test function, not several: the counter is process-wide, and the test
+//! harness runs functions on separate threads. A mutex is not enough — the
+//! harness allocates around each function it starts — so the measurements are
+//! kept in one function that never yields.
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::collections::HashMap;
@@ -93,4 +94,27 @@ fn reported_bytes_match_what_the_table_allocates() {
              the old one ({previous_formula} B)"
         );
     }
+
+    // A table that has seen removals reports a `capacity()` below the
+    // canonical one for its buckets: hashbrown leaves tombstones that consume
+    // growth slots without shrinking the array. The figure is a floor there
+    // rather than exact — the safe direction, and the property worth pinning
+    // is that it never reads *over* what the table holds.
+    let before = LIVE.load(Ordering::Relaxed);
+    let mut map: HashMap<u64, [u8; 16]> = HashMap::with_capacity(1000);
+    for i in 0..1000u64 {
+        map.insert(i, [0u8; 16]);
+    }
+    for i in 0..900u64 {
+        map.remove(&i);
+    }
+    let allocated = LIVE.load(Ordering::Relaxed) - before;
+    let reported = hash_table_bytes(map.capacity(), size_of::<Entry>());
+    drop(map);
+
+    assert!(
+        reported <= allocated,
+        "after removals the report must stay a floor: {reported} B reported, \
+         {allocated} B held"
+    );
 }

--- a/wacore/tests/hash_table_bytes_matches_the_allocator.rs
+++ b/wacore/tests/hash_table_bytes_matches_the_allocator.rs
@@ -6,10 +6,16 @@
 //! Its own integration test, not a unit test: a global allocator applies to the
 //! whole binary, and the library's other tests must not run under one.
 //!
-//! One test function, not several: the counter is process-wide, and the test
-//! harness runs functions on separate threads. A mutex is not enough — the
-//! harness allocates around each function it starts — so the measurements are
-//! kept in one function that never yields.
+//! What a table holds is measured by **dropping** it and reading how much the
+//! counter falls, not by bracketing its construction. The counter is
+//! process-wide, so a window around a construction also catches whatever else
+//! the process allocated in it — a lazily seeded global, the harness, a
+//! neighbouring test — and under `--all-features` that is not nothing. A drop
+//! frees exactly the table's own allocation and nothing else, so unrelated
+//! allocations in the window cancel instead of inflating the figure.
+//!
+//! Still one test function, not several: the counter is process-wide and the
+//! harness runs functions on separate threads.
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::collections::HashMap;
@@ -47,26 +53,34 @@ static ALLOC: Counting = Counting;
 /// reports actually hold.
 type Entry = (u64, [u8; 16]);
 
+/// Bytes the allocator reclaims when `map` is dropped — that is, exactly what
+/// its table held.
+///
+/// `HashMap<u64, [u8; 16]>` owns a single allocation and its entries own none,
+/// so the fall in the counter across the drop is the table and nothing else.
+fn bytes_released_by_dropping(map: HashMap<u64, [u8; 16]>) -> usize {
+    let before = LIVE.load(Ordering::Relaxed);
+    drop(map);
+    before - LIVE.load(Ordering::Relaxed)
+}
+
 #[test]
 fn reported_bytes_match_what_the_table_allocates() {
-    // One throwaway table first: `RandomState` seeds a thread-local on first
-    // use, and that allocation would otherwise land on the first measurement.
+    // One throwaway table first, so `RandomState`'s thread-local seeding is
+    // done before anything is measured.
     drop(HashMap::<u64, [u8; 16]>::from_iter([(0, [0u8; 16])]));
 
     // Sizes either side of hashbrown's small-table cases (4 and 8 buckets) and
     // across several resize boundaries.
     for entries in [1usize, 3, 4, 7, 8, 9, 100, 1000, 1024, 1792, 1793] {
-        let before = LIVE.load(Ordering::Relaxed);
         // `with_capacity`, so the table is one allocation of the final size
-        // rather than a series of doublings whose freed intermediates the
-        // counter would have to net out.
+        // rather than a series of doublings.
         let mut map: HashMap<u64, [u8; 16]> = HashMap::with_capacity(entries);
         for i in 0..entries {
             map.insert(i as u64, [0u8; 16]);
         }
-        let allocated = LIVE.load(Ordering::Relaxed) - before;
         let capacity = map.capacity();
-        drop(map);
+        let allocated = bytes_released_by_dropping(map);
 
         let reported = hash_table_bytes(capacity, size_of::<Entry>());
 
@@ -100,7 +114,6 @@ fn reported_bytes_match_what_the_table_allocates() {
     // growth slots without shrinking the array. The figure is a floor there
     // rather than exact — the safe direction, and the property worth pinning
     // is that it never reads *over* what the table holds.
-    let before = LIVE.load(Ordering::Relaxed);
     let mut map: HashMap<u64, [u8; 16]> = HashMap::with_capacity(1000);
     for i in 0..1000u64 {
         map.insert(i, [0u8; 16]);
@@ -108,9 +121,8 @@ fn reported_bytes_match_what_the_table_allocates() {
     for i in 0..900u64 {
         map.remove(&i);
     }
-    let allocated = LIVE.load(Ordering::Relaxed) - before;
     let reported = hash_table_bytes(map.capacity(), size_of::<Entry>());
-    drop(map);
+    let allocated = bytes_released_by_dropping(map);
 
     assert!(
         reported <= allocated,

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -419,6 +419,21 @@ pub mod codec {
         record.encode(out);
     }
 
+    /// One archived Signal session state, held by `SessionRecord` as the bytes
+    /// it was persisted as and decoded only when a message arrives for the
+    /// session it belongs to.
+    #[inline(never)]
+    pub fn session_structure_decode(
+        bytes: &[u8],
+    ) -> Result<whatsapp::SessionStructure, buffa::DecodeError> {
+        whatsapp::SessionStructure::decode_from_slice(bytes)
+    }
+
+    #[inline(never)]
+    pub fn session_structure_to_vec(session: &whatsapp::SessionStructure) -> Vec<u8> {
+        session.encode_to_vec()
+    }
+
     #[inline(never)]
     pub fn signed_pre_key_record_decode(
         bytes: &[u8],

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -419,21 +419,6 @@ pub mod codec {
         record.encode(out);
     }
 
-    /// One archived Signal session state, held by `SessionRecord` as the bytes
-    /// it was persisted as and decoded only when a message arrives for the
-    /// session it belongs to.
-    #[inline(never)]
-    pub fn session_structure_decode(
-        bytes: &[u8],
-    ) -> Result<whatsapp::SessionStructure, buffa::DecodeError> {
-        whatsapp::SessionStructure::decode_from_slice(bytes)
-    }
-
-    #[inline(never)]
-    pub fn session_structure_to_vec(session: &whatsapp::SessionStructure) -> Vec<u8> {
-        session.encode_to_vec()
-    }
-
     #[inline(never)]
     pub fn signed_pre_key_record_decode(
         bytes: &[u8],


### PR DESCRIPTION
## Summary

Applies the per-entry layout work from Cloudflare's [DNS cache memory optimization](https://blog.cloudflare.com/dns-cache-memory-optimization-1111) to the structures a connected client keeps resident for hours. Same levers: drop `Vec`'s capacity field where the data is immutable, replace a duplicated reverse collection with an index, derive a field from the cache key instead of storing it twice, pack bitflags out of alignment padding, and keep cold data in wire format.

Four independent changes plus the review and CI follow-ups, one commit each:

| Structure | Before | After | |
| --- | ---: | ---: | ---: |
| `GroupInfo`, per participant (1024-member LID group) | 244 B | **92 B** | **−62%** |
| `DeviceListRecord`, per contact (3 devices) | 213 B | **160 B** | **−25%** |
| `SessionRecord`, 8 archived states resident | 280,791 B | **73,279 B** | **−74%** |

Measured with a counting `GlobalAlloc` — real allocation, not `size_of` arithmetic — running the *same* harness against `main` (d6a0455) and this branch. Inline sizes: `GroupInfo` 128 → 64, `DeviceListRecord` 88 → 64, `DeviceInfo` 16 → 8.

The accounting fix comes second on purpose: the reports that measure all of this were themselves wrong, in both directions, and a report that is quietest when memory is climbing is worse than none.

## Changes

### 1. `wacore::client::context` — group LID mappings

`GroupInfo` held `lid_to_pn_map: HashMap<CompactString, Jid>` plus `pn_to_lid_map: HashMap<CompactString, CompactString>`, the second re-storing both identifier strings purely to invert the lookup. hashbrown rounds to a power of two, so a 1024-member LID group put 1024 entries into 2048 buckets — about half the bytes were empty slots — and the reverse map cost 48 B/entry on top.

Both become slices built at construction: `lid_pn: Box<[(CompactString, Jid)]>` sorted by LID user and searched with `binary_search`, plus `pn_order: Box<[u32]>` indexing it by phone user. The reverse direction goes from 48 bytes per mapping to 4.

The pair keeps the whole `Jid` rather than a user part plus an assumed `Pn` server: `(CompactString, Jid)` and `(CompactString, CompactString, Server)` both pad to 56 bytes, so it is free, `phone_jid_for_lid_user` keeps handing out a borrow (no signature change), and a malformed response mapping a LID to another LID stays visible to the callers that check for it — `collect_stale_device_users` does, and `skips_non_pn_alias` pins it.

Reads dominate: a group send does one forward lookup per participant. Writes arrive on membership notifications, and `add_participants` rebuilds the pair list **once per batch** instead of once per member; a notification that maps nobody (every PN group) never touches it.

The persisted `group_metadata` blob is unchanged — `lid_pn` serializes as the same `lid_to_pn_map` object via `serialize_with`, and the reverse index stays derived and `#[serde(skip)]`.

The reverse index holds **one slot per phone number**, the shape the `HashMap` keyed by phone user had. Keeping every duplicate would have answered reverse lookups differently from the map it replaced and made `remove_participants` drop mappings the map left alone; `binary_search_by` also does not say which of several equal entries it returns, so a documented tie-break was not actually enforced. It is resolved at build time now, to the last LID in sort order.

### 2. `wacore::stats`, `SessionRecord`/`SenderKeyRecord::estimated_size` — report what is really retained

Two figures understated the structures they exist to watch.

`HashMap::capacity()` is how many entries fit before the next resize, not how many buckets exist — so multiplying it by the entry size under-counts by an eighth at best and nearly half right after a resize, and misses the control byte per bucket. `wacore::stats::hash_table_bytes` inverts hashbrown's own `capacity_to_buckets` instead. A new integration test checks it against a counting `GlobalAlloc`: the gap is a fixed 16-byte tail at every size from 1 to 1793 entries, and stays a floor for a table that has seen removals.

`estimated_size` reported the **protobuf-encoded** size as a proxy for memory. For a session carrying skipped message keys — the one structure in the store that grows without bound, up to `MAX_MESSAGE_KEYS` per chain — that is off by about 5×: a modern seed-only message key is ~36 bytes encoded but a 136-byte `MessageKey` plus a 32-byte `Bytes` allocation in memory, because the three fields it leaves empty still occupy their `Option` slots. Both records now walk their live structures.

### 3. `wacore::store::traits` — the device registry record

`DeviceInfo` carried a `u32` device id, an `Option<u32>` key index and a `bool`: 5 bytes of information in 16, the rest alignment padding. Packed to 8 — the device id is a `u16` because that is what it is on the wire and what `Jid::device` has always been, and the hosted flag shares a byte with the key index's presence bit. `Some(0)` and `None` stay distinct, which a sentinel value would not have managed.

`user` was a `String` holding exactly what the registry cache keys the record by — `update_device_list_guarded` assigns the canonical name to both, so every cached contact paid for two allocations of the same bytes. It is an `Arc<str>` now, shared with the key. `devices` becomes a `Box<[DeviceInfo]>` (`retain_devices_by_key_index` shortens it without releasing capacity, leaving the filtered devices' slots resident) and `phash` an `Option<Box<str>>`. Two allocations per contact instead of four.

Persisted blobs are unchanged in both directions: `DeviceInfo` serializes through a shadow struct with the same three fields, `is_hosted` still defaults when absent, and a blob claiming a device id past `u16` is now rejected by serde instead of being truncated into a different device — which also removes the two defensive `u16::try_from` paths that guarded for it, since the type no longer admits the value.

### 4. `wacore-libsignal` — archived session states in wire format

A `SessionRecord` holds up to `ARCHIVED_STATES_MAX_LENGTH` (40) archived states, each with its own chains and skipped-key backlog, and they are the coldest thing in the store: nothing reads one until a message arrives for a session that has since been replaced.

They are retained as the protobuf bytes they were persisted as, decoded only when one is promoted. Two paths get *simpler* rather than slower: serialization copies instead of re-encoding (which also removes the two-pass sizing and the stack array plus heap spill that existed only to avoid computing each length twice), and the search for a session to promote reads `sessionVersion` and `aliceBaseKey` off a view, so only the winning candidate is materialized.

Load-time validation is deliberately unchanged: `deserialize` still decodes every archived state and rejects a malformed record there, then drops the parsed tree instead of retaining it. Deferring that rejection to a promotion would turn a quarantined row into an error that strands the address, which `agent_docs/signal_durability.md` calls out as the worse failure. The element bytes come from a scan of the record's own top-level fields rather than the decoded view, so a re-serialized record is byte-for-byte what was read — `test_session_record_manual_encoding_matches_generated_record_structure` still holds untouched.

Re-encoding a promoted state goes through one small generic helper local to this file rather than a `waproto::codec` wrapper. Routing it through the pinned wrappers was tried first and turned out to *add* an encode and a decode tree to `waproto` (+9.97 KiB of `.text`) for a message nothing else encodes — the opposite of what the rule in `clippy.toml` exists to prevent. The `#[allow(clippy::disallowed_methods)]` carries that reason, alongside the one already sitting on `serialize_into_inner` a few lines above on the same grounds.

### 5. Review follow-up — charge each container's slots once

Review found the same defect in both new walkers: a `Vec`'s capacity term already covers every inline element, and the per-element walker added `size_of` for that element again — `SessionRecord` double-counted each receiver chain, `SenderKeyRecord` each state's inline `SenderKeyStateStructure` and `sender_chain`. One rule now, stated where the walkers are: a walker returns only what hangs off a value, and whoever owns the value charges its inline size once. `a_chain_is_charged_once_not_once_per_walker` pins it.

Two claims are also brought back to what the code does — `hash_table_bytes` is a floor rather than exact after removals (hashbrown's tombstones consume growth slots without shrinking the bucket array), and `agent_docs/observability.md` now names which collections use it rather than implying all hash-backed ones do.

### 6. Size follow-up — the group index sorts without pdqsort

The size gate reported +43 KiB of `.text` against a 32 KiB per-PR budget, and two rounds of guessing at the cause moved it barely at all. A symbol-level diff of `wacore`'s release object against `main` settled it: **one** `sort_unstable_by` call site cost **15.6 KiB**, because pdqsort monomorphizes into thirteen specialized routines per (element type, comparator type) — `sort13_optimal` alone is 5,576 B, `sort9_optimal` 3,099 B. Funnelling all four orderings through a single closure, which an earlier commit did, had already cut that from four copies to one; one copy was still half of the crate's entire growth.

A bottom-up merge sort replaces it, with the comparator as a trait object so the routine exists exactly once however many orderings are added later — a guarantee of the signature rather than a convention callers must keep. Being a merge sort it is also stable, so the determinism claimed above now comes from the algorithm.

The trade is real and on the cold path: the build arms slow down (`group_info_build[1024]` 970 µs → 1.4 ms, `add_participants[1024]` 677 µs → 1.5 ms), while the read arm — the one a group send pays per participant — is unchanged at 393 µs. That buys, in the linked binary:

| Metric | with pdqsort | with the merge sort | budget |
| --- | ---: | ---: | ---: |
| `bin .text` | +38.69 KiB 🚨 | **+6.44 KiB** ✅ | 32 KiB |
| bin size (stripped) | +41.47 KiB | **+8.75 KiB** ✅ | 64 KiB |
| `.text wacore` | +32.38 KiB | **+227 B** | — |

### 7. CI follow-up — measure a table by what dropping it releases

The allocator test bracketed the map's construction and called the difference the table's size. The counter is process-wide, so that window also caught whatever else the process allocated inside it; under `--all-features` something did, and the 1792-entry case read 916 bytes over the truth. Dropping the map is the measurement that isolates it — the map owns one allocation and its entries own none, so the fall in the counter across a drop is the table and nothing else, and anything else allocated in the window is still live and cancels. Same interference that had made the test order-dependent earlier, addressed at the cause this time.

### `wacore/benches/retained_memory_benchmark.rs`

New `divan` suite (joins the existing `core` CodSpeed shard): build, forward lookup, reverse lookup and a participant-add notification, each at 64/256/1024 members. The read arms are the regression gate for `binary_search` against the `HashMap` it replaced.

## Tests

Beyond the existing suites, each change carries the assertion that would catch its regression:

- `retained_bytes_per_participant_stay_bounded` — ≤92 B/participant on a 1024-member group.
- `pair_slices_stay_consistent_with_a_map_oracle` — 40 rounds of adds, remaps, and removals from both namespaces against a `HashMap` oracle, checking both slices stay sorted and in step.
- `the_index_sort_orders_every_length_and_keeps_ties_in_input_order` — every length from 0 to 65 with runs of equal keys crossing the merge boundaries, checking the result is a permutation, ordered, and stable.
- `two_lids_claiming_one_phone_number_resolve_deterministically`, `remove_by_phone_side_drops_the_mapping`, `a_non_pn_mapping_survives_the_round_trip`.
- `the_persisted_shape_is_unchanged`, `a_device_id_beyond_the_wire_range_is_rejected`, `a_zero_key_index_is_not_an_absent_one`, `a_device_entry_is_eight_bytes`, `a_device_list_record_is_sixty_four_bytes`.
- `archived_states_are_held_as_bytes_not_parsed_trees` — the archive costs a fraction of its parsed form *and* every state survives the round trip unchanged.
- `skipped_message_keys_are_reported_at_their_in_memory_cost`, `a_chain_is_charged_once_not_once_per_walker`.
- `wacore/tests/hash_table_bytes_matches_the_allocator.rs` — the bucket conversion against a counting allocator, insert-only and after removals.

## Validation

CI on the final head: Build & Test, Rustdoc, Clippy, Format, Test Stable (MSRV), Generated Artifacts, waproto serde, wasm32 release, E2E, all three Miri jobs, every Feature Matrix shard, CodSpeed and the binary-size gate all green. CodSpeed reports 1 improved benchmark (`bench_decrypt_with_archived_session`, 9.4 KB → 6.9 KB of memory, −35%), 361 untouched and no regressions.

Semver Checks is red and is not this change: the job is `continue-on-error: true` and documented as advisory ("the workspace is pre-1.0 and intentionally breaks API between minors"), and every item it reports is a `waproto` field removed by a whatspec regen already on `main` — `git diff origin/main...HEAD -- waproto/` is empty.