### PR TITLE
fix(version): resolve the app version where sw.js cannot be reached

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -5,42 +5,108 @@ use anyhow::{Context as _, Result, anyhow};
 use log::debug;
 use std::sync::Arc;
 
-pub use wacore::version::{WA_WEB_VERSION, WA_WEB_VERSION_STR, parse_sw_js};
+pub use wacore::version::{WA_WEB_VERSION, WA_WEB_VERSION_STR, parse_meta_sdk_js, parse_sw_js};
 
-const SW_URL: &str = "https://web.whatsapp.com/sw.js";
+/// Where the client revision is read from on one target.
+struct VersionSource {
+    url: &'static str,
+    headers: &'static [(&'static str, &'static str)],
+    parse: fn(&str) -> Option<(u32, u32, u32)>,
+    /// The field the parser looks for, so a parse failure can name it.
+    field: &'static str,
+}
+
+/// WhatsApp Web's own service worker: the most direct source, and the one used
+/// wherever the request is not made by a browser.
+///
+/// It answers 200 only to a request carrying `Sec-Fetch-Site: none`; any other
+/// value, or none at all, is a 400. That header, `Connection` and `User-Agent`
+/// are all forbidden header names under the Fetch spec, and no response from
+/// `web.whatsapp.com` carries `Access-Control-Allow-Origin`, so this source is
+/// doubly unreachable from a page. That is the whole reason for [`SDK_SOURCE`].
+// Both are referenced: one by this target's build, the other by the other
+// target's and by the source-selection tests.
+#[allow(dead_code)]
+const SW_SOURCE: VersionSource = VersionSource {
+    url: "https://web.whatsapp.com/sw.js",
+    // `Connection: close` because this fetch runs at most once a day per
+    // device: a pooled idle TLS connection would be retained for the rest of
+    // the session and buys nothing back before it is purged.
+    headers: &[
+        ("sec-fetch-site", "none"),
+        ("connection", "close"),
+        (
+            "user-agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        ),
+    ],
+    parse: parse_sw_js,
+    field: "client_revision",
+};
+
+/// The Facebook JS SDK bundle, used on wasm because it is the one place Meta
+/// publishes this revision for cross-origin loading (`Access-Control-Allow-Origin: *`,
+/// no fetch-metadata gate). The number is the revision of Meta's shared `www`
+/// build, so it is the same one `sw.js` reports.
+///
+/// It is not a published contract: the field can be renamed or dropped, and a
+/// failure here reaches the caller as an ordinary network failure. No headers
+/// are sent because a browser sets its own and discards anything set here.
+#[allow(dead_code)]
+const SDK_SOURCE: VersionSource = VersionSource {
+    url: "https://connect.facebook.net/en_US/sdk.js",
+    headers: &[],
+    parse: parse_meta_sdk_js,
+    field: "JSSDKRuntimeConfig.revision",
+};
+
+/// One source per target, not a fallback chain: falling back would hide a real
+/// break of the primary source, which is the thing worth hearing about.
+const fn version_source() -> VersionSource {
+    #[cfg(target_family = "wasm")]
+    {
+        SDK_SOURCE
+    }
+    #[cfg(not(target_family = "wasm"))]
+    {
+        SW_SOURCE
+    }
+}
 
 pub async fn fetch_latest_app_version(
     http_client: &Arc<dyn HttpClient>,
 ) -> Result<(u32, u32, u32)> {
-    // `Connection: close` because this fetch runs at most once a day per
-    // device: a pooled idle TLS connection would be retained for the rest of
-    // the session and buys nothing back before it is purged.
-    let request = HttpRequest::get(SW_URL).with_header("sec-fetch-site", "none")
-    .with_header("connection", "close")
-    .with_header(
-        "user-agent",
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-    );
+    let source = version_source();
+    let mut request = HttpRequest::get(source.url);
+    for (key, value) in source.headers {
+        request = request.with_header(*key, *value);
+    }
     let response = http_client
         .execute(request)
         .await
-        .map_err(|e| anyhow!("HTTP request to {} failed: {}", SW_URL, e))?;
+        .map_err(|e| anyhow!("HTTP request to {} failed: {}", source.url, e))?;
 
     // `HttpClient` returns a non-2xx as a response, so name the status here
-    // instead of letting an error page fall through to a "no client_revision"
-    // parse failure.
+    // instead of letting an error page fall through to a parse failure.
     if response.status_code >= HTTP_STATUS_REDIRECTION_START {
         let status = response.status_code;
-        return Err(crate::http::HttpStatusError { status }
-            .into_error(format!("HTTP request to {SW_URL} returned status {status}")));
+        return Err(crate::http::HttpStatusError { status }.into_error(format!(
+            "HTTP request to {} returned status {status}",
+            source.url
+        )));
     }
 
     let body_str = response
         .body_string()
         .map_err(|e| anyhow!("Failed to decode response body: {}", e))?;
 
-    parse_sw_js(&body_str)
-        .ok_or_else(|| anyhow!("Could not find 'client_revision' version in sw.js response"))
+    (source.parse)(&body_str).ok_or_else(|| {
+        anyhow!(
+            "Could not find '{}' in the response from {}",
+            source.field,
+            source.url
+        )
+    })
 }
 
 pub async fn resolve_and_update_version(
@@ -105,11 +171,13 @@ mod tests {
     #[derive(Default)]
     struct HeaderCapturingHttpClient {
         seen: std::sync::Mutex<Option<std::collections::HashMap<String, String>>>,
+        url: std::sync::Mutex<Option<String>>,
     }
 
     #[async_trait::async_trait]
     impl HttpClient for HeaderCapturingHttpClient {
         async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
+            *self.url.lock().unwrap() = Some(request.url.clone());
             *self.seen.lock().unwrap() = Some(request.headers);
             Ok(HttpResponse {
                 status_code: 200,
@@ -194,6 +262,98 @@ mod tests {
             headers.get("connection").map(String::as_str),
             Some("close"),
             "got: {headers:?}"
+        );
+    }
+
+    /// Every header name the Fetch spec forbids a page from setting. A source
+    /// that depends on one of these cannot work in a browser, whatever the
+    /// server answers.
+    const FORBIDDEN_HEADER_PREFIXES: &[&str] = &[
+        "sec-fetch-",
+        "connection",
+        "user-agent",
+        "origin",
+        "host",
+        "referer",
+    ];
+
+    /// The wasm source exists precisely because the default one cannot be
+    /// requested from a page, so it must not repeat the mistake.
+    #[test]
+    fn the_browser_source_sends_no_header_a_page_is_forbidden_to_set() {
+        for (key, _) in SDK_SOURCE.headers {
+            let key = key.to_ascii_lowercase();
+            assert!(
+                !FORBIDDEN_HEADER_PREFIXES
+                    .iter()
+                    .any(|forbidden| key.starts_with(forbidden)),
+                "the wasm version source cannot depend on '{key}'"
+            );
+        }
+    }
+
+    /// The saving header is what turns a 400 into a 200, so pin that the
+    /// non-browser source still sends it.
+    #[test]
+    fn the_default_source_is_the_service_worker_with_its_fetch_metadata_header() {
+        assert_eq!(SW_SOURCE.url, "https://web.whatsapp.com/sw.js");
+        assert!(
+            SW_SOURCE.headers.contains(&("sec-fetch-site", "none")),
+            "got: {:?}",
+            SW_SOURCE.headers
+        );
+    }
+
+    /// The choice of source is a compile-time fact, so assert it as one.
+    #[test]
+    fn the_source_is_chosen_by_target() {
+        let source = version_source();
+        if cfg!(target_family = "wasm") {
+            assert_eq!(source.url, SDK_SOURCE.url);
+        } else {
+            assert_eq!(source.url, SW_SOURCE.url);
+        }
+    }
+
+    /// A source that fails must not spend the 24 h cache: the next connect has
+    /// to be free to try again, and a still-valid stamp has to survive.
+    #[tokio::test]
+    async fn a_failed_fetch_leaves_a_valid_cache_stamp_alone() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("in-memory persistence"),
+        );
+        let fresh_stamp = wacore::time::now_utc().timestamp_millis();
+        persistence_manager
+            .process_command(DeviceCommand::SetAppVersion((2, 3000, 111)))
+            .await;
+        let stamp_after_success = persistence_manager
+            .get_device_snapshot()
+            .app_version_last_fetched_ms;
+        assert!(
+            stamp_after_success >= fresh_stamp,
+            "a successful resolve stamps the cache"
+        );
+
+        let http_client: Arc<dyn HttpClient> = Arc::new(StatusOnlyHttpClient(500));
+        resolve_and_update_version(&persistence_manager, &http_client, None)
+            .await
+            .expect("a valid cache is used without fetching");
+
+        let device = persistence_manager.get_device_snapshot();
+        assert_eq!(
+            device.app_version_last_fetched_ms, stamp_after_success,
+            "the cached stamp must survive"
+        );
+        assert_eq!(
+            (
+                device.app_version_primary,
+                device.app_version_secondary,
+                device.app_version_tertiary
+            ),
+            (2, 3000, 111),
+            "the cached version must survive"
         );
     }
 

--- a/wacore/src/version.rs
+++ b/wacore/src/version.rs
@@ -5,6 +5,35 @@ pub use generated::{WA_WEB_VERSION, WA_WEB_VERSION_STR};
 const REVISION_KEY: &str = "client_revision";
 const ASSETS_KEY: &str = "assets-manifest-";
 
+/// The object that carries the build revision in the Facebook JS SDK bundle.
+/// `revision` alone is far too common a word to look for in a JS blob, so the
+/// search starts at the object that owns the field we mean.
+const SDK_CONFIG_ANCHOR: &str = "JSSDKRuntimeConfig";
+const SDK_REVISION_KEY: &str = "\"revision\"";
+
+/// Reads the integer that `key` names, tolerating the JSON punctuation that may
+/// sit between a key and its value in a bundle (`:`, quotes, and the
+/// backslashes of a string-embedded JSON blob). Anything else between the two
+/// means the value is not a number, and that is a miss rather than a guess.
+fn revision_after(s: &str, key: &str) -> Option<u32> {
+    let after = &s[s.find(key)? + key.len()..];
+    let value =
+        after.trim_start_matches(|c: char| matches!(c, ':' | '"' | '\\') || c.is_whitespace());
+    let end = value
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(value.len());
+    value[..end].parse().ok()
+}
+
+/// Parses the Meta build revision from a Facebook JS SDK bundle.
+/// Returns the same `(2, 3000, revision)` shape as [`parse_sw_js`]: the two
+/// sources carry the same number, since it is the revision of Meta's shared
+/// `www` build rather than anything specific to one property.
+pub fn parse_meta_sdk_js(s: &str) -> Option<(u32, u32, u32)> {
+    let anchored = &s[s.find(SDK_CONFIG_ANCHOR)?..];
+    Some((2, 3000, revision_after(anchored, SDK_REVISION_KEY)?))
+}
+
 /// Parses the WhatsApp Web version from sw.js content.
 /// Returns `(2, 3000, revision)` tuple.
 pub fn parse_sw_js(s: &str) -> Option<(u32, u32, u32)> {
@@ -65,6 +94,41 @@ mod tests {
     fn test_parse_sw_js_realistic_sw_js() {
         let s = r#"{"client_revision":1026131876}"#;
         assert_eq!(parse_sw_js(s), Some((2, 3000, 1026131876)));
+    }
+
+    #[test]
+    fn test_parse_meta_sdk_js_happy() {
+        let s =
+            r#"a={"JSSDKRuntimeConfig":{"locale":"en_US","revision":"1046341789","rtl":false}};"#;
+        assert_eq!(parse_meta_sdk_js(s), Some((2, 3000, 1046341789)));
+    }
+
+    #[test]
+    fn test_parse_meta_sdk_js_missing_field() {
+        let s = r#"a={"JSSDKRuntimeConfig":{"locale":"en_US","rtl":false}};"#;
+        assert_eq!(parse_meta_sdk_js(s), None);
+    }
+
+    #[test]
+    fn test_parse_meta_sdk_js_missing_anchor() {
+        let s = r#"a={"revision":"1046341789"};"#;
+        assert_eq!(parse_meta_sdk_js(s), None);
+    }
+
+    #[test]
+    fn test_parse_meta_sdk_js_non_numeric_value() {
+        let s = r#"a={"JSSDKRuntimeConfig":{"revision":null,"rtl":false}};"#;
+        assert_eq!(parse_meta_sdk_js(s), None);
+    }
+
+    /// The anchor exists because the bare word appears elsewhere in the bundle:
+    /// the first occurrence is not the one we mean.
+    #[test]
+    fn test_parse_meta_sdk_js_ignores_earlier_unrelated_revisions() {
+        let s = r#"var a={"revision":"1"};var b={"x":{"revision":"2"}};
+                   c={"JSSDKRuntimeConfig":{"locale":"en_US","revision":"1046341789"}};
+                   d={"revision":"3"};"#;
+        assert_eq!(parse_meta_sdk_js(s), Some((2, 3000, 1046341789)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A consumer building for `wasm32-unknown-unknown` never gets past version resolution: the socket connects, then `resolve_and_update_version` fails and `connect()` returns `ConnectError::Version` on every attempt. The single source, `https://web.whatsapp.com/sw.js`, is behind two independent walls that a page cannot cross. It answers 200 only to a request carrying `Sec-Fetch-Site: none`, and that is a forbidden header name under the Fetch spec, so a browser drops it silently and gets a 400. And no response from `web.whatsapp.com` carries `Access-Control-Allow-Origin`, so a cross-origin fetch fails before any status is readable. Neither is workable client-side: `no-cors` returns an opaque body and the body is the whole point.

The fix picks the source by target. The number in `sw.js` is not a WhatsApp number at all: it is the revision of Meta's shared `www` build, identical across facebook.com, instagram.com, messenger.com and web.whatsapp.com, and Meta publishes it in the Facebook JS SDK bundle, which is served for cross-origin loading by design. wasm reads it from there; every other target keeps reading `sw.js` exactly as before.

One source per target, not a fallback chain: falling back from `sw.js` would mask a real break of the primary source, which is the thing worth hearing about. Nothing else changes. A source that fails still raises `ConnectError::Version`, so there is no new public surface, no new promise, and no path where a client silently connects on a stale compiled-in version.

## Evidence

Reconfirmed 2026-08-29 from this container; every number below is one I measured, and they match the numbers in the report.

`sw.js`, varying only the fetch-metadata header:

```
Sec-Fetch-Site: none         -> 200
Sec-Fetch-Site: cross-site   -> 400
Sec-Fetch-Dest: script       -> 400
no Sec-Fetch-* header        -> 400
```

The header is load-bearing, not cosmetic, and it is exactly the one a page cannot send. A 200 response from that URL carries no `access-control-allow-origin` (checked with an `Origin: https://example.com` request), which is the second wall.

`https://connect.facebook.net/en_US/sdk.js`: HTTP 200, 12461 bytes, `access-control-allow-origin: *`, `cache-control: public,max-age=1200,stale-while-revalidate=3600`. `"revision":"..."` appears exactly once in the bundle, inside `JSSDKRuntimeConfig`:

```js
"JSSDKRuntimeConfig":{"locale":"en_US","revision":"1046341789","rtl":false,"sdkab":null,"sdkns":"","sdkurl":"https:\/\/connect.facebook.net\/en_US\/sdk.js",...}
```

Fetched in the same minute, `web.whatsapp.com/sw.js` reported `client_revision\":1046341789`. Same number, so the substitution is a substitution and not an approximation.

## Audit

Every `HttpRequest` constructor in the repo, against three questions: does it send a header the Fetch spec forbids a page from setting, does the target host answer with `Access-Control-Allow-Origin`, and is the path exercised on wasm.

| Site | Forbidden headers | ACAO | Verdict |
| --- | --- | --- | --- |
| `src/version.rs:18` (was) | `sec-fetch-site`, `connection`, `user-agent` | none | The bug. Fixed here. |
| `src/upload.rs:79`, `src/upload.rs:91` | `Origin` | `*` on `mmg.whatsapp.net` | Divergence, benign. See below. |
| `src/download.rs:573,739,811` | none | `*` | Correct as written. |
| `http_clients/ureq-client/src/lib.rs:749,1024` | none | n/a | Test fixtures, not a runtime path. |

The `connection: close` on the old version fetch was already a forbidden header of the same class. It was harmless because the server does not require it, and it is now scoped to the non-browser source where it still buys what its comment claims.

## Investigado e correto

**Media upload's explicit `Origin` header.** `build_upload_request` and `build_resume_check_request` set `Origin: https://web.whatsapp.com`, which is a forbidden header name: a browser discards it and substitutes the page's own origin. Not a bug, and not changed here, because `mmg.whatsapp.net` answers `access-control-allow-origin: *` and does not gate on the request's origin, so the header is a no-op in a page and correct off it. Recorded so the next person does not reopen the trail.

**Media download.** `mmg.whatsapp.net` responded `access-control-allow-origin: *` on the measurement, and the download builders send no headers at all. Reachable from a page as written.

**`ConnectError::Version` is already distinguishable.** It is produced only by version resolution (`src/client/lifecycle.rs:1094`); a server that resolves a version and then refuses it surfaces as `Handshake` or `Transport`, never as `Version`. It is classified as non-timeout (`src/client.rs:1023`), which stays correct: a source that 400s or never loads is not a timeout. No change needed, and nothing in this design needs a finer signal, since the caller's options are the same either way.

**Cache.** `resolve_and_update_version` only issues `SetAppVersion` after a successful fetch, so a failing source cannot spend a still-valid `app_version_last_fetched_ms`. Confirmed, and now pinned by a test.

**Follow-up, different class, not fixed here:** the `assets-manifest-` branch of `parse_sw_js` returns `(2, 3000, 0)`. A tertiary of `0` is not a version WhatsApp will accept, so that branch can only turn a clean "no version found" into a bad version that fails later and further away. It is dead weight rather than a fallback, and worth deleting on its own.

## Changes

- `wacore/src/version.rs`: add `parse_meta_sdk_js`, returning the same `(2, 3000, revision)` shape as `parse_sw_js`. It anchors on `JSSDKRuntimeConfig` before looking for `"revision"`, because that word alone is far too common to search for bare in a JS bundle.
- `wacore/src/version.rs`: `revision_after` reads the number, tolerating only the punctuation that can legally sit between a JSON key and its value (`:`, quotes, the backslashes of a string-embedded blob). Anything else is a miss, not a guess, so `"revision":null` yields `None` instead of scanning ahead for an unrelated digit.
- `src/version.rs`: `VersionSource` names the url, headers, parser and expected field in one place; `version_source()` picks it by `target_family`. The rationale for two sources lives on those two constants and nowhere else.
- `src/version.rs`: the parse-failure message now names the field and the url it came from, so a source that changes shape says which one it was.

No public API change, no new dependency, no change to `ClientPayload`, the handshake, the wire, the `HttpClient` port, or any media path. `with_version` keeps its meaning as an override rather than becoming the wasm happy path.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib version::            # 10 passed
cargo test -p whatsapp-rust --lib version::     # 11 passed
cargo clippy -p wacore -p whatsapp-rust --lib --all-features -- -D warnings
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features
```

The wasm check is the target this batch exists for, so it ran here; the two warnings it emits are pre-existing `unnecessary qualification` lints in `src/upload.rs`, untouched by this change. No new test touches the network. Existing tests pass unmodified. Full matrix left to CI.

New tests: the sdk parser's happy path, missing field, missing anchor, non-numeric value, and a blob where the anchor word appears several times (which is what the anchoring is for); that the browser source sends no header a page is forbidden to set; that the non-browser source still carries `sec-fetch-site: none`; that the source is chosen by target; and that a failing source leaves a valid 24 h cache stamp and its version alone.

Branch note: pushed to `claude/version-sw-js-unreachable-qb1qej`, the branch this environment designates, rather than `fix/version-source-reachable-from-a-browser`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mnr4xjXpSN5ghUPKedURNC)_