### PR TITLE
fix: four wire/reporting divergences from WhatsApp Web — status receipts, prekey-low routing, encrypt acks, replay classification

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1860,8 +1860,8 @@ fn ack_participant<'node, 'data>(
 /// - `id`, `to` (flipped from `from`) copied from original
 /// - `participant` follows the generic or receipt-specialized policy
 /// - `from` = own device PN, only for message acks
-/// - `type` echoed when present, except `notification type="encrypt"` with
-///   an `<identity/>` child
+/// - `type` echoed when present, except `notification type="encrypt"`, whose
+///   ack WA Web builds without one
 ///
 /// For receipt acks, WA Web uses `MAYBE_CUSTOM_STRING(ackString)` where
 /// `ackString = maybeAttrString("type")` — so `type` is only included when
@@ -1886,7 +1886,14 @@ fn encode_ack_bytes(
     // Dropping it makes the server close the stream with `<stream:error><ack/>`.
     let recipient_val = node.get_attr("recipient");
 
-    let typ_val = if !is_encrypt_identity_notification(node) {
+    // Every WA Web handler for `<notification type="encrypt">` builds its ack
+    // as `wap("ack", {to, id, class: "notification"})` with no `type` at all:
+    // `WAWebHandlePreKeyLow` (`<count>`/`<pq_count>`), `WAWebHandleDigestKey`
+    // (`<digest>`) and `WAWebHandleIdentityChange` (`<identity>`) all agree,
+    // and the IR mirrors the same three ack shapes. Echoing `type="encrypt"`
+    // on the other two was a stanza this client sends and the official one
+    // never does.
+    let typ_val = if !is_encrypt_notification(node) {
         node.get_attr("type")
     } else {
         None
@@ -2017,7 +2024,7 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
     )
     .map(|value| value.to_node_value());
     let recipient = node.get_attr("recipient").map(|v| v.to_node_value());
-    let typ = if !is_encrypt_identity_notification(node) {
+    let typ = if !is_encrypt_notification(node) {
         node.get_attr("type").map(|v| v.to_node_value())
     } else {
         None
@@ -2048,12 +2055,11 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
 }
 
 /// WA Web omits `type` when ACKing `<notification type="encrypt"><identity/></notification>`.
-fn is_encrypt_identity_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
+fn is_encrypt_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
     node.tag == StanzaTag::Notification.as_str()
         && node
             .get_attr("type")
             .is_some_and(|value| value == NotificationType::Encrypt.as_str())
-        && node.get_optional_child("identity").is_some()
 }
 
 /// Whether the reconnect backoff counter should snap back to its 1s base after

--- a/src/client.rs
+++ b/src/client.rs
@@ -1886,18 +1886,7 @@ fn encode_ack_bytes(
     // Dropping it makes the server close the stream with `<stream:error><ack/>`.
     let recipient_val = node.get_attr("recipient");
 
-    // Every WA Web handler for `<notification type="encrypt">` builds its ack
-    // as `wap("ack", {to, id, class: "notification"})` with no `type` at all:
-    // `WAWebHandlePreKeyLow` (`<count>`/`<pq_count>`), `WAWebHandleDigestKey`
-    // (`<digest>`) and `WAWebHandleIdentityChange` (`<identity>`) all agree,
-    // and the IR mirrors the same three ack shapes. Echoing `type="encrypt"`
-    // on the other two was a stanza this client sends and the official one
-    // never does.
-    let typ_val = if !is_encrypt_notification(node) {
-        node.get_attr("type")
-    } else {
-        None
-    };
+    let typ_val = ack_type(node);
 
     // WA Web stamps the own device JID for both classes.
     let own_device_pn = if tag == StanzaTag::Message.as_str() || tag == StanzaTag::Status.as_str() {
@@ -2024,11 +2013,7 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
     )
     .map(|value| value.to_node_value());
     let recipient = node.get_attr("recipient").map(|v| v.to_node_value());
-    let typ = if !is_encrypt_notification(node) {
-        node.get_attr("type").map(|v| v.to_node_value())
-    } else {
-        None
-    };
+    let typ = ack_type(node).map(|v| v.to_node_value());
     let mut attrs = Attrs::with_capacity(7);
     attrs.insert("class", NodeValue::from(tag));
     attrs.insert("id", id);
@@ -2054,7 +2039,26 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
     })
 }
 
-/// WA Web omits `type` when ACKing `<notification type="encrypt"><identity/></notification>`.
+/// The `type` an ack echoes back, or `None` when it must carry none.
+///
+/// Every WA Web handler for `<notification type="encrypt">` builds its ack as
+/// `wap("ack", {to, id, class: "notification"})` with no `type` at all:
+/// `WAWebHandlePreKeyLow` (`<count>`/`<pq_count>`), `WAWebHandleDigestKey`
+/// (`<digest>`) and `WAWebHandleIdentityChange` (`<identity>`) all agree, and
+/// the IR mirrors the same three ack shapes. Echoing `type="encrypt"` on the
+/// other two was a stanza this client sends and the official one never does.
+fn ack_type<'n, 'a>(
+    node: &'n wacore_binary::NodeRef<'a>,
+) -> Option<&'n wacore_binary::node::ValueRef<'a>> {
+    if is_encrypt_notification(node) {
+        None
+    } else {
+        node.get_attr("type")
+    }
+}
+
+/// Whether `node` is a `<notification type="encrypt">`, whatever child it
+/// carries.
 fn is_encrypt_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
     node.tag == StanzaTag::Notification.as_str()
         && node

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -699,7 +699,7 @@ impl Client {
     /// decrypt error) intentionally skip the delivery receipt to avoid
     /// inflating the server-side offline counter for messages we'll never
     /// process. Without the transport `<ack>` from this gate, the server
-    /// would redeliver indefinitely. WA Web emits `<receipt context="status">`
+    /// would redeliver indefinitely. WA Web emits `<receipt class="status">`
     /// in the success path on top of this; the duplicate is tolerated.
     pub(crate) fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         let tag = StanzaTag::try_from(node.tag.as_ref());

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -94,7 +94,7 @@ async fn test_ack_behavior_for_incoming_stanzas() {
     // status@broadcast gets the transport <ack> as a fallback so that
     // drop paths in process_group_enc_batch (expired status, missing
     // sender key, decrypt error) don't leave the server retransmitting.
-    // The success path also emits <receipt context="status">; the
+    // The success path also emits <receipt class="status">; the
     // duplicate is tolerated.
     let mut status_attrs = Attrs::new();
     status_attrs.insert("from".to_string(), "status@broadcast".to_string());

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2414,9 +2414,8 @@ fn test_encrypt_identity_notification_omits_type() {
 }
 
 /// Every `<notification type="encrypt">` acks without a `type`, not just the
-/// identity-change one: `WAWebHandlePreKeyLow` and `WAWebHandleDigestKey` both
-/// build `wap("ack", {to, id, class: "notification"})` exactly like
-/// `WAWebHandleIdentityChange` does.
+/// identity-change one. The three WA Web handlers this mirrors are named at
+/// `encode_ack_bytes`.
 #[test]
 fn test_encrypt_count_and_digest_notifications_also_omit_type() {
     for child in ["count", "pq_count", "digest"] {

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2435,7 +2435,7 @@ fn test_encrypt_count_and_digest_notifications_also_omit_type() {
 }
 
 #[test]
-fn test_device_notification_is_not_encrypt_identity() {
+fn test_device_notification_is_not_an_encrypt_notification() {
     let node = NodeBuilder::new("notification")
         .attr("from", "186303081611421@lid")
         .attr("id", "269488578")

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2408,9 +2408,31 @@ fn test_encrypt_identity_notification_omits_type() {
         .build();
 
     assert!(
-        is_encrypt_identity_notification(&node.as_node_ref()),
+        is_encrypt_notification(&node.as_node_ref()),
         "identity-change notification ACK must omit type to match WA Web"
     );
+}
+
+/// Every `<notification type="encrypt">` acks without a `type`, not just the
+/// identity-change one: `WAWebHandlePreKeyLow` and `WAWebHandleDigestKey` both
+/// build `wap("ack", {to, id, class: "notification"})` exactly like
+/// `WAWebHandleIdentityChange` does.
+#[test]
+fn test_encrypt_count_and_digest_notifications_also_omit_type() {
+    for child in ["count", "pq_count", "digest"] {
+        let node = NodeBuilder::new("notification")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "4128735302")
+            .attr("type", "encrypt")
+            .children([NodeBuilder::new(child).build()])
+            .build();
+
+        let ack = build_ack_node(&node.as_node_ref(), None).expect("ack");
+        assert!(
+            ack.attrs.get("type").is_none(),
+            "<{child}> encrypt notification ack must omit type to match WA Web"
+        );
+    }
 }
 
 #[test]
@@ -2423,8 +2445,8 @@ fn test_device_notification_is_not_encrypt_identity() {
         .build();
 
     assert!(
-        !is_encrypt_identity_notification(&node.as_node_ref()),
-        "device notification is not an encrypt+identity notification"
+        !is_encrypt_notification(&node.as_node_ref()),
+        "device notification is not an encrypt notification"
     );
 }
 

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -20,7 +20,30 @@ pub(crate) async fn handle_encrypt_notification(client: &Arc<Client>, nr: &NodeR
             .children()
             .and_then(|c| c.first().map(|n| n.tag.as_ref()));
         match first_child_tag {
-            Some("count") => handle_prekey_low(client).await,
+            // WA Web's stanza router sends BOTH `count` and `pq_count` to
+            // `WAWebHandlePreKeyLow` (`case"count":case"pq_count"` in
+            // `Comms.handleStanza`), and that handler then decides what to
+            // refill by *tag*, not by position: `hasLegacyCount =
+            // maybeChild("count") != null` drives the classic one-time-prekey
+            // upload, while `hasPqCount` drives a separate Kyber upload that is
+            // additionally gated on `isPqKeysUploadEnabled()`.
+            //
+            // Matching only `count` here dropped the whole notification
+            // whenever the server put `<pq_count>` first — including when the
+            // same stanza also carried `<count>`, so the one-time prekey pool
+            // never refilled and peers eventually could not fetch a bundle to
+            // start a session with this device.
+            Some("count" | "pq_count") => {
+                if nr.get_optional_child("count").is_some() {
+                    handle_prekey_low(client).await;
+                } else {
+                    // PQ-only: this client uploads no Kyber prekeys, so there
+                    // is nothing to refill. The stanza is still acked by the
+                    // router, which is what WA Web does when its own PQ gate
+                    // is off.
+                    debug!("encrypt notification carried only <pq_count>; no PQ prekeys to upload");
+                }
+            }
             Some("digest") => handle_digest_key(client),
             other => warn!("Unhandled encrypt notification child: {:?}", other),
         }

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -256,6 +256,82 @@ mod tests {
         assert_eq!(adv_secret(&client).await, before);
     }
 
+    // ── `<notification type="encrypt">` prekey-low routing
+    //
+    // WA Web's stanza router reads the FIRST child tag and sends both `count`
+    // and `pq_count` to `WAWebHandlePreKeyLow`
+    // (`case"count":case"pq_count":return yield r("WAWebHandlePreKeyLow")(e,t)`).
+    // That handler then decides what to refill by TAG, not by position:
+    // `hasLegacyCount = maybeChild("count") != null` is what drives the classic
+    // one-time-prekey upload. So WA Web refills the classic pool for
+    // `<count><pq_count>` and `<pq_count><count>` alike.
+
+    fn encrypt_notif(children: &[&'static str]) -> Node {
+        NodeBuilder::new("notification")
+            .attr("type", "encrypt")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "prekey-low-1")
+            .children(children.iter().map(|c| NodeBuilder::new(c).build()))
+            .build()
+    }
+
+    /// `handle_prekey_low` clears `server_has_prekeys` synchronously, before it
+    /// spawns the upload, so the flag is the observable that says the stanza was
+    /// routed to the prekey-low path at all.
+    async fn server_has_prekeys(client: &Arc<Client>) -> bool {
+        client
+            .persistence_manager
+            .get_device_snapshot()
+            .server_has_prekeys
+    }
+
+    async fn dispatch_encrypt(client: &Arc<Client>, children: &[&'static str]) -> bool {
+        client
+            .persistence_manager
+            .modify_device(|d| d.server_has_prekeys = true)
+            .await;
+        handle_notification_impl(client, node_to_arc(encrypt_notif(children))).await;
+        !server_has_prekeys(client).await
+    }
+
+    /// A `<count>` child refills the classic pool wherever it sits among the
+    /// children. Routing on `<count>`-first alone dropped the whole stanza when
+    /// the server led with `<pq_count>`, and the one-time prekey pool then never
+    /// refilled — peers can no longer fetch a bundle to open a session with this
+    /// device, so they stop being able to message it.
+    #[tokio::test]
+    async fn a_pq_count_first_encrypt_notification_still_refills_the_classic_pool() {
+        let client = create_test_client().await;
+
+        assert!(
+            dispatch_encrypt(&client, &["count"]).await,
+            "<count> alone must reach the prekey-low path"
+        );
+        assert!(
+            dispatch_encrypt(&client, &["count", "pq_count"]).await,
+            "<count> first must reach the prekey-low path"
+        );
+        assert!(
+            dispatch_encrypt(&client, &["pq_count", "count"]).await,
+            "WA Web routes a pq_count-first notification to the same handler, \
+             which finds <count> by tag and refills the classic pool"
+        );
+    }
+
+    /// The other half of `hasLegacyCount`: with no `<count>` anywhere there is
+    /// no classic pool to refill, and this client uploads no Kyber prekeys, so
+    /// the stanza is acked and nothing else happens. Without this the fix would
+    /// be free to upload on every PQ-only notification, which WA Web does not do.
+    #[tokio::test]
+    async fn a_pq_count_only_encrypt_notification_uploads_nothing() {
+        let client = create_test_client().await;
+
+        assert!(
+            !dispatch_encrypt(&client, &["pq_count"]).await,
+            "a PQ-only prekey-low notification must not trigger the classic upload"
+        );
+    }
+
     /// Regression: the displayed-code window and the pending-link window are not
     /// the same. A `primary_hello` accepted near the end of the 180s validity
     /// leaves `companion_finish` waiting up to another minute for pair-success,

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -290,11 +290,8 @@ mod tests {
         !server_has_prekeys(client).await
     }
 
-    /// A `<count>` child refills the classic pool wherever it sits among the
-    /// children. Routing on `<count>`-first alone dropped the whole stanza when
-    /// the server led with `<pq_count>`, and the one-time prekey pool then never
-    /// refilled — peers can no longer fetch a bundle to open a session with this
-    /// device, so they stop being able to message it.
+    /// Every child arrangement that carries `<count>` must reach the prekey-low
+    /// path, whatever the tag order.
     #[tokio::test]
     async fn a_pq_count_first_encrypt_notification_still_refills_the_classic_pool() {
         let client = create_test_client().await;
@@ -309,15 +306,13 @@ mod tests {
         );
         assert!(
             dispatch_encrypt(&client, &["pq_count", "count"]).await,
-            "WA Web routes a pq_count-first notification to the same handler, \
-             which finds <count> by tag and refills the classic pool"
+            "<count> after <pq_count> must reach the prekey-low path"
         );
     }
 
-    /// The other half of `hasLegacyCount`: with no `<count>` anywhere there is
-    /// no classic pool to refill, and this client uploads no Kyber prekeys, so
-    /// the stanza is acked and nothing else happens. Without this the fix would
-    /// be free to upload on every PQ-only notification, which WA Web does not do.
+    /// A notification with no `<count>` anywhere must reach nothing. This one
+    /// holds on both sides of the fix; it is here to pin the other half of the
+    /// routing condition, not to demonstrate the bug.
     #[tokio::test]
     async fn a_pq_count_only_encrypt_notification_uploads_nothing() {
         let client = create_test_client().await;

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -258,13 +258,9 @@ mod tests {
 
     // ── `<notification type="encrypt">` prekey-low routing
     //
-    // WA Web's stanza router reads the FIRST child tag and sends both `count`
-    // and `pq_count` to `WAWebHandlePreKeyLow`
-    // (`case"count":case"pq_count":return yield r("WAWebHandlePreKeyLow")(e,t)`).
-    // That handler then decides what to refill by TAG, not by position:
-    // `hasLegacyCount = maybeChild("count") != null` is what drives the classic
-    // one-time-prekey upload. So WA Web refills the classic pool for
-    // `<count><pq_count>` and `<pq_count><count>` alike.
+    // What these pin: a `<count>` child reaches the prekey-low path wherever it
+    // sits among the children, and a PQ-only notification reaches nothing. Why
+    // WA Web splits it that way is stated once, at `handle_encrypt_notification`.
 
     fn encrypt_notif(children: &[&'static str]) -> Node {
         NodeBuilder::new("notification")

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7009,7 +7009,8 @@ struct SentReceipt {
     typ: Option<String>,
     recipient: Option<String>,
     participant: Option<String>,
-    context: Option<String>,
+    /// The `class` attr — WA Web's status marker on a `<receipt>`.
+    class_attr: Option<String>,
     category: Option<String>,
     has_keys: bool,
 }
@@ -7053,7 +7054,7 @@ fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt
                 typ: node.get_attr("type").map(|v| v.as_str().to_string()),
                 recipient: node.get_attr("recipient").map(|v| v.as_str().to_string()),
                 participant: node.get_attr("participant").map(|v| v.as_str().to_string()),
-                context: node.get_attr("context").map(|v| v.as_str().to_string()),
+                class_attr: node.get_attr("class").map(|v| v.as_str().to_string()),
                 category: node.get_attr("category").map(|v| v.as_str().to_string()),
                 has_keys: node.get_optional_child("keys").is_some(),
             });
@@ -8328,7 +8329,11 @@ async fn status_skdm_only_session_uses_one_status_receipt() {
     let sender_str = alice.jid.to_string();
     assert_eq!(receipt.to, status.to_string());
     assert_eq!(receipt.participant.as_deref(), Some(sender_str.as_str()));
-    assert_eq!(receipt.context.as_deref(), Some("status"));
+    assert_eq!(
+        receipt.class_attr.as_deref(),
+        Some("status"),
+        "WA Web marks a status receipt with class=\"status\"          (WAWebSendDeliveryReceiptJob), not with a context attr"
+    );
     assert_eq!(
         message_events_for_id(&rx, id),
         (0, 0),

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7011,6 +7011,9 @@ struct SentReceipt {
     participant: Option<String>,
     /// The `class` attr — WA Web's status marker on a `<receipt>`.
     class_attr: Option<String>,
+    /// The attr the marker used to be spelled as, captured so a regression
+    /// that emits both cannot pass.
+    context_attr: Option<String>,
     category: Option<String>,
     has_keys: bool,
 }
@@ -7055,6 +7058,7 @@ fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt
                 recipient: node.get_attr("recipient").map(|v| v.as_str().to_string()),
                 participant: node.get_attr("participant").map(|v| v.as_str().to_string()),
                 class_attr: node.get_attr("class").map(|v| v.as_str().to_string()),
+                context_attr: node.get_attr("context").map(|v| v.as_str().to_string()),
                 category: node.get_attr("category").map(|v| v.as_str().to_string()),
                 has_keys: node.get_optional_child("keys").is_some(),
             });
@@ -8333,6 +8337,10 @@ async fn status_skdm_only_session_uses_one_status_receipt() {
         receipt.class_attr.as_deref(),
         Some("status"),
         "WA Web marks a status receipt with class=\"status\"          (WAWebSendDeliveryReceiptJob), not with a context attr"
+    );
+    assert_eq!(
+        receipt.context_attr, None,
+        "emitting both attrs would let the old spelling survive on the wire"
     );
     assert_eq!(
         message_events_for_id(&rx, id),

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -196,8 +196,14 @@ fn build_played_receipt_node(
 
 /// Pure builder for the read `<receipt>` node. Mirrors WA Web
 /// `WAWebSendReadReceiptJob` + `sendAggregateReceipts`: newsletters use
-/// `read-self`, everything else `read`; status reads carry `context="status"`
+/// `read-self`, everything else `read`; status reads carry `class="status"`
 /// and, for a LID author, `peer_participant_pn` (the resolved LID->PN).
+///
+/// The status marker is the `class` attribute, not `context`:
+/// `sendAggregateReceipts` computes `h = isStatusReceipt || to == STATUS_JID
+/// ? "status" : null` and emits it as `class`, and the IR carries the same
+/// shape as the `class="status"` const in `WASmaxOutReceiptStatusClassMixin`.
+/// `context` is a `<usync>` attribute in WA Web and appears on no `<receipt>`.
 /// `read_receipts_disabled` is the `readreceipts==none` privacy gate: only a DM
 /// (not group, status, or broadcast list) then uses `read-self` (does not notify
 /// the sender), matching WA Web `ReadReceiptJob.js`.
@@ -228,7 +234,7 @@ fn build_read_receipt_node(
     }
 
     if chat.is_status_broadcast() {
-        builder = builder.attr("context", "status");
+        builder = builder.attr("class", "status");
         if let Some(pn) = peer_participant_pn {
             builder = builder.attr("peer_participant_pn", pn);
         }
@@ -294,7 +300,7 @@ fn delivery_receipt_builder(info: &MessageInfo, active: bool) -> NodeBuilder {
     }
 
     if is_status {
-        builder = builder.attr("context", "status");
+        builder = builder.attr("class", "status");
     }
 
     builder
@@ -526,10 +532,10 @@ impl Client {
         // this companion device received the message.
         // For all other messages, skip receipts for our own messages.
         //
-        // status@broadcast: WA Web sends `<receipt context="status">`
-        // (`Send/DeliveryReceiptJob.js` + `Handle/MsgSendReceipt.js` —
-        // `C = y && isStatusStanzaReceiveEnabled() ? "status" : void 0`).
-        // The context attribute is added in send_delivery_receipt below.
+        // status@broadcast: WA Web sends `<receipt class="status">`
+        // (`WAWebSendDeliveryReceiptJob`: the `isStatusContext` flag becomes
+        // `class: isStatusContext ? CUSTOM_STRING("status") : DROP_ATTR`).
+        // The class attribute is added in `delivery_receipt_builder` below.
         //
         // Self-fanout (own message echoed back, carrying a `recipient`) needs a
         // sender receipt to drain the offline queue; without it the server
@@ -1130,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn delivery_receipt_for_status_broadcast_carries_context_status_and_participant() {
+    fn delivery_receipt_for_status_broadcast_carries_class_status_and_participant() {
         // WA Web's gate is `(isGroup || isBroadcast) && participant` for the
         // participant attr, and `isStatus && gating` for context — see
         // `Send/DeliveryReceiptJob.js`. Status broadcasts must carry BOTH so
@@ -1139,7 +1145,7 @@ mod tests {
         let node = build_delivery_receipt_node(&info, true);
         assert_eq!(node.tag, "receipt");
         assert_eq!(
-            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
         assert_eq!(
@@ -1149,10 +1155,10 @@ mod tests {
     }
 
     #[test]
-    fn delivery_receipt_for_dm_has_no_context_no_participant() {
+    fn delivery_receipt_for_dm_has_no_class_no_participant() {
         let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
         let node = build_delivery_receipt_node(&info, true);
-        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("class").is_none());
         assert!(node.attrs.get("participant").is_none());
         assert!(node.attrs.get("type").is_none());
     }
@@ -1190,7 +1196,7 @@ mod tests {
             Some("200000000000002@bot")
         );
         assert!(node.attrs.get("participant").is_none());
-        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("class").is_none());
     }
 
     #[test]
@@ -1291,10 +1297,10 @@ mod tests {
     fn status_and_peer_receipts_ignore_inactive() {
         let status = info_with("status@broadcast", "12345@s.whatsapp.net", false);
         let node = build_delivery_receipt_node(&status, false);
-        // status keeps context, never type=inactive
+        // status keeps class="status", never type=inactive
         assert!(node.attrs.get("type").is_none());
         assert_eq!(
-            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
 
@@ -1319,7 +1325,7 @@ mod tests {
             node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
             Some("15551234567@s.whatsapp.net")
         );
-        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("class").is_none());
     }
 
     #[test]
@@ -1455,7 +1461,7 @@ mod tests {
             Some("156535032389744:7@lid")
         );
         assert_eq!(
-            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
     }
@@ -1463,7 +1469,7 @@ mod tests {
     #[test]
     fn delivery_receipt_for_peer_dm_carries_type_peer_msg() {
         // category=Peer + DM (self device sync) → type="peer_msg", no
-        // participant, no context. Matches WA Web's DROP_ATTR gating.
+        // participant, no class. Matches WA Web's DROP_ATTR gating.
         let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
         info.category = MessageCategory::Peer;
         let node = build_delivery_receipt_node(&info, true);
@@ -1472,7 +1478,7 @@ mod tests {
             Some("peer_msg")
         );
         assert!(node.attrs.get("participant").is_none());
-        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("class").is_none());
     }
 
     #[test]
@@ -1488,7 +1494,7 @@ mod tests {
             Some("12345@s.whatsapp.net")
         );
         assert_eq!(
-            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
     }
@@ -3203,7 +3209,7 @@ mod tests {
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
             Some("read")
         );
-        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("class").is_none());
         assert!(node.attrs.get("peer_participant_pn").is_none());
     }
 
@@ -3218,7 +3224,7 @@ mod tests {
     }
 
     #[test]
-    fn read_receipt_status_carries_context_and_peer_pn() {
+    fn read_receipt_status_carries_class_and_peer_pn() {
         let pn = jid("559980000001@s.whatsapp.net");
         let node = build_read_receipt_node(
             &jid("status@broadcast"),
@@ -3233,7 +3239,7 @@ mod tests {
             Some("read")
         );
         assert_eq!(
-            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
         assert_eq!(

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1138,9 +1138,7 @@ mod tests {
 
     #[test]
     fn delivery_receipt_for_status_broadcast_carries_class_status_and_participant() {
-        // WA Web's gate is `(isGroup || isBroadcast) && participant` for the
-        // participant attr, and `isStatus && gating` for context — see
-        // `Send/DeliveryReceiptJob.js`. Status broadcasts must carry BOTH so
+        // Status broadcasts must carry BOTH the class and the participant, so
         // the server can map the ack back to the status owner.
         let info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
         let node = build_delivery_receipt_node(&info, true);
@@ -1148,6 +1146,10 @@ mod tests {
         assert_eq!(
             node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
+        );
+        assert!(
+            node.attrs.get("context").is_none(),
+            "the marker moved to `class`; emitting both would let the old attr survive"
         );
         assert_eq!(
             node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
@@ -3197,7 +3199,7 @@ mod tests {
     }
 
     #[test]
-    fn read_receipt_dm_is_read_without_context() {
+    fn read_receipt_dm_is_read_without_class() {
         let node = build_read_receipt_node(
             &jid("456@s.whatsapp.net"),
             None,
@@ -3242,6 +3244,10 @@ mod tests {
         assert_eq!(
             node.attrs.get("class").map(|v| v.as_str()).as_deref(),
             Some("status")
+        );
+        assert!(
+            node.attrs.get("context").is_none(),
+            "the marker moved to `class`; emitting both would let the old attr survive"
         );
         assert_eq!(
             node.attrs

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -752,8 +752,9 @@ impl Client {
     /// - Group messages — `<receipt participant=...>` to the group JID.
     /// - Peer device messages (`category="peer"`) — `<receipt type="peer_msg">`
     ///   to acknowledge self-synced messages from the primary phone.
-    /// - Status broadcasts — `<receipt context="status">` (WA Web's
-    ///   `Send/DeliveryReceiptJob.js`); these are NOT skipped anymore.
+    /// - Status broadcasts — `<receipt class="status">`; these are NOT
+    ///   skipped anymore. Why `class` and not `context` is stated once, at
+    ///   `delivery_receipt_builder`.
     /// - Newsletters and messages without an ID are skipped (newsletters are
     ///   handled by the ack gate, not here).
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.receipt.send_delivery", level = "debug", skip_all, fields(chat = %info.source.chat.observe(), sender = %info.source.sender.observe(), msg_id = %info.id)))]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -198,15 +198,26 @@ fn build_played_receipt_node(
 /// `WAWebSendReadReceiptJob` + `sendAggregateReceipts`: newsletters use
 /// `read-self`, everything else `read`; status reads carry `class="status"`
 /// and, for a LID author, `peer_participant_pn` (the resolved LID->PN).
-///
-/// The status marker is the `class` attribute, not `context`:
-/// `sendAggregateReceipts` computes `h = isStatusReceipt || to == STATUS_JID
-/// ? "status" : null` and emits it as `class`, and the IR carries the same
-/// shape as the `class="status"` const in `WASmaxOutReceiptStatusClassMixin`.
-/// `context` is a `<usync>` attribute in WA Web and appears on no `<receipt>`.
 /// `read_receipts_disabled` is the `readreceipts==none` privacy gate: only a DM
 /// (not group, status, or broadcast list) then uses `read-self` (does not notify
 /// the sender), matching WA Web `ReadReceiptJob.js`.
+/// Stamps the status marker onto a `<receipt>`, on both the read and the
+/// delivery path.
+///
+/// The marker is the `class` attribute, not `context`. `sendAggregateReceipts`
+/// computes `h = isStatusReceipt || to == STATUS_JID ? "status" : null` and
+/// emits it as `class`; `WAWebSendDeliveryReceiptJob` reaches the same shape
+/// from its own flag (`class: isStatusContext ? CUSTOM_STRING("status") :
+/// DROP_ATTR`), and the IR carries the `class="status"` const of
+/// `WASmaxOutReceiptStatusClassMixin`. `context` is a `<usync>` attribute in
+/// WA Web and appears on no `<receipt>`.
+///
+/// Both builders go through here because writing the marker twice is how it
+/// came to be wrong in both places at once.
+fn with_status_class(builder: NodeBuilder) -> NodeBuilder {
+    builder.attr("class", "status")
+}
+
 fn build_read_receipt_node(
     chat: &Jid,
     sender: Option<&Jid>,
@@ -234,7 +245,7 @@ fn build_read_receipt_node(
     }
 
     if chat.is_status_broadcast() {
-        builder = builder.attr("class", "status");
+        builder = with_status_class(builder);
         if let Some(pn) = peer_participant_pn {
             builder = builder.attr("peer_participant_pn", pn);
         }
@@ -300,7 +311,7 @@ fn delivery_receipt_builder(info: &MessageInfo, active: bool) -> NodeBuilder {
     }
 
     if is_status {
-        builder = builder.attr("class", "status");
+        builder = with_status_class(builder);
     }
 
     builder
@@ -532,10 +543,8 @@ impl Client {
         // this companion device received the message.
         // For all other messages, skip receipts for our own messages.
         //
-        // status@broadcast: WA Web sends `<receipt class="status">`
-        // (`WAWebSendDeliveryReceiptJob`: the `isStatusContext` flag becomes
-        // `class: isStatusContext ? CUSTOM_STRING("status") : DROP_ATTR`).
-        // The class attribute is added in `delivery_receipt_builder` below.
+        // status@broadcast: WA Web sends `<receipt class="status">`; the
+        // marker is stamped by `with_status_class`, which says why.
         //
         // Self-fanout (own message echoed back, carrying a `recipient`) needs a
         // sender receipt to drain the offline queue; without it the server
@@ -754,7 +763,7 @@ impl Client {
     ///   to acknowledge self-synced messages from the primary phone.
     /// - Status broadcasts — `<receipt class="status">`; these are NOT
     ///   skipped anymore. Why `class` and not `context` is stated once, at
-    ///   `delivery_receipt_builder`.
+    ///   `with_status_class`.
     /// - Newsletters and messages without an ID are skipped (newsletters are
     ///   handled by the ack gate, not here).
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.receipt.send_delivery", level = "debug", skip_all, fields(chat = %info.source.chat.observe(), sender = %info.source.sender.observe(), msg_id = %info.id)))]

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1023,8 +1023,18 @@ fn decrypt_message_with_record<'a, R: Rng + CryptoRng>(
     ));
     let log_decryption_failure =
         |message: &SignalMessage, state: &SessionState, error: &SignalProtocolError| {
-            // A warning rather than an error because we try multiple sessions.
-            log::warn!(
+            // A warning rather than an error because we try multiple sessions:
+            // one candidate failing is not yet a verdict. A replay is not even
+            // a candidate failure — the chain was recognized and its counter is
+            // simply spent — so it drops another level, to match the verdict
+            // the tail of this function is about to reach.
+            let level = if matches!(error, SignalProtocolError::DuplicatedMessage(..)) {
+                log::Level::Debug
+            } else {
+                log::Level::Warn
+            };
+            log::log!(
+                level,
                 "Failed to decrypt {:?} message with ratchet key: {} and counter: {}. \
              Session loaded for {}. Local session has base key: {} and counter: {}. {}",
                 original_message_type,
@@ -1229,8 +1239,36 @@ fn decrypt_message_with_record<'a, R: Rng + CryptoRng>(
         }
     }
 
-    // No session worked - log error and return failure
+    // No session worked. The verdict decides the log level, so it is taken
+    // BEFORE anything is written: a replay is an expected outcome, and the
+    // caller already treats it as one.
     let previous_state_count = record.previous_session_count();
+
+    // A state that recognized the exact chain and an already-consumed counter is
+    // definitive evidence of a replay; sibling sessions sharing that ratchet key
+    // derive different keys and fail their MAC as expected noise. Classifying a
+    // replay as BadMac would trigger a retry receipt for an already-processed
+    // message, so the duplicate verdict must win.
+    //
+    // It also has to win over the failure logging below. WA Web classifies this
+    // the same way and gives it its own outcome rather than a failure:
+    // `WAWebMsgProcessingDecryptionHandler` maps `errDuplicateMsg` to
+    // `DecryptionErrorType.SignalDuplicateMessage`, which is excluded from the
+    // retryable set, creates no E2E placeholder, and returns
+    // `E2EProcessResult.SIGNAL_OLD_COUNTER_ERROR`; its only log is a WARN, for
+    // group chats, sampled at 1%. Announcing a replay as "No valid session"
+    // also contradicts the record in hand — the chain was recognized, which is
+    // the only reason we know it is a replay — and every reconnect that
+    // redelivers an unacked message printed it.
+    if let Some((chain, counter)) = errs.iter().find_map(|error| match error {
+        SignalProtocolError::DuplicatedMessage(chain, counter) => Some((*chain, *counter)),
+        _ => None,
+    }) {
+        log::debug!(
+            "Replayed message from {remote_address}: chain recognized, counter {counter} already consumed (chain {chain}, {previous_state_count} previous states). Expected when a reconnect redelivers a message whose ack the server never saw."
+        );
+        return Err(SignalProtocolError::DuplicatedMessage(chain, counter));
+    }
 
     if let Some(current_state) = record.session_state() {
         log::error!(
@@ -1253,17 +1291,6 @@ fn decrypt_message_with_record<'a, R: Rng + CryptoRng>(
         create_decryption_failure_log(remote_address, &errs, record, ciphertext.signal_message())?
     );
 
-    // A state that recognized the exact chain and an already-consumed counter is
-    // definitive evidence of a replay; sibling sessions sharing that ratchet key
-    // derive different keys and fail their MAC as expected noise. Classifying a
-    // replay as BadMac would trigger a retry receipt for an already-processed
-    // message, so the duplicate verdict must win.
-    if let Some((chain, counter)) = errs.iter().find_map(|error| match error {
-        SignalProtocolError::DuplicatedMessage(chain, counter) => Some((*chain, *counter)),
-        _ => None,
-    }) {
-        return Err(SignalProtocolError::DuplicatedMessage(chain, counter));
-    }
     if let Some(refused) = take_key_agreement_failure(&mut errs) {
         return Err(refused);
     }

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1566,11 +1566,18 @@ fn decrypt_with_message_keys(
     if !mac_valid {
         // A MAC failure here is not exceptional: the decrypt path probes the
         // current session and then each archived one, and every miss lands
-        // exactly here. Formatting through `Hex` defers the three allocations
-        // to `log::error!`'s own argument formatting, so a probe that the next
-        // candidate session goes on to satisfy pays nothing, and a build with
-        // the level filtered out pays nothing either.
-        log::error!(
+        // exactly here. So this is a candidate diagnostic, not a verdict, and
+        // it is logged at the same level as the caller's per-candidate line —
+        // one session failing is not yet a failure, and a replay reaches this
+        // site for every sibling that shares the ratchet key before the
+        // archived state recognizes its spent counter. A genuine dead end
+        // still gets its `log::error!` from the verdict at the end of
+        // `decrypt_message_with_record`, so nothing is lost by not shouting
+        // here. Formatting through `Hex` defers the three allocations to the
+        // macro's own argument formatting, so a probe that the next candidate
+        // session goes on to satisfy pays nothing, and a build with the level
+        // filtered out pays nothing either.
+        log::warn!(
             "MAC verification failed for message from {}. \
              Remote Identity: {}, \
              Local Identity: {}, \

--- a/wacore/libsignal/tests/session_divergence.rs
+++ b/wacore/libsignal/tests/session_divergence.rs
@@ -898,18 +898,9 @@ mod announced {
 /// exactly what a companion sees on startup when the previous run exited
 /// before its ack was flushed.
 ///
-/// WA Web gives that case its own classification rather than a failure:
-/// `WAWebMsgProcessingDecryptionHandler` maps `errDuplicateMsg` to
-/// `DecryptionErrorType.SignalDuplicateMessage`, which is excluded from the
-/// retryable set, creates no E2E placeholder, and returns
-/// `E2EProcessResult.SIGNAL_OLD_COUNTER_ERROR`. Its only log is a WARN, for
-/// group chats, sampled at 1%.
-///
-/// We reached the same verdict — `DuplicatedMessage`, no retry receipt — but
-/// announced it first as `ERROR ... No valid session for recipient`, because
-/// both error logs ran before the classification that was about to call it a
-/// replay. The claim is also untrue: the chain was recognized, which is the
-/// only reason we know it is a replay at all.
+/// What this pins: the verdict is `DuplicatedMessage` and nothing about it is
+/// announced at error level. Why the protocol wants that is stated once, at the
+/// classification in `decrypt_message_with_record`.
 #[test]
 fn a_replayed_message_is_not_announced_as_a_session_failure() {
     const PEER: &str = "replayed-peer";
@@ -954,5 +945,57 @@ fn a_replayed_message_is_not_announced_as_a_session_failure() {
     assert!(
         failures.is_empty(),
         "a replay must not be announced as an error; got {failures:?}"
+    );
+}
+
+/// The same guarantee when the replay has to be recognized across more than one
+/// candidate session.
+///
+/// A rebuild archives the state that consumed the counter and installs a fresh
+/// one, so the replay now fails the current session before the archived one
+/// recognizes it. The duplicate verdict still has to win, and still has to keep
+/// the failure logging quiet — that is the ordering this pins, and it is the
+/// case a reviewer flagged as the one that could still leak an error record.
+#[test]
+fn a_replay_stays_quiet_when_a_sibling_candidate_session_fails_first() {
+    const PEER: &str = "replayed-peer-archived";
+    announced::install();
+
+    let mut alice = Peer::new(PEER, 1);
+    let mut bob = Peer::new("replay-archive-receiver", 1);
+    establish(&mut alice, &mut bob);
+
+    let reply = send(&mut bob, &alice.address, b"hi alice");
+    receive(&mut alice, &bob.address, &reply).expect("reply decrypts");
+
+    let ct = send(&mut alice, &bob.address, b"delivered once");
+    assert_eq!(
+        receive(&mut bob, &alice.address, &ct).expect("first delivery decrypts"),
+        b"delivered once"
+    );
+
+    // Bob rebuilds toward Alice: the state that just consumed the counter is
+    // archived and a fresh current session takes its place.
+    alice.rotate_one_time_prekey();
+    let bundle = alice.bundle();
+    process_bundle(&mut bob, &alice.address, &bundle);
+
+    let replay = receive(&mut bob, &alice.address, &ct)
+        .expect_err("a consumed counter cannot decrypt twice");
+    assert!(
+        matches!(replay, SignalProtocolError::DuplicatedMessage(_, _)),
+        "the archived state's duplicate must outrank the current state's failure: {replay:?}"
+    );
+
+    let records = announced::about(PEER);
+    // The current session really did fail on its own terms first — without this
+    // the test could pass on a single-candidate path and prove nothing new.
+    assert!(
+        records.iter().any(|(level, _)| *level == log::Level::Warn),
+        "expected a candidate-failure warning from the fresh session; got {records:?}"
+    );
+    assert!(
+        records.iter().all(|(level, _)| *level > log::Level::Error),
+        "a replay must stay out of the error log even when a sibling candidate fails; got {records:?}"
     );
 }

--- a/wacore/libsignal/tests/session_divergence.rs
+++ b/wacore/libsignal/tests/session_divergence.rs
@@ -827,3 +827,132 @@ fn pkmsg_decrypt_failure_does_not_persist_promoted_session() {
          the receiver into a session only they can write to."
     );
 }
+
+// ---- a replay is not a session failure ---------------------------------------
+
+/// Buffers the levels this crate announced, so a test can assert that an
+/// expected outcome was not announced as a failure.
+///
+/// `log`'s global logger is install-once per process. This is an integration
+/// test binary, so the slot is this file's — but its tests still run
+/// concurrently, and several of them fail decryption for real. Records are
+/// therefore matched on the asserting test's own peer name, which no other
+/// scenario in this file uses.
+mod announced {
+    use std::sync::{LazyLock, Mutex, OnceLock};
+
+    struct Capture {
+        records: Mutex<Vec<(log::Level, String)>>,
+    }
+
+    impl log::Log for Capture {
+        fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+            metadata.target().starts_with("wacore_libsignal")
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            if !self.enabled(record.metadata()) {
+                return;
+            }
+            self.records
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((record.level(), record.args().to_string()));
+        }
+
+        fn flush(&self) {}
+    }
+
+    static CAPTURE: LazyLock<Capture> = LazyLock::new(|| Capture {
+        records: Mutex::new(Vec::new()),
+    });
+
+    /// Idempotent per process; the verdict is cached so concurrent tests do not
+    /// race for the slot.
+    pub fn install() {
+        static INSTALLED: OnceLock<()> = OnceLock::new();
+        INSTALLED.get_or_init(|| {
+            if log::set_logger(&*CAPTURE).is_ok() {
+                log::set_max_level(log::LevelFilter::Trace);
+            }
+        });
+    }
+
+    /// Every buffered record whose message names `peer`.
+    pub fn about(peer: &str) -> Vec<(log::Level, String)> {
+        CAPTURE
+            .records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .filter(|(_, message)| message.contains(peer))
+            .cloned()
+            .collect()
+    }
+}
+
+/// A replayed message is an expected outcome, not a session failure.
+///
+/// The server redelivers anything it has not seen acked, so a reconnect can
+/// hand this client a message whose counter it already consumed — which is
+/// exactly what a companion sees on startup when the previous run exited
+/// before its ack was flushed.
+///
+/// WA Web gives that case its own classification rather than a failure:
+/// `WAWebMsgProcessingDecryptionHandler` maps `errDuplicateMsg` to
+/// `DecryptionErrorType.SignalDuplicateMessage`, which is excluded from the
+/// retryable set, creates no E2E placeholder, and returns
+/// `E2EProcessResult.SIGNAL_OLD_COUNTER_ERROR`. Its only log is a WARN, for
+/// group chats, sampled at 1%.
+///
+/// We reached the same verdict — `DuplicatedMessage`, no retry receipt — but
+/// announced it first as `ERROR ... No valid session for recipient`, because
+/// both error logs ran before the classification that was about to call it a
+/// replay. The claim is also untrue: the chain was recognized, which is the
+/// only reason we know it is a replay at all.
+#[test]
+fn a_replayed_message_is_not_announced_as_a_session_failure() {
+    const PEER: &str = "replayed-peer";
+    announced::install();
+
+    let mut alice = Peer::new(PEER, 1);
+    let mut bob = Peer::new("replay-receiver", 1);
+    establish(&mut alice, &mut bob);
+
+    // The replay in the field is an `<enc type="msg">`, so the session must
+    // leave its pending-prekey state first: a duplicate PreKey message returns
+    // from the current-state arm and never reaches the classification under
+    // test, while a duplicate Whisper keeps searching and does.
+    let reply = send(&mut bob, &alice.address, b"hi alice");
+    assert_eq!(
+        receive(&mut alice, &bob.address, &reply).expect("reply decrypts"),
+        b"hi alice"
+    );
+
+    let ct = send(&mut alice, &bob.address, b"delivered once");
+    assert!(
+        matches!(ct, CiphertextMessage::SignalMessage(_)),
+        "the replayed stanza must be a Whisper, like the `<enc type=\"msg\">` on the wire"
+    );
+    assert_eq!(
+        receive(&mut bob, &alice.address, &ct).expect("first delivery decrypts"),
+        b"delivered once"
+    );
+
+    // The redelivery the server makes when it never saw an ack.
+    let replay = receive(&mut bob, &alice.address, &ct)
+        .expect_err("a consumed counter cannot decrypt twice");
+    assert!(
+        matches!(replay, SignalProtocolError::DuplicatedMessage(_, _)),
+        "a replay must classify as a duplicate, not as a decryption failure: {replay:?}"
+    );
+
+    let failures: Vec<_> = announced::about(PEER)
+        .into_iter()
+        .filter(|(level, _)| *level <= log::Level::Error)
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "a replay must not be announced as an error; got {failures:?}"
+    );
+}

--- a/wacore/libsignal/tests/session_divergence.rs
+++ b/wacore/libsignal/tests/session_divergence.rs
@@ -954,8 +954,7 @@ fn a_replayed_message_is_not_announced_as_a_session_failure() {
 /// A rebuild archives the state that consumed the counter and installs a fresh
 /// one, so the replay now fails the current session before the archived one
 /// recognizes it. The duplicate verdict still has to win, and still has to keep
-/// the failure logging quiet — that is the ordering this pins, and it is the
-/// case a reviewer flagged as the one that could still leak an error record.
+/// the failure logging quiet — that ordering is what this pins.
 #[test]
 fn a_replay_stays_quiet_when_a_sibling_candidate_session_fails_first() {
     const PEER: &str = "replayed-peer-archived";

--- a/wacore/libsignal/tests/session_divergence.rs
+++ b/wacore/libsignal/tests/session_divergence.rs
@@ -891,29 +891,19 @@ mod announced {
     }
 }
 
-/// A replayed message is an expected outcome, not a session failure.
+/// Alice and Bob past the pkmsg handshake, plus one Whisper message Bob has
+/// already decrypted — the state a server redelivery arrives into.
 ///
-/// The server redelivers anything it has not seen acked, so a reconnect can
-/// hand this client a message whose counter it already consumed — which is
-/// exactly what a companion sees on startup when the previous run exited
-/// before its ack was flushed.
-///
-/// What this pins: the verdict is `DuplicatedMessage` and nothing about it is
-/// announced at error level. Why the protocol wants that is stated once, at the
-/// classification in `decrypt_message_with_record`.
-#[test]
-fn a_replayed_message_is_not_announced_as_a_session_failure() {
-    const PEER: &str = "replayed-peer";
-    announced::install();
-
-    let mut alice = Peer::new(PEER, 1);
-    let mut bob = Peer::new("replay-receiver", 1);
+/// The session has to leave its pending-prekey state before the replay: a
+/// duplicate PreKey message returns from the current-state arm and never
+/// reaches the classification under test, while a duplicate Whisper keeps
+/// searching and does. Bob's reply is what moves it, so it is part of the
+/// fixture rather than of any one test.
+fn delivered_once(sender: &str, receiver: &str) -> (Peer, Peer, CiphertextMessage) {
+    let mut alice = Peer::new(sender, 1);
+    let mut bob = Peer::new(receiver, 1);
     establish(&mut alice, &mut bob);
 
-    // The replay in the field is an `<enc type="msg">`, so the session must
-    // leave its pending-prekey state first: a duplicate PreKey message returns
-    // from the current-state arm and never reaches the classification under
-    // test, while a duplicate Whisper keeps searching and does.
     let reply = send(&mut bob, &alice.address, b"hi alice");
     assert_eq!(
         receive(&mut alice, &bob.address, &reply).expect("reply decrypts"),
@@ -930,12 +920,35 @@ fn a_replayed_message_is_not_announced_as_a_session_failure() {
         b"delivered once"
     );
 
-    // The redelivery the server makes when it never saw an ack.
-    let replay = receive(&mut bob, &alice.address, &ct)
-        .expect_err("a consumed counter cannot decrypt twice");
+    (alice, bob, ct)
+}
+
+/// The redelivery the server makes when it never saw an ack.
+fn replay(bob: &mut Peer, from: &ProtocolAddress, ct: &CiphertextMessage) -> SignalProtocolError {
+    receive(bob, from, ct).expect_err("a consumed counter cannot decrypt twice")
+}
+
+/// A replayed message is an expected outcome, not a session failure.
+///
+/// The server redelivers anything it has not seen acked, so a reconnect can
+/// hand this client a message whose counter it already consumed — which is
+/// exactly what a companion sees on startup when the previous run exited
+/// before its ack was flushed.
+///
+/// What this pins: the verdict is `DuplicatedMessage` and nothing about it is
+/// announced at error level. Why the protocol wants that is stated once, at the
+/// classification in `decrypt_message_with_record`.
+#[test]
+fn a_replayed_message_is_not_announced_as_a_session_failure() {
+    const PEER: &str = "replayed-peer";
+    announced::install();
+
+    let (alice, mut bob, ct) = delivered_once(PEER, "replay-receiver");
+
+    let verdict = replay(&mut bob, &alice.address, &ct);
     assert!(
-        matches!(replay, SignalProtocolError::DuplicatedMessage(_, _)),
-        "a replay must classify as a duplicate, not as a decryption failure: {replay:?}"
+        matches!(verdict, SignalProtocolError::DuplicatedMessage(_, _)),
+        "a replay must classify as a duplicate, not as a decryption failure: {verdict:?}"
     );
 
     let failures: Vec<_> = announced::about(PEER)
@@ -960,18 +973,7 @@ fn a_replay_stays_quiet_when_a_sibling_candidate_session_fails_first() {
     const PEER: &str = "replayed-peer-archived";
     announced::install();
 
-    let mut alice = Peer::new(PEER, 1);
-    let mut bob = Peer::new("replay-archive-receiver", 1);
-    establish(&mut alice, &mut bob);
-
-    let reply = send(&mut bob, &alice.address, b"hi alice");
-    receive(&mut alice, &bob.address, &reply).expect("reply decrypts");
-
-    let ct = send(&mut alice, &bob.address, b"delivered once");
-    assert_eq!(
-        receive(&mut bob, &alice.address, &ct).expect("first delivery decrypts"),
-        b"delivered once"
-    );
+    let (mut alice, mut bob, ct) = delivered_once(PEER, "replay-archive-receiver");
 
     // Bob rebuilds toward Alice: the state that just consumed the counter is
     // archived and a fresh current session takes its place.
@@ -979,11 +981,10 @@ fn a_replay_stays_quiet_when_a_sibling_candidate_session_fails_first() {
     let bundle = alice.bundle();
     process_bundle(&mut bob, &alice.address, &bundle);
 
-    let replay = receive(&mut bob, &alice.address, &ct)
-        .expect_err("a consumed counter cannot decrypt twice");
+    let verdict = replay(&mut bob, &alice.address, &ct);
     assert!(
-        matches!(replay, SignalProtocolError::DuplicatedMessage(_, _)),
-        "the archived state's duplicate must outrank the current state's failure: {replay:?}"
+        matches!(verdict, SignalProtocolError::DuplicatedMessage(_, _)),
+        "the archived state's duplicate must outrank the current state's failure: {verdict:?}"
     );
 
     let records = announced::about(PEER);

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -128,7 +128,7 @@ pub fn collect_simple_message_ids(
 /// NOTE: the message-dispatch hot path uses
 /// `crate::client::Client::should_send_delivery_receipt` (in the
 /// `whatsapp-rust` crate), which is authoritative and intentionally diverges
-/// here (it also sends `<receipt context="status">` for status broadcasts,
+/// here (it also sends `<receipt class="status">` for status broadcasts,
 /// which this copy still skips). The self-fanout rule is shared via
 /// [`MessageSource::is_self_fanout`](crate::types::message::MessageSource::is_self_fanout).
 pub fn should_send_delivery_receipt(info: &MessageInfo) -> bool {


### PR DESCRIPTION
Four divergences from WhatsApp Web. Three came from comparing this client
against the whatspec IR at the pinned commit and against the raw JS bundle it
was extracted from; the fourth (#4) came from a log and session database
supplied by a downstream GUI consumer, and was then checked against the same
bundle. Findings I could not close are listed at the bottom.

## What I compared, and how

**whatspec IR** — cloned `oxidezap/whatspec` and it landed exactly on
`12dbeeb`, the commit `tools/whatspec-codegen/whatspec.lock.json` pins, so no
version drift stands between the IR and this tree. `cargo run -p
whatspec-codegen -- --check --from …` reports *all artifacts match the pinned
IR*, so nothing in the generated set had drifted either. Domains queried:
`iq` (request/response shapes and `repeatMin`/`repeatMax` per namespace),
`stanza` (outgoing non-IQ, including every `ack` and `receipt` mixin),
`incoming` (`WAWebHandleMsgParser`, `WAWebHandleMsgReceiptParser`),
`notif` (27 types, the 47 `w:gp2` actions), `srvreq`, `enums`, `abprops`,
`appstate`.

**Raw bundle** — `docs/captured-js/` is untracked and absent here, so I
rebuilt it: `generated/bundles.lock.json` names all 516 bundle URLs with their
digests, and all 516 fetched and verified byte-for-byte against the lock. That
is the exact source the IR was extracted from, which is what makes the
control-flow claims below checkable rather than inferred. Modules read in full:
`WAWebSendReceiptJobCommon`, `WAWebSendDeliveryReceiptJob`,
`WAWebSendRetryReceiptJob`, `WAWebHandlePreKeyLow`, `WAWebHandleDigestKey`,
`WAWebMsgProcessingDecryptionHandler`, and `Comms.handleStanza`'s notification
dispatch table.

**unwasm** — read `README.md` and `VOIP_STATUS.md` from `oxidezap/unwasm`. It
does cover the part of WA Web that whatspec's AST cannot see: the VoIP engine
is a wasm module, and `VOIP_STATUS.md` publishes a decoded `<offer>` the real
engine put on the wire. That produced one comparison, in the last bullet below,
which I did not act on — for a reason I had to correct once.

---

## 1. Status receipts carried `context="status"`; WA Web sends `class="status"`

**Ours** — `src/receipt.rs:237` (`build_read_receipt_node`) and
`src/receipt.rs:303` (`delivery_receipt_builder`), both `attr("context", "status")`.

**WA Web** — the delivery sender, `WAWebSendDeliveryReceiptJob`:

```js
var m = i /* isStatusContext */ ? CUSTOM_STRING("status") : DROP_ATTR, …
g = wap("receipt", { id, to: JID(p), participant: …, recipient: …,
                     type: d, class: m }, f);
```

and the aggregate sender, `WAWebSendReceiptJobCommon.sendAggregateReceipts`:

```js
var h = a === !0 || k.toString() === STATUS_JID ? "status" : null, v = l != null ? l : h,
S = wap("receipt", { to: JID(D), type: …, class: v != null ? CUSTOM_STRING(v) : DROP_ATTR,
                     id, t, participant, peer_participant_pn, recipient, sts }, r, f);
```

The IR agrees from the other side: `WASmaxOutReceiptStatusClassMixin` is a
`receipt` fragment whose single attr is the const `class="status"`, and
`WAWebSendReceiptJobCommon`'s attr list is `to, type, class, id, t,
participant, peer_participant_pn, recipient, sts`.

`context` is not an alternative spelling for it. Grepping the whole 516-bundle
set for `context` used as a wap attribute returns exactly one hit, on
`<usync>`; no `<receipt>` WA Web builds carries one, and nothing parses one.
Our own tree only ever wrote it — nothing read it back.

**What a user sees** — every status view and status delivery receipt leaves
without the marker that tells the server it is a status receipt, and carries an
attribute the official client never sends. The status author's "viewed by" /
"delivered to" list is what depends on that classification.

The name came from the JS local `isStatusContext`, which is the flag, not the
wire attribute it produces — the comment at the old `should_send_delivery_receipt`
site quoted that variable as if it were the attribute.

## 2. A prekey-low notification led by `<pq_count>` was dropped whole

**Ours** — `src/handlers/notification/device.rs:22`, matching `Some("count")`
and `Some("digest")` on the first child tag, everything else falling to a
`warn!` and no action.

**WA Web** — `Comms.handleStanza`:

```js
case"encrypt":{var p=e.content; if(!Array.isArray(p)||!p.length)break; var _=p[0].tag;
  switch(_){case"count":case"pq_count":return yield r("WAWebHandlePreKeyLow")(e,t);
            case"digest":return yield r("WAWebHandleDigestKey")(e)}break}
```

Same first-child dispatch we use — but `count` **and** `pq_count` reach the
same handler. `WAWebHandlePreKeyLow` then decides what to refill by *tag*, not
by position:

```js
var t=e.maybeChild("count"), n=e.maybeChild("pq_count");
return t==null&&n==null&&e.child("count"),
       {hasLegacyCount:t!=null, hasPqCount:n!=null, stanzaId:e.attrString("id")}
…
return !a.hasLegacyCount||g.has(n)
  ? (a.hasPqCount && isPqKeysUploadEnabled() && S(), i)
  : (g.add(n), setServerHasPreKeys(!1), yield waitForOfflineDeliveryEnd(),
     uploadPreKeys().then(…))
```

So WA Web refills the classic one-time-prekey pool for `<count><pq_count>` and
`<pq_count><count>` alike; only the Kyber upload is position-independent *and*
separately gated.

**What a user sees** — a notification that leads with `<pq_count>` fell into
our unhandled arm and was dropped, **including when the same stanza also carried
`<count>`**. The one-time prekey pool then never refills: the server runs out of
bundles for this device, peers can no longer fetch one to open a Signal session,
and they stop being able to message it. This is the most serious of the four —
it is silent, and it degrades in one direction only.

The fix routes both tags to the prekey-low path and keeps the classic upload
gated on an actual `<count>` child, found by tag. A PQ-only notification acks
and does nothing: this client uploads no Kyber prekeys, which is exactly what
WA Web does when its own PQ gate is off.

## 3. Encrypt-notification acks echoed `type="encrypt"`

**Ours** — `src/client.rs`, `is_encrypt_identity_notification` suppressed the
`type` attr only for an encrypt notification that also had an `<identity>`
child; the prekey-low and digest-key acks kept it.

**WA Web** — all three handlers for `type="encrypt"` build the same ack, and
none of them carries a `type`:

```js
WAWebHandlePreKeyLow   wap("ack",{to:S_WHATSAPP_NET,id:CUSTOM_STRING(a.stanzaId),class:"notification"})
WAWebHandleDigestKey   wap("ack",{to:S_WHATSAPP_NET,id:CUSTOM_STRING(a.stanzaId),class:"notification"})
```

and the IR's third shape, `WAWebHandleIdentityChange`, is
`{to: device_jid, id, class: "notification"}` — also no `type`. There is no
fourth handler for this notification type.

**What a user sees** — nothing directly; this is a stanza we send that the
official client does not, on a path the server is unlikely to be strict about.
It is included because the `<identity>` child was never the reason for the
omission — being an encrypt notification is — and the narrow condition would
have gone on being read as if it were.

## 4. A replayed message was announced as a session failure

Reported downstream as "every time I open the GUI client it gives a session
error", with a log and the session database that produced it.

**What actually happened**, from the log, in order: the server delivered one
offline `<message … category="peer" type="text"><enc v="2" type="msg">` from
the account's own primary device; decryption failed with `message with old
counter 2 / 1`; `message::receive` logged *"Skipping already-processed message
… This is normal during reconnection"* at debug, sent no retry receipt, and
sent `<receipt type="peer_msg">`; the server replied `<ack class="receipt"
type="peer_msg">`. The database confirms the reading — the failing address is
the account's own LID at device 0, and the session record is intact.

So the handling was already right. What was wrong was the report. Two lines
fired from `wacore-libsignal` first:

```
ERROR No valid session for recipient: <peer>, current session base key <key>,
      number of previous states: 0
ERROR Message from <peer> failed to decrypt; …
      Candidate session 0 failed with 'message with old counter 2 / 1',
      had 4 receiver chains
```

Both ran in `decrypt_message_with_record` *before* the block that inspects
`errs`, finds `DuplicatedMessage`, and returns it — the classification that was
about to call this a replay. The first line is also untrue: the chain was
recognized, which is the only reason we can call it a replay at all, and the
same log prints the four intact receiver chains underneath it.

**WA Web** treats this as its own outcome rather than a failure.
`WAWebMsgProcessingDecryptionHandler` declares
`DecryptionErrorType = Mirrored(["SignalRetryable","SignalDuplicateMessage",…])`
with `v = new Set([b.SignalRetryable])` as the retryable set, and classifies:

```js
function S(e){ return e.message === "errDuplicateMsg" ? b.SignalDuplicateMessage : b.SignalRetryable }
…
m !== b.SignalDuplicateMessage
  ? (c.hideFail || (p = yield processPlaceholderMsg({… PlaceholderType.E2E …})))
  : (l.msgInfo.chat.isGroup() && WARN(…).sendLogs("grouplidinfra-duplicate-skip-drop",{sampling:.01}))
…
m === b.SignalRetryable || m === b.UnknownDevice ? {result: RETRY, …}
: m === b.SignalDuplicateMessage ? {result: E2EProcessResult.SIGNAL_OLD_COUNTER_ERROR, failedEnc: c}
```

No retry, no placeholder, and its only log is a WARN — for group chats, sampled
at 1%.

**What a user sees** — a red `ERROR … No valid session` on essentially every
start, describing a healthy session as broken. It sends operators chasing
session corruption that is not there, and it buries the one real error in this
log (an audio-device underrun, outside this crate).

The fix takes the verdict before writing anything, and drops the per-candidate
warning to debug for a duplicate. Behaviour is unchanged: same error returned,
same skip, same receipt.

**One thing I could not establish**: the log covers a single connection, so it
does not prove the redelivery recurs every launch. The mechanism makes a
recurrence unsurprising — any run that exits before the ack for its last peer
message is flushed leaves exactly that message queued, and the server hands it
back on the next connect — but that is an explanation, not a measurement, and
the redelivery itself is correct server behaviour. `offline="7"` on the stanza
is the offline-batch index, not a redelivery count: WA Web reads that attribute
as a presence flag (`isOffline: e.hasAttr("offline")`) and never as a counter.

---

## How each fix is proven

I reverted each behaviour (keeping every new name and test in place) and re-ran
the affected tests.

For findings 1–3, five failed together:

```
failures:
    client::tests::test_encrypt_count_and_digest_notifications_also_omit_type
    handlers::notification::tests::a_pq_count_first_encrypt_notification_still_refills_the_classic_pool
    receipt::tests::delivery_receipt_for_status_broadcast_carries_class_status_and_participant
    receipt::tests::read_receipt_status_carries_class_and_peer_pn
    receipt::tests::status_and_peer_receipts_ignore_inactive
```

With the fixes restored, all 17 tests in that filter pass.

For finding 4, `a_replayed_message_is_not_announced_as_a_session_failure` fails
against unfixed `session_cipher.rs` with the two captured records — the same
shape the downstream log showed, on a synthetic session:

```
a replay must not be announced as an error; got [
  (Error, "No valid session for recipient: replayed-peer.1, current session base key …, number of previous states: 0"),
  (Error, "Message from replayed-peer.1 failed to decrypt; … Candidate session 0 failed with 'message with old counter 1 / 0', had 2 receiver chains …")]
```

and passes with it, alongside the other 12 tests in that binary and the 241
`wacore-libsignal` unit tests.

| Test | Covers |
| --- | --- |
| `a_pq_count_first_encrypt_notification_still_refills_the_classic_pool` | finding 2 — asserts all three of `count`, `count,pq_count`, `pq_count,count` reach the prekey-low path. Only the third fails without the fix, which is the point. |
| `a_pq_count_only_encrypt_notification_uploads_nothing` | **passes either way** — it is a control, not a regression test. It pins `hasLegacyCount`'s other half so a later change cannot start uploading on every PQ-only notification. Saying it proves the fix would be false. |
| `test_encrypt_count_and_digest_notifications_also_omit_type` | finding 3 — builds the ack for `<count>`, `<pq_count>` and `<digest>` and asserts no `type` on any. |
| `delivery_receipt_for_status_broadcast_carries_class_status_and_participant`, `read_receipt_status_carries_class_and_peer_pn`, `status_and_peer_receipts_ignore_inactive` | finding 1, at the two builders. |
| the status assertion in `src/message/tests.rs` | finding 1 through the real send path, on the decoded wire frame rather than the builder — it reads `class` off the stanza the transport actually saw. |
| `a_replayed_message_is_not_announced_as_a_session_failure` | finding 4. |

Two notes on how those last two tests are built, because both took a wrong
first cut:

- The prekey-low test observes `server_has_prekeys`, which `handle_prekey_low`
  clears synchronously before it spawns the upload, so it witnesses routing
  without running the upload. It goes through `modify_device`, the same
  snapshot-maintaining accessor the production path uses — no write-lock
  mutation.
- The replay test has to send a **Whisper**, not a PreKey message. A duplicate
  PreKey message returns from the current-state arm and never reaches the
  classification under test; my first version did that and passed against the
  unfixed code. It now drives a reply through so the session leaves its
  pending-prekey state, and asserts the ciphertext is a `SignalMessage` — which
  is what the field log showed (`<enc v="2" type="msg">`). Its log capture is
  installed once per process and matches records on a peer name no other test
  in that binary uses, so a concurrent scenario that legitimately errors cannot
  pollute it.

`cargo fmt --all` is clean. Workspace clippy and the full test matrix are left
to CI; this box could not finish them.

---

## Found, not fixed

- **`sts` on read receipts.** `sendAggregateReceipts` sends
  `sts: maxStsByAuthor.get(author)` — the max `serverStoreTimeMicros` per
  author — on read receipts generally, not just status ones. We never send it.
  The downstream log incidentally confirms where the value comes from: incoming
  messages carry `sts="…"` alongside `t="…"`, in microseconds. Fixing it means
  tracking that per message in the store, which is more than a parity patch.

- **`<meta target_chat_jid_lid>` is parsed and dropped.** `WAWebHandleMsgParser`
  reads it beside `target_chat_jid` (`wacore/src/messages.rs:1352` reads only
  the latter), and the one consumer I found resolves a PN-bot message's chat as
  `targetChatJidLid ?? targetChatJid`. So on a LID-migrated account a bot reply
  would be attributed to the PN chat, and `src/message/msg_secret.rs:562` keys
  the msmsg secret lookup off that chat. It already has a PN↔LID alternate for
  the *sender* but not for the chat. Real, but bot-only and I could not
  demonstrate the miss end to end, so it is a finding rather than a patch.

- **`<meta status_mentioned>`, `is_group_status`, `session_scope`,
  `context_source`** are parsed by WA Web and by nothing here. Each needs a
  product decision about what to surface before it is worth plumbing.

- **`max_manual_retry` / `max_auto_download_retry`** are parsed out of the
  `w:m` media-conn response by WA Web (`mediaConnParser`) and ignored by
  `wacore/src/iq/mediaconn.rs`, which parses `auth`, `auth_ttl`, `ttl` and
  `max_buckets` only. Our download loop retries on auth refresh and host
  failover instead, on its own counter.

- **`missing_participant_identification`** exists as a `w:gp2` notification
  action in the IR and as a group-info flag in
  `wacore/src/iq/groups.rs:1126`, but not as a `GroupNotificationAction`
  variant, so it parses to `None` when it arrives as a notification.

- **`NackReason::UnsupportedMessage = 415`** is in
  `WAWebCreateNackFromStanza.NackReason` and absent from
  `wacore/src/protocol/nack.rs`. It round-trips through `Unknown(415)`, and we
  never emit it, so this is a naming gap rather than a wire bug.

- **VoIP `<capability>` blob — open, and no static read can close it.**
  `CAPABILITY_OFFER` in `wacore/src/stanza/call.rs:491` is
  `01 05 f7 09 e0 bb 13`; the offer unwasm decoded straight out of the running
  VoIP engine ends `… bb 5b`, i.e. two further mask bits set.

  My first reading blamed the build gap — unwasm's captures are WhatsApp
  2.3000.1044659339 / `JgwtTQVeWPm` against the 2.3000.1045368834 pinned here.
  That objection turns out not to be the real one, so I checked it rather than
  leave it standing. `https://static.whatsapp.net/rsrc.php/yI/r/oLAKP2keVwi.wasm`
  has sha256 `7a95296c8a5531948c6de53a23221f8c24dc6c8bcae94597122f081f776e9828`,
  which matches **both** whatspec's `generated/wasm.lock.json` and the
  content-addressed path
  `/wasm/whatsapp/versioned/7a95296c…/wa_voip_shared.wasm` in
  `generated/wasm/index.json` — so it is exactly the VoIP engine of the pinned
  WA version, no build gap at all. Searching that module for the mask bytes
  (`01 05 f7 09 e0`, `f7 09 e0`, `01 05 f7`) returns **zero hits**: the
  capability is not a stored constant, it is assembled at runtime by setting bit
  indices.

  So the blocker is not which build you read — it is that reading is the wrong
  instrument. Only executing the engine can arbitrate this, which is what
  unwasm/oracle exist for. Reported as a difference, not a bug.

  Worth recording for whoever picks it up: that module's symbol table does carry
  the engine's stanza grammar statically, as a `fill_*` family of 90 symbols
  plus `createRustStanzaFromXmlNode` — `fill_capability`,
  `fill_offer_common_fields`, `fill_terminate_hint`, `fill_relay_latency_list`,
  `fill_group_av_upgrade_info`, `fill_hbh_srtp_crypto` and the rest. That is a
  comparison against `wacore/src/stanza/call.rs` nobody has made yet, and
  `send_update_joinable_call_log_event_from_offer_terminate_hint` hints that an
  `<offer>` can carry a terminate hint we do not model.

## Checked, and matching

Worth stating so the next reader knows the ground is covered:

- Retry-receipt key policy. `should_include_keys_with_policy` is
  `force || is_stateless || retry_count >= 2`; WA Web is
  `p = isStateless || retryCount >= d` with a module-level `d = 2`. Same, and
  the retry stanza's child order (`retry`, `registration`, `keys`, `meta`)
  matches too.
- Retry-receipt addressing. WA Web branches on `to.isUser()`; we branch on
  `is_group`, and `is_group` is set for `Server::Broadcast` as well as groups
  (`wacore/src/messages.rs:1217`), so `status@broadcast` takes the
  chat+participant branch on both sides.
- The 256-id receipt cap. `sendAggregateReceipts` does `_.splice(0, 256)` and
  puts `t[0]` in `id` with the rest in `<list><item>` — at most 255 items,
  which is the IR's `repeatMax`. `MAX_RECEIPT_IDS_PER_STANZA` and the
  `chunks()` calls in `src/receipt.rs` already match.
- `peer_participant_pn` on LID status reads, including its
  `lid_status_non_soaked_client_support_enabled` gate (default `true` in the
  registry) — already implemented at `src/receipt.rs:1029`.
- `handle_prekey_low`'s ordering: `setServerHasPreKeys(false)` →
  `waitForOfflineDeliveryEnd()` → dedupe → upload, all four in the same order
  as WA Web.
- Duplicate-message *behaviour* (finding 4 was reporting only): no retry
  receipt, no placeholder, skip and ack — the same outcome WA Web reaches via
  `SIGNAL_OLD_COUNTER_ERROR`.
- The `w:gp2` action set: 46 of the IR's 47 wire tags have a
  `GroupNotificationAction` variant.
- Group limits: `group_size_limit = 257`, `group_max_subject = 100`,
  `group_description_length = 2048`, `BATCH_GROUP_INFO_LIMIT` vs the IR's
  `repeatMax: 10000`, `GROUP_INFO_PARTICIPANT_LIMIT` vs `repeatMax: 19999`,
  and `group_call_max_participants = 32` — all agree.
- `tctoken_duration = 604800` / `tctoken_num_buckets = 4`, and every name in
  `props::WATCHED`; both `props::stale` entries are genuinely absent from the
  registry, as that module claims.
- `ReceiptType` covers all of `WAWebAck.ACK_STRING`; `EditAttribute`'s wire
  values match `WAWebAck.EDIT_ATTR` (`3` is `NEWSLETTER_MSG_EDIT` upstream and
  `AdminEdit` here — a naming difference, not a wire one).
- Prekey `<key>` / `<key_fetch>` / `uploadPreKeys` / `<digest>` request shapes
  against the `encrypt` namespace in the IR.
- The incoming `<receipt>` parser against `WAWebHandleMsgReceiptParser`,
  including the `<error reason="lid" type="feature-incapable">` downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAtbjhy2KtHysHVgdNg8Tx