### PR TITLE
perf(core): shrink device-resolution and Signal bookkeeping caches

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -162,7 +162,13 @@ figures come from the `wacore::stats::HeapSize` trait:
   beside it. Those sets are charged for their **slots only**: their addresses
   are the cache's own `Arc<str>` keys, which eviction cannot drop while an
   address is dirty, deleted or pending, so charging the payloads again would
-  double-count them.
+  double-count them. `sender_keys.bytes` additionally covers
+  `pending_distributions` — table slots, distribution payloads, and the key
+  bytes of pending entries the cache no longer holds — and `sender_keys.entries`
+  counts those pending-only addresses. One overlap is accepted rather than
+  tracked: an address evicted while still pending is charged both as a
+  pending-only key and in the 64-entry removal window that named it, which
+  bounds the overstatement to a handful of addresses.
   `wacore/tests/hash_table_bytes_matches_the_allocator.rs` checks the conversion
   against a counting `GlobalAlloc`. After removals the figure is a lower bound
   rather than exact: hashbrown leaves tombstones that consume growth slots

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -155,9 +155,14 @@ figures come from the `wacore::stats::HeapSize` trait:
   converts a `capacity()` into the buckets hashbrown actually owns: it rounds to
   a power of two and keeps an eighth free, so `capacity() * size_of::<(K, V)>()`
   under-counts by up to a half. The device-list memos
-  (`GroupDevicesMemo`/`DmDevicesMemo`) and the sender-key device cache use it;
-  `SignalStoreCache::memory_stats` does **not** — it sums key and payload bytes
-  and does not charge for its tables' slots at all, so its figures are a floor.
+  (`GroupDevicesMemo`/`DmDevicesMemo`), the sender-key device cache and
+  `SignalStoreCache::memory_stats` all use it — the last charges each store's
+  own tables (`UserIndexedCache::overhead_bytes`: the primary map, the user
+  index, the removal ring) plus the dirty/deleted sets and pre-wire gates
+  beside it. Those sets are charged for their **slots only**: their addresses
+  are the cache's own `Arc<str>` keys, which eviction cannot drop while an
+  address is dirty, deleted or pending, so charging the payloads again would
+  double-count them.
   `wacore/tests/hash_table_bytes_matches_the_allocator.rs` checks the conversion
   against a counting `GlobalAlloc`. After removals the figure is a lower bound
   rather than exact: hashbrown leaves tombstones that consume growth slots

--- a/src/client.rs
+++ b/src/client.rs
@@ -353,7 +353,10 @@ pub(crate) type SkdmWarmMemoEntry = (
     std::sync::Weak<crate::sender_key_device_cache::SenderKeyDeviceMap>,
     u64,
     Jid,
-    Vec<Jid>,
+    // Frozen: the memoized targets never change once stored (a change of the
+    // inputs produces a new entry), and the steady state is empty or the own
+    // devices, so the filter's growth capacity has nothing to park here for.
+    Box<[Jid]>,
 );
 use wacore::runtime::timeout as rt_timeout;
 use waproto::whatsapp as wa;

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@ pub mod interceptor;
 mod iq_ops;
 mod lid_pn;
 mod lifecycle;
+pub(crate) mod member_index;
 mod messaging;
 mod node_io;
 pub(crate) mod offline_resume;

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use wacore_binary::{Jid, JidExt as _, Server};
 
 use super::Client;
+use super::member_index::MemberIndex;
 
 const SIGNAL_NAMESPACE_COUNT: usize = 4;
 
@@ -25,7 +26,7 @@ pub(crate) struct GroupDevicesMemo {
     /// Member identifiers in BOTH namespaces (participant users, their mapped
     /// counterparts, resolved device users): the scoped-invalidation check
     /// tests the topology log's touched users against this set.
-    pub(crate) members: Arc<std::collections::HashSet<wacore_binary::CompactString>>,
+    pub(crate) members: Arc<MemberIndex>,
     pub(crate) devices: Arc<wacore::send::ResolvedGroupDevices>,
 }
 
@@ -33,12 +34,7 @@ impl wacore::stats::HeapSize for GroupDevicesMemo {
     fn heap_bytes(&self) -> usize {
         // The Weak keeps only the GroupInfo allocation header alive; the memo
         // does not retain its payload.
-        self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-            + wacore::stats::hash_table_bytes(
-                self.members.capacity(),
-                size_of::<wacore_binary::CompactString>(),
-            )
-            + self.devices.heap_bytes()
+        self.members.heap_bytes() + self.devices.heap_bytes()
     }
 }
 
@@ -58,7 +54,7 @@ pub(crate) struct DmDevicesMemo {
     /// BOTH namespaces (recipient, self, and every resolved device user, each
     /// with its mapped counterpart): the scoped-invalidation check tests the
     /// topology log's touched users against this set.
-    pub(crate) members: Arc<std::collections::HashSet<wacore_binary::CompactString>>,
+    pub(crate) members: Arc<MemberIndex>,
     pub(crate) devices: Arc<wacore::send::ResolvedDmDevices>,
 }
 
@@ -66,11 +62,7 @@ impl wacore::stats::HeapSize for DmDevicesMemo {
     fn heap_bytes(&self) -> usize {
         self.own_pn.heap_bytes()
             + self.own_lid.as_ref().map_or(0, |lid| lid.heap_bytes())
-            + self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-            + wacore::stats::hash_table_bytes(
-                self.members.capacity(),
-                size_of::<wacore_binary::CompactString>(),
-            )
+            + self.members.heap_bytes()
             + self.devices.heap_bytes()
     }
 }
@@ -245,23 +237,23 @@ impl Client {
         // this set carries each member's group-facing identity (participant
         // user + mapped counterpart) plus the namespace the resolved device
         // JIDs ended up in.
-        let mut members = std::collections::HashSet::with_capacity(
-            group_info.participants.len() * 2 + devices.len() + 2,
-        );
+        let mut members =
+            MemberIndex::builder(group_info.participants.len() * 2 + devices.len() + 2);
         for participant in &group_info.participants {
-            members.insert(participant.user.clone());
+            members.insert(&participant.user);
             if participant.is_lid()
                 && let Some(pn) = group_info.phone_jid_for_lid_user(&participant.user)
             {
-                members.insert(pn.user.clone());
+                members.insert(&pn.user);
             } else if let Some(lid) = group_info.lid_user_for_phone_user(&participant.user) {
-                members.insert(lid.clone());
+                members.insert(lid);
             }
         }
-        members.insert(own_sending_jid.user.clone());
+        members.insert(&own_sending_jid.user);
         for device in &devices {
-            members.insert(device.user.clone());
+            members.insert(&device.user);
         }
+        let members = members.build();
 
         let devices = Arc::new(wacore::send::ResolvedGroupDevices::new(devices));
         self.group_devices_memo
@@ -566,29 +558,38 @@ impl Client {
         own_jid: &Jid,
         own_lid: Option<&Jid>,
         devices: &[Jid],
-    ) -> std::collections::HashSet<wacore_binary::CompactString> {
-        let mut members = std::collections::HashSet::with_capacity(devices.len() + 6);
+    ) -> MemberIndex {
+        let mut members = MemberIndex::builder(devices.len() + 6);
+        // The skip below is control flow, so it dedups on the identifiers
+        // themselves and not on their fingerprints: a collision that skipped a
+        // distinct user would leave that user's mapped counterpart out of the
+        // index entirely, which is the one error direction the index must not
+        // have. The set is one fan-out's worth of devices, so a linear scan
+        // over borrowed strs beats a hash set.
+        let mut probed: Vec<&str> = Vec::with_capacity(devices.len() + 3);
         for user in [recipient_bare.user.as_str(), own_jid.user.as_str()]
             .into_iter()
             .chain(own_lid.map(|lid| lid.user.as_str()))
             .chain(devices.iter().map(|d| d.user.as_str()))
         {
-            if !members.insert(wacore_binary::CompactString::from(user)) {
+            members.insert(user);
+            if probed.contains(&user) {
                 // Already probed on an earlier pass; the mapping relation is
                 // symmetric, so its counterpart is in too.
                 continue;
             }
+            probed.push(user);
             // Probe BOTH directions instead of trusting the jid's namespace:
             // a hosted or unmapped identity can be keyed either way, and a
             // mapping missed here is a change we could not prove unrelated.
             if let Some(pn) = self.lid_pn_cache.get_phone_number(user).await {
-                members.insert(wacore_binary::CompactString::from(pn.as_str()));
+                members.insert(pn.as_str());
             }
             if let Some(lid) = self.lid_pn_cache.get_current_lid(user).await {
-                members.insert(lid);
+                members.insert(&lid);
             }
         }
-        members
+        members.build()
     }
 
     /// Resolve a user identifier to its lookup keys with type information.
@@ -4038,23 +4039,22 @@ mod tests {
 
         // Exactly what `resolve_group_devices_memoized` builds: every member in
         // both namespaces, plus the sender and every resolved device user.
-        let mut members_set =
-            std::collections::HashSet::with_capacity(participants.len() * 2 + devices.len() + 2);
+        let mut member_index = MemberIndex::builder(participants.len() * 2 + devices.len() + 2);
         for participant in &participants {
-            members_set.insert(participant.user.clone());
+            member_index.insert(&participant.user);
             if let Some(pn) = lid_to_pn.get(&participant.user) {
-                members_set.insert(pn.user.clone());
+                member_index.insert(&pn.user);
             }
         }
-        members_set.insert(wacore_binary::CompactString::from("5511999990000"));
+        member_index.insert("5511999990000");
         for device in &devices {
-            members_set.insert(device.user.clone());
+            member_index.insert(&device.user);
         }
 
         GroupDevicesMemo {
             group_info: Arc::downgrade(&group_info),
             generation: 0,
-            members: Arc::new(members_set),
+            members: Arc::new(member_index.build()),
             devices: Arc::new(wacore::send::ResolvedGroupDevices::new(devices)),
         }
         // `group_info` drops here on purpose: the memo retains only the
@@ -4077,8 +4077,8 @@ mod tests {
         let per_device =
             (size_of::<GroupDevicesMemo>() + memo.heap_bytes()) / (MEMBERS * DEVICES_PER_USER);
         assert!(
-            per_device <= 98,
-            "a warm 1024-member group memo must stay within 98 B per resolved device, \
+            per_device <= 37,
+            "a warm 1024-member group memo must stay within 37 B per resolved device, \
              got {per_device}"
         );
     }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -4005,4 +4005,81 @@ mod tests {
             "the next send must retry the resolution instead of reusing the fallback"
         );
     }
+
+    // -- Retained memory --
+
+    /// A group memo of `members` users, each contributing `devices_per_user`
+    /// resolved devices in both namespaces — the shape a community group
+    /// actually parks in the cache for the life of the connection.
+    fn group_memo_fixture(members: usize, devices_per_user: usize) -> GroupDevicesMemo {
+        use wacore::client::context::GroupInfo;
+        use wacore::types::message::AddressingMode;
+
+        let mut participants = Vec::with_capacity(members);
+        let mut lid_to_pn = std::collections::HashMap::with_capacity(members);
+        for i in 0..members {
+            let lid_user = wacore_binary::CompactString::from(format!("1000000{i:08}"));
+            let pn_user = wacore_binary::CompactString::from(format!("5511{i:09}"));
+            participants.push(Jid::lid(lid_user.clone()));
+            lid_to_pn.insert(lid_user, Jid::pn(pn_user));
+        }
+        let group_info = Arc::new(GroupInfo::with_lid_to_pn_map(
+            participants.clone(),
+            AddressingMode::Lid,
+            lid_to_pn.clone(),
+        ));
+
+        let mut devices = Vec::with_capacity(members * devices_per_user);
+        for participant in &participants {
+            for device in 0..devices_per_user {
+                devices.push(Jid::lid_device(participant.user.clone(), device as u16));
+            }
+        }
+
+        // Exactly what `resolve_group_devices_memoized` builds: every member in
+        // both namespaces, plus the sender and every resolved device user.
+        let mut members_set =
+            std::collections::HashSet::with_capacity(participants.len() * 2 + devices.len() + 2);
+        for participant in &participants {
+            members_set.insert(participant.user.clone());
+            if let Some(pn) = lid_to_pn.get(&participant.user) {
+                members_set.insert(pn.user.clone());
+            }
+        }
+        members_set.insert(wacore_binary::CompactString::from("5511999990000"));
+        for device in &devices {
+            members_set.insert(device.user.clone());
+        }
+
+        GroupDevicesMemo {
+            group_info: Arc::downgrade(&group_info),
+            generation: 0,
+            members: Arc::new(members_set),
+            devices: Arc::new(wacore::send::ResolvedGroupDevices::new(devices)),
+        }
+        // `group_info` drops here on purpose: the memo retains only the
+        // allocation header behind its `Weak`, which is the point of the Weak
+        // and is what the bound below must be measured against.
+    }
+
+    /// The memo is per group and lives as long as the group stays warm, so its
+    /// cost has to be a bound rather than a comment. Measured per (member,
+    /// device) pair because both halves scale with it: the membership index is
+    /// keyed by user and the device list by device.
+    #[test]
+    fn group_devices_memo_retained_bytes_stay_bounded() {
+        use wacore::stats::HeapSize;
+
+        const MEMBERS: usize = 1024;
+        const DEVICES_PER_USER: usize = 3;
+
+        let memo = group_memo_fixture(MEMBERS, DEVICES_PER_USER);
+        let per_device =
+            (size_of::<GroupDevicesMemo>() + memo.heap_bytes()) / (MEMBERS * DEVICES_PER_USER);
+        assert!(
+            per_device <= 98,
+            "a warm 1024-member group memo must stay within 98 B per resolved device, \
+             got {per_device}"
+        );
+    }
 }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -4030,7 +4030,10 @@ mod tests {
             lid_to_pn.clone(),
         ));
 
-        let mut devices = Vec::with_capacity(members * devices_per_user);
+        // Reserved the way `get_user_devices_owned` does — two devices per
+        // input user — and then grown past it, so the fixture carries the same
+        // idle capacity a real fan-out hands the memo.
+        let mut devices = Vec::with_capacity(members * 2);
         for participant in &participants {
             for device in 0..devices_per_user {
                 devices.push(Jid::lid_device(participant.user.clone(), device as u16));

--- a/src/client/member_index.rs
+++ b/src/client/member_index.rs
@@ -1,0 +1,229 @@
+//! The membership index behind the device-list memos.
+
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
+use std::sync::OnceLock;
+
+/// The set of user identifiers a device-list memo was built over, stored as
+/// sorted 64-bit fingerprints rather than the identifiers themselves.
+///
+/// The only question ever asked of it is the scoped-invalidation probe "did
+/// this topology write touch a member of that memo?", and its two answers are
+/// not symmetric: a spurious `true` recomputes a memo that did not need it, a
+/// spurious `false` serves a device list that is missing a device. A hash
+/// collision can only produce the former, so the identifiers themselves earn
+/// nothing here — which is why a memo over a 1024-member group can index its
+/// membership in 8 bytes per identifier instead of a `HashSet` of strings
+/// whose buckets alone cost an order of magnitude more.
+///
+/// Construction must therefore stay push-only: every identifier that reaches
+/// the builder is indexed, and no control flow may depend on two fingerprints
+/// being equal (see [`crate::client::device_registry`]'s DM member walk, which
+/// dedups on the strings for exactly that reason).
+pub(crate) struct MemberIndex {
+    /// Sorted and deduplicated, so a probe is a binary search. Boxed rather
+    /// than a `Vec` because it never changes after construction and the memo
+    /// holds it for the life of the group.
+    fingerprints: Box<[u64]>,
+}
+
+/// One `RandomState` for the whole process. The fingerprints of two different
+/// indexes are never compared, so nothing requires a shared seed — but sharing
+/// one keeps `MemberIndex` a single pointer wide, and drawing it randomly once
+/// per process keeps a remote peer from choosing identifiers that collide.
+fn fingerprint_hasher() -> &'static RandomState {
+    static HASHER: OnceLock<RandomState> = OnceLock::new();
+    HASHER.get_or_init(RandomState::new)
+}
+
+fn fingerprint(user: &str) -> u64 {
+    fingerprint_hasher().hash_one(user)
+}
+
+impl MemberIndex {
+    pub(crate) fn builder(capacity: usize) -> MemberIndexBuilder {
+        MemberIndexBuilder {
+            fingerprints: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Whether `user` may be a member. `true` is "possibly", `false` is
+    /// definite — see the type's note on which direction is safe.
+    pub(crate) fn contains(&self, user: &str) -> bool {
+        self.fingerprints.binary_search(&fingerprint(user)).is_ok()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.fingerprints.len()
+    }
+}
+
+impl wacore::stats::HeapSize for MemberIndex {
+    fn heap_bytes(&self) -> usize {
+        self.fingerprints.len() * size_of::<u64>()
+    }
+}
+
+impl std::fmt::Debug for MemberIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemberIndex")
+            .field("members", &self.fingerprints.len())
+            .finish()
+    }
+}
+
+pub(crate) struct MemberIndexBuilder {
+    fingerprints: Vec<u64>,
+}
+
+impl MemberIndexBuilder {
+    pub(crate) fn insert(&mut self, user: &str) {
+        self.fingerprints.push(fingerprint(user));
+    }
+
+    pub(crate) fn build(mut self) -> MemberIndex {
+        sort_fingerprints(&mut self.fingerprints);
+        dedup_sorted(&mut self.fingerprints);
+        MemberIndex {
+            // Shrinks the over-reserved build buffer to what the deduplicated
+            // membership actually needs, which for a group whose members were
+            // each pushed under several aliases is most of it.
+            fingerprints: self.fingerprints.into_boxed_slice(),
+        }
+    }
+}
+
+/// In-place heapsort over the fingerprints.
+///
+/// Deliberately not `sort_unstable`: a fresh instantiation of the standard
+/// library's pdqsort cost 15.6 KiB of `.text` when #1353 added one, which is a
+/// bad trade for a sort that runs once per memo recompute. This is a few
+/// hundred bytes, monomorphic on `u64`, and still O(n log n).
+fn sort_fingerprints(values: &mut [u64]) {
+    let len = values.len();
+    if len < 2 {
+        return;
+    }
+    for root in (0..len / 2).rev() {
+        sift_down(values, root, len);
+    }
+    for end in (1..len).rev() {
+        values.swap(0, end);
+        sift_down(values, 0, end);
+    }
+}
+
+fn sift_down(values: &mut [u64], mut root: usize, end: usize) {
+    loop {
+        let mut child = 2 * root + 1;
+        if child >= end {
+            return;
+        }
+        if child + 1 < end && values[child] < values[child + 1] {
+            child += 1;
+        }
+        if values[root] >= values[child] {
+            return;
+        }
+        values.swap(root, child);
+        root = child;
+    }
+}
+
+/// Drop runs of equal values from a sorted slice, monomorphically — same
+/// reason as the sort above, `Vec::dedup` would instantiate `dedup_by`.
+fn dedup_sorted(values: &mut Vec<u64>) {
+    if values.is_empty() {
+        return;
+    }
+    let mut write = 1;
+    for read in 1..values.len() {
+        if values[read] != values[write - 1] {
+            values[write] = values[read];
+            write += 1;
+        }
+    }
+    values.truncate(write);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indexes_every_inserted_identifier() {
+        let mut builder = MemberIndex::builder(4);
+        for user in ["100000000000001", "5511999990001", "100000000000002"] {
+            builder.insert(user);
+        }
+        let index = builder.build();
+
+        for user in ["100000000000001", "5511999990001", "100000000000002"] {
+            assert!(index.contains(user), "{user} was inserted");
+        }
+        // A `false` is the definite answer, so an unrelated identifier must
+        // produce one (barring a collision, which this fixture does not hit).
+        assert!(!index.contains("100000000000009"));
+    }
+
+    #[test]
+    fn duplicate_identifiers_collapse() {
+        let mut builder = MemberIndex::builder(8);
+        for _ in 0..4 {
+            builder.insert("100000000000001");
+        }
+        builder.insert("5511999990001");
+        let index = builder.build();
+
+        assert_eq!(index.len(), 2, "aliases pushed repeatedly index once");
+        assert!(index.contains("100000000000001"));
+        assert!(index.contains("5511999990001"));
+    }
+
+    #[test]
+    fn empty_index_answers_no() {
+        let index = MemberIndex::builder(0).build();
+        assert_eq!(index.len(), 0);
+        assert!(!index.contains("100000000000001"));
+    }
+
+    /// The probe is a binary search, so the sort is load-bearing: an unsorted
+    /// slice would answer `false` for a member and serve a stale device list.
+    /// Exercised across the sizes that reach both heapsort phases.
+    #[test]
+    fn every_member_is_found_at_any_size() {
+        for size in [1usize, 2, 3, 7, 8, 9, 64, 1000] {
+            let users: Vec<String> = (0..size).map(|i| format!("1000000{i:08}")).collect();
+            let mut builder = MemberIndex::builder(size);
+            for user in &users {
+                builder.insert(user);
+            }
+            let index = builder.build();
+            assert_eq!(index.len(), size, "size {size}");
+            for user in &users {
+                assert!(index.contains(user), "size {size} lost {user}");
+            }
+        }
+    }
+
+    #[test]
+    fn sorts_and_dedups_adversarial_orders() {
+        // Reversed, all-equal and duplicate-heavy inputs, which are where a
+        // hand-written heapsort or dedup goes wrong.
+        for mut values in [
+            vec![9u64, 8, 7, 6, 5, 4, 3, 2, 1],
+            vec![5u64; 9],
+            vec![3u64, 1, 3, 1, 2, 2, 3],
+            vec![u64::MAX, 0, u64::MAX, 0],
+        ] {
+            let mut expected = values.clone();
+            expected.sort_unstable();
+            expected.dedup();
+
+            sort_fingerprints(&mut values);
+            dedup_sorted(&mut values);
+            assert_eq!(values, expected);
+        }
+    }
+}

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1619,17 +1619,12 @@ impl Client {
                             .record_skdm_targets(Outcome::MissAbsent),
                     }
                 }
-                // Frozen before it can be memoized: what the filter returns
-                // carries the growth capacity of a scan over every device, and
-                // the entry it lands in is retained for the life of the group.
-                let needs_skdm: Box<[Jid]> = self
-                    .filter_skdm_targets(
-                        group_jid,
-                        all_devices.devices(),
-                        &cached_map,
-                        own_sending_jid,
-                    )
-                    .into_boxed_slice();
+                let needs_skdm = self.filter_skdm_targets(
+                    group_jid,
+                    all_devices.devices(),
+                    &cached_map,
+                    own_sending_jid,
+                );
                 // Still inside the `device_memos_enabled` guard, and still
                 // short-circuiting: a client with store-backed caches must not
                 // pay the snapshot read for a memo it will never write.
@@ -1651,7 +1646,17 @@ impl Client {
                                     std::sync::Arc::downgrade(&cached_map),
                                     cached_map_gen,
                                     own_sending_jid.clone(),
-                                    needs_skdm.clone(),
+                                    // Frozen only here, on the one path that
+                                    // retains it: what the filter returns
+                                    // carries the growth capacity of a scan
+                                    // over every device, and the entry keeps
+                                    // it for the life of the group. Built
+                                    // straight from the slice, so storing
+                                    // costs the one exact allocation a
+                                    // `Vec` clone would have cost anyway —
+                                    // and the send keeps its own `Vec`
+                                    // untouched.
+                                    Box::from(needs_skdm.as_slice()),
                                 ),
                             )
                             .await;
@@ -1666,7 +1671,7 @@ impl Client {
                         self.device_memo_counters.record_skdm_not_stored();
                     }
                 }
-                Some((all_devices, needs_skdm.into_vec()))
+                Some((all_devices, needs_skdm))
             }
             Err(e) => {
                 // Recorded so `SkdmTargetsMemoStats::calls()` really is one

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1601,7 +1601,10 @@ impl Client {
                             ) {
                                 None => {
                                     self.device_memo_counters.record_skdm_targets(Outcome::Hit);
-                                    return Some((all_devices, memo.4));
+                                    // Free: the stored slice is exact, so
+                                    // reclaiming it as a `Vec` reuses its
+                                    // allocation rather than copying.
+                                    return Some((all_devices, memo.4.into_vec()));
                                 }
                                 Some(term) => self.device_memo_counters.record_skdm_targets(term),
                             }
@@ -1611,12 +1614,17 @@ impl Client {
                             .record_skdm_targets(Outcome::MissAbsent),
                     }
                 }
-                let needs_skdm = self.filter_skdm_targets(
-                    group_jid,
-                    all_devices.devices(),
-                    &cached_map,
-                    own_sending_jid,
-                );
+                // Frozen before it can be memoized: what the filter returns
+                // carries the growth capacity of a scan over every device, and
+                // the entry it lands in is retained for the life of the group.
+                let needs_skdm: Box<[Jid]> = self
+                    .filter_skdm_targets(
+                        group_jid,
+                        all_devices.devices(),
+                        &cached_map,
+                        own_sending_jid,
+                    )
+                    .into_boxed_slice();
                 // Still inside the `device_memos_enabled` guard, and still
                 // short-circuiting: a client with store-backed caches must not
                 // pay the snapshot read for a memo it will never write.
@@ -1653,7 +1661,7 @@ impl Client {
                         self.device_memo_counters.record_skdm_not_stored();
                     }
                 }
-                Some((all_devices, needs_skdm))
+                Some((all_devices, needs_skdm.into_vec()))
             }
             Err(e) => {
                 // Recorded so `SkdmTargetsMemoStats::calls()` really is one
@@ -3456,7 +3464,7 @@ mod tests {
         // The same predicate the send path applies, not a second copy of it.
         skdm_memo_entry_stale_term(&memo, &devices, &cached_map, generation, &own)
             .is_none()
-            .then_some(memo.4)
+            .then(|| memo.4.into_vec())
     }
 
     /// The premise of every "the warm group send is flat in group size" claim:

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1601,9 +1601,14 @@ impl Client {
                             ) {
                                 None => {
                                     self.device_memo_counters.record_skdm_targets(Outcome::Hit);
-                                    // Free: the stored slice is exact, so
+                                    // `Cache::get` already cloned the stored
+                                    // slice, and that clone is exact, so
                                     // reclaiming it as a `Vec` reuses its
-                                    // allocation rather than copying.
+                                    // buffer instead of adding a second one.
+                                    // The hit still pays that one clone —
+                                    // same as the `Vec` this replaced; what
+                                    // the boxed form buys is retention, not a
+                                    // cheaper hit.
                                     return Some((all_devices, memo.4.into_vec()));
                                 }
                                 Some(term) => self.device_memo_counters.record_skdm_targets(term),

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -45,6 +45,12 @@ pub(crate) struct SenderKeyDeviceMap {
     generation: AtomicU64,
 }
 
+/// The two reference counts an `Arc` allocation carries ahead of its payload.
+/// A user key is one `Arc<str>` per user, so leaving this out understated a
+/// 1024-user map by 16 KiB — and a report that understates what grows is the
+/// one thing `HeapSize` says these figures must not do.
+const ARC_HEADER: usize = 2 * size_of::<usize>();
+
 /// The state of `device_id` within one user's devices.
 ///
 /// A linear scan, not a binary search: a user has a handful of devices, and at
@@ -198,7 +204,9 @@ impl SenderKeyDeviceMap {
         ) + self
             .devices
             .iter()
-            .map(|(user, states)| user.len() + states.len() * size_of::<DeviceWarmState>())
+            .map(|(user, states)| {
+                ARC_HEADER + user.len() + states.len() * size_of::<DeviceWarmState>()
+            })
             .sum::<usize>()
     }
 }
@@ -536,8 +544,8 @@ mod tests {
         let per_device =
             (size_of::<SenderKeyDeviceMap>() + map.retained_bytes()) / (USERS * DEVICES_PER_USER);
         assert!(
-            per_device <= 31,
-            "a warm 1024-user sender-key map must stay within 31 B per device, got {per_device}"
+            per_device <= 36,
+            "a warm 1024-user sender-key map must stay within 36 B per device, got {per_device}"
         );
     }
 

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -78,17 +78,42 @@ impl SenderKeyDeviceMap {
         for (jid_str, has_key) in rows {
             match jid_str.parse::<Jid>() {
                 Ok(jid) => {
-                    let state = DeviceWarmState {
-                        device_id: jid.device,
-                        has_key: AtomicBool::new(*has_key),
-                    };
                     // `Arc<str>: Borrow<str>`, so the repeat rows of a user
                     // that already has an entry cost a lookup instead of a
                     // fresh `Arc` allocation per device.
                     match by_user.get_mut(jid.user.as_str()) {
-                        Some(states) => states.push(state),
+                        Some(states) => match device_state(states, jid.device) {
+                            // Two rows can collapse onto one (user, device):
+                            // this indexes the PARSED jid's user and device,
+                            // so rows differing only in server — the same
+                            // member left behind under both `@s.whatsapp.net`
+                            // and `@lid` by an addressing-mode migration —
+                            // land on the same slot. Conflicting
+                            // values resolve to cold, never to warm — the
+                            // whole map already reads a missing entry as cold
+                            // because redistributing a sender key nobody
+                            // needed is free, while skipping one a device did
+                            // need leaves that device unable to read the
+                            // message. Order-independent, so it cannot matter
+                            // which row the backend happened to return first.
+                            Some(existing) => {
+                                if !*has_key {
+                                    existing.has_key.store(false, Ordering::Relaxed);
+                                }
+                            }
+                            None => states.push(DeviceWarmState {
+                                device_id: jid.device,
+                                has_key: AtomicBool::new(*has_key),
+                            }),
+                        },
                         None => {
-                            by_user.insert(Arc::from(jid.user.as_str()), vec![state]);
+                            by_user.insert(
+                                Arc::from(jid.user.as_str()),
+                                vec![DeviceWarmState {
+                                    device_id: jid.device,
+                                    has_key: AtomicBool::new(*has_key),
+                                }],
+                            );
                         }
                     }
                 }
@@ -397,6 +422,44 @@ mod tests {
     /// is load-bearing: rows arrive in whatever order the DB hands them, and an
     /// unsorted slice would report a user with a warm primary as cold and
     /// redistribute their sender key on every single send.
+    /// The index keys on the parsed jid's user and device, so rows differing
+    /// only in server collapse onto one slot — the shape an addressing-mode
+    /// migration leaves behind, with the same member stored under both
+    /// `@s.whatsapp.net` and `@lid`. Whichever order they arrive in, the
+    /// collapse must land cold: a spurious redistribution costs one SKDM,
+    /// while a spurious warm reading skips a distribution the device needed
+    /// and leaves it unable to read the message.
+    #[test]
+    fn conflicting_duplicate_rows_collapse_to_cold() {
+        for rows in [
+            [
+                ("111:0@lid".to_string(), true),
+                ("111:0@s.whatsapp.net".to_string(), false),
+            ],
+            [
+                ("111:0@lid".to_string(), false),
+                ("111:0@s.whatsapp.net".to_string(), true),
+            ],
+        ] {
+            let m = SenderKeyDeviceMap::from_db_rows(&rows);
+            assert_eq!(
+                m.device_has_key("111", 0),
+                Some(false),
+                "conflicting rows {rows:?} must read cold"
+            );
+            assert!(!m.device_and_primary_warm("111", 0));
+        }
+
+        // Agreeing duplicates keep their value — the collapse must not turn a
+        // genuinely warm device cold and redistribute on every send.
+        let m = SenderKeyDeviceMap::from_db_rows(&[
+            ("111:0@lid".to_string(), true),
+            ("111:0@s.whatsapp.net".to_string(), true),
+        ]);
+        assert_eq!(m.device_has_key("111", 0), Some(true));
+        assert!(m.device_and_primary_warm("111", 0));
+    }
+
     #[test]
     fn devices_are_ordered_whatever_order_the_rows_arrive_in() {
         let m = SenderKeyDeviceMap::from_db_rows(&[

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -12,42 +12,99 @@ use crate::cache_config::CacheEntryConfig;
 use wacore::stats::hash_table_bytes;
 use wacore_binary::Jid;
 
-/// Pre-parsed, pre-indexed sender key device map for one group.
+/// One tracked device of a user: which device it is, and whether it holds the
+/// group's sender key.
 ///
 /// `has_key` is an [`AtomicBool`] so `markForgetSenderKey` can flip one device
 /// cold in place, matching WA Web's per-device participant-record update,
 /// instead of invalidating the whole group and forcing the next send to re-read
-/// and re-parse every row from the DB. An in-place flip keeps the same `Arc`, so
-/// `generation` is the version stamp the `skdm_warm_memo` compares to notice the
-/// change (pointer identity alone cannot).
+/// and re-parse every row from the DB.
+#[derive(Debug)]
+struct DeviceWarmState {
+    device_id: u16,
+    has_key: AtomicBool,
+}
+
+/// Pre-parsed, pre-indexed sender key device map for one group.
+///
+/// A user's devices are a compact slice, not a nested `HashMap`. WA gives a
+/// user a handful of devices, so a per-user table spends more on buckets than
+/// it holds and a scan over three or four 4-byte entries beats hashing a `u16`;
+/// the slice also stays sorted by device id, which puts the primary — the one
+/// device every warm check has to consult — first.
+///
+/// An in-place flip keeps the same `Arc`, so `generation` is the version stamp
+/// the `skdm_warm_memo` compares to notice the change (pointer identity alone
+/// cannot).
 #[derive(Debug)]
 pub(crate) struct SenderKeyDeviceMap {
-    /// user → (device_id → has_key)
-    devices: HashMap<Arc<str>, HashMap<u16, AtomicBool>>,
+    /// user → its devices, sorted by device id.
+    devices: HashMap<Arc<str>, Box<[DeviceWarmState]>>,
     /// Bumped on every in-place warm-state change. Same freshness contract the
     /// device-registry generation gives membership.
     generation: AtomicU64,
 }
 
+/// The state of `device_id` within one user's devices.
+///
+/// A linear scan, not a binary search: a user has a handful of devices, and at
+/// that size the branch-free walk over 4-byte entries wins outright — the sort
+/// is there for the primary shortcut below, not for this.
+fn device_state(states: &[DeviceWarmState], device_id: u16) -> Option<&DeviceWarmState> {
+    states.iter().find(|state| state.device_id == device_id)
+}
+
+/// Order a user's devices by id. Insertion sort because the slice is a handful
+/// of entries built once per group load; a generic `sort_unstable_by` here
+/// would instantiate pdqsort for a new element type, which #1353 measured at
+/// 15.6 KiB of `.text`.
+fn sort_by_device_id(states: &mut [DeviceWarmState]) {
+    for i in 1..states.len() {
+        let mut j = i;
+        while j > 0 && states[j - 1].device_id > states[j].device_id {
+            states.swap(j - 1, j);
+            j -= 1;
+        }
+    }
+}
+
 impl SenderKeyDeviceMap {
     pub fn from_db_rows(rows: &[(String, bool)]) -> Self {
-        let mut devices: HashMap<Arc<str>, HashMap<u16, AtomicBool>> =
-            HashMap::with_capacity(rows.len());
+        // Deliberately unsized: `rows` counts devices, not users, so reserving
+        // by it over-allocates the outer table by however many devices a user
+        // averages — three, in a group whose members carry companions.
+        let mut by_user: HashMap<Arc<str>, Vec<DeviceWarmState>> = HashMap::new();
 
         for (jid_str, has_key) in rows {
             match jid_str.parse::<Jid>() {
                 Ok(jid) => {
-                    let user: Arc<str> = Arc::from(jid.user.as_str());
-                    devices
-                        .entry(user)
-                        .or_default()
-                        .insert(jid.device, AtomicBool::new(*has_key));
+                    let state = DeviceWarmState {
+                        device_id: jid.device,
+                        has_key: AtomicBool::new(*has_key),
+                    };
+                    // `Arc<str>: Borrow<str>`, so the repeat rows of a user
+                    // that already has an entry cost a lookup instead of a
+                    // fresh `Arc` allocation per device.
+                    match by_user.get_mut(jid.user.as_str()) {
+                        Some(states) => states.push(state),
+                        None => {
+                            by_user.insert(Arc::from(jid.user.as_str()), vec![state]);
+                        }
+                    }
                 }
                 Err(e) => {
                     log::warn!("Skipping malformed device JID '{}': {}", jid_str, e);
                 }
             }
         }
+
+        let devices = by_user
+            .into_iter()
+            .map(|(user, mut states)| {
+                sort_by_device_id(&mut states);
+                (user, states.into_boxed_slice())
+            })
+            .collect();
 
         Self {
             devices,
@@ -73,9 +130,8 @@ impl SenderKeyDeviceMap {
     #[cfg(test)]
     pub fn device_has_key(&self, user: &str, device: u16) -> Option<bool> {
         Some(
-            self.devices
-                .get(user)?
-                .get(&device)?
+            device_state(self.devices.get(user)?, device)?
+                .has_key
                 .load(Ordering::Relaxed),
         )
     }
@@ -85,13 +141,18 @@ impl SenderKeyDeviceMap {
     /// so the two device lookups share a single outer (user-string) hash instead
     /// of re-hashing the user per call. A missing entry counts as cold.
     pub fn device_and_primary_warm(&self, user: &str, device: u16) -> bool {
-        let Some(by_device) = self.devices.get(user) else {
+        let Some(states) = self.devices.get(user) else {
             return false;
         };
-        by_device
-            .get(&device)
-            .is_some_and(|k| k.load(Ordering::Relaxed))
-            && by_device.get(&0).is_some_and(|k| k.load(Ordering::Relaxed))
+        // Sorted by device id, so the primary is the first entry when it is
+        // present at all — the check every warm device pays is a single load.
+        let primary_warm = states
+            .first()
+            .is_some_and(|state| state.device_id == 0 && state.has_key.load(Ordering::Relaxed));
+        primary_warm
+            && (device == 0
+                || device_state(states, device)
+                    .is_some_and(|state| state.has_key.load(Ordering::Relaxed)))
     }
 
     /// Bytes this map retains beyond its own struct: the tables it owns plus
@@ -102,19 +163,17 @@ impl SenderKeyDeviceMap {
     /// the bound drift apart, and the bound is the only thing standing between
     /// a layout change and a silent regression.
     pub(crate) fn retained_bytes(&self) -> usize {
-        // Table allocations go through `hash_table_bytes` (outer and inner
-        // maps alike), which accounts for the buckets hashbrown really owns
-        // rather than the entries that fit in them; per-entry heap is summed
-        // by iteration.
+        // The one table left goes through `hash_table_bytes`, which accounts
+        // for the buckets hashbrown really owns rather than the entries that
+        // fit in them; the per-user slices are exact, so they are summed by
+        // iteration.
         hash_table_bytes(
             self.devices.capacity(),
-            size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>(),
+            size_of::<(Arc<str>, Box<[DeviceWarmState]>)>(),
         ) + self
             .devices
             .iter()
-            .map(|(user, by_device)| {
-                user.len() + hash_table_bytes(by_device.capacity(), size_of::<(u16, AtomicBool)>())
-            })
+            .map(|(user, states)| user.len() + states.len() * size_of::<DeviceWarmState>())
             .sum::<usize>()
     }
 }
@@ -161,9 +220,9 @@ impl SenderKeyDeviceCache {
         };
         let mut changed = false;
         for jid in devices {
-            if let Some(by_device) = map.devices.get(jid.user.as_str())
-                && let Some(flag) = by_device.get(&jid.device)
-                && flag.swap(false, Ordering::Relaxed)
+            if let Some(states) = map.devices.get(jid.user.as_str())
+                && let Some(state) = device_state(states, jid.device)
+                && state.has_key.swap(false, Ordering::Relaxed)
             {
                 // Only a real high→low transition is a warm-state change; a
                 // device already cold must not advance the generation, or a
@@ -193,7 +252,7 @@ impl SenderKeyDeviceCache {
             .filter_map(|(group_jid, map)| {
                 map.devices
                     .get(user)
-                    .and_then(|devmap| devmap.get(&device_id))
+                    .and_then(|states| device_state(states, device_id))
                     .map(|_| group_jid.as_ref().clone())
             })
             .collect();
@@ -334,6 +393,47 @@ mod tests {
         assert!(!m.device_and_primary_warm("999", 0));
     }
 
+    /// The warm gate reads the primary off the front of the slice, so the sort
+    /// is load-bearing: rows arrive in whatever order the DB hands them, and an
+    /// unsorted slice would report a user with a warm primary as cold and
+    /// redistribute their sender key on every single send.
+    #[test]
+    fn devices_are_ordered_whatever_order_the_rows_arrive_in() {
+        let m = SenderKeyDeviceMap::from_db_rows(&[
+            ("111:9@lid".to_string(), true),
+            ("111:5@lid".to_string(), true),
+            ("111:0@lid".to_string(), true),
+            ("222:3@lid".to_string(), true),
+            ("222:0@lid".to_string(), false),
+        ]);
+
+        assert!(m.device_and_primary_warm("111", 9));
+        assert!(m.device_and_primary_warm("111", 5));
+        assert!(m.device_and_primary_warm("111", 0));
+        // Primary cold, and it is not the first row of its user either.
+        assert!(!m.device_and_primary_warm("222", 3));
+        assert!(!m.device_and_primary_warm("222", 0));
+        // Every device is still individually addressable after the reorder.
+        assert_eq!(m.device_has_key("111", 9), Some(true));
+        assert_eq!(m.device_has_key("222", 3), Some(true));
+        assert_eq!(m.device_has_key("222", 0), Some(false));
+    }
+
+    /// A user whose primary row is missing entirely: the shortcut must read
+    /// that as cold rather than mistaking the lowest device it does have for
+    /// the primary.
+    #[test]
+    fn a_user_without_a_primary_row_is_cold() {
+        let m = SenderKeyDeviceMap::from_db_rows(&[
+            ("111:5@lid".to_string(), true),
+            ("111:9@lid".to_string(), true),
+        ]);
+
+        assert!(!m.device_and_primary_warm("111", 5));
+        assert!(!m.device_and_primary_warm("111", 9));
+        assert_eq!(m.device_has_key("111", 5), Some(true));
+    }
+
     #[test]
     fn from_db_rows_skips_malformed_and_keeps_valid() {
         // A corrupt or partially-migrated row must not poison the whole map: bad
@@ -373,8 +473,8 @@ mod tests {
         let per_device =
             (size_of::<SenderKeyDeviceMap>() + map.retained_bytes()) / (USERS * DEVICES_PER_USER);
         assert!(
-            per_device <= 98,
-            "a warm 1024-user sender-key map must stay within 98 B per device, got {per_device}"
+            per_device <= 31,
+            "a warm 1024-user sender-key map must stay within 31 B per device, got {per_device}"
         );
     }
 

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -93,6 +93,30 @@ impl SenderKeyDeviceMap {
             .is_some_and(|k| k.load(Ordering::Relaxed))
             && by_device.get(&0).is_some_and(|k| k.load(Ordering::Relaxed))
     }
+
+    /// Bytes this map retains beyond its own struct: the tables it owns plus
+    /// the user strings it keys on.
+    ///
+    /// One definition, shared by the cache's `memory_stats` and by the test
+    /// that pins the per-device bound — a second copy would let the report and
+    /// the bound drift apart, and the bound is the only thing standing between
+    /// a layout change and a silent regression.
+    pub(crate) fn retained_bytes(&self) -> usize {
+        // Table allocations go through `hash_table_bytes` (outer and inner
+        // maps alike), which accounts for the buckets hashbrown really owns
+        // rather than the entries that fit in them; per-entry heap is summed
+        // by iteration.
+        hash_table_bytes(
+            self.devices.capacity(),
+            size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>(),
+        ) + self
+            .devices
+            .iter()
+            .map(|(user, by_device)| {
+                user.len() + hash_table_bytes(by_device.capacity(), size_of::<(u16, AtomicBool)>())
+            })
+            .sum::<usize>()
+    }
 }
 
 pub(crate) struct SenderKeyDeviceCache {
@@ -180,28 +204,8 @@ impl SenderKeyDeviceCache {
 
     /// Approximate entry count plus estimated retained bytes.
     pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
-        // Table allocations go through `hash_table_bytes` (outer and inner
-        // maps alike), which accounts for the buckets hashbrown really owns
-        // rather than the entries that fit in them; per-entry heap is summed
-        // by iteration.
         self.inner
-            .memory_stats(|k, v| {
-                k.capacity()
-                    + hash_table_bytes(
-                        v.devices.capacity(),
-                        size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>(),
-                    )
-                    + v.devices
-                        .iter()
-                        .map(|(user, by_device)| {
-                            user.len()
-                                + hash_table_bytes(
-                                    by_device.capacity(),
-                                    size_of::<(u16, AtomicBool)>(),
-                                )
-                        })
-                        .sum::<usize>()
-            })
+            .memory_stats(|k, v| k.capacity() + v.retained_bytes())
             .await
     }
 }
@@ -346,6 +350,32 @@ mod tests {
         // The malformed rows produced no entries at all.
         assert_eq!(m.device_has_key("not-a-jid", 0), None);
         assert_eq!(m.device_has_key("111", 1), None);
+    }
+
+    /// A group's sender-key map stays resident for as long as the group is
+    /// warm, and there is one per group, so its cost per tracked device is a
+    /// bound rather than a comment. Uses the same 1024x3 shape as the device
+    /// memo test in `device_registry`, since the two sit side by side behind
+    /// every group send.
+    #[test]
+    fn retained_bytes_per_device_stay_bounded() {
+        const USERS: usize = 1024;
+        const DEVICES_PER_USER: usize = 3;
+
+        let mut rows = Vec::with_capacity(USERS * DEVICES_PER_USER);
+        for i in 0..USERS {
+            for device in 0..DEVICES_PER_USER {
+                rows.push((format!("1000000{i:08}:{device}@lid"), true));
+            }
+        }
+        let map = SenderKeyDeviceMap::from_db_rows(&rows);
+
+        let per_device =
+            (size_of::<SenderKeyDeviceMap>() + map.retained_bytes()) / (USERS * DEVICES_PER_USER);
+        assert!(
+            per_device <= 98,
+            "a warm 1024-user sender-key map must stay within 98 B per device, got {per_device}"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -38,19 +38,22 @@ pub(crate) fn partition_dm_devices(
     }
 
     PartitionedDmDevices {
-        devices: all_devices,
+        // Frozen once the partition is settled: nothing appends to it
+        // afterwards, and the fan-out build over-reserves, so the boxed slice
+        // keeps a resident DM memo from parking that slack.
+        devices: all_devices.into_boxed_slice(),
         recipient_count,
     }
 }
 
 pub(crate) struct PartitionedDmDevices {
-    devices: Vec<Jid>,
+    devices: Box<[Jid]>,
     recipient_count: usize,
 }
 
 impl crate::stats::HeapSize for PartitionedDmDevices {
     fn heap_bytes(&self) -> usize {
-        self.devices.capacity() * size_of::<Jid>()
+        self.devices.len() * size_of::<Jid>()
             + self.devices.iter().map(|j| j.heap_bytes()).sum::<usize>()
     }
 }
@@ -597,8 +600,29 @@ where
 mod partition_tests {
     use super::*;
 
+    /// Classification is in place, so a fan-out that drops nothing keeps the
+    /// caller's allocation: the freeze into a boxed slice is a no-op when the
+    /// input was already exact, and no per-partition `Vec` is ever built.
     #[test]
-    fn partition_dm_devices_reuses_input_allocation() {
+    fn partition_dm_devices_reuses_an_exact_input_allocation() {
+        let own_jid = Jid::lid_device("123456789".to_owned(), 7);
+        // `vec![]` allocates exactly three slots, so the freeze below has no
+        // slack to hand back and must leave the buffer where it is.
+        let devices = vec![
+            Jid::lid_device("987654321".to_owned(), 0),
+            Jid::lid_device("123456789".to_owned(), 0),
+            Jid::lid_device("987654321".to_owned(), 1),
+        ];
+        let allocation = devices.as_ptr();
+
+        let partitioned = partition_dm_devices(devices, &own_jid, None);
+
+        assert_eq!(partitioned.devices.as_ptr(), allocation);
+        assert_eq!(partitioned.devices.len(), 3);
+    }
+
+    #[test]
+    fn partition_dm_devices_splits_recipients_from_own_devices() {
         let own_jid = Jid::lid_device("123456789".to_owned(), 7);
         let devices = vec![
             Jid::lid_device("987654321".to_owned(), 0),
@@ -606,13 +630,12 @@ mod partition_tests {
             own_jid.clone(),
             Jid::lid_device("987654321".to_owned(), 1),
         ];
-        let allocation = devices.as_ptr();
-        let capacity = devices.capacity();
 
         let partitioned = partition_dm_devices(devices, &own_jid, None);
 
-        assert_eq!(partitioned.devices.as_ptr(), allocation);
-        assert_eq!(partitioned.devices.capacity(), capacity);
+        // The sending device is dropped, so the frozen slice holds exactly the
+        // three survivors rather than the four slots it was built in.
+        assert_eq!(partitioned.devices.len(), 3);
         assert_eq!(partitioned.valid_devices().len(), 3);
         assert_eq!(partitioned.recipient_devices().len(), 2);
         assert_eq!(partitioned.own_other_devices().len(), 1);

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -19,7 +19,11 @@ use wacore_binary::jid::Jid;
 /// A phash is 10 bytes ("2:" + 8 base64 chars), inline in `CompactString`:
 /// serving a warm send costs a pointer-free copy, no allocation.
 pub struct ResolvedGroupDevices {
-    devices: Vec<Jid>,
+    /// Frozen at construction: the set never changes afterwards (a topology
+    /// change produces a new memo entry, not a mutation), so the boxed slice
+    /// hands back the growth capacity the fan-out build over-reserved instead
+    /// of parking it for the life of the group.
+    devices: Box<[Jid]>,
     /// `(sending jid, phash)`. The jid pins the only other input, so a
     /// change of sending identity (PN/LID mode flip, re-pair) can never be
     /// served a stale hash; it recomputes without overwriting.
@@ -28,7 +32,7 @@ pub struct ResolvedGroupDevices {
 
 impl crate::stats::HeapSize for ResolvedGroupDevices {
     fn heap_bytes(&self) -> usize {
-        self.devices.capacity() * size_of::<Jid>()
+        self.devices.len() * size_of::<Jid>()
             + self.devices.iter().map(|j| j.heap_bytes()).sum::<usize>()
             + self
                 .phash
@@ -40,7 +44,7 @@ impl crate::stats::HeapSize for ResolvedGroupDevices {
 impl ResolvedGroupDevices {
     pub fn new(devices: Vec<Jid>) -> Self {
         Self {
-            devices,
+            devices: devices.into_boxed_slice(),
             phash: OnceLock::new(),
         }
     }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1,6 +1,8 @@
+use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::BuildHasher;
 use std::num::NonZeroU64;
-use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard};
+use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard, OnceLock};
 
 use anyhow::Result;
 use async_lock::Mutex;
@@ -188,6 +190,20 @@ fn user_of_protocol_address(address: &str) -> &str {
     }
 }
 
+/// One `RandomState` for the whole process, drawn once. The user index only
+/// ever compares a fingerprint against its own set, so nothing requires a
+/// shared seed — but sharing one keeps the hasher out of every cache, and
+/// drawing it randomly keeps a peer from choosing identifiers that collide.
+fn fingerprint_hasher() -> &'static RandomState {
+    static HASHER: OnceLock<RandomState> = OnceLock::new();
+    HASHER.get_or_init(RandomState::new)
+}
+
+/// The 64-bit stand-in for a user identifier in [`UserIndexedCache::users`].
+fn user_fingerprint(user: &str) -> u64 {
+    fingerprint_hasher().hash_one(user)
+}
+
 /// A cache map that can answer "is any address here owned by this user?"
 /// without scanning every key.
 ///
@@ -197,9 +213,14 @@ fn user_of_protocol_address(address: &str) -> &str {
 /// user that has some, which is the direction that would silently skip a
 /// migration. `insert` is the only way in, so an entry cannot reach the map
 /// without registering its user.
+///
+/// Because a false `true` is already the accepted error, the set holds
+/// 64-bit fingerprints rather than the identifiers: a hash collision produces
+/// exactly that same error and nothing else, and the index stops duplicating
+/// every user string the three Signal stores already key on.
 struct UserIndexedCache<V> {
     map: HashMap<Arc<str>, V>,
-    users: HashSet<Arc<str>>,
+    users: HashSet<u64>,
     /// Counts removal events. A cold reader that saw a slot absent, released
     /// the lock, and finds it absent again cannot otherwise tell "never
     /// written" from "written, flushed, and evicted": a clean removal keeps the
@@ -227,10 +248,8 @@ impl<V> UserIndexedCache<V> {
     }
 
     fn insert(&mut self, key: Arc<str>, value: V) -> Option<V> {
-        let user = user_of_protocol_address(&key);
-        if !self.users.contains(user) {
-            self.users.insert(Arc::from(user));
-        }
+        self.users
+            .insert(user_fingerprint(user_of_protocol_address(&key)));
         self.map.insert(key, value)
     }
 
@@ -273,19 +292,22 @@ impl<V> UserIndexedCache<V> {
         // address begins with `user`, so a separator inside `user` is also the
         // address's first one and both collapse to the same key: an addressed
         // `19995551006:5` and a bare `19995551006` are one entry here.
-        self.users.contains(user_of_protocol_address(user))
+        self.users
+            .contains(&user_fingerprint(user_of_protocol_address(user)))
     }
 
     /// Drop users no longer backed by an entry. Bounds the superset's drift
     /// after eviction; callers gate it on a watermark so it stays amortized.
     fn compact_users(&mut self) {
         self.users.clear();
-        let users: Vec<Arc<str>> = self
-            .map
-            .keys()
-            .map(|key| Arc::from(user_of_protocol_address(key)))
-            .collect();
-        self.users.extend(users);
+        // Fingerprints are `Copy`, so the rebuild reads straight off the live
+        // keys — no intermediate `Vec` and no `Arc<str>` per surviving user,
+        // which is what this used to allocate under the store's global mutex.
+        self.users.extend(
+            self.map
+                .keys()
+                .map(|key| user_fingerprint(user_of_protocol_address(key))),
+        );
     }
 
     fn users_len(&self) -> usize {
@@ -297,7 +319,7 @@ impl<V> UserIndexedCache<V> {
     /// name and so are owned solely here. Keeps `memory_stats` from reporting
     /// only the map.
     fn overhead_bytes(&self) -> usize {
-        self.users.iter().map(|user| user.len()).sum::<usize>()
+        crate::stats::hash_table_bytes(self.users.capacity(), size_of::<u64>())
             + self
                 .recent_removals
                 .iter()

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1913,10 +1913,9 @@ impl SignalStoreCache {
     ///
     /// One residual overlap is accepted rather than tracked: an address
     /// evicted while still pending is charged both as a pending-only key and
-    /// in the removal window that named it. The window holds
-    /// [`RECENT_REMOVALS`] entries, which bounds the overstatement to a
-    /// handful of addresses — cheaper to state than to reconcile on a report
-    /// that is an estimate by contract.
+    /// in the removal window that named it. That window holds 64 entries,
+    /// which bounds the overstatement to a handful of addresses — cheaper to
+    /// state than to reconcile on a report that is an estimate by contract.
     pub async fn memory_stats(
         &self,
     ) -> (

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -657,10 +657,18 @@ impl SenderKeyStoreState {
     }
 
     fn key_for(&self, address: &str) -> Arc<str> {
-        match self.cache.get_key_value(address) {
-            Some((existing, _)) => existing.clone(),
-            None => Arc::from(address),
+        if let Some((existing, _)) = self.cache.get_key_value(address) {
+            return existing.clone();
         }
+        // The other place this address may already own an `Arc`: a
+        // distribution is retained when its durability gate fails, which can
+        // happen before the record itself reaches the cache. Reusing that key
+        // keeps one allocation per address instead of two, and keeps
+        // `memory_stats` from charging a string the store holds twice.
+        if let Some((existing, _)) = self.pending_distributions.get_key_value(address) {
+            return existing.clone();
+        }
+        Arc::from(address)
     }
 
     fn put(&mut self, address: &str, mut record: SenderKeyRecord) {
@@ -1896,6 +1904,19 @@ impl SignalStoreCache {
     /// their addresses are the cache's `Arc<str>` keys, which eviction cannot
     /// drop while an address is dirty, deleted or pending, so charging the
     /// payloads again would double-count them.
+    ///
+    /// The sender-key figure additionally covers `pending_distributions`: its
+    /// table slots, its distribution payloads, and the key bytes of entries
+    /// the cache no longer holds (a pending entry whose record is in the cache
+    /// shares that key, which `key_for` canonicalizes, so it is charged once).
+    /// Its entry count includes those pending-only addresses.
+    ///
+    /// One residual overlap is accepted rather than tracked: an address
+    /// evicted while still pending is charged both as a pending-only key and
+    /// in the removal window that named it. The window holds
+    /// [`RECENT_REMOVALS`] entries, which bounds the overstatement to a
+    /// handful of addresses — cheaper to state than to reconcile on a report
+    /// that is an estimate by contract.
     pub async fn memory_stats(
         &self,
     ) -> (
@@ -2332,6 +2353,53 @@ mod sender_key_lock_tests {
              got {}",
             identities.bytes
         );
+    }
+
+    /// A distribution is retained when its durability gate fails, which can
+    /// land before the record itself reaches the cache. Both orders must end
+    /// up sharing one `Arc<str>`: two allocations for one address is a real
+    /// (if small) waste, and it also makes `memory_stats` charge the string
+    /// once for storage it holds twice.
+    #[tokio::test]
+    async fn pending_distribution_and_cache_share_one_key() {
+        for pending_first in [true, false] {
+            let cache = SignalStoreCache::new();
+            let name =
+                SenderKeyName::from_parts("19995550001@g.us", "19995550002@s.whatsapp.net:0");
+
+            let retain = || async {
+                cache
+                    .cache_pending_sender_key_distribution(&name, Arc::from(&[1u8, 2, 3][..]))
+                    .await
+            };
+            let store = || async {
+                cache
+                    .put_sender_key(&name, sender_key_record_with_chain(3))
+                    .await
+            };
+
+            if pending_first {
+                retain().await;
+                store().await;
+            } else {
+                store().await;
+                retain().await;
+            }
+
+            let state = cache.sender_keys.lock().await;
+            let (cache_key, _) = state
+                .cache
+                .get_key_value(name.cache_key())
+                .expect("record cached");
+            let (pending_key, _) = state
+                .pending_distributions
+                .get_key_value(name.cache_key())
+                .expect("distribution retained");
+            assert!(
+                Arc::ptr_eq(cache_key, pending_key),
+                "pending_first={pending_first}: the two sides must share one allocation"
+            );
+        }
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1479,7 +1479,12 @@ impl SignalStoreCache {
             // the chain resume an iteration that has already been published.
             if state.incarnation == incarnation && !state.cache.removed_since(key, since) {
                 let record = decoded?;
-                state.cache.insert(Arc::from(key), record.clone());
+                // Through `key_for`, not `Arc::from`: a distribution retained
+                // for this address while the record was still cold already
+                // owns a key, and allocating a second one for the same string
+                // is what the canonicalization exists to avoid.
+                let addr = state.key_for(key);
+                state.cache.insert(addr, record.clone());
                 state.evict_if_needed(self.max_entries);
                 return Ok(record);
             }
@@ -1497,7 +1502,8 @@ impl SignalStoreCache {
             )?)),
             None => None,
         };
-        state.cache.insert(Arc::from(key), record.clone());
+        let addr = state.key_for(key);
+        state.cache.insert(addr, record.clone());
         state.evict_if_needed(self.max_entries);
         Ok(record)
     }
@@ -2399,6 +2405,51 @@ mod sender_key_lock_tests {
                 "pending_first={pending_first}: the two sides must share one allocation"
             );
         }
+    }
+
+    /// The third way a record reaches the cache: not a `put`, but a cold read
+    /// populating it from the backend. It has to canonicalize too, or a
+    /// distribution retained while the record was still cold leaves the store
+    /// holding two keys for one address.
+    #[tokio::test]
+    async fn a_cold_load_reuses_a_pending_distribution_key() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let name = SenderKeyName::from_parts("19995550001@g.us", "19995550002@s.whatsapp.net:0");
+        backend
+            .put_sender_key(
+                name.cache_key(),
+                &sender_key_record_with_chain(5)
+                    .serialize()
+                    .expect("serialize record"),
+            )
+            .await
+            .expect("seed backend");
+
+        // Retained first, so the pending map owns the only key for this
+        // address when the cold load goes to insert its own.
+        cache
+            .cache_pending_sender_key_distribution(&name, Arc::from(&[9u8, 8][..]))
+            .await;
+        cache
+            .get_sender_key(&name, &backend)
+            .await
+            .expect("cold load")
+            .expect("record present");
+
+        let state = cache.sender_keys.lock().await;
+        let (cache_key, _) = state
+            .cache
+            .get_key_value(name.cache_key())
+            .expect("record cached");
+        let (pending_key, _) = state
+            .pending_distributions
+            .get_key_value(name.cache_key())
+            .expect("distribution retained");
+        assert!(
+            Arc::ptr_eq(cache_key, pending_key),
+            "the cold load must adopt the pending key, not allocate a second"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -167,6 +167,14 @@ impl PendingWireGate {
         self.addresses.iter()
     }
 
+    /// Bytes the gate's table allocates. The addresses themselves are the
+    /// cache's own `Arc<str>` keys — the gate is always a subset of `dirty` +
+    /// `deleted`, which eviction cannot drop — so charging their payloads here
+    /// would count them twice.
+    fn table_bytes(&self) -> usize {
+        crate::stats::hash_table_bytes(self.addresses.capacity(), size_of::<Arc<str>>())
+    }
+
     /// `Release` so a reader whose `Acquire` load sees the lowered flag also
     /// sees the removals that emptied the set.
     fn publish(&self) {
@@ -314,16 +322,22 @@ impl<V> UserIndexedCache<V> {
         self.users.len()
     }
 
-    /// Retained bytes of the bookkeeping beside the primary map: the user
-    /// index, plus the removal window, whose keys outlive the entries they
-    /// name and so are owned solely here. Keeps `memory_stats` from reporting
-    /// only the map.
+    /// Retained bytes of everything this cache allocates except the entry
+    /// payloads: the primary map's buckets, the user index, the removal ring,
+    /// and the removal window's keys — which outlive the entries they name and
+    /// so are owned solely here.
+    ///
+    /// Slots, not entries: a `HashMap` holding n entries owns more buckets than
+    /// n (see [`crate::stats::hash_table_bytes`]), and it is the buckets the
+    /// allocator is holding. `memory_stats` adds the keys and payloads on top.
     fn overhead_bytes(&self) -> usize {
-        crate::stats::hash_table_bytes(self.users.capacity(), size_of::<u64>())
+        crate::stats::hash_table_bytes(self.map.capacity(), size_of::<(Arc<str>, V)>())
+            + crate::stats::hash_table_bytes(self.users.capacity(), size_of::<u64>())
+            + self.recent_removals.capacity() * size_of::<(u64, Arc<str>)>()
             + self
                 .recent_removals
                 .iter()
-                .map(|(_, key)| key.len() + size_of::<u64>())
+                .map(|(_, key)| key.len())
                 .sum::<usize>()
     }
 
@@ -1874,6 +1888,14 @@ impl SignalStoreCache {
     /// Session entry counts include negative (`Absent`) and checked-out slots
     /// — they occupy the map. Byte totals include the key length for every
     /// slot, but the estimated record payload only for `Present` entries.
+    ///
+    /// Structural allocations are charged too, through
+    /// [`crate::stats::hash_table_bytes`]: each cache's own tables (see
+    /// `UserIndexedCache::overhead_bytes`) plus the dirty/deleted sets and the
+    /// pre-wire gates beside it. Those sets are charged for their slots only —
+    /// their addresses are the cache's `Arc<str>` keys, which eviction cannot
+    /// drop while an address is dirty, deleted or pending, so charging the
+    /// payloads again would double-count them.
     pub async fn memory_stats(
         &self,
     ) -> (
@@ -1902,7 +1924,10 @@ impl SignalStoreCache {
                     }
                 })
                 .collect();
-            keys_len += s.cache.overhead_bytes();
+            keys_len += s.cache.overhead_bytes()
+                + crate::stats::hash_table_bytes(s.dirty.capacity(), size_of::<Arc<str>>())
+                + crate::stats::hash_table_bytes(s.deleted.capacity(), size_of::<Arc<str>>())
+                + s.reservation_pending.table_bytes();
             (s.cache.len() as u64, keys_len, recs)
         };
         let session_bytes: usize = session_keys_len
@@ -1919,7 +1944,9 @@ impl SignalStoreCache {
                 .iter()
                 .map(|(k, v)| k.len() + v.as_ref().map_or(0, |b| b.len()))
                 .sum::<usize>()
-                + i.cache.overhead_bytes();
+                + i.cache.overhead_bytes()
+                + crate::stats::hash_table_bytes(i.dirty.capacity(), size_of::<Arc<str>>())
+                + crate::stats::hash_table_bytes(i.deleted.capacity(), size_of::<Arc<str>>());
             CollectionStats::new(i.cache.len() as u64, bytes as u64)
         };
 
@@ -1946,7 +1973,14 @@ impl SignalStoreCache {
                 .fold((0usize, 0usize), |(count, bytes), key| {
                     (count + 1, bytes + key.len())
                 });
-            keys_len += pending_only_key_bytes + sk.cache.overhead_bytes();
+            keys_len += pending_only_key_bytes
+                + sk.cache.overhead_bytes()
+                + crate::stats::hash_table_bytes(sk.dirty.capacity(), size_of::<Arc<str>>())
+                + sk.wire_gate_pending.table_bytes()
+                + crate::stats::hash_table_bytes(
+                    sk.pending_distributions.capacity(),
+                    size_of::<(Arc<str>, Arc<[u8]>)>(),
+                );
             (
                 (sk.cache.len() + pending_only_count) as u64,
                 keys_len,
@@ -2268,6 +2302,36 @@ mod sender_key_lock_tests {
             .sender_key_state()
             .expect("record must carry a state")
             .chain_id()
+    }
+
+    /// The report has to charge what the allocator is holding, not what the
+    /// entries measure: a `HashMap` of n identities owns more buckets than n,
+    /// and the dirty set, the user index and the pre-wire gate beside it are
+    /// allocations too. Before these were counted the identity store reported
+    /// only its keys and payloads — which is exactly the figure that stays
+    /// quiet while the tables are what is growing.
+    #[tokio::test]
+    async fn identity_report_charges_the_tables_not_just_the_entries() {
+        const IDENTITIES: usize = 200;
+
+        let cache = SignalStoreCache::new();
+        let mut entry_bytes = 0usize;
+        for i in 0..IDENTITIES {
+            let address = format!("1999555{i:04}:0");
+            entry_bytes += address.len() + 32;
+            cache
+                .put_identity(&ProtocolAddress::new(&address, 0.into()), &[7u8; 32])
+                .await;
+        }
+
+        let (_, identities, _) = cache.memory_stats().await;
+        assert_eq!(identities.entries, IDENTITIES as u64);
+        assert!(
+            identities.bytes > entry_bytes as u64,
+            "the report must exceed the {entry_bytes} B of keys and payloads it holds, \
+             got {}",
+            identities.bytes
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #1353, on the caches that sit behind every send and stay resident for the life of a warm connection: the per-group and per-recipient device-list memos, the sender-key device map, and the Signal stores' user index.

Measured on the shape a community group actually has — 1024 members, three devices each.

## What changed

| Commit | Effect |
| --- | --- |
| `test(memory)` | Pins the device memo and the sender-key map at what they cost today (98 B per resolved device), so the rest is measured rather than argued |
| `perf(core)` topology members | Memo membership index: `HashSet<CompactString>` → sorted `Box<[u64]>` fingerprints. **98 → 37 B/device** (~301 KiB → ~113 KiB) |
| `perf(core)` frozen lists | `ResolvedGroupDevices`, `PartitionedDmDevices` and the SKDM memo targets become boxed slices. **48 → 37 B/device** once the fixture models the real over-reservation |
| `perf(signal)` device states | Sender-key map: `HashMap<Arc<str>, HashMap<u16, AtomicBool>>` → `HashMap<Arc<str>, Box<[DeviceWarmState]>>`. **98 → 31 B/device** (~301 KiB → ~95 KiB) |
| `perf(signal)` user index | The three Signal stores' migration index: `HashSet<Arc<str>>` → `HashSet<u64>` |
| `fix(observability)` | `SignalStoreCache::memory_stats` charges its structural allocations |

Together the first four take a resident 1024×3 group from roughly 0.6 MiB across the two caches down to roughly 0.2 MiB, before allocator overhead.

### Review follow-ups

Everything below came out of review on this PR rather than the original plan:

| Commit | Effect |
| --- | --- |
| `docs(send)` | The warm SKDM memo hit is not allocation-free — `Cache::get` clones the stored slice first. The comment said otherwise (Greptile) |
| `fix(signal)` duplicate rows | Rows differing only in server collapse onto one `(user, device)` slot. The slice changed the tie-break from last-wins to first-wins, which could **skip a needed SKDM**. Conflicts now resolve to cold, order-independently (CodeRabbit) |
| `perf(signal)` shared key | `key_for` reuses a pending distribution's `Arc<str>` instead of allocating a second for the same address (CodeRabbit) |
| `perf(send)` no rebox | The filter's `Vec` is no longer boxed-then-unboxed on sends that never memoize it (CodeRabbit) |
| `fix(observability)` Arc header | `retained_bytes` counted a user key as its string bytes alone, missing 16 B of reference counts per user — 16 KiB on a 1024-user map (CodeRabbit) |
| `fix(docs)` | Rustdoc gate: a public doc comment linked a private const |
| `perf(signal)` cold loads | `get_sender_key`'s two cold-load inserts also canonicalize, so all three ways a record enters the cache share one key (Codex + CodeRabbit) |

**The sender-key bound is now 36 B/device, not 31.** The Arc-header fix made the *report* more honest; the layout did not grow. The 98 B baseline was measured the same incomplete way, so the reduction itself is unchanged — but the new figure should not be the flattering one.

## Why the fingerprints are safe

Both indexes exist to answer one question conservatively, and their two answers are not symmetric.

- The **memo membership index** answers "did this topology write touch a member?". A spurious `true` recomputes a memo that did not need it; a spurious `false` serves a device list missing a device. A hash collision can only produce the former.
- The **Signal user index** is already a deliberate superset — removals leave it untouched, so a `true` for a user whose last entry is gone costs one migration pass that finds nothing. A collision produces that same accepted error and nothing else.

One place is deliberately excluded: the DM member walk dedups on the identifiers, not on their fingerprints, because there the skip is control flow. A collision that skipped a distinct user would leave that user's mapped counterpart out of the index entirely — the one error direction the index must not have.

## Binary size

No new `sort_unstable` instantiation anywhere: #1353 measured one at 15.6 KiB of `.text`. The fingerprints are sorted by a hand-written monomorphic heapsort, the per-user device slices by an insertion sort (a handful of entries), and the dedup is a manual pass rather than `Vec::dedup`.

That held up: **+3.38 KiB `.text` against a 32 KiB budget** (+3.53 KiB stripped against 64 KiB), with `.text whatsapp_rust` itself *down* 4.08 KiB. No new dependencies.

## Performance

CodSpeed found the compact sender-key slice is also faster on the read path, which was the bet behind replacing the nested `HashMap`:

| Benchmark | base | head | |
| --- | --- | --- | --- |
| `skdm_target_resolution_memo_cold[512]` | 338.8 µs | 233.1 µs | +45% |
| `skdm_target_resolution_memo_cold[128]` | 119.4 µs | 93.2 µs | +28% |
| `skdm_target_resolution_memo_cold[32]` | 63.9 µs | 57.3 µs | +11% |

No benchmark regressed (383 untouched).

## Observability

`SignalStoreCache::memory_stats` documented its own figures as a floor: it summed keys and payloads and charged nothing for the tables holding them, which is quietest in exactly the case the report exists for. It now charges slots through `hash_table_bytes` — each cache's primary map, user index and removal ring, plus the dirty/deleted sets, pre-wire gates and pending distributions beside it.

Those sets are charged for their **slots only**. Their addresses are the cache's own `Arc<str>` keys, which eviction cannot drop while an address is dirty, deleted or pending, so charging the payloads again would double-count them — the same trap #1353 hit and fixed.

One overlap is stated rather than reconciled: an address evicted while still pending is charged both as a pending-only key and in the 64-entry removal window that named it. On a report that is an estimate by contract, stating the bound beats tracking it. `agent_docs/observability.md` carries the same wording for operators.

## Verification

`cargo fmt --check`, clippy `-D warnings` on the touched crates, 1502 `wacore` + 1786 `whatsapp-rust` unit tests, the integration tests and the doctests pass locally, plus `RUSTDOCFLAGS="-D warnings" cargo doc` after the Rustdoc fix.

New tests worth calling out, since several of these layouts have a load-bearing invariant nothing else would catch. Each was checked to fail when its fix is reverted:

- `member_index`: every inserted identifier is found at sizes reaching both heapsort phases, plus reversed/all-equal/duplicate-heavy inputs. An unsorted slice would answer `false` for a real member and serve a stale device list.
- `sender_key_device_cache`: rows out of device order; a user whose primary row is missing entirely (must read cold, not promote the lowest device it has); and conflicting duplicate rows in both arrival orders.
- `signal_cache`: the identity report must exceed the keys and payloads it holds, which is what proves the tables are charged; and the pending/cached key sharing across all three population paths.

## Left out

The app-state key cache (base64 keys → `Arc<[u8]>`, shared `Arc<HashMap<…>>` snapshot) is a real win but a smaller one, and folding it in would widen this PR past the device-resolution story. Separate PR.

Consistent `Arc<str>` header accounting for `UserIndexedCache`'s removal window is the same omission the sender-key map just fixed, left as follow-up because that report already documents a bounded estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017X49NX8Qm95eLNsqVsDmNN