### PR TITLE
fix(notif): stop dropping four things WA Web's own parsers read

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -678,39 +678,26 @@ impl GroupMetadataGuard<'_> {
         self.cache(info).await;
     }
 
+    /// Drop this group's snapshot, in memory and on disk.
+    ///
+    /// The cache goes first. A lookup defaults to `Freshness::CachePreferred`
+    /// and a send does not take this lane, so for as long as the snapshot is
+    /// readable a concurrent send can encrypt to a participant set the group no
+    /// longer has — and the persisted delete is an `await` on storage, which is
+    /// exactly the pause that would let one through.
     pub(crate) async fn invalidate(&self) {
-        self.client.delete_persisted_group_metadata(self.jid).await;
-        self.client.evict_group_metadata_cache(self.jid).await;
-    }
-}
-
-impl Client {
-    /// Drop a group's cached snapshot, leaving the persisted blob alone.
-    ///
-    /// Split out of [`GroupMetadataGuard::invalidate`] because the two halves
-    /// have different urgency. This one closes a correctness window: a lookup
-    /// defaults to [`Freshness::CachePreferred`], and outgoing sends are
-    /// deliberately not ordered behind incoming processing (see AGENTS.md), so
-    /// for as long as the snapshot is readable a concurrent send can encrypt to
-    /// a participant set the group no longer has. Callers that learn a group is
-    /// stale should do this before they let anything else run.
-    pub(crate) async fn evict_group_metadata_cache(&self, jid: &Jid) {
-        self.get_group_cache().invalidate(jid).await;
-    }
-
-    /// Delete a group's persisted metadata, leaving the cache alone.
-    ///
-    /// The other half. The blob is only read on a cache miss, so this can lag
-    /// behind the eviction above without a send ever seeing stale state — which
-    /// is what lets a bulk invalidation defer it off the acknowledgement path.
-    pub(crate) async fn delete_persisted_group_metadata(&self, jid: &Jid) {
+        self.client.get_group_cache().invalidate(self.jid).await;
         if let Err(error) = self
+            .client
             .persistence_manager
             .backend()
-            .delete_group_metadata(&jid.to_string())
+            .delete_group_metadata(&self.jid.to_string())
             .await
         {
-            log::warn!("Failed to invalidate persisted group metadata for {jid}: {error}");
+            log::warn!(
+                "Failed to invalidate persisted group metadata for {}: {error}",
+                self.jid
+            );
         }
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -679,19 +679,39 @@ impl GroupMetadataGuard<'_> {
     }
 
     pub(crate) async fn invalidate(&self) {
+        self.client.delete_persisted_group_metadata(self.jid).await;
+        self.client.evict_group_metadata_cache(self.jid).await;
+    }
+}
+
+impl Client {
+    /// Drop a group's cached snapshot, leaving the persisted blob alone.
+    ///
+    /// Split out of [`GroupMetadataGuard::invalidate`] because the two halves
+    /// have different urgency. This one closes a correctness window: a lookup
+    /// defaults to [`Freshness::CachePreferred`], and outgoing sends are
+    /// deliberately not ordered behind incoming processing (see AGENTS.md), so
+    /// for as long as the snapshot is readable a concurrent send can encrypt to
+    /// a participant set the group no longer has. Callers that learn a group is
+    /// stale should do this before they let anything else run.
+    pub(crate) async fn evict_group_metadata_cache(&self, jid: &Jid) {
+        self.get_group_cache().invalidate(jid).await;
+    }
+
+    /// Delete a group's persisted metadata, leaving the cache alone.
+    ///
+    /// The other half. The blob is only read on a cache miss, so this can lag
+    /// behind the eviction above without a send ever seeing stale state — which
+    /// is what lets a bulk invalidation defer it off the acknowledgement path.
+    pub(crate) async fn delete_persisted_group_metadata(&self, jid: &Jid) {
         if let Err(error) = self
-            .client
             .persistence_manager
             .backend()
-            .delete_group_metadata(&self.jid.to_string())
+            .delete_group_metadata(&jid.to_string())
             .await
         {
-            log::warn!(
-                "Failed to invalidate persisted group metadata for {}: {error}",
-                self.jid
-            );
+            log::warn!("Failed to invalidate persisted group metadata for {jid}: {error}");
         }
-        self.client.get_group_cache().invalidate(self.jid).await;
     }
 }
 

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -37,6 +37,15 @@ pub(crate) async fn handle_account_sync_notification(client: &Arc<Client>, nr: &
     if let Some(devices_node) = nr.get_optional_child_by_tag(&["devices"]) {
         handle_account_sync_devices(client, nr, devices_node).await;
     }
+    // WA Web's account_sync parser reads a `<disappearing_mode duration t>`
+    // child alongside `<devices>`. It is the same child the standalone
+    // `type="disappearing_mode"` notification carries, so it goes through the
+    // same parser — the difference is only whose setting it is: `from` on an
+    // account_sync is our own account, so this is the account default changed
+    // from another device rather than a contact changing theirs.
+    if nr.get_optional_child("disappearing_mode").is_some() {
+        super::groups::handle_disappearing_mode_notification(client, nr);
+    }
 }
 
 /// Handle encrypt/count notification (PreKey Low).

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -37,14 +37,39 @@ pub(crate) async fn handle_account_sync_notification(client: &Arc<Client>, nr: &
     if let Some(devices_node) = nr.get_optional_child_by_tag(&["devices"]) {
         handle_account_sync_devices(client, nr, devices_node).await;
     }
-    // WA Web's account_sync parser reads a `<disappearing_mode duration t>`
-    // child alongside `<devices>`. It is the same child the standalone
-    // `type="disappearing_mode"` notification carries, so it goes through the
-    // same parser — the difference is only whose setting it is: `from` on an
-    // account_sync is our own account, so this is the account default changed
-    // from another device rather than a contact changing theirs.
-    if nr.get_optional_child("disappearing_mode").is_some() {
-        super::groups::handle_disappearing_mode_notification(client, nr);
+    // WA Web's account_sync parser reads a `<disappearing_mode>` child
+    // alongside `<devices>`, and both arms end at the same place the standalone
+    // `type="disappearing_mode"` notification does —
+    // `updateDisappearingModeForContact({contactId: from, ...})` — so the
+    // difference is only whose setting it is: `from` on an account_sync is our
+    // own account.
+    //
+    // The two arms are mutually exclusive, and the parser makes that explicit:
+    //
+    //     h.hasAttr("action") ? y = h.attrString("action")
+    //                         : (C = h.attrInt("duration"), b = h.attrInt("t"))
+    //
+    // With `action` present the stanza carries no duration/`t` at all, and WA
+    // Web answers `action === "modify"` by re-querying the server
+    // (`getDisappearingMode(from, DM_FORCE_REFRESH)`) and applying the answer.
+    // That needs a `disappearing_mode` *get* this client does not have — only
+    // `SetDefaultDisappearingModeSpec`, the set — so the action arm is logged
+    // rather than guessed at.
+    //
+    // Splitting the arms changes no outcome: the parser below already declines
+    // an action-only stanza, because it requires `t`. What it does is stop that
+    // decline being announced as `warn!("… missing or invalid 't' …")` on a
+    // stanza that is perfectly well formed, which is a false lead for whoever
+    // reads the log next.
+    if let Some(dm) = nr.get_optional_child("disappearing_mode") {
+        if dm.attrs().optional_string("action").is_some() {
+            debug!(
+                "account_sync disappearing_mode carried an action and no duration; \
+                 re-querying the account default is not implemented"
+            );
+        } else {
+            super::groups::handle_disappearing_mode_notification(client, nr);
+        }
     }
 }
 

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -127,7 +127,7 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
     // notification would name the server as the group in every event it
     // produced, so it is routed out before that can happen.
     if let Some(groups) = wacore::stanza::groups::parse_groups_dirty(node.get()) {
-        handle_groups_dirty(client, groups);
+        handle_groups_dirty(client, groups).await;
         client
             .core
             .event_bus
@@ -287,44 +287,57 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
 
 /// The server named these groups' cached metadata stale.
 ///
-/// Dropping the cached blob is what every other staleness signal in this file
-/// does (see the `Remove` / expired-cache arms above); the next send or
+/// Dropping the group's snapshot is what every other staleness signal in this
+/// file does (see the `Remove` / expired-cache arms above); the next send or
 /// `group_info` query re-fetches. Doing nothing would leave a group's
 /// participant list wrong for as long as the cache lives, which is a message
 /// encrypted to a device set the group no longer has.
 ///
-/// Spawned rather than awaited, because the work is unbounded in a way the
-/// rest of this file's is not. `Client::process_node` defers this stanza's
-/// transport `<ack>` until the router's dispatch returns, and one notification
-/// may name up to 10 000 groups — WA Web's parser bounds the `<group>`
-/// children at `1..1e4`. Draining that many lock acquisitions and metadata
-/// deletes inline would hold the ack long enough for the server to retransmit
-/// the notification, and the retransmission would repeat the whole loop. WA
-/// Web does not do it inline either: `handleGroupsDirtyNotificationJob` queues
-/// a persisted job and runs it after `waitForOfflineDeliveryEnd()`.
+/// The two halves of that invalidation run at different times on purpose.
 ///
-/// Deliberately unguarded, unlike the dirty-bit resync in `handlers/ib.rs`.
-/// That one sends an IQ whose result belongs to the connection that asked for
-/// it, so it checks both the connection generation and `is_shutting_down`.
-/// This does no I/O: it drops local cache entries, which is idempotent and
-/// correct on any generation, and the worst a late run costs is one refetch.
-/// `is_shutting_down` would be actively wrong here — it is
-/// `expected_disconnect || !is_running`, so it reads true between connections
-/// as well as at the end of one, and the work would throw itself away exactly
-/// when a reconnect is about to make the stale metadata reachable again.
-fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
+/// The cache eviction is awaited here. A lookup defaults to
+/// `Freshness::CachePreferred` and outgoing sends are deliberately not ordered
+/// behind incoming processing, so anything that runs while a stale snapshot is
+/// still readable — a consumer reacting to the raw notification dispatched
+/// just below, or an unrelated send already in flight — can encrypt to the
+/// participant set this notification exists to retire. Deferring it would
+/// leave exactly that window open.
+///
+/// The persisted deletes are spawned. `Client::process_node` defers this
+/// stanza's transport `<ack>` until the router's dispatch returns, and one
+/// notification may name up to 10 000 groups — WA Web's parser bounds the
+/// `<group>` children at `1..1e4`. Holding the ack for that many round trips
+/// to storage, each behind a per-group lock, is long enough for the server to
+/// retransmit and start the work over. The blob is only read on a cache miss,
+/// so it can lag without a send ever seeing it. WA Web defers here too:
+/// `handleGroupsDirtyNotificationJob` queues a persisted job and runs it after
+/// `waitForOfflineDeliveryEnd()`.
+///
+/// The spawned half is deliberately unguarded, unlike the dirty-bit resync in
+/// `handlers/ib.rs`. That one sends an IQ whose result belongs to the
+/// connection that asked for it, so it checks the connection generation and
+/// `is_shutting_down`. A storage delete is idempotent and correct on any
+/// generation, and `is_shutting_down` would be actively wrong: it is
+/// `expected_disconnect || !is_running`, true between connections as well as
+/// at the end of one, so the work would throw itself away exactly when a
+/// reconnect is about to make the stale metadata reachable again.
+async fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
+    for jid in &groups {
+        debug!(
+            target: "Client/Group",
+            "groups_dirty: invalidating cached metadata for {}",
+            jid.observe()
+        );
+        client.evict_group_metadata_cache(jid).await;
+    }
+
     let client = Arc::clone(client);
     client
         .clone()
         .runtime
         .spawn(Box::pin(async move {
-            for jid in groups {
-                debug!(
-                    target: "Client/Group",
-                    "groups_dirty: invalidating cached metadata for {}",
-                    jid.observe()
-                );
-                client.lock_group_metadata(&jid).await.invalidate().await;
+            for jid in &groups {
+                client.delete_persisted_group_metadata(jid).await;
             }
         }))
         .detach();

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -127,7 +127,7 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
     // notification would name the server as the group in every event it
     // produced, so it is routed out before that can happen.
     if let Some(groups) = wacore::stanza::groups::parse_groups_dirty(node.get()) {
-        handle_groups_dirty(client, &groups).await;
+        handle_groups_dirty(client, groups);
         client
             .core
             .event_bus
@@ -292,16 +292,42 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
 /// `group_info` query re-fetches. Doing nothing would leave a group's
 /// participant list wrong for as long as the cache lives, which is a message
 /// encrypted to a device set the group no longer has.
-async fn handle_groups_dirty(client: &Arc<Client>, groups: &[wacore_binary::Jid]) {
-    for jid in groups {
-        debug!(
-            target: "Client/Group",
-            "groups_dirty: invalidating cached metadata for {}",
-            jid.observe()
-        );
-        let metadata = client.lock_group_metadata(jid).await;
-        metadata.invalidate().await;
-    }
+///
+/// Spawned rather than awaited, because the work is unbounded in a way the
+/// rest of this file's is not. `Client::process_node` defers this stanza's
+/// transport `<ack>` until the router's dispatch returns, and one notification
+/// may name up to 10 000 groups — WA Web's parser bounds the `<group>`
+/// children at `1..1e4`. Draining that many lock acquisitions and metadata
+/// deletes inline would hold the ack long enough for the server to retransmit
+/// the notification, and the retransmission would repeat the whole loop. WA
+/// Web does not do it inline either: `handleGroupsDirtyNotificationJob` queues
+/// a persisted job and runs it after `waitForOfflineDeliveryEnd()`.
+///
+/// Deliberately unguarded, unlike the dirty-bit resync in `handlers/ib.rs`.
+/// That one sends an IQ whose result belongs to the connection that asked for
+/// it, so it checks both the connection generation and `is_shutting_down`.
+/// This does no I/O: it drops local cache entries, which is idempotent and
+/// correct on any generation, and the worst a late run costs is one refetch.
+/// `is_shutting_down` would be actively wrong here — it is
+/// `expected_disconnect || !is_running`, so it reads true between connections
+/// as well as at the end of one, and the work would throw itself away exactly
+/// when a reconnect is about to make the stale metadata reachable again.
+fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
+    let client = Arc::clone(client);
+    client
+        .clone()
+        .runtime
+        .spawn(Box::pin(async move {
+            for jid in groups {
+                debug!(
+                    target: "Client/Group",
+                    "groups_dirty: invalidating cached metadata for {}",
+                    jid.observe()
+                );
+                client.lock_group_metadata(&jid).await.invalidate().await;
+            }
+        }))
+        .detach();
 }
 
 /// Handle `<notification type="newsletter">` — live updates with reaction counts.

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -122,6 +122,19 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
     tracing::instrument(name = "wa.notif.group", level = "debug", skip_all)
 )]
 pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>) {
+    // `<groups_dirty>` is the one `w:gp2` stanza the server sends about itself:
+    // `from` is `s.whatsapp.net`, not a group. Parsing it as an ordinary group
+    // notification would name the server as the group in every event it
+    // produced, so it is routed out before that can happen.
+    if let Some(groups) = wacore::stanza::groups::parse_groups_dirty(node.get()) {
+        handle_groups_dirty(client, &groups).await;
+        client
+            .core
+            .event_bus
+            .dispatch(Event::Notification(Arc::clone(&node)));
+        return;
+    }
+
     let mut notification = match GroupNotification::try_from_node_ref(node.get()) {
         Some(n) => n,
         None => {
@@ -270,6 +283,25 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
         .core
         .event_bus
         .dispatch(Event::Notification(Arc::clone(&node)));
+}
+
+/// The server named these groups' cached metadata stale.
+///
+/// Dropping the cached blob is what every other staleness signal in this file
+/// does (see the `Remove` / expired-cache arms above); the next send or
+/// `group_info` query re-fetches. Doing nothing would leave a group's
+/// participant list wrong for as long as the cache lives, which is a message
+/// encrypted to a device set the group no longer has.
+async fn handle_groups_dirty(client: &Arc<Client>, groups: &[wacore_binary::Jid]) {
+    for jid in groups {
+        debug!(
+            target: "Client/Group",
+            "groups_dirty: invalidating cached metadata for {}",
+            jid.observe()
+        );
+        let metadata = client.lock_group_metadata(jid).await;
+        metadata.invalidate().await;
+    }
 }
 
 /// Handle `<notification type="newsletter">` — live updates with reaction counts.

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -315,7 +315,7 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
 ///
 /// That leaves a window between this returning and the task running, in which
 /// a send can still read a stale snapshot. It is bounded by an uncontended
-/// lane acquisition, and it is strictly narrower than the official client's:
+/// lane acquisition and the fan-out below, and it is strictly narrower than the official client's:
 /// `handleGroupsDirtyNotificationJob` queues a persisted job and does not run
 /// it until `waitForOfflineDeliveryEnd()` and `waitForConnection()` have both
 /// resolved. Closing it entirely needs an invalidation generation the cache
@@ -330,19 +330,36 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
 /// work would throw itself away exactly when a reconnect is about to make the
 /// stale metadata reachable again.
 fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
+    use futures::StreamExt;
+
+    // Each group's work sits behind its own per-JID lane, so entries never
+    // contend with one another; this bounds how many storage round trips — and,
+    // for a custom cache store, remote ones — are in flight at once. Draining
+    // serially would make a group's stale window the sum of every entry ahead
+    // of it, which with the parser's 10 000-group ceiling is a tail measured in
+    // whole round-trip multiples rather than one.
+    const GROUPS_DIRTY_INVALIDATE_CONCURRENCY: usize = 16;
+
     let client = Arc::clone(client);
     client
         .clone()
         .runtime
         .spawn(Box::pin(async move {
-            for jid in &groups {
-                debug!(
-                    target: "Client/Group",
-                    "groups_dirty: invalidating cached metadata for {}",
-                    jid.observe()
-                );
-                client.lock_group_metadata(jid).await.invalidate().await;
-            }
+            futures::stream::iter(groups)
+                .map(|jid| {
+                    let client = Arc::clone(&client);
+                    async move {
+                        debug!(
+                            target: "Client/Group",
+                            "groups_dirty: invalidating cached metadata for {}",
+                            jid.observe()
+                        );
+                        client.lock_group_metadata(&jid).await.invalidate().await;
+                    }
+                })
+                .buffer_unordered(GROUPS_DIRTY_INVALIDATE_CONCURRENCY)
+                .for_each(|()| std::future::ready(()))
+                .await;
         }))
         .detach();
 }

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -127,7 +127,7 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
     // notification would name the server as the group in every event it
     // produced, so it is routed out before that can happen.
     if let Some(groups) = wacore::stanza::groups::parse_groups_dirty(node.get()) {
-        handle_groups_dirty(client, groups).await;
+        handle_groups_dirty(client, groups);
         client
             .core
             .event_bus
@@ -293,51 +293,55 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
 /// participant list wrong for as long as the cache lives, which is a message
 /// encrypted to a device set the group no longer has.
 ///
-/// The two halves of that invalidation run at different times on purpose.
+/// Two properties are in tension here, and the lane wins.
 ///
-/// The cache eviction is awaited here. A lookup defaults to
-/// `Freshness::CachePreferred` and outgoing sends are deliberately not ordered
-/// behind incoming processing, so anything that runs while a stale snapshot is
-/// still readable — a consumer reacting to the raw notification dispatched
-/// just below, or an unrelated send already in flight — can encrypt to the
-/// participant set this notification exists to retire. Deferring it would
-/// leave exactly that window open.
+/// It goes through `lock_group_metadata` rather than dropping the cache entry
+/// directly, because that lane *is* the invalidation protocol. A cold
+/// `query_info` holds the guard across its IQ precisely so an invalidation
+/// cannot be lost against it — with no cached `Arc` to compare, the lane is
+/// the only thing that distinguishes "still absent" from "a notification
+/// invalidated an already-absent snapshot", and it publishes its result
+/// unconditionally. An eviction taken outside the lane is invisible to that
+/// query, which then republishes membership it fetched before this
+/// notification. (The warm path is safe either way: it publishes only when
+/// `Arc::ptr_eq` says its snapshot is still current.)
 ///
-/// The persisted deletes are spawned. `Client::process_node` defers this
-/// stanza's transport `<ack>` until the router's dispatch returns, and one
-/// notification may name up to 10 000 groups — WA Web's parser bounds the
-/// `<group>` children at `1..1e4`. Holding the ack for that many round trips
-/// to storage, each behind a per-group lock, is long enough for the server to
-/// retransmit and start the work over. The blob is only read on a cache miss,
-/// so it can lag without a send ever seeing it. WA Web defers here too:
-/// `handleGroupsDirtyNotificationJob` queues a persisted job and runs it after
-/// `waitForOfflineDeliveryEnd()`.
+/// It is spawned, because `Client::process_node` defers this stanza's
+/// transport `<ack>` until the router's dispatch returns, and one notification
+/// may name up to 10 000 groups — WA Web's parser bounds the `<group>`
+/// children at `1..1e4`. A lane acquisition and a storage round trip each,
+/// drained serially, is long enough for the server to retransmit and start the
+/// work over.
 ///
-/// The spawned half is deliberately unguarded, unlike the dirty-bit resync in
-/// `handlers/ib.rs`. That one sends an IQ whose result belongs to the
-/// connection that asked for it, so it checks the connection generation and
-/// `is_shutting_down`. A storage delete is idempotent and correct on any
-/// generation, and `is_shutting_down` would be actively wrong: it is
-/// `expected_disconnect || !is_running`, true between connections as well as
-/// at the end of one, so the work would throw itself away exactly when a
-/// reconnect is about to make the stale metadata reachable again.
-async fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
-    for jid in &groups {
-        debug!(
-            target: "Client/Group",
-            "groups_dirty: invalidating cached metadata for {}",
-            jid.observe()
-        );
-        client.evict_group_metadata_cache(jid).await;
-    }
-
+/// That leaves a window between this returning and the task running, in which
+/// a send can still read a stale snapshot. It is bounded by an uncontended
+/// lane acquisition, and it is strictly narrower than the official client's:
+/// `handleGroupsDirtyNotificationJob` queues a persisted job and does not run
+/// it until `waitForOfflineDeliveryEnd()` and `waitForConnection()` have both
+/// resolved. Closing it entirely needs an invalidation generation the cache
+/// does not have — see the PR discussion.
+///
+/// Deliberately unguarded, unlike the dirty-bit resync in `handlers/ib.rs`.
+/// That one sends an IQ whose result belongs to the connection that asked for
+/// it, so it checks the connection generation and `is_shutting_down`. Dropping
+/// a snapshot is idempotent and correct on any generation, and
+/// `is_shutting_down` would be actively wrong: it is `expected_disconnect ||
+/// !is_running`, true between connections as well as at the end of one, so the
+/// work would throw itself away exactly when a reconnect is about to make the
+/// stale metadata reachable again.
+fn handle_groups_dirty(client: &Arc<Client>, groups: Vec<wacore_binary::Jid>) {
     let client = Arc::clone(client);
     client
         .clone()
         .runtime
         .spawn(Box::pin(async move {
             for jid in &groups {
-                client.delete_persisted_group_metadata(jid).await;
+                debug!(
+                    target: "Client/Group",
+                    "groups_dirty: invalidating cached metadata for {}",
+                    jid.observe()
+                );
+                client.lock_group_metadata(jid).await.invalidate().await;
             }
         }))
         .detach();

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -230,10 +230,19 @@ mod tests {
 
         let (client, collector) = client_with_collector().await;
 
-        let dirty: Jid = "120363000000000001@g.us".parse().unwrap();
+        // Several dirty groups, so the bounded fan-out is exercised with more
+        // than one entry rather than degenerating to the single-item case.
+        let dirty: Vec<Jid> = [
+            "120363000000000001@g.us",
+            "120363000000000003@g.us",
+            "120363000000000004@g.us",
+        ]
+        .iter()
+        .map(|jid| jid.parse().unwrap())
+        .collect();
         let untouched: Jid = "120363000000000002@g.us".parse().unwrap();
         let cache = client.get_group_cache();
-        for jid in [&dirty, &untouched] {
+        for jid in dirty.iter().chain([&untouched]) {
             cache
                 .insert(
                     jid.clone(),
@@ -251,7 +260,11 @@ mod tests {
             .attr("id", "groups-dirty-1")
             .attr("t", "1704067200")
             .children([NodeBuilder::new("groups_dirty")
-                .children([NodeBuilder::new("group").attr("jid", dirty.clone()).build()])
+                .children(
+                    dirty
+                        .iter()
+                        .map(|jid| NodeBuilder::new("group").attr("jid", jid).build()),
+                )
                 .build()])
             .build();
         handle_notification_impl(&client, node_to_arc(notif)).await;
@@ -261,12 +274,14 @@ mod tests {
         // `poll_until` takes a sync predicate and this one is async, hence a
         // bounded timeout around the poll rather than that helper.
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while cache.get(&dirty).await.is_some() {
-                tokio::task::yield_now().await;
+            for jid in &dirty {
+                while cache.get(jid).await.is_some() {
+                    tokio::task::yield_now().await;
+                }
             }
         })
         .await
-        .expect("the group the server called stale must lose its cached metadata");
+        .expect("every group the server called stale must lose its cached metadata");
         assert!(
             cache.get(&untouched).await.is_some(),
             "a group the notification did not name must keep its cache"

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -256,16 +256,17 @@ mod tests {
             .build();
         handle_notification_impl(&client, node_to_arc(notif)).await;
 
-        // Awaited, not eventual: a lookup defaults to `CachePreferred` and
-        // outgoing sends are not ordered behind incoming processing, so a
-        // snapshot still readable when the handler returns is one a concurrent
-        // send can encrypt against. Deferring the eviction would leave that
-        // window open, and this assertion is what closes it.
-        assert!(
-            cache.get(&dirty).await.is_none(),
-            "the group the server called stale must lose its cached snapshot \
-             before the handler returns"
-        );
+        // The invalidation runs in the per-group lane, off the ack path, so it
+        // lands shortly after the handler returns rather than inside it.
+        // `poll_until` takes a sync predicate and this one is async, hence a
+        // bounded timeout around the poll rather than that helper.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while cache.get(&dirty).await.is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the group the server called stale must lose its cached metadata");
         assert!(
             cache.get(&untouched).await.is_some(),
             "a group the notification did not name must keep its cache"

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -184,6 +184,37 @@ mod tests {
         );
     }
 
+    /// A client with an event collector already subscribed. Every test below
+    /// observes the dispatcher through the bus, so the wiring is shared rather
+    /// than repeated per test.
+    async fn client_with_collector() -> (Arc<Client>, Arc<TestEventCollector>) {
+        use crate::types::events::EventHandler;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+        (client, collector)
+    }
+
+    /// The account this client owns, as the `from` of a notification the
+    /// server sends about it.
+    const OWN_PN: &str = "12025550199@s.whatsapp.net";
+
+    /// `<notification type="account_sync" from=OWN_PN>` wrapping one
+    /// `<disappearing_mode>` child — the envelope both arms share, so only the
+    /// child differs between them.
+    fn account_sync_disappearing_mode(id: &str, disappearing_mode: Node) -> Node {
+        NodeBuilder::new("notification")
+            .attr("type", NotificationType::AccountSync.as_str())
+            .attr("from", OWN_PN)
+            .attr("id", id)
+            .attr("t", "1704067200")
+            .children([disappearing_mode])
+            .build()
+    }
+
     // ── `w:gp2` / `<groups_dirty>` (WA Web
     // `WASmaxInGroupsGroupsDirtyNotificationRequest`)
     //
@@ -194,15 +225,10 @@ mod tests {
 
     #[tokio::test]
     async fn groups_dirty_invalidates_the_named_groups_and_names_no_group_update() {
-        use crate::types::events::EventHandler;
         use wacore::client::context::GroupInfo;
         use wacore::types::message::AddressingMode;
 
-        let client = create_test_client().await;
-        let collector = Arc::new(TestEventCollector::default());
-        client
-            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
-            .detach();
+        let (client, collector) = client_with_collector().await;
 
         let dirty: Jid = "120363000000000001@g.us".parse().unwrap();
         let untouched: Jid = "120363000000000002@g.us".parse().unwrap();
@@ -230,10 +256,17 @@ mod tests {
             .build();
         handle_notification_impl(&client, node_to_arc(notif)).await;
 
-        assert!(
-            cache.get(&dirty).await.is_none(),
-            "the group the server called stale must lose its cached metadata"
-        );
+        // The invalidation is spawned off the ack path, so it lands after the
+        // handler returns rather than inside it. `poll_until` takes a sync
+        // predicate and this one is async, so the wait is a bounded timeout
+        // around the poll rather than that helper.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while cache.get(&dirty).await.is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the group the server called stale must lose its cached metadata");
         assert!(
             cache.get(&untouched).await.is_some(),
             "a group the notification did not name must keep its cache"
@@ -267,25 +300,15 @@ mod tests {
 
     #[tokio::test]
     async fn account_sync_disappearing_mode_reaches_the_consumer() {
-        use crate::types::events::EventHandler;
+        let (client, collector) = client_with_collector().await;
 
-        let client = create_test_client().await;
-        let collector = Arc::new(TestEventCollector::default());
-        client
-            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
-            .detach();
-
-        let own: Jid = "12025550199@s.whatsapp.net".parse().unwrap();
-        let notif = NodeBuilder::new("notification")
-            .attr("type", NotificationType::AccountSync.as_str())
-            .attr("from", own.clone())
-            .attr("id", "acct-sync-dm-1")
-            .attr("t", "1704067200")
-            .children([NodeBuilder::new("disappearing_mode")
+        let notif = account_sync_disappearing_mode(
+            "acct-sync-dm-1",
+            NodeBuilder::new("disappearing_mode")
                 .attr("duration", "604800")
                 .attr("t", "1704067200")
-                .build()])
-            .build();
+                .build(),
+        );
         handle_notification_impl(&client, node_to_arc(notif)).await;
 
         let changed = collector
@@ -296,7 +319,7 @@ mod tests {
                 _ => None,
             })
             .expect("an account_sync disappearing_mode must reach the consumer");
-        assert_eq!(changed.from, own);
+        assert_eq!(changed.from, OWN_PN.parse::<Jid>().unwrap());
         assert_eq!(changed.duration, 604_800);
     }
 
@@ -306,23 +329,14 @@ mod tests {
     /// notification never stated, so nothing is dispatched.
     #[tokio::test]
     async fn account_sync_disappearing_mode_action_reports_no_duration() {
-        use crate::types::events::EventHandler;
+        let (client, collector) = client_with_collector().await;
 
-        let client = create_test_client().await;
-        let collector = Arc::new(TestEventCollector::default());
-        client
-            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
-            .detach();
-
-        let notif = NodeBuilder::new("notification")
-            .attr("type", NotificationType::AccountSync.as_str())
-            .attr("from", "12025550199@s.whatsapp.net")
-            .attr("id", "acct-sync-dm-2")
-            .attr("t", "1704067200")
-            .children([NodeBuilder::new("disappearing_mode")
+        let notif = account_sync_disappearing_mode(
+            "acct-sync-dm-2",
+            NodeBuilder::new("disappearing_mode")
                 .attr("action", "modify")
-                .build()])
-            .build();
+                .build(),
+        );
         handle_notification_impl(&client, node_to_arc(notif)).await;
 
         assert!(

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -184,6 +184,119 @@ mod tests {
         );
     }
 
+    // ── `w:gp2` / `<groups_dirty>` (WA Web
+    // `WASmaxInGroupsGroupsDirtyNotificationRequest`)
+    //
+    // The one `w:gp2` stanza whose `from` is the server rather than a group.
+    // We ran it through the ordinary group-notification parser, which named
+    // `s.whatsapp.net` as the group in the event it produced and left the
+    // groups the server had actually called stale still cached.
+
+    #[tokio::test]
+    async fn groups_dirty_invalidates_the_named_groups_and_names_no_group_update() {
+        use crate::types::events::EventHandler;
+        use wacore::client::context::GroupInfo;
+        use wacore::types::message::AddressingMode;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+
+        let dirty: Jid = "120363000000000001@g.us".parse().unwrap();
+        let untouched: Jid = "120363000000000002@g.us".parse().unwrap();
+        let cache = client.get_group_cache();
+        for jid in [&dirty, &untouched] {
+            cache
+                .insert(
+                    jid.clone(),
+                    Arc::new(GroupInfo::new(
+                        vec!["12025550101@s.whatsapp.net".parse().unwrap()],
+                        AddressingMode::Pn,
+                    )),
+                )
+                .await;
+        }
+
+        let notif = NodeBuilder::new("notification")
+            .attr("type", NotificationType::WGp2.as_str())
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "groups-dirty-1")
+            .attr("t", "1704067200")
+            .children([NodeBuilder::new("groups_dirty")
+                .children([NodeBuilder::new("group").attr("jid", dirty.clone()).build()])
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(notif)).await;
+
+        assert!(
+            cache.get(&dirty).await.is_none(),
+            "the group the server called stale must lose its cached metadata"
+        );
+        assert!(
+            cache.get(&untouched).await.is_some(),
+            "a group the notification did not name must keep its cache"
+        );
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|event| matches!(event.as_ref(), Event::GroupUpdate(_))),
+            "groups_dirty must not be reported as an update to a group named by `from`"
+        );
+        assert!(
+            collector
+                .events()
+                .iter()
+                .any(|event| matches!(event.as_ref(), Event::Notification(_))),
+            "the stanza must still reach the consumer raw"
+        );
+    }
+
+    // ── `account_sync` / `<disappearing_mode>` (WA Web's account_sync parser)
+    //
+    // Our own account's default disappearing-messages timer, changed from
+    // another device. We read only `pushname` and `<devices>` out of this
+    // notification, so the change was dropped without even the raw-event
+    // fallback, which the matched `account_sync` arm skips.
+
+    #[tokio::test]
+    async fn account_sync_disappearing_mode_reaches_the_consumer() {
+        use crate::types::events::EventHandler;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+
+        let own: Jid = "12025550199@s.whatsapp.net".parse().unwrap();
+        let notif = NodeBuilder::new("notification")
+            .attr("type", NotificationType::AccountSync.as_str())
+            .attr("from", own.clone())
+            .attr("id", "acct-sync-dm-1")
+            .attr("t", "1704067200")
+            .children([NodeBuilder::new("disappearing_mode")
+                .attr("action", "update")
+                .attr("duration", "604800")
+                .attr("t", "1704067200")
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(notif)).await;
+
+        let changed = collector
+            .events()
+            .into_iter()
+            .find_map(|event| match event.as_ref() {
+                Event::DisappearingModeChanged(changed) => Some(changed.clone()),
+                _ => None,
+            })
+            .expect("an account_sync disappearing_mode must reach the consumer");
+        assert_eq!(changed.from, own);
+        assert_eq!(changed.duration, 604_800);
+    }
+
     /// A type a subsystem claims must not be shadowed by a core arm. The seam
     /// is consulted only in the fallthrough, so an arm added here later would
     /// take the stanza and the subsystem would silently stop seeing it. The

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -256,17 +256,16 @@ mod tests {
             .build();
         handle_notification_impl(&client, node_to_arc(notif)).await;
 
-        // The invalidation is spawned off the ack path, so it lands after the
-        // handler returns rather than inside it. `poll_until` takes a sync
-        // predicate and this one is async, so the wait is a bounded timeout
-        // around the poll rather than that helper.
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while cache.get(&dirty).await.is_some() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("the group the server called stale must lose its cached metadata");
+        // Awaited, not eventual: a lookup defaults to `CachePreferred` and
+        // outgoing sends are not ordered behind incoming processing, so a
+        // snapshot still readable when the handler returns is one a concurrent
+        // send can encrypt against. Deferring the eviction would leave that
+        // window open, and this assertion is what closes it.
+        assert!(
+            cache.get(&dirty).await.is_none(),
+            "the group the server called stale must lose its cached snapshot \
+             before the handler returns"
+        );
         assert!(
             cache.get(&untouched).await.is_some(),
             "a group the notification did not name must keep its cache"

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -221,7 +221,7 @@ mod tests {
 
         let notif = NodeBuilder::new("notification")
             .attr("type", NotificationType::WGp2.as_str())
-            .attr("from", "s.whatsapp.net")
+            .attr("from", "g.us")
             .attr("id", "groups-dirty-1")
             .attr("t", "1704067200")
             .children([NodeBuilder::new("groups_dirty")
@@ -260,6 +260,10 @@ mod tests {
     // another device. We read only `pushname` and `<devices>` out of this
     // notification, so the change was dropped without even the raw-event
     // fallback, which the matched `account_sync` arm skips.
+    //
+    // WA Web's parser makes `action` and `duration`/`t` mutually exclusive
+    // (`h.hasAttr("action") ? … : (duration, t)`), so the two shapes are
+    // tested apart: only the second carries a timer to report.
 
     #[tokio::test]
     async fn account_sync_disappearing_mode_reaches_the_consumer() {
@@ -278,7 +282,6 @@ mod tests {
             .attr("id", "acct-sync-dm-1")
             .attr("t", "1704067200")
             .children([NodeBuilder::new("disappearing_mode")
-                .attr("action", "update")
                 .attr("duration", "604800")
                 .attr("t", "1704067200")
                 .build()])
@@ -295,6 +298,40 @@ mod tests {
             .expect("an account_sync disappearing_mode must reach the consumer");
         assert_eq!(changed.from, own);
         assert_eq!(changed.duration, 604_800);
+    }
+
+    /// The other arm. `action` present means the stanza carries no timer at
+    /// all — WA Web goes back to the server for it. Reporting a
+    /// `DisappearingModeChanged` here would be inventing a duration the
+    /// notification never stated, so nothing is dispatched.
+    #[tokio::test]
+    async fn account_sync_disappearing_mode_action_reports_no_duration() {
+        use crate::types::events::EventHandler;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+
+        let notif = NodeBuilder::new("notification")
+            .attr("type", NotificationType::AccountSync.as_str())
+            .attr("from", "12025550199@s.whatsapp.net")
+            .attr("id", "acct-sync-dm-2")
+            .attr("t", "1704067200")
+            .children([NodeBuilder::new("disappearing_mode")
+                .attr("action", "modify")
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(notif)).await;
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|event| matches!(event.as_ref(), Event::DisappearingModeChanged(_))),
+            "an action-only disappearing_mode states no duration, so none may be reported"
+        );
     }
 
     /// A type a subsystem claims must not be shadowed by a core arm. The seam

--- a/wacore/src/protocol/nack.rs
+++ b/wacore/src/protocol/nack.rs
@@ -6,6 +6,8 @@
 #[wire(kind = "int")]
 #[allow(dead_code)]
 pub enum NackReason {
+    #[wire = 415]
+    UnsupportedMessage,
     #[wire = 421]
     StaleGroupAddressingMode,
     #[wire = 475]
@@ -49,6 +51,7 @@ mod tests {
     /// can't silently break server compatibility.
     #[test]
     fn nack_reason_codes_match_wa_web() {
+        assert_eq!(NackReason::UnsupportedMessage.code(), 415);
         assert_eq!(NackReason::StaleGroupAddressingMode.code(), 421);
         assert_eq!(NackReason::NewChatMessagesCapped.code(), 475);
         assert_eq!(NackReason::ParsingError.code(), 487);

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -17,6 +17,34 @@ use wacore_binary::{Node, NodeRef};
 
 const MISSING_PARTICIPANT_IDENTIFICATION_TAG: &str = "missing_participant_identification";
 
+/// Tag of the server-originated `<groups_dirty>` child.
+const GROUPS_DIRTY_TAG: &str = "groups_dirty";
+
+/// Parse the server's "these groups went stale" notification.
+///
+/// ```xml
+/// <notification type="w:gp2" from="s.whatsapp.net" id="..." t="...">
+///   <groups_dirty><group jid="...@g.us"/></groups_dirty>
+/// </notification>
+/// ```
+///
+/// WA Web gives this shape a parser of its own
+/// (`WASmaxInGroupsGroupsDirtyNotificationRequest`) rather than routing it
+/// through the group-notification parser, because it is the one `w:gp2`
+/// stanza whose `from` is the server instead of a group — the groups it
+/// speaks about are named by the `<group jid>` children. Returns `None` for
+/// an ordinary group update, which [`GroupNotification::try_from_node_ref`]
+/// handles.
+pub fn parse_groups_dirty(node: &NodeRef<'_>) -> Option<Vec<Jid>> {
+    let dirty = node.get_optional_child(GROUPS_DIRTY_TAG)?;
+    Some(
+        dirty
+            .get_children_by_tag("group")
+            .filter_map(|group| group.attrs().optional_jid("jid"))
+            .collect(),
+    )
+}
+
 /// How a membership request was initiated.
 ///
 /// Maps to `WAWebRequestMethodType` in WhatsApp Web JS.
@@ -160,11 +188,21 @@ pub enum GroupNotificationAction {
     },
 
     // -- Metadata --
-    /// `<subject subject="..." s_o="..." s_t="..."/>` — Group name changed
+    /// `<subject subject="..." s_o="..." s_o_pn="..." s_o_username="..." s_t="..."/>`
+    /// — Group name changed.
+    ///
+    /// `s_o` follows the group's addressing mode, so in a LID-addressed group it
+    /// is a `@lid` JID and the phone-number alias arrives separately in `s_o_pn`
+    /// — the same split the notification's own `participant` / `participant_pn`
+    /// pair uses.
     #[wire = "subject"]
     Subject {
         subject: String,
         subject_owner: Option<Jid>,
+        /// Phone-number JID of the renamer when `subject_owner` is a LID.
+        subject_owner_pn: Option<Jid>,
+        /// Renamer's username, when username addressing is enabled.
+        subject_owner_username: Option<String>,
         subject_time: Option<u64>,
     },
     /// `<description id="..."><body>text</body></description>` or `<description id="..."><delete/></description>`
@@ -465,6 +503,11 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .unwrap_or_default()
                 .to_string(),
             subject_owner: node.attrs().optional_jid("s_o"),
+            subject_owner_pn: node.attrs().optional_jid("s_o_pn"),
+            subject_owner_username: node
+                .attrs()
+                .optional_string("s_o_username")
+                .map(|value| value.into_owned()),
             subject_time: node.attrs().optional_u64("s_t"),
         },
         T::Description => {
@@ -1057,6 +1100,7 @@ mod tests {
                 subject,
                 subject_owner,
                 subject_time,
+                ..
             } => {
                 assert_eq!(subject, "New Group Name");
                 assert_eq!(*subject_owner, Some(admin_jid()));
@@ -1064,6 +1108,76 @@ mod tests {
             }
             other => panic!("expected Subject, got {:?}", other),
         }
+    }
+
+    /// A LID-addressed group names the renamer by LID in `s_o` and carries the
+    /// phone-number alias in `s_o_pn` (plus `s_o_username`), the same split the
+    /// notification root uses for `participant` / `participant_pn`. Reading
+    /// only `s_o` leaves a consumer with a LID it cannot resolve to a contact.
+    #[test]
+    fn test_parse_subject_notification_carries_owner_pn_and_username() {
+        let owner_lid: Jid = "271060335329480@lid".parse().unwrap();
+        let node = make_notification(vec![
+            NodeBuilder::new("subject")
+                .attr("subject", "New Group Name")
+                .attr("s_o", owner_lid.clone())
+                .attr("s_o_pn", admin_jid())
+                .attr("s_o_username", "group-admin")
+                .attr("s_t", "1704067200")
+                .build(),
+        ]);
+
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::Subject {
+                subject,
+                subject_owner,
+                subject_owner_pn,
+                subject_owner_username,
+                subject_time,
+            } => {
+                assert_eq!(subject, "New Group Name");
+                assert_eq!(*subject_owner, Some(owner_lid));
+                assert_eq!(*subject_owner_pn, Some(admin_jid()));
+                assert_eq!(subject_owner_username.as_deref(), Some("group-admin"));
+                assert_eq!(*subject_time, Some(1704067200));
+            }
+            other => panic!("expected Subject, got {:?}", other),
+        }
+    }
+
+    /// `<groups_dirty>` is the one `w:gp2` stanza whose `from` is the server
+    /// rather than a group; the groups it speaks about are its `<group jid>`
+    /// children.
+    #[test]
+    fn test_parse_groups_dirty_collects_group_jids() {
+        let a: Jid = "120363000000000001@g.us".parse().unwrap();
+        let b: Jid = "120363000000000002@g.us".parse().unwrap();
+        let node = NodeBuilder::new("notification")
+            .attr("type", "w:gp2")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "GD-1")
+            .attr("t", "1704067200")
+            .children(vec![
+                NodeBuilder::new("groups_dirty")
+                    .children(vec![
+                        NodeBuilder::new("group").attr("jid", a.clone()).build(),
+                        NodeBuilder::new("group").attr("jid", b.clone()).build(),
+                    ])
+                    .build(),
+            ])
+            .build();
+
+        let groups = parse_groups_dirty(&node.as_node_ref())
+            .expect("a groups_dirty notification must be recognized");
+        assert_eq!(groups, vec![a, b]);
+    }
+
+    /// An ordinary group update must not be mistaken for one.
+    #[test]
+    fn test_parse_groups_dirty_ignores_ordinary_group_notification() {
+        let node = make_notification(vec![NodeBuilder::new("announcement").build()]);
+        assert!(parse_groups_dirty(&node.as_node_ref()).is_none());
     }
 
     #[test]
@@ -1606,6 +1720,8 @@ mod tests {
             GroupNotificationAction::Subject {
                 subject: "s".into(),
                 subject_owner: None,
+                subject_owner_pn: None,
+                subject_owner_username: None,
                 subject_time: None,
             },
             GroupNotificationAction::Description {

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -31,12 +31,26 @@ const GROUPS_DIRTY_TAG: &str = "groups_dirty";
 /// WA Web gives this shape a parser of its own
 /// (`WASmaxInGroupsGroupsDirtyNotificationRequest`) rather than routing it
 /// through the group-notification parser, because it is the one `w:gp2`
-/// stanza whose `from` is the server instead of a group — the groups it
-/// speaks about are named by the `<group jid>` children. Returns `None` for
-/// an ordinary group update, which [`GroupNotification::try_from_node_ref`]
-/// handles.
+/// stanza whose `from` is the group *server* — the parser pins it with
+/// `literalJid(attrDomainJid, "from", "g.us")` — instead of one group's JID.
+/// The groups it speaks about are named by the `<group jid>` children.
+///
+/// The discriminator is the **first** child's tag, matching
+/// `WAWebHandleGroupNotification`, which branches before its own parser runs:
+///
+/// ```js
+/// var r = t[0], a = r.tag;
+/// if (a === "groups_dirty")
+///   return handleGroupsDirtyNotificationJob(e)
+/// ```
+///
+/// Returns `None` for an ordinary group update, which
+/// [`GroupNotification::try_from_node_ref`] handles.
 pub fn parse_groups_dirty(node: &NodeRef<'_>) -> Option<Vec<Jid>> {
-    let dirty = node.get_optional_child(GROUPS_DIRTY_TAG)?;
+    let dirty = node
+        .children()
+        .and_then(|children| children.first())
+        .filter(|first| first.tag.as_ref() == GROUPS_DIRTY_TAG)?;
     Some(
         dirty
             .get_children_by_tag("group")
@@ -1155,7 +1169,7 @@ mod tests {
         let b: Jid = "120363000000000002@g.us".parse().unwrap();
         let node = NodeBuilder::new("notification")
             .attr("type", "w:gp2")
-            .attr("from", "s.whatsapp.net")
+            .attr("from", "g.us")
             .attr("id", "GD-1")
             .attr("t", "1704067200")
             .children(vec![

--- a/wacore/tests/wire_enum_serde_test.rs
+++ b/wacore/tests/wire_enum_serde_test.rs
@@ -380,7 +380,9 @@ fn group_notification_action_serializes_every_field_present() {
     assert_eq!(
         serde_json::to_value(GroupNotificationAction::Subject {
             subject: "Team".into(),
-            subject_owner: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner: Some("271060335329480@lid".parse::<Jid>().unwrap()),
+            subject_owner_pn: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner_username: Some("team-admin".into()),
             subject_time: Some(1_704_067_200),
         })
         .unwrap(),
@@ -388,12 +390,20 @@ fn group_notification_action_serializes_every_field_present() {
             "type": "subject",
             "subject": "Team",
             "subject_owner": {
+                "user": "271060335329480",
+                "server": "lid",
+                "agent": 0,
+                "device": 0,
+                "integrator": 0,
+            },
+            "subject_owner_pn": {
                 "user": "555000111",
                 "server": "s.whatsapp.net",
                 "agent": 0,
                 "device": 0,
                 "integrator": 0,
             },
+            "subject_owner_username": "team-admin",
             "subject_time": 1_704_067_200,
         })
     );
@@ -435,6 +445,8 @@ fn group_notification_action_omits_none_fields() {
         serde_json::to_value(GroupNotificationAction::Subject {
             subject: "Team".into(),
             subject_owner: None,
+            subject_owner_pn: None,
+            subject_owner_username: None,
             subject_time: None,
         })
         .unwrap(),
@@ -509,17 +521,23 @@ fn group_notification_action_declares_exact_field_count() {
         // Mixed constant + optional, both present and absent.
         GroupNotificationAction::Subject {
             subject: "Team".into(),
-            subject_owner: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner: Some("271060335329480@lid".parse::<Jid>().unwrap()),
+            subject_owner_pn: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner_username: Some("team-admin".into()),
             subject_time: Some(1_704_067_200),
         },
         GroupNotificationAction::Subject {
             subject: "Team".into(),
             subject_owner: None,
+            subject_owner_pn: None,
+            subject_owner_username: None,
             subject_time: Some(1_704_067_200),
         },
         GroupNotificationAction::Subject {
             subject: "Team".into(),
             subject_owner: None,
+            subject_owner_pn: None,
+            subject_owner_username: None,
             subject_time: None,
         },
         // Only-optional, only-skipped, unit and fallback variants.

--- a/wacore/tests/wire_enum_serde_test.rs
+++ b/wacore/tests/wire_enum_serde_test.rs
@@ -381,7 +381,7 @@ fn group_notification_action_serializes_every_field_present() {
         serde_json::to_value(GroupNotificationAction::Subject {
             subject: "Team".into(),
             subject_owner: Some("271060335329480@lid".parse::<Jid>().unwrap()),
-            subject_owner_pn: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner_pn: Some("12025550111@s.whatsapp.net".parse::<Jid>().unwrap()),
             subject_owner_username: Some("team-admin".into()),
             subject_time: Some(1_704_067_200),
         })
@@ -397,7 +397,7 @@ fn group_notification_action_serializes_every_field_present() {
                 "integrator": 0,
             },
             "subject_owner_pn": {
-                "user": "555000111",
+                "user": "12025550111",
                 "server": "s.whatsapp.net",
                 "agent": 0,
                 "device": 0,
@@ -522,7 +522,7 @@ fn group_notification_action_declares_exact_field_count() {
         GroupNotificationAction::Subject {
             subject: "Team".into(),
             subject_owner: Some("271060335329480@lid".parse::<Jid>().unwrap()),
-            subject_owner_pn: Some("555000111@s.whatsapp.net".parse::<Jid>().unwrap()),
+            subject_owner_pn: Some("12025550111@s.whatsapp.net".parse::<Jid>().unwrap()),
             subject_owner_username: Some("team-admin".into()),
             subject_time: Some(1_704_067_200),
         },


### PR DESCRIPTION
## What I compared, and how

A 1:1 sweep of this repo's **hand-written** protocol parsers against WhatsApp Web, at the version this tree already pins: whatspec commit `12dbeeb89be46d823902aa73859373440e0eb014`, WhatsApp `2.3000.1045368834`.

Two sources, and the second is what makes this PR trustworthy:

1. **The whatspec IR** — verified against the lock before reading anything (`git rev-parse HEAD` plus the per-domain `sha256`s in `tools/whatspec-codegen/whatspec.lock.json`). Domains queried: `iq`, `notif`, `srvreq`, `incoming`, `stanza`, `enums`, `appstate`, `abprops`, `mex`.
2. **The official bundle.** The IR describes shape, never sequencing, so every "what does WA Web *do*" question below is answered from the minified source. I pulled the exact 516-bundle set the pinned IR was extracted from — whatspec's content-addressed `bundle-store` release, `bundles-2.3000.1045368834-99a75bd7….tar.xz` — and verified **all 516 files byte-for-byte against `generated/bundles.lock.json`** (516 matched, 0 missing, 0 extra) before reading a line. So the JS quoted here and the IR cited here describe the same WhatsApp build, by construction.

**That check changed two of my conclusions**, both recorded below rather than quietly amended. The first version of this PR inferred `groups_dirty`'s behaviour from the tag name; the bundle both confirmed the routing and corrected the `from` value I had asserted.

Repo files read: `wacore/src/stanza/`, `wacore/src/iq/`, `wacore/src/protocol/`, `src/handlers/`, `src/receipt.rs`, `src/retry.rs`, `src/features/`.

Scope was everything except VoIP (`wacore/src/voip/`, `src/voip/`, `src/handlers/call.rs`, `examples/voip-cli/`, call stanzas) — untouched. Checked #1277 and #1356 for overlap: #1356 touches two of the same files (`src/handlers/notification/device.rs`, `mod.rs`) but different functions, ~10 and ~70 lines apart; no duplicated findings.

---

## Divergences this PR fixes

### 1. The group `<subject>` action drops the renamer's phone number and username

**Our code**, `wacore/src/stanza/groups.rs:460-468` on `main`:

```rust
T::Subject => GroupNotificationAction::Subject {
    subject: …,
    subject_owner: node.attrs().optional_jid("s_o"),
    subject_time: node.attrs().optional_u64("s_t"),
},
```

**The evidence.** The IR lists five fields; the bundle's handler shows the same five with their exact optionality:

```js
case GROUP_NOTIFICATION_TAG.SUBJECT:
  return { actionType: GROUP_ACTIONS.SUBJECT,
           subject: t.attrString("subject"),
           s_o:               t.hasAttr("s_o")    ? userJidToUserWid(t.attrUserJid("s_o"))    : null,
           subjectOwnerPn:    t.hasAttr("s_o_pn") ? userJidToUserWid(t.attrUserJid("s_o_pn")) : null,
           subjectOwnerUsername: t.maybeAttrString("s_o_username"),
           s_t: t.maybeAttrTime("s_t") };
```

**What a user experiences.** In a LID-addressed group `s_o` is a `@lid` JID and the phone-number alias arrives separately in `s_o_pn`, so a consumer handed only the LID cannot resolve who renamed the group. It is also an internal inconsistency: the notification root already carries `participant` **and** `participant_pn`, and `GroupParticipantInfo` already carries `phone_number`, `lid` and `username`. The subject action was the one place keeping the LID half and discarding the PN half.

**Fixed by** adding `subject_owner_pn` and `subject_owner_username`, both `Option<T>`.

**Test:** `wacore` → `stanza::groups::tests::test_parse_subject_notification_carries_owner_pn_and_username`. Confirmed failing with the parser reverted (struct fields kept so it still compiles), passing with it restored.

### 2. `<notification type="w:gp2"><groups_dirty>` is parsed as an update to a group that does not exist

**The evidence.** WA Web branches on the **first child's tag**, before its own group parser runs — `WAWebHandleGroupNotification`:

```js
var t = e.content;
if (t != null && Array.isArray(t) && t.length > 0) {
  var r = t[0], a = r.tag;
  if (a === "groups_dirty")
    return Promise.resolve(WAWebHandleGroupsDirtyNotification.handleGroupsDirtyNotificationJob(e))
}
var i = D.parse(e);           // otherwise the ordinary group-notification parser
… return handleParsedGroupNotification(i.success)
```

and the dedicated parser pins `from` to the group **server**:

```js
literalJid(attrDomainJid, t, "from", "g.us")
mapChildrenWithTag(r.value, "group", 1, 1e4, …)   // 1..10000 <group jid>
```

**Correction to my first reading.** I originally wrote that `from` is `s.whatsapp.net`. It is `g.us`. The point holds — it is a server domain JID, not a group's own JID, which is why the ordinary parser mis-keys it — but the value I stated was wrong, and the test fixture used it. Both are fixed in `b5a00e3`.

**Our code**, `src/handlers/notification/groups.rs:124` on `main`, sends *everything* through `GroupNotification::try_from_node_ref`, which takes `from` as the group JID. Every other w:gp2 notification reads `from` with `attrGroupJid`; this one alone with `literalJid`. `grep -rn groups_dirty --include=*.rs .` returned nothing on `main`.

**What a user experiences.** The tag has no matching `GroupNotificationAction`, so it falls to `Unknown { tag }` and we emit an `Event::GroupUpdate` whose `group_jid` is the bare server — a consumer keyed on group JID gets an event for a non-group. And the groups the server called stale keep their cached metadata, so sends to them keep encrypting to a participant list the group no longer has.

**Fixed by** `wacore::stanza::groups::parse_groups_dirty`, matching on the first child exactly as WA Web does, plus an early branch in `handle_group_notification` that routes it out before the group parser can mis-key it, invalidates each named group's cache, and still dispatches the raw `Event::Notification`.

**One deliberate deviation, now measured rather than guessed.** `handleGroupsDirtyNotificationJob` does not merely drop a cache — it queues `queryAndUpdateGroupsMetadataByJids(jids)` and runs it after `waitForOfflineDeliveryEnd()` and `waitForConnection()`:

```js
var t = e.groupsDirtyGroup.map(e => e.jid), n = yield maybeCreateJob(
    jobSerializers.queryAndUpdateGroupsMetadataByJids(t));
yield waitForOfflineDeliveryEnd(); yield WAComms.waitForConnection();
loadAndRunJobFromId(n)
```

This PR invalidates instead of eagerly re-querying. That is the lazy equivalent — the next send or `group_info` query refetches, and no stale participant list is ever used — and it avoids putting a fan-out of up to 10 000 group JIDs' worth of IQs on a notification path. The eager version needs the offline-wait and connection-generation guards that `src/handlers/ib.rs` already uses for the sibling `dirty` bit, plus batching through `BatchGetGroupInfoIq`; that is a follow-up, not something to fold in here. Flagging it because it is a real behavioural difference from the official client, not a detail.

**Test:** `wacore` → `test_parse_groups_dirty_collects_group_jids`, `…_ignores_ordinary_group_notification`; `whatsapp-rust` → `handlers::notification::tests::groups_dirty_invalidates_the_named_groups_and_names_no_group_update`, which seeds two groups, feeds the stanza through `handle_notification_impl`, and asserts the named group lost its cache, the unnamed one kept it, no `GroupUpdate` was emitted, and the raw notification still arrived. All three confirmed failing with the fix reverted, re-confirmed after the `g.us` correction.

### 3. `<notification type="account_sync">` drops its `<disappearing_mode>` child

**Our code**, `src/handlers/notification/device.rs:30-40` on `main`: `handle_account_sync_notification` reads exactly two things — the `pushname` attribute and the `<devices>` child.

**The evidence.** The account_sync parser is an if/else chain over eleven children (`status`, `text_status`, `privacy`, `devices`, `blocklist`, `picture`, `tos`, `disappearing_mode`, `notice`, `user`, `biz_opt_out_list`), and the disappearing-mode arm is:

```js
else if (e.hasChild("disappearing_mode")) {
  var h = e.child("disappearing_mode"), y, C, b;
  return h.hasAttr("action") ? y = h.attrString("action")
                             : (C = h.attrInt("duration"), b = h.attrInt("t")),
  extends({}, t, { type: DISAPPEARING_MODE, action: y,
                   disappearingModeDuration: C, disappearingModeSettingTimestamp: b })
}
```

and its consumer ends at the same call the standalone `type="disappearing_mode"` notification makes:

```js
if (t === "modify") {
  var i = yield getDisappearingMode(n, SYNC_REQUEST_ORIGIN.DM_FORCE_REFRESH);
  … (r = i.disappearingModeDuration, a = i.disappearingModeSettingTimestamp)
}
r != null && a != null && (yield updateDisappearingModeForContact({ contactId: n, newDuration: r, newSettingTimestamp: a }))
```

**What a user experiences.** Change your account's default disappearing-messages timer on your phone and this client never learns — and it is worse than an ordinary unhandled stanza, because `account_sync` *is* matched in the dispatcher, so the `_ =>` raw-`Event::Notification` fallback never fires either.

**Fixed by** routing the child through the parser that already exists for it, `handle_disappearing_mode_notification`. `from` on an account_sync is our own account, which lands in the existing `DisappearingModeChanged.from` correctly. No new event type, no new field.

**Correction to my first reading, and an honest note on one test.** `action` and `duration`/`t` are **mutually exclusive** — my original fixture set all three, a shape the server never sends. Fixed in `b5a00e3`, which also splits the arms so only the no-`action` case reaches the parser. Be clear about what that split is worth: it changes **no** observable behaviour, because the parser already declined an action-only stanza (it requires `t`). What it stops is that decline being announced as `warn!("… missing or invalid 't' …")` about a stanza that is perfectly well formed — a false lead in the log. Handling the `action === "modify"` arm properly means re-querying the server, and this client has no `disappearing_mode` *get* (only `SetDefaultDisappearingModeSpec`, the set), so that arm is logged and left as a follow-up.

**Tests:** `account_sync_disappearing_mode_reaches_the_consumer` — confirmed failing with the branch removed. `account_sync_disappearing_mode_action_reports_no_duration` — **this one passes without the fix too**, and I am not presenting it as proof of anything; it is a contract guard that pins "the action arm reports no duration" so a future change cannot start inventing one.

### 4. `NackReason` is missing 415

`enums/index.json`, `WAWebCreateNackFromStanza::NackReason`, first entry: `UnsupportedMessage->415`, then `StaleGroupAddressingMode->421`, … `wacore/src/protocol/nack.rs` on `main` starts at 421. The other fifteen match exactly, and the file's own test says it pins the table against `Create/NackFromStanza.js` — a hole in a table meant to be complete. Server-visible only; no user-facing symptom. The variant proves itself: `main` does not compile with the new assertion.

---

## Found, not fixed

- **`account_sync`'s `<blocklist>` child — question now answered.** I previously wrote that the IR could not tell me whether it is a full list or a delta, and that it needed the bundle. It is **neither**: the `<item>` children are harvested only for usernames, and only behind a gate, while the blocklist itself is re-fetched wholesale.
  ```js
  case AccountSyncType.BLOCKLIST:
    usernameDisplayedEnabled() && r.usernames != null && (yield setUsernamesJob(r.usernames)),
    fetchAndUpdateBlocklist("notification");
  ```
  So the correct handling is "treat it as a signal to refetch", which needs the `dhash` round-trip below. Still not fixed — it needs that plus a new event payload — but it is now a specified piece of work rather than an open question.
- **Blocklist responses drop `lid`, and we never send `dhash`.** `wacore/src/iq/blocklist.rs` reads `jid` and `t` and sends no `dhash`; WA Web's request carries `<item dhash>` and its parser reads `<list dhash addressing_mode>` plus `<item jid lid …>`. The bundle shows all three are load-bearing: `fetchAndUpdateBlocklist` branches on `type === "mismatch"` (else "no change in blocklist, skip update"), stores the new hash with `setBlocklistHash(n.dhash)`, and uses `addressingMode === "pn"` to decide whether to mark the device blocklist-migrated, feeding each item's `lid` and `displayName` into `updateLidMetadataJob`. Not fixed because `GetBlocklistSpec::Response = Vec<BlocklistEntry>` has nowhere to put the list-level attributes without a breaking signature change, and `dhash` needs somewhere to persist across sessions.
- **`account_sync`'s other children.** `privacy` and `picture` are two the IR does not list at all — they carry no fields beyond the base, so the extractor had nothing to emit, but the bundle shows both branches (`forceUpdatePrivacySettings()`, `getAndUpdateProfilePicture()`). Along with `status`, `text_status`, `tos`, `notice`, `user` and `biz_opt_out_list`, all still unread here.
- **Group-info `create_ctx` / `key` are read by nobody.** Creation-dedup attributes; low value for a library client and an additive public-API change to `GroupInfo`.
- **Stanza-level `participant_username` on incoming receipts.** Read by `WAWebHandleMsgReceiptParser`; `src/receipt.rs:551` reads `participant_pn` and not the username. `wacore/src/stanza/receipt.rs:59` does read it in the aggregated `<participants>` shape, so this is only the non-aggregated path.
- **`has_staging` on profile-picture responses.** Cosmetic.

**Nothing for the VoIP or wasm agents** — no finding in this sweep landed in either's territory.

---

## Checked and matching

| Checked | Result |
| --- | --- |
| `appstate` action registry — all 66 names | Identical to `wacore/appstate/src/schemas.rs` (`diff` of both sorted lists is empty). |
| `NackReason` codes 421–552 | All fifteen match exactly (only 415 was missing). |
| `ReceiptType` | All ten of `WAWebSendReceiptJobCommon::RECEIPT_TYPE`, right wire strings, `read-self` / `played-self` / `hist_sync` / `peer_msg` included. |
| Nack `<ack>` shape | `class/id/to/type/participant/error` matches all five `WAWebCreateNackFromStanza` variants. |
| Group limits | `group_max_subject=100`, `group_description_length=2048`, `group_size_limit=257` — three for three; the bundle reads the first two through `getABPropConfigValue`, so the registry really is the source. |
| tcToken timing | `TC_TOKEN_BUCKET_DURATION=604800` = `tctoken_duration`; `TC_TOKEN_NUM_BUCKETS=4` = `tctoken_num_buckets`. |
| Edit window | `EDIT_PROCESSING_WINDOW_SECS=1200` = `message_edit_window_duration_seconds`. |
| `contacts` notification `<modify>` | We read `old`, `new`, `old_lid`, `new_lid` and build both LID-PN mappings — field for field. |
| w:gp2 action tag set | All 47 IR tags present in `GroupNotificationAction`; participant children read all seven attrs WA Web reads. |
| usync request | `sid`/`index`/`last`/`mode`/`context` and the `<user jid pn_jid>` list all present. |
| Retry receipt | `<retry v count id t error?>` + `<registration>` + `<meta mode>` matches `WAWebSendRetryReceiptJob`. |
| Group participant requests | `<participant jid phone_number? username?>` sent, normalised to drop `phone_number` for non-LID JIDs. |
| Profile-picture request/response | `type`/`id`/`query` sent; `id`/`url`/`direct_path`/`hash` read. |
| `mex` doc IDs | No hardcoded doc id outside the generated `mex_operations.rs`. |
| `clean` dirty-bit IQ | `<clean type timestamp>` matches `clearDirtyBits`; `src/handlers/ib.rs` echoes the timestamp back. |

---

## Verification

- `cargo fmt --all --check` — clean.
- `cargo test -p wacore --lib` — 1515 passed, 0 failed.
- `cargo test -p whatsapp-rust --lib` — 1789 passed, 0 failed.
- `cargo test -p wacore --test wire_enum_serde_test` — 20 passed.
- `cargo clippy -p wacore -p whatsapp-rust --all-targets` — no warnings.
- Every regression test was confirmed to fail with its fix reverted and pass with it restored, **except** `account_sync_disappearing_mode_action_reports_no_duration`, which is labelled above as a contract guard rather than proof. No `unsafe` touched, so Miri is not in play. E2E not run (needs the mock server); nothing in the diff reaches that surface.
- `cargo build --workspace --all-targets` fails in this container on `alsa-sys` (missing system ALSA headers, a VoIP-example dependency) — pre-existing and environmental. `-p wacore -p whatsapp-rust --all-targets` builds clean.