### PR TITLE
fix(send): let a caller see a DM fan-out that skipped devices

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -71,6 +71,12 @@ change; what these answer is *how often it happens*, which is the difference
 between "the session repair worked" and a screenshot of a chat stuck on
 "Waiting for this message".
 
+These are process-wide totals, so they say a device went unkeyed somewhere but
+never which message lost it. The per-message question is answered by
+`SendResult::recipient_fanout` (`RecipientFanout`), which a DM fills in with how
+many recipient devices it addressed, how many encrypted, and whether the one
+that dropped was the recipient's phone.
+
 **Per attempt, not per delivered stanza**, and the distinction is not academic:
 a batch-wide `406` and a `Required` distribution that cannot reach every target
 both abort the send, and both are counted. Skipping them would make the metric

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -74,8 +74,8 @@ between "the session repair worked" and a screenshot of a chat stuck on
 These are process-wide totals, so they say a device went unkeyed somewhere but
 never which message lost it. The per-message question is answered by
 `SendResult::recipient_fanout` (`RecipientFanout`), which a DM fills in with how
-many recipient devices it addressed, how many encrypted, and whether the one
-that dropped was the recipient's phone.
+many recipient devices it addressed, how many encrypted, and whether the
+recipient's primary device was among the ones that did not.
 
 **Per attempt, not per delivered stanza**, and the distinction is not academic:
 a batch-wide `406` and a `Required` distribution that cannot reach every target

--- a/src/client.rs
+++ b/src/client.rs
@@ -1069,6 +1069,11 @@ pub(crate) struct PhashWaiter {
     pub(crate) expected: wacore_binary::CompactString,
     pub(crate) jid: Jid,
     pub(crate) invalidate_group_cache: bool,
+    /// DM sends only: the device set this stanza actually covered, shared with
+    /// the send's own memo entry rather than copied. A mismatch resends to the
+    /// devices a refreshed list holds and this one does not, which is what the
+    /// `excludeList` in WA Web's `resendUserMsg` job amounts to.
+    pub(crate) dm_devices: Option<Arc<wacore::send::ResolvedDmDevices>>,
     /// Sweep epoch this waiter was registered in. Expiry is counted in sweeps
     /// rather than seconds: a wall deadline is subject to clock jumps (see
     /// wacore::time) and would have to be derived from an instant sampled well

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -2741,7 +2741,8 @@ impl Client {
                             ..Default::default()
                         },
                     )
-                    .await
+                    .await?;
+                    Ok::<(), anyhow::Error>(())
                 }
                 .await;
                 (device, result)

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -395,6 +395,7 @@ impl Client {
         expected: wacore_binary::CompactString,
         jid: Jid,
         invalidate_group_cache: bool,
+        dm_devices: Option<Arc<wacore::send::ResolvedDmDevices>>,
     ) {
         let mut waiters = self.response_waiters_guard();
         // Stamped with the sweep epoch under the lock the insert already holds:
@@ -407,6 +408,7 @@ impl Client {
                 expected,
                 jid,
                 invalidate_group_cache,
+                dm_devices,
                 registered_epoch,
             }),
         );

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1673,13 +1673,28 @@ impl Client {
         }
         let client = Arc::clone(self);
         let server = server.as_str().to_string();
+        // Read off the ack rather than stored on the waiter: the id is only
+        // needed on this path, and a copy per send is a copy per send.
+        let message_id = waiter
+            .dm_devices
+            .is_some()
+            .then(|| node.get_attr("id").map(|id| id.as_str().to_string()))
+            .flatten();
         self.runtime.spawn_detached(Box::pin(async move {
+            let resend = match (message_id.as_deref(), waiter.dm_devices) {
+                (Some(message_id), Some(covered)) => Some(crate::send::DmDeltaResend {
+                    message_id,
+                    covered,
+                }),
+                _ => None,
+            };
             client
                 .handle_phash_mismatch(
                     &waiter.jid,
                     &waiter.expected,
                     &server,
                     waiter.invalidate_group_cache,
+                    resend,
                 )
                 .await;
         }));

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -15,6 +15,7 @@ use wacore_binary::Jid;
 
 use super::Client;
 use crate::types::events::{Event, OfflineSyncCompleted};
+use wacore::send::PrimaryDeviceRejected;
 
 /// Waiter side of an in-flight ensure: it never receives a value, only the
 /// close that the leader's drop produces. A leader that panics or is cancelled
@@ -836,6 +837,22 @@ impl Client {
                 );
                 self.invalidate_device_caches_for(&rejected).await;
             }
+            // A 406 naming a device 0 fails the whole fetch, mirroring WA Web's
+            // `ensureE2ESessions`, whose 406 catch resolves quietly only while
+            // `x.every(e => e.device !== DEFAULT_DEVICE_ID)` holds and rethrows
+            // otherwise. The device the server says is gone owns the chat, so
+            // continuing builds a stanza that is acked and read by nobody; the
+            // send fails against a list that has just been refreshed, and the
+            // retry resolves the peer again. Only 406: every other code says
+            // the server could not answer, not that the device is gone, which
+            // is the same line the refresh above draws.
+            if prekey_bundles
+                .rejected
+                .iter()
+                .any(|device| device.jid.device == 0 && device.code == UNREGISTERED_DEVICE_CODE)
+            {
+                return Err(PrimaryDeviceRejected::new(UNREGISTERED_DEVICE_CODE).into());
+            }
         }
 
         let mut adapter = self.signal_adapter();
@@ -1015,11 +1032,14 @@ mod tests {
     /// The non-406 half also pins the behavior decision: a code that does not
     /// claim the device is gone is counted and nothing else, so a server-side
     /// failure cannot trigger a device-list refresh storm.
+    ///
+    /// A companion, because a 406 naming a primary now fails the fetch instead
+    /// of returning zero; that gate has its own tests below.
     #[tokio::test]
     async fn a_rejected_device_is_counted_on_the_stats_snapshot() {
         for code in ["406", "503"] {
             let (client, transport) = crate::test_utils::create_iq_test_client().await;
-            let gone = Jid::pn_device("5511900000060", 0);
+            let gone = Jid::pn_device("5511900000060", 4);
 
             let fetch = tokio::spawn({
                 let client = client.clone();
@@ -1059,6 +1079,120 @@ mod tests {
             );
             assert_eq!(stats.devices_unkeyed_total(), 1);
         }
+    }
+
+    /// A 406 naming the primary is the server saying the device that owns the
+    /// chat is gone. Continuing would key the companions and build a stanza the
+    /// recipient cannot read, so the fetch fails and the caller retries against
+    /// the list this call just refreshed. Mirrors `ensureE2ESessions`, whose
+    /// 406 catch rethrows unless every requested wid is a companion.
+    #[tokio::test]
+    async fn a_406_naming_the_primary_fails_the_fetch() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let primary = Jid::pn_device("5511900000061", 0);
+        let companion = Jid::pn_device("5511900000061", 2);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![primary.clone(), companion.clone()];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        answer_prekey_fetch(
+            &client,
+            &transport,
+            vec![
+                NodeBuilder::new("user")
+                    .attr("jid", NodeValue::Jid(primary.clone()))
+                    .children([NodeBuilder::new("error")
+                        .attr("code", "406")
+                        .attr("text", "not-acceptable")
+                        .build()])
+                    .build(),
+            ],
+        )
+        .await;
+
+        let err = fetch
+            .await
+            .expect("join")
+            .expect_err("a rejected primary must not be reported as a clean fetch");
+        assert!(
+            err.downcast_ref::<PrimaryDeviceRejected>().is_some(),
+            "the caller must be able to match on this, not parse it: {err}"
+        );
+    }
+
+    /// The same rejection on a companion still lets the send through: the
+    /// device that owns the chat answered, so the message is readable.
+    #[tokio::test]
+    async fn a_406_naming_only_a_companion_does_not_fail_the_fetch() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let companion = Jid::pn_device("5511900000062", 3);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![companion.clone()];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        answer_prekey_fetch(
+            &client,
+            &transport,
+            vec![
+                NodeBuilder::new("user")
+                    .attr("jid", NodeValue::Jid(companion.clone()))
+                    .children([NodeBuilder::new("error")
+                        .attr("code", "406")
+                        .attr("text", "not-acceptable")
+                        .build()])
+                    .build(),
+            ],
+        )
+        .await;
+
+        let established = fetch
+            .await
+            .expect("join")
+            .expect("a companion 406 is survivable");
+        assert_eq!(established, 0);
+    }
+
+    /// A code that does not claim the device is gone never fails the fetch,
+    /// primary or not: a 5xx says the server could not answer, and turning
+    /// that into a failed send would make a server wobble look like a stale
+    /// device list.
+    #[tokio::test]
+    async fn a_non_406_rejection_of_the_primary_does_not_fail_the_fetch() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let primary = Jid::pn_device("5511900000063", 0);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![primary.clone()];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        answer_prekey_fetch(
+            &client,
+            &transport,
+            vec![
+                NodeBuilder::new("user")
+                    .attr("jid", NodeValue::Jid(primary.clone()))
+                    .children([NodeBuilder::new("error")
+                        .attr("code", "503")
+                        .attr("text", "service-unavailable")
+                        .build()])
+                    .build(),
+            ],
+        )
+        .await;
+
+        let established = fetch
+            .await
+            .expect("join")
+            .expect("a 503 is not the server saying the device is gone");
+        assert_eq!(established, 0);
     }
 
     /// A batch-wide 406 answers for every device at once and fails the send, so

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5271,6 +5271,7 @@ fn phash_waiter_sweep_drops_only_entries_that_lived_through_a_sweep() {
             expected: wacore_binary::CompactString::from("hash"),
             jid: "13135550100@s.whatsapp.net".parse().expect("valid jid"),
             invalidate_group_cache: false,
+            dm_devices: None,
             registered_epoch,
         })
     };

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -359,7 +359,8 @@ impl Client {
                 ..Default::default()
             },
         )
-        .await
+        .await?;
+        Ok(())
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.skdm", level = "debug", skip_all, fields(group = %group_jid.observe(), sender = %sender_jid.observe())))]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -43,7 +43,7 @@ fn get_bytes_content_ref<'a>(node: &'a NodeRef<'_>) -> Option<&'a [u8]> {
 const RECREATE_SESSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3600);
 
 #[derive(Clone, Copy)]
-enum RetransmissionRoute {
+pub(crate) enum RetransmissionRoute {
     Direct,
     Group,
     Status,
@@ -62,20 +62,20 @@ fn is_own_account_jid(jid: &Jid, own_pn: Option<&Jid>, own_lid: Option<&Jid>) ->
         || own_lid.is_some_and(|lid| jid.is_same_user_as(lid))
 }
 
-struct PreparedRetransmission {
-    route: RetransmissionRoute,
-    chat: Jid,
-    wire_requester: Jid,
-    encryption_jid: Jid,
-    message: wa::Message,
-    message_id: String,
-    retry_count: u8,
-    recipient: Option<Jid>,
-    group_info: Option<Arc<wacore::client::context::GroupInfo>>,
+pub(crate) struct PreparedRetransmission {
+    pub(crate) route: RetransmissionRoute,
+    pub(crate) chat: Jid,
+    pub(crate) wire_requester: Jid,
+    pub(crate) encryption_jid: Jid,
+    pub(crate) message: wa::Message,
+    pub(crate) message_id: String,
+    pub(crate) retry_count: u8,
+    pub(crate) recipient: Option<Jid>,
+    pub(crate) group_info: Option<Arc<wacore::client::context::GroupInfo>>,
     /// Canonical unpadded protobuf bytes shared with the recent-message cache.
     /// Public retransmissions provide them; the automatic path may fall back
     /// to its already-decoded message when the cache bytes are unavailable.
-    pre_encoded: Option<Arc<Vec<u8>>>,
+    pub(crate) pre_encoded: Option<Arc<Vec<u8>>>,
 }
 
 fn validate_retransmission(
@@ -829,7 +829,7 @@ impl Client {
         Ok(())
     }
 
-    async fn retransmit_message_prepared(
+    pub(crate) async fn retransmit_message_prepared(
         &self,
         request: PreparedRetransmission,
     ) -> Result<(), anyhow::Error> {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -10,7 +10,7 @@ use crate::types::message::EditAttribute;
 use anyhow::anyhow;
 use log::debug;
 use wacore::libsignal::protocol::SignalProtocolError;
-use wacore::send::StanzaType;
+use wacore::send::{RecipientFanout, StanzaType};
 use wacore::types::jid::JidExt;
 use wacore::types::message::AddressingMode;
 #[cfg(test)]
@@ -220,6 +220,8 @@ struct SendBranchOutput {
     /// its own on the ack and a disagreement is the only signal a send gets
     /// that its participant device set is stale.
     ack_phash: Option<wacore_binary::CompactString>,
+    /// DM branch only: what the recipient half of the fan-out reached.
+    recipient_fanout: Option<RecipientFanout>,
 }
 
 struct GroupBranchRequest<'a> {
@@ -318,6 +320,7 @@ impl SendBranchOutput {
             distribution_guard: None,
             issue_tc_token_after_send: false,
             ack_phash: None,
+            recipient_fanout: None,
         }
     }
 }
@@ -482,6 +485,17 @@ pub(crate) struct SendPipelineOptions<'a> {
 pub struct SendResult {
     pub message_id: String,
     pub to: Jid,
+    /// For a DM, what the recipient half of the fan-out actually encrypted for.
+    /// `None` for every other send shape: a group, a status, a peer sync and a
+    /// newsletter plaintext each answer a different question about who was
+    /// reached, and answering it with a DM's numbers would be a lie the caller
+    /// cannot see through.
+    ///
+    /// A send that dropped devices still returns `Ok`, matching what WA Web
+    /// itself sends, so a caller that treats delivery as more than "the server
+    /// took it" reads [`RecipientFanout::is_partial`] and
+    /// [`RecipientFanout::skipped_primary`] here and decides its own policy.
+    pub recipient_fanout: Option<RecipientFanout>,
 }
 
 impl SendResult {
@@ -1086,6 +1100,7 @@ impl Client {
             return Ok(SendResult {
                 message_id: request_id,
                 to: result_to,
+                recipient_fanout: None,
             });
         }
 
@@ -1098,25 +1113,27 @@ impl Client {
         // frame (prologue + epilogue) embeds here without a second box; the
         // shim's Box::pin above still keeps `send_message`'s future
         // pointer-sized for callers embedding it in their own futures.
-        self.send_message_impl(
-            to,
-            &message,
-            SendPipelineOptions {
-                sent_at: Some(sent_at),
-                request_id: Some(&request_id),
-                edit,
-                extra_stanza_nodes: extra_nodes,
-                stanza_type: stanza_type_override,
-                group_metadata_freshness,
-                device_freshness,
-                ..Default::default()
-            },
-        )
-        .await
-        .map_err(SendError::from_anyhow)?;
+        let recipient_fanout = self
+            .send_message_impl(
+                to,
+                &message,
+                SendPipelineOptions {
+                    sent_at: Some(sent_at),
+                    request_id: Some(&request_id),
+                    edit,
+                    extra_stanza_nodes: extra_nodes,
+                    stanza_type: stanza_type_override,
+                    group_metadata_freshness,
+                    device_freshness,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(SendError::from_anyhow)?;
         Ok(SendResult {
             message_id: request_id,
             to: result_to,
+            recipient_fanout,
         })
     }
 
@@ -1392,6 +1409,7 @@ impl Client {
         Ok(SendResult {
             message_id: request_id,
             to,
+            recipient_fanout: None,
         })
     }
 
@@ -1817,7 +1835,7 @@ impl Client {
         to: Jid,
         message: &wa::Message,
         options: SendPipelineOptions<'_>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<Option<RecipientFanout>, anyhow::Error> {
         let SendPipelineOptions {
             sent_at,
             request_id: request_id_override,
@@ -1899,6 +1917,7 @@ impl Client {
             distribution_guard,
             issue_tc_token_after_send: should_issue_tc_token_after_send,
             ack_phash,
+            recipient_fanout,
         } = if peer && !to.is_group() {
             box_send_branch(self.send_peer_branch(to, message, request_id)).await?
         } else if to.is_group() {
@@ -2031,7 +2050,7 @@ impl Client {
             }
         }
 
-        Ok(())
+        Ok(recipient_fanout)
     }
 
     /// Peer branch of [`Self::send_message_impl`]: own-device sync messages,
@@ -2450,6 +2469,7 @@ impl Client {
             distribution_guard,
             issue_tc_token_after_send: false,
             ack_phash: group_ack_phash,
+            recipient_fanout: None,
         })
     }
 
@@ -2606,6 +2626,7 @@ impl Client {
             distribution_guard: None,
             issue_tc_token_after_send: should_issue_tc_token_after_send,
             ack_phash: prepared.phash,
+            recipient_fanout: Some(prepared.recipient_fanout),
         })
     }
 
@@ -7154,6 +7175,7 @@ mod tests {
         // through to send_message_impl which calls persist_outbound_msg_secret.
         let prepared = wacore::send::PreparedDmStanza {
             node: NodeBuilder::new("message").build(),
+            recipient_fanout: Default::default(),
             phash: None,
             message_secret: Some(result.message_secret),
         };
@@ -7206,6 +7228,38 @@ mod tests {
             secret.is_some(),
             "the outbound messageSecret must be bound to the same id"
         );
+    }
+
+    /// A DM's `SendResult` carries the recipient fan-out; every other send
+    /// shape leaves it `None` rather than reporting a DM's numbers for a
+    /// question it did not ask. The count itself is covered in wacore, against
+    /// the real fan-out; what this pins is that it survives the trip out
+    /// through `send_message_impl` instead of being dropped at the boundary.
+    #[tokio::test]
+    async fn a_dm_result_carries_its_recipient_fanout() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+
+        let result = client
+            .send_message(
+                peer_pn.clone(),
+                wa::Message {
+                    conversation: Some("hi".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("connected test client should complete the send");
+
+        let fanout = result
+            .recipient_fanout
+            .expect("a DM must report what its recipient half reached");
+        assert_eq!(
+            fanout.encrypted, fanout.addressed,
+            "this fixture keys every device, so nothing was lost"
+        );
+        assert!(!fanout.is_partial());
+        assert!(!fanout.skipped_primary);
     }
 
     /// The waiter is installed before the stanza reaches the socket (a fast ack

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1917,23 +1917,26 @@ impl Client {
             return;
         }
 
-        // Looked up after the refresh, not before: repairing the device list is
-        // worth doing whether or not the plaintext is still around to resend.
-        let Some((message, _)) = self.peek_recent_message(chat, message_id).await else {
-            log::debug!(
-                "phash mismatch for {}: message {message_id} is no longer cached; \
-                 the device list is refreshed, so the next send reaches everyone",
-                chat.observe()
-            );
-            return;
-        };
-
         log::info!(
             "phash mismatch for {}: resending {message_id} to {} device(s) the send missed",
             chat.observe(),
             uncovered.len()
         );
         for device in uncovered {
+            // Decoded per device rather than cloned once and copied: a
+            // `wa::Message` clone is its own ~66 KiB of instantiated code, and
+            // this path runs only on a mismatch, so the decode the retry cache
+            // already does is the cheaper of the two to pay for. Read inside
+            // the loop for the same reason, which also keeps the device-list
+            // refresh above worth doing when the plaintext has aged out.
+            let Some((owned, _)) = self.peek_recent_message(chat, message_id).await else {
+                log::debug!(
+                    "phash mismatch for {}: message {message_id} is no longer cached; \
+                     the device list is refreshed, so the next send reaches everyone",
+                    chat.observe()
+                );
+                return;
+            };
             // Our own companion needs the chat named as the recipient, or the
             // copy it receives has no destination to file itself under; a peer
             // device is its own routing identity.
@@ -1942,17 +1945,29 @@ impl Client {
                     .lid
                     .as_ref()
                     .is_some_and(|lid| device.user == lid.user);
-            let mut request = crate::features::MessageRetransmission::new(
-                chat.clone(),
-                device.clone(),
-                message.clone(),
-                message_id.to_string(),
-                1,
-            );
-            if is_own {
-                request = request.with_recipient(chat.clone());
-            }
-            if let Err(e) = self.retransmit_message(request).await {
+            // Straight to the prepared form rather than through
+            // `retransmit_message`: its validation guards a caller-supplied
+            // request, and every jid here was built from our own resolved
+            // device list. The route is known to be `Direct`, so its
+            // group-metadata query would answer a question this cannot ask.
+            let outcome = self
+                .retransmit_message_prepared(crate::retry::PreparedRetransmission {
+                    route: crate::retry::RetransmissionRoute::Direct,
+                    chat: chat.clone(),
+                    wire_requester: device.clone(),
+                    // The session address, which is LID wherever a mapping is
+                    // known: the same rule `retransmit_message` applies for
+                    // this route, and the one the fan-out encrypted under.
+                    encryption_jid: self.resolve_encryption_jid(&device).await,
+                    message: owned,
+                    message_id: message_id.to_string(),
+                    retry_count: 1,
+                    recipient: is_own.then(|| chat.clone()),
+                    group_info: None,
+                    pre_encoded: None,
+                })
+                .await;
+            if let Err(e) = outcome {
                 log::warn!(
                     "phash mismatch for {}: resend of {message_id} to {} failed: {e}",
                     chat.observe(),

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -61,6 +61,12 @@ pub enum SendError {
     /// ([`crate::cache::Freshness::Refresh`]) rather than an immediate resend.
     #[error("{0}")]
     NoRecipientDevice(#[source] wacore::send::NoRecipientDeviceError),
+    /// The server rejected a primary device (device 0) while the send was
+    /// establishing its sessions, so nothing was built or sent. The device
+    /// lists it names have been refreshed by the time this returns, so an
+    /// immediate retry resolves them again rather than repeating the question.
+    #[error("{0}")]
+    PrimaryDeviceRejected(#[source] wacore::send::PrimaryDeviceRejected),
     /// Catch-all for internal send failures (Signal encrypt, protobuf, group
     /// resolution) that have no dedicated variant yet. `Display` forwards to
     /// the inner error while `source()` still exposes it for downcast.
@@ -87,6 +93,12 @@ impl SendError {
         // it must be able to match on it instead of parsing a message.
         let err = match err.downcast::<wacore::send::NoRecipientDeviceError>() {
             Ok(no_recipient) => return SendError::NoRecipientDevice(no_recipient),
+            Err(other) => other,
+        };
+        // Same reasoning one layer down: the send never reached the wire, and
+        // the caller's answer is a device-refreshing retry rather than a resend.
+        let err = match err.downcast::<wacore::send::PrimaryDeviceRejected>() {
+            Ok(rejected) => return SendError::PrimaryDeviceRejected(rejected),
             Err(other) => other,
         };
         // A group-metadata IQ in the send path (e.g. query_info) bubbles up as
@@ -222,6 +234,9 @@ struct SendBranchOutput {
     ack_phash: Option<wacore_binary::CompactString>,
     /// DM branch only: what the recipient half of the fan-out reached.
     recipient_fanout: Option<RecipientFanout>,
+    /// DM branch only: the device set the stanza covered, shared with the memo
+    /// entry it came from. Handed to the phash waiter as its exclude list.
+    dm_devices: Option<std::sync::Arc<wacore::send::ResolvedDmDevices>>,
 }
 
 struct GroupBranchRequest<'a> {
@@ -321,6 +336,7 @@ impl SendBranchOutput {
             issue_tc_token_after_send: false,
             ack_phash: None,
             recipient_fanout: None,
+            dm_devices: None,
         }
     }
 }
@@ -477,6 +493,28 @@ pub(crate) struct SendPipelineOptions<'a> {
     /// Without this, the borrowed id clobbers the original message's retry
     /// content and outbound secret.
     pub(crate) borrowed_message_id: bool,
+}
+
+/// The devices a freshly resolved fan-out holds that the sent stanza did not.
+///
+/// The other direction is deliberately not reported: a device the send covered
+/// and the refresh dropped has already received its copy, and the refresh is
+/// the whole repair it needs.
+fn devices_missed_by_send(covered: &[Jid], fresh: &[Jid]) -> Vec<Jid> {
+    // Linear scan rather than a set: both sides are one user's devices plus our
+    // own, which is single digits, and this runs only on a mismatch.
+    fresh
+        .iter()
+        .filter(|device| !covered.contains(device))
+        .cloned()
+        .collect()
+}
+
+/// What a DM phash mismatch needs to deliver the message to the devices its
+/// stanza missed: the id to resend under, and the set it already covered.
+pub(crate) struct DmDeltaResend<'a> {
+    pub(crate) message_id: &'a str,
+    pub(crate) covered: std::sync::Arc<wacore::send::ResolvedDmDevices>,
 }
 
 /// Result of a successfully sent message.
@@ -1034,6 +1072,7 @@ impl Client {
         #[cfg(feature = "tracing")]
         self.record_identity_on_span(&tracing::Span::current());
 
+        let to = canonical_user_server(to);
         validate_extra_stanza_nodes(&options.extra_stanza_nodes)?;
         if options.message_id.as_ref().is_some_and(String::is_empty) {
             return Err(SendError::InvalidRequest(
@@ -1388,7 +1427,7 @@ impl Client {
             .optional_string("phash")
             .map(|s| wacore_binary::CompactString::from(s.as_ref()));
         if let Some(phash) = ack.clone() {
-            self.register_phash_waiter(&request_id, phash, to.clone(), true);
+            self.register_phash_waiter(&request_id, phash, to.clone(), true, None);
         }
 
         if let Err(e) = self.send_node(stanza).await {
@@ -1756,16 +1795,17 @@ impl Client {
     /// the common path costs a string comparison on the read loop.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.phash_mismatch", level = "debug", skip_all, fields(jid = %jid.observe())))]
     pub(crate) async fn handle_phash_mismatch(
-        &self,
+        self: &std::sync::Arc<Self>,
         jid: &Jid,
         our_phash: &str,
         server_phash: &str,
         invalidate_group_cache: bool,
+        resend: Option<DmDeltaResend<'_>>,
     ) {
         // The one signal a bot gets that its participant device set disagrees
-        // with the server's, whatever the cause. What follows repairs a
-        // participant-level divergence; a device-level one only gets logged
-        // here, so keep the line saying what happened and not what was fixed.
+        // with the server's, whatever the cause. What follows repairs the
+        // participant-level divergence and, for a DM, delivers the message to
+        // the devices the divergence hid.
         log::warn!(
             "Phash mismatch for {}: ours={our_phash}, server={server_phash}",
             jid.observe()
@@ -1814,6 +1854,112 @@ impl Client {
         if invalidate_group_cache {
             self.lock_group_metadata(jid).await.invalidate().await;
         }
+        // Last, so the re-resolve below reads through the invalidations above
+        // rather than racing them.
+        if let Some(resend) = resend {
+            self.resend_dm_to_uncovered_devices(jid, resend).await;
+        }
+    }
+
+    /// Deliver a DM to the devices a refreshed list holds and the sent stanza
+    /// did not.
+    ///
+    /// The mismatch says the server saw a device set we did not, and the caller
+    /// already has an `Ok` for this message id, so the repair is a resend to
+    /// the difference rather than an error or a full re-send: WA Web answers
+    /// the same ack by enqueueing `resendUserMsg` with an `excludeList` of the
+    /// devices that already hold a copy. Each device is retransmitted
+    /// pairwise, under the original message id, so a device that receives both
+    /// copies deduplicates on it.
+    async fn resend_dm_to_uncovered_devices(
+        self: &std::sync::Arc<Self>,
+        chat: &Jid,
+        resend: DmDeltaResend<'_>,
+    ) {
+        let DmDeltaResend {
+            message_id,
+            covered,
+        } = resend;
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        let Some(own_jid) = device_snapshot.pn.clone() else {
+            return;
+        };
+        let recipient_bare = self.resolve_dm_wire_jid(chat).await;
+        let fresh = match self
+            .resolve_dm_devices_memoized(
+                chat,
+                &recipient_bare,
+                &own_jid,
+                device_snapshot.lid.as_ref(),
+                crate::cache::Freshness::Refresh,
+            )
+            .await
+        {
+            Ok(fresh) => fresh,
+            Err(e) => {
+                log::warn!(
+                    "phash mismatch for {}: could not re-resolve devices: {e:?}",
+                    chat.observe()
+                );
+                return;
+            }
+        };
+
+        let uncovered = devices_missed_by_send(covered.devices(), fresh.devices());
+        if uncovered.is_empty() {
+            // The set disagreed with the server's without gaining a device:
+            // the divergence was a device we sent to and the server no longer
+            // counts, which the refresh above has already fixed.
+            log::debug!(
+                "phash mismatch for {}: refreshed list holds no device the send missed",
+                chat.observe()
+            );
+            return;
+        }
+
+        // Looked up after the refresh, not before: repairing the device list is
+        // worth doing whether or not the plaintext is still around to resend.
+        let Some((message, _)) = self.peek_recent_message(chat, message_id).await else {
+            log::debug!(
+                "phash mismatch for {}: message {message_id} is no longer cached; \
+                 the device list is refreshed, so the next send reaches everyone",
+                chat.observe()
+            );
+            return;
+        };
+
+        log::info!(
+            "phash mismatch for {}: resending {message_id} to {} device(s) the send missed",
+            chat.observe(),
+            uncovered.len()
+        );
+        for device in uncovered {
+            // Our own companion needs the chat named as the recipient, or the
+            // copy it receives has no destination to file itself under; a peer
+            // device is its own routing identity.
+            let is_own = device.user == own_jid.user
+                || device_snapshot
+                    .lid
+                    .as_ref()
+                    .is_some_and(|lid| device.user == lid.user);
+            let mut request = crate::features::MessageRetransmission::new(
+                chat.clone(),
+                device.clone(),
+                message.clone(),
+                message_id.to_string(),
+                1,
+            );
+            if is_own {
+                request = request.with_recipient(chat.clone());
+            }
+            if let Err(e) = self.retransmit_message(request).await {
+                log::warn!(
+                    "phash mismatch for {}: resend of {message_id} to {} failed: {e}",
+                    chat.observe(),
+                    device.observe()
+                );
+            }
+        }
     }
 
     /// Ensure the status stanza has a <participants> node listing all recipient
@@ -1847,6 +1993,7 @@ impl Client {
             device_freshness,
             borrowed_message_id,
         } = options;
+        let to = canonical_user_server(to);
         // Callers that already stamped their message hand the instant down; the
         // rest sample here so the pipeline below still has exactly one.
         let sent_at = sent_at.unwrap_or_else(SendInstant::now);
@@ -1918,6 +2065,7 @@ impl Client {
             issue_tc_token_after_send: should_issue_tc_token_after_send,
             ack_phash,
             recipient_fanout,
+            dm_devices: covered_dm_devices,
         } = if peer && !to.is_group() {
             box_send_branch(self.send_peer_branch(to, message, request_id)).await?
         } else if to.is_group() {
@@ -1980,6 +2128,7 @@ impl Client {
                 phash,
                 tc_issue_target.clone(),
                 invalidate_group,
+                covered_dm_devices,
             );
             Some(request_id)
         } else {
@@ -2470,6 +2619,7 @@ impl Client {
             issue_tc_token_after_send: false,
             ack_phash: group_ack_phash,
             recipient_fanout: None,
+            dm_devices: None,
         })
     }
 
@@ -2491,7 +2641,7 @@ impl Client {
             borrowed_message_id,
         } = request;
         let mut should_issue_tc_token_after_send = false;
-        let prepared = {
+        let (prepared, dm_devices) = {
             // Per-device locking to match decrypt path (message.rs:684),
             // preventing ratchet desync on concurrent send/receive.
 
@@ -2599,7 +2749,7 @@ impl Client {
 
             let mut stores = store_adapter.as_signal_stores();
 
-            wacore::send::prepare_dm_stanza(
+            let prepared = wacore::send::prepare_dm_stanza(
                 &*self.runtime,
                 &mut stores,
                 self,
@@ -2616,7 +2766,8 @@ impl Client {
                     pre_encoded: shared_content.as_deref().map(Vec::as_slice),
                 },
             )
-            .await?
+            .await?;
+            (prepared, dm_devices)
         };
         Ok(SendBranchOutput {
             node: prepared.node,
@@ -2626,7 +2777,13 @@ impl Client {
             distribution_guard: None,
             issue_tc_token_after_send: should_issue_tc_token_after_send,
             ack_phash: prepared.phash,
-            recipient_fanout: Some(prepared.recipient_fanout),
+            // A status reaction borrows this branch but keeps `status@broadcast`
+            // as the result's `to`, and the devices below are the status
+            // author's. Reporting either would describe a status send in a DM's
+            // terms, and the delta resend would route the retransmission as a
+            // status message rather than to the device it names.
+            recipient_fanout: (!is_status_addon).then_some(prepared.recipient_fanout),
+            dm_devices: (!is_status_addon).then_some(dm_devices),
         })
     }
 
@@ -2762,9 +2919,28 @@ pub(crate) fn is_self_dm_recipient(
 ) -> bool {
     match recipient_bare.server {
         Server::Lid => own_lid.is_some_and(|lid| recipient_bare.user == lid.user),
-        Server::Pn => recipient_bare.user == own_pn.user,
+        // `Legacy` alongside `Pn` for the same reason `canonical_user_server`
+        // exists: both name a phone user, and reading one as "not me" sends a
+        // note to self down the third-party path.
+        Server::Pn | Server::Legacy => recipient_bare.user == own_pn.user,
         _ => false,
     }
+}
+
+/// `@c.us` is not a namespace of its own: it is what WA Web calls a phone user
+/// in memory, mapped to `s.whatsapp.net` only when a wid is serialized
+/// (`WAWebWid`: `this.server==="c.us"?"s.whatsapp.net":this.server`). We take
+/// `Server::Pn` as the canonical spelling instead, so a `to` that arrives the
+/// other way is rewritten here rather than travelling the send path as a
+/// namespace nothing recognises: `is_pn()` is false for it, so it misses the
+/// self-chat check, the PN-to-LID usync, the LID resolution and, worst, the
+/// pre-key fetch, whose response is matched back by whole-`Jid` equality and
+/// so reports every bundle the server did return as absent.
+pub(crate) fn canonical_user_server(mut jid: Jid) -> Jid {
+    if jid.server == Server::Legacy {
+        jid.server = Server::Pn;
+    }
+    jid
 }
 
 /// The outer `<message to>`, the DeviceSentMessage destinationJid, and the
@@ -4130,7 +4306,7 @@ mod tests {
 
         fixture
             .client
-            .handle_phash_mismatch(&fixture.group, "2:ours", "2:theirs", true)
+            .handle_phash_mismatch(&fixture.group, "2:ours", "2:theirs", true, None)
             .await;
 
         let after = fixture.client.skdm_device_map(&group_str).await;
@@ -4371,6 +4547,7 @@ mod tests {
     const SELF_LID: &str = "111111111111111";
     const SELF_DEVICE: u16 = 7;
     const OTHER_LID: &str = "222222222222222";
+    const OTHER_PN: &str = "5500000000001";
 
     #[test]
     fn self_dm_lid_recipient_matches_own_lid() {
@@ -4398,6 +4575,47 @@ mod tests {
         let recipient = Jid::pn(SELF_PN);
 
         assert!(is_self_dm_recipient(&recipient, &own_pn, None));
+    }
+
+    /// A note to self addressed in the legacy namespace is still a note to
+    /// self. Read as a third party it takes the recipient path and asks the
+    /// server for our own pre-key bundles, which is the shape the reporter of
+    /// #1361 saw on every failing send.
+    #[test]
+    fn self_dm_legacy_recipient_matches_own_pn() {
+        let own_pn = Jid::pn_device(SELF_PN, SELF_DEVICE);
+        let own_lid = Jid::lid_device(SELF_LID, SELF_DEVICE);
+        let recipient = Jid::new(SELF_PN, Server::Legacy);
+
+        assert!(is_self_dm_recipient(&recipient, &own_pn, Some(&own_lid)));
+    }
+
+    #[test]
+    fn non_self_legacy_recipient_is_not_self_dm() {
+        let own_pn = Jid::pn_device(SELF_PN, SELF_DEVICE);
+        let recipient = Jid::new(OTHER_PN, Server::Legacy);
+
+        assert!(!is_self_dm_recipient(&recipient, &own_pn, None));
+    }
+
+    /// `Legacy` is a spelling of the phone-user namespace, not a namespace of
+    /// its own, and only that one is rewritten: nothing else may be quietly
+    /// re-pointed at a different server.
+    #[test]
+    fn canonical_user_server_rewrites_only_legacy() {
+        assert_eq!(
+            canonical_user_server(Jid::new(OTHER_PN, Server::Legacy).with_device(3)),
+            Jid::pn_device(OTHER_PN, 3),
+            "the device survives the rewrite"
+        );
+        for untouched in [
+            Jid::pn(OTHER_PN),
+            Jid::lid(OTHER_LID),
+            Jid::group("120363000000000000"),
+            Jid::status_broadcast(),
+        ] {
+            assert_eq!(canonical_user_server(untouched.clone()), untouched);
+        }
     }
 
     #[test]
@@ -7170,16 +7388,9 @@ mod tests {
             "ordinary text messages must produce a reporting token + secret"
         );
         let result = result.unwrap();
+        // PreparedDmStanza/PreparedGroupStanza carry this exact array through to
+        // send_message_impl, which calls persist_outbound_msg_secret with it.
         assert_eq!(result.message_secret.len(), 32);
-        // PreparedDmStanza/PreparedGroupStanza now carry this exact array
-        // through to send_message_impl which calls persist_outbound_msg_secret.
-        let prepared = wacore::send::PreparedDmStanza {
-            node: NodeBuilder::new("message").build(),
-            recipient_fanout: Default::default(),
-            phash: None,
-            message_secret: Some(result.message_secret),
-        };
-        assert_eq!(prepared.message_secret.as_ref().unwrap().len(), 32);
     }
 
     /// A send names its message once and every downstream stage reads that same
@@ -7260,6 +7471,217 @@ mod tests {
         );
         assert!(!fanout.is_partial());
         assert!(!fanout.skipped_primary);
+    }
+
+    /// A status reaction borrows the DM branch but keeps `status@broadcast` as
+    /// the result's chat, so the fan-out it happens to compute describes the
+    /// status author's devices and not the send the caller made. Reporting it
+    /// would invite a caller to apply a DM's delivery policy to a status.
+    #[tokio::test]
+    async fn a_status_reaction_reports_no_recipient_fanout() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+
+        let reaction = wa::Message {
+            reaction_message: buffa::MessageField::some(wa::message::ReactionMessage {
+                key: buffa::MessageField::some(wa::MessageKey {
+                    remote_jid: Some(Jid::status_broadcast().to_string()),
+                    from_me: Some(false),
+                    id: Some("STATUSPOST1".into()),
+                    participant: Some(peer_pn.to_string()),
+                }),
+                text: Some("\u{1f44d}".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = client
+            .send_message(Jid::status_broadcast(), reaction)
+            .await
+            .expect("a status reaction fans out to the author's devices");
+
+        assert_eq!(result.to, Jid::status_broadcast(), "the chat is the status");
+        assert!(
+            result.recipient_fanout.is_none(),
+            "a status send must not describe itself in a DM's terms"
+        );
+    }
+
+    /// `@c.us` is the namespace WA Web keeps a phone user in; a caller that
+    /// spells a recipient that way is naming a PN user, and the send must treat
+    /// it as one. Left alone it misses `is_pn()` everywhere that matters, most
+    /// damagingly in the pre-key fetch, whose response is matched back by whole
+    /// jid and so reports every bundle as absent.
+    #[tokio::test]
+    async fn a_legacy_namespace_recipient_is_sent_as_a_phone_user() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+        let legacy = Jid::new(peer_pn.user.as_str(), Server::Legacy);
+
+        let message_id = "LEGACYNSDM1";
+        client
+            .send_message_with_options(
+                legacy,
+                wa::Message {
+                    conversation: Some("hi".into()),
+                    ..Default::default()
+                },
+                SendOptions::default().with_message_id(message_id),
+            )
+            .await
+            .expect("a legacy-spelled recipient is a recipient");
+
+        let stanza = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let stanza = stanza.get();
+        assert_eq!(stanza.tag, "message");
+        let to = stanza
+            .attrs()
+            .optional_jid("to")
+            .expect("the stanza names its chat");
+        assert_ne!(
+            to.server,
+            Server::Legacy,
+            "the legacy spelling must not reach the wire: {to}"
+        );
+        assert_eq!(to.user, peer_pn.user, "and it must still be the same user");
+    }
+
+    /// The exclude list: only what the refresh added is resent. A device the
+    /// send covered has its copy, and one the refresh dropped is not worth a
+    /// second attempt, so neither belongs in the delta.
+    #[test]
+    fn only_the_devices_a_refresh_adds_are_resent() {
+        let peer_primary: Jid = "5511900000090:0@s.whatsapp.net".parse().unwrap();
+        let peer_new: Jid = "5511900000090:4@s.whatsapp.net".parse().unwrap();
+        let peer_gone: Jid = "5511900000090:9@s.whatsapp.net".parse().unwrap();
+        let own_companion: Jid = "5511900000091:2@s.whatsapp.net".parse().unwrap();
+
+        let covered = [peer_primary.clone(), peer_gone.clone()];
+        let fresh = [
+            peer_primary.clone(),
+            peer_new.clone(),
+            own_companion.clone(),
+        ];
+
+        assert_eq!(
+            devices_missed_by_send(&covered, &fresh),
+            vec![peer_new, own_companion],
+            "a device the send covered stays out, and one it lost is not chased"
+        );
+        assert!(
+            devices_missed_by_send(&covered, &covered).is_empty(),
+            "an unchanged list resends nothing"
+        );
+        assert!(
+            devices_missed_by_send(&fresh, &[]).is_empty(),
+            "a refresh that found nothing resends nothing"
+        );
+    }
+
+    /// A DM whose ack disagrees on the phash re-resolves the peer's device list
+    /// from the server, which is the first half of the repair: WA Web answers
+    /// the same ack with `fetchResendMissingKeys` + `syncDeviceListJob` before
+    /// enqueueing its resend. Before this the mismatch only dropped caches, so
+    /// the divergence was not acted on until some later send happened to
+    /// re-resolve.
+    #[tokio::test]
+    async fn a_dm_phash_mismatch_re_resolves_the_peer_device_list() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+
+        let message_id = "DMPHASHMISMATCH1";
+        client
+            .send_message_with_options(
+                peer_pn.clone(),
+                wa::Message {
+                    conversation: Some("hi".into()),
+                    ..Default::default()
+                },
+                SendOptions::default().with_message_id(message_id),
+            )
+            .await
+            .expect("the send itself succeeds");
+
+        assert!(
+            deliver_dm_ack(&client, message_id, "2:notwhatwesent"),
+            "the send's waiter must claim its own ack"
+        );
+
+        let usync = wait_for_usync_request(&transport, 8).await;
+        assert!(
+            usync,
+            "a disagreeing phash must ask the server for the device list again"
+        );
+    }
+
+    /// The mismatch handler is only armed for a DM. A group answers its own
+    /// mismatch by re-querying metadata, and a status reaction keeps
+    /// `status@broadcast` as its chat, so neither may enter the pairwise
+    /// resend: it would address a retransmission to the wrong route.
+    #[tokio::test]
+    async fn a_group_phash_mismatch_arms_no_dm_resend() {
+        let fixture = GroupSendFixture::new().await;
+        let message_id = "GROUPPHASHNODMRESEND";
+        fixture.send_with_id(message_id).await;
+
+        let waiter = fixture
+            .client
+            .response_waiters_guard()
+            .remove(message_id)
+            .expect("the group send registered its phash waiter");
+        let crate::client::ResponseWaiter::Phash(waiter) = waiter else {
+            panic!("a phash send registers a phash waiter");
+        };
+        assert!(
+            waiter.dm_devices.is_none(),
+            "a group send must not carry a DM exclude list"
+        );
+    }
+
+    /// Deliver an ack carrying `phash` to whatever waiter claims `message_id`.
+    fn deliver_dm_ack(client: &Arc<Client>, message_id: &str, phash: &str) -> bool {
+        let node = NodeBuilder::new("ack")
+            .attr("id", message_id)
+            .attr("from", "s.whatsapp.net")
+            .attr("phash", phash)
+            .build();
+        let marshaled =
+            wacore_binary::marshal::marshal_ref(&node.as_node_ref()).expect("valid node");
+        let owned = wacore_binary::OwnedNodeRef::new(
+            wacore_binary::util::unpack(&marshaled)
+                .expect("packed payload")
+                .into_owned(),
+        )
+        .expect("valid node");
+        client.handle_ack_response_arc(&Arc::new(owned))
+    }
+
+    /// True once one of the first `limit` frames the client wrote is a usync
+    /// device query. Frames decrypt in order, so they are read in order.
+    async fn wait_for_usync_request(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        limit: usize,
+    ) -> bool {
+        for index in 0..limit {
+            let Ok(node) = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                crate::test_utils::decode_sent_iq(transport, index),
+            )
+            .await
+            else {
+                return false;
+            };
+            let node = node.get();
+            if node.tag == "iq"
+                && node
+                    .get_attr("xmlns")
+                    .is_some_and(|ns| ns.as_str() == "usync")
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// The waiter is installed before the stanza reaches the socket (a fast ack

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -110,10 +110,42 @@ impl NoRecipientDeviceError {
     }
 }
 
+/// What the recipient half of a DM fan-out managed to encrypt for.
+///
+/// A DM whose fan-out lost some but not all of the recipient's devices still
+/// builds a stanza, is acked, and returns a real message id, so this is the
+/// only place the loss is visible. `skipped_primary` is the case that costs
+/// the recipient the message outright: their phone holds the chat, so a stanza
+/// that reaches only their companions renders as "waiting for this message".
+///
+/// Zero-valued for a self-chat, which has no recipient half at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct RecipientFanout {
+    /// Recipient devices the fan-out attempted.
+    pub addressed: usize,
+    /// Of those, how many produced a `<to><enc>` node.
+    pub encrypted: usize,
+    /// The recipient's device 0 was addressed and encrypted for nothing.
+    pub skipped_primary: bool,
+    /// The server answered 406 (unregistered) for at least one of them.
+    pub had_unregistered_device: bool,
+}
+
+impl RecipientFanout {
+    /// Some recipient device was addressed and dropped. The total-loss case
+    /// never reaches a caller: it is [`NoRecipientDeviceError`].
+    pub fn is_partial(&self) -> bool {
+        self.encrypted < self.addressed
+    }
+}
+
 /// Result of `prepare_dm_stanza` — carries the stanza node and the
 /// locally computed phash for server ACK validation.
 pub struct PreparedDmStanza {
     pub node: Node,
+    /// What the recipient half of the fan-out reached. See [`RecipientFanout`].
+    pub recipient_fanout: RecipientFanout,
     /// Locally computed phash from the sent device set. Not sent on the
     /// wire (WA Web only sends phash for groups). Used by the caller to
     /// compare against the server's ACK phash for device-list drift detection.
@@ -232,6 +264,7 @@ pub async fn prepare_dm_stanza(
 
     let mut participant_nodes = Vec::with_capacity(total_devices);
     let mut includes_prekey_message = false;
+    let mut recipient_fanout = RecipientFanout::default();
 
     let hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit, message);
 
@@ -258,6 +291,12 @@ pub async fn prepare_dm_stanza(
         )
         .await?;
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;
+        recipient_fanout = RecipientFanout {
+            addressed: recipient_devices.len(),
+            encrypted: summary.encrypted_devices,
+            skipped_primary: summary.skipped_primary,
+            had_unregistered_device: summary.had_unregistered_device,
+        };
         // The recipient half wrote into an empty buffer, so an emptiness test
         // here is a recipient-node count without walking anything. Bailing
         // before the own half also keeps a companion's sender chain from
@@ -350,6 +389,7 @@ pub async fn prepare_dm_stanza(
 
     Ok(PreparedDmStanza {
         node: stanza,
+        recipient_fanout,
         phash,
         message_secret: reporting_result.map(|r| r.message_secret),
     })

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -98,6 +98,28 @@ pub enum NoRecipientDeviceError {
     Unresolved,
 }
 
+/// The server named a device 0 as gone while the send was establishing
+/// sessions for it.
+///
+/// Kept apart from [`NoRecipientDeviceError`] because it can name our own
+/// primary as easily as the peer's, and the two ask for different things: this
+/// says one identity's device list is stale on a device that owns its chat, so
+/// the stanza is not built at all. Nothing was on the wire, and the useful
+/// retry is one that resolves devices again.
+#[derive(Debug, thiserror::Error)]
+#[error("the server rejected the primary device with code {code}")]
+#[non_exhaustive]
+pub struct PrimaryDeviceRejected {
+    /// The `<error code>` the server attached to it.
+    pub code: u16,
+}
+
+impl PrimaryDeviceRejected {
+    pub fn new(code: u16) -> Self {
+        Self { code }
+    }
+}
+
 impl NoRecipientDeviceError {
     fn encryption_failed(attempted: usize, source: Option<anyhow::Error>) -> Self {
         Self::EncryptionFailed {
@@ -114,9 +136,10 @@ impl NoRecipientDeviceError {
 ///
 /// A DM whose fan-out lost some but not all of the recipient's devices still
 /// builds a stanza, is acked, and returns a real message id, so this is the
-/// only place the loss is visible. `skipped_primary` is the case that costs
-/// the recipient the message outright: their phone holds the chat, so a stanza
-/// that reaches only their companions renders as "waiting for this message".
+/// only place the loss is visible. `skipped_primary` is called out separately
+/// because a recipient's phone holds the chat whether or not they have a
+/// companion linked and open: a stanza that reached only companions is the one
+/// a recipient is most likely to never see.
 ///
 /// Zero-valued for a self-chat, which has no recipient half at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -126,7 +149,9 @@ pub struct RecipientFanout {
     pub addressed: usize,
     /// Of those, how many produced a `<to><enc>` node.
     pub encrypted: usize,
-    /// The recipient's device 0 was addressed and encrypted for nothing.
+    /// The recipient's device 0 was among the devices that encrypted for
+    /// nothing. Says nothing about how many others were skipped; `addressed`
+    /// against `encrypted` answers that.
     pub skipped_primary: bool,
     /// The server answered 406 (unregistered) for at least one of them.
     pub had_unregistered_device: bool,
@@ -142,6 +167,11 @@ impl RecipientFanout {
 
 /// Result of `prepare_dm_stanza` — carries the stanza node and the
 /// locally computed phash for server ACK validation.
+///
+/// Sealed: it is a return type, and every field it has grown was a fact the
+/// send already knew and threw away. Sealing it means the next one costs
+/// nobody a compile error.
+#[non_exhaustive]
 pub struct PreparedDmStanza {
     pub node: Node,
     /// What the recipient half of the fan-out reached. See [`RecipientFanout`].

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -454,6 +454,15 @@ pub struct EncryptFanoutSummary {
     pub includes_prekey_message: bool,
     /// True if any device returned 406 (unregistered) during prekey fetch.
     pub had_unregistered_device: bool,
+    /// How many of the fan-out's devices produced a `<to><enc>` node. Compared
+    /// against the device count the caller passed in, this is the only thing
+    /// that separates a complete fan-out from one that dropped devices and
+    /// still built a stanza.
+    pub encrypted_devices: usize,
+    /// A device 0 was addressed and produced nothing. For a DM this is the
+    /// recipient's own phone, so the stanza reaches the server, gets acked, and
+    /// arrives nowhere the recipient can read it.
+    pub skipped_primary: bool,
     /// First failure of the fan-out (session, prekey fetch or spawn), or `None`
     /// when every device produced a node. Already collected for the group
     /// path's detailed attempt, so a caller that turns "nothing encrypted"
@@ -465,11 +474,12 @@ pub struct EncryptFanoutSummary {
 /// belong in.
 ///
 /// [`EncryptResult`] is shaped for the group path, which needs the encrypted
-/// device list to tell a partial SKDM distribution from a complete one. A DM
-/// never asks that question and knows up front how many participants it can
-/// have, so it sizes one vector and lets each fan-out append into it: the
-/// per-fan-out node vector and the device list it would otherwise carry are
-/// both work done only to be moved and dropped.
+/// device list by name to pick the users whose device list to refresh. A DM
+/// only needs to know how many of its devices made it and whether the primary
+/// was one of them, which [`EncryptFanoutSummary`] answers without a list, so
+/// it sizes one vector and lets each fan-out append into it: the per-fan-out
+/// node vector and the device list it would otherwise carry are both work done
+/// only to be moved and dropped.
 #[allow(clippy::too_many_arguments)]
 pub async fn encrypt_for_devices_into(
     runtime: &dyn Runtime,
@@ -495,6 +505,13 @@ pub async fn encrypt_for_devices_into(
     .await?;
     report_encrypt_drops(resolver, raw.unkeyed_at_encrypt);
 
+    let encrypted_devices = raw.devices.len();
+    // Gated on the counts disagreeing so the send that keyed everyone -- every
+    // send, until one does not -- pays a single comparison and neither scan.
+    let skipped_primary = encrypted_devices < devices.len()
+        && !raw.devices.iter().any(|one| one.device_jid.device == 0)
+        && devices.iter().any(|jid| jid.device == 0);
+
     participant_nodes.reserve(raw.devices.len());
     for one in raw.devices {
         participant_nodes.push(encrypted_device_to_participant_node(
@@ -507,6 +524,8 @@ pub async fn encrypt_for_devices_into(
     Ok(EncryptFanoutSummary {
         includes_prekey_message: raw.includes_prekey_message,
         had_unregistered_device: raw.had_unregistered_device,
+        encrypted_devices,
+        skipped_primary,
         first_error,
     })
 }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -450,6 +450,10 @@ pub(crate) fn report_encrypt_drops(resolver: &dyn SendContextResolver, unkeyed_a
 
 /// What a fan-out reports back when its `<to><enc>` nodes went straight into
 /// the caller's stanza buffer instead of a per-fan-out [`EncryptResult`].
+///
+/// Sealed for the same reason as [`super::PreparedDmStanza`]: nothing outside
+/// the fan-out builds one, and the set of facts worth reporting still grows.
+#[non_exhaustive]
 pub struct EncryptFanoutSummary {
     pub includes_prekey_message: bool,
     /// True if any device returned 406 (unregistered) during prekey fetch.

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -5803,6 +5803,134 @@ mod local_identity_change_on_send {
                 vec![reachable.to_string(), own_companion.to_string()],
                 "the stanza carries what encrypted, recipients first"
             );
+            let fanout = prepared.recipient_fanout;
+            assert_eq!(
+                (fanout.addressed, fanout.encrypted),
+                (2, 1),
+                "the caller must be able to see one recipient device was dropped"
+            );
+            assert!(fanout.is_partial());
+            assert!(
+                !fanout.skipped_primary,
+                "the device that dropped was a companion, not the phone"
+            );
+        }
+
+        /// Regression (issue #1361): the recipient's phone drops out of the
+        /// fan-out and a companion does not, so the stanza is built, acked and
+        /// returned as `Ok`. Nothing the recipient can read was sent (the
+        /// chat lives on the phone) and before this the return value was
+        /// identical to a send that reached every device.
+        #[tokio::test]
+        async fn a_dm_that_lost_the_recipients_phone_says_so() {
+            let own_jid: Jid = "5511900000050:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000050:1@s.whatsapp.net".parse().unwrap();
+            let recipient_primary: Jid = "5511900000051:0@s.whatsapp.net".parse().unwrap();
+            let recipient_companion: Jid = "5511900000051:2@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![
+                    recipient_primary.clone(),
+                    recipient_companion.clone(),
+                    own_companion.clone(),
+                    own_jid.clone(),
+                ],
+                &own_jid,
+                None,
+            );
+
+            let prepared = prepare_dm(
+                &own_jid,
+                &recipient_primary.to_non_ad(),
+                &devices,
+                &[recipient_companion.clone(), own_companion.clone()],
+                std::slice::from_ref(&recipient_primary),
+                "DM_SINK_10",
+            )
+            .await
+            .expect("a companion still encrypted, so the stanza is built");
+
+            let fanout = prepared.recipient_fanout;
+            assert_eq!((fanout.addressed, fanout.encrypted), (2, 1));
+            assert!(
+                fanout.skipped_primary,
+                "the one device whose absence means undelivered must be named"
+            );
+            assert!(fanout.is_partial());
+        }
+
+        /// The happy path answers the same question, and answers it "nobody was
+        /// lost": a caller reading `is_partial` must not have to special-case
+        /// a complete send.
+        #[tokio::test]
+        async fn a_dm_that_reached_every_device_reports_no_loss() {
+            let own_jid: Jid = "5511900000060:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000060:1@s.whatsapp.net".parse().unwrap();
+            let recipient_primary: Jid = "5511900000061:0@s.whatsapp.net".parse().unwrap();
+            let recipient_companion: Jid = "5511900000061:2@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![
+                    recipient_primary.clone(),
+                    recipient_companion.clone(),
+                    own_companion.clone(),
+                    own_jid.clone(),
+                ],
+                &own_jid,
+                None,
+            );
+
+            let prepared = prepare_dm(
+                &own_jid,
+                &recipient_primary.to_non_ad(),
+                &devices,
+                &[
+                    recipient_primary.clone(),
+                    recipient_companion.clone(),
+                    own_companion.clone(),
+                ],
+                &[],
+                "DM_SINK_11",
+            )
+            .await
+            .expect("every device has a session");
+
+            let fanout = prepared.recipient_fanout;
+            assert_eq!((fanout.addressed, fanout.encrypted), (2, 2));
+            assert!(!fanout.is_partial());
+            assert!(!fanout.skipped_primary);
+            assert!(!fanout.had_unregistered_device);
+        }
+
+        /// A note to self has no recipient half, so the fan-out it reports is
+        /// the empty one. `is_partial` must read false there: nothing was
+        /// addressed, so nothing was lost.
+        #[tokio::test]
+        async fn a_self_chat_reports_an_empty_recipient_fanout() {
+            let own_jid: Jid = "5511900000070:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000070:1@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![own_companion.clone(), own_jid.clone()],
+                &own_jid,
+                None,
+            );
+
+            let prepared = prepare_dm(
+                &own_jid,
+                &own_jid.to_non_ad(),
+                &devices,
+                std::slice::from_ref(&own_companion),
+                &[],
+                "DM_SINK_12",
+            )
+            .await
+            .expect("a note to self is its own-devices copy");
+
+            let fanout = prepared.recipient_fanout;
+            assert_eq!((fanout.addressed, fanout.encrypted), (0, 0));
+            assert!(!fanout.is_partial());
+            assert!(!fanout.skipped_primary);
         }
 
         /// A note to self has no recipient half at all: every resolved device is


### PR DESCRIPTION
## Summary

A DM whose recipient half loses some but not all of its devices still builds a stanza, is acked, and returns `Ok(SendResult)` with a real message id. When the device it lost is the recipient's phone, the return value was byte-identical to a send that reached every device. The count that would have said so existed inside the fan-out and was discarded on the way out.

This PR makes that visible, and fixes the three separate paths the audit found that produce the same shape (a stanza the server accepts and the recipient never reads):

1. **Visibility.** `EncryptFanoutSummary` carries how many devices produced a `<to><enc>` node, which ones produced none, and whether a device 0 was among them; `prepare_dm_stanza` hands the counts up as `RecipientFanout` on `SendResult`.
2. **`@c.us` is a phone user.** A `to` in `Server::Legacy` was travelling the send path as a namespace nothing recognises, including through the pre-key fetch, whose response is matched back by whole-jid equality. It is rewritten at the send entry now.
3. **A 406 naming a primary fails the fetch,** instead of keying the companions and shipping the stanza anyway.
4. **A phash mismatch on a DM repairs what it reveals:** it re-resolves the device list and resends, pairwise and under the original id, to the devices the fresh list holds that the sent stanza did not reach.

Nothing about the wire stanza or the DM's success on a partial fan-out changes. WA Web builds `<participants>` from the survivors of its own per-device catch and rejects only when every device fails, so erroring on a partial fan-out would be a divergence and stays the caller's policy: what changes is that the caller can now have one.

## Audit

Confirmed, against `main` and against the `v0.7.0` tag the issue was filed on:

- `src/client/sessions.rs` (`v0.7.0`: `509-519`) - a missing bundle increments a local `missing_count`, records `UnkeyableDevice::NoBundle`, logs at `warn!` only when `jid.device == 0`, and the function returns `success_count` alone. `missing_count` never leaves the frame.
- `wacore/src/send/encrypt.rs:91-104` vs `453-462` - `EncryptResult` (group) carries `encrypted_devices: Vec<Jid>` and `rejected_devices`; `EncryptFanoutSummary` (DM) carried only `includes_prekey_message`, `had_unregistered_device` and `first_error`. The count existed as `raw.devices.len()` and was used only to `reserve` the node vector.
- `wacore/src/send/dm.rs:249-292` - the DM read `summary.includes_prekey_message` from each half and `summary.first_error` only inside the empty-list guard. A workspace grep for `had_unregistered_device` puts every read in `group.rs`; the DM path had none, and `src/voip/facade.rs` only writes a literal `false`. The empty guard does cover only the total case: it tests `participant_nodes.is_empty()` right after the recipient half writes into a fresh buffer.
- `src/send/mod.rs:482-485` - `SendResult` was `message_id` + `to`. Three construction sites, all in that file.
- `wacore/src/send/group.rs:440-441` - the `encrypted_devices.len() != distribution_list.len()` comparison is inside `distribution_policy == SenderKeyDistributionPolicy::Required`. Under `BestEffort` the group path does not surface a partial distribution either, so "the group already asks this question" is weaker than the issue suggests: the group asks it only when the caller opted into a policy that turns the answer into an error.
- `wacore/src/stats.rs:162-217` and `agent_docs/observability.md` - `Client::stats()` does expose `devices_unkeyed_no_bundle` and siblings, publicly and documented. A consumer can already see *that* this happens. What was missing is correlating it with one message, which a process-wide counter cannot do by construction.

The `@c.us` chain, confirmed link by link before it was fixed: the send entry did not validate the server the way the status path does at `src/send/mod.rs:1180`; `is_self_dm_recipient` matched only `Lid` and `Pn` with `_ => false`, so a note to self addressed that way took the third-party path and asked the server for our own bundles; `resolve_lid_mappings` and the usync gate at `src/send/mod.rs:2509` both pass it through untouched; `reconstruct_device_jids` derives every device jid from `query_jid.to_non_ad()`, so the server propagates onto companions; and `build_fetch_prekeys_request` writes the jid verbatim while `parse_prekeys_response` keys its map by the jid the server echoed, matched back by `Jid::eq`, which compares `server`.

Refuted, and the issue and the earlier analysis deserve the correction:

- **`<recipient>:13@c.us.0` in the log is not evidence of a `@c.us` JID.** `wacore/src/types/jid.rs:13-22` maps `s.whatsapp.net` to `c.us` unconditionally when rendering a Signal address name, because that is the address format WA Web uses. Every PN device in this codebase renders as `...@c.us.0` in a libsignal error. The trailing `.0` is the libsignal `DeviceId`, pinned to `0` at `jid.rs:11` because the real device is in the address name, and `13` is a device id, not an agent. That half of the log says nothing about namespaces.
- The **first** log line is different: `sessions.rs` logs through `jid.observe()`, which renders the real server (`wacore/binary/src/jid.rs:1289-1330`), so `pn#...@c.us` there does mean `Server::Legacy`. That line was hand-redacted, so it is strong evidence rather than proof, but it is the one that pointed at the namespace bug.
- The comment the issue quotes ("a DM never asks that question") came from #1131, a five-cuts allocation PR, as justification for the shape of the data, not for the delivery semantics. `git log -S` puts its introduction in that commit and nowhere else. It is reworded rather than deleted, because the reason the DM does not want the group's `Vec<Jid>` in its result type is still true.
- The follow-up I originally filed as "the 406 gate" was stated backwards. Our **batch-wide** 406 already propagates (`fetch_and_establish_sessions`), which is *stricter* than WA Web, whose catch swallows it when every wid is a companion. The real gap was the **per-device named rejection**, which we refreshed and continued past even for a primary. That is what is fixed.

Lineage checks out: #1131 introduced `encrypt_for_devices_into`/`EncryptFanoutSummary`, #1139 and #1153 handled the 406 half, #1299/#1301 turned total failure into the sealed `NoRecipientDeviceError`, and #1304 added the counters as observability without changing any return. No PR ever named the partial case, and no open issue duplicates #1361.

## WA Web

From the bundle set pinned in `whatspec`'s `generated/bundles.lock.json` (`2.3000.1045368834`, restored and SHA-256 verified, 516 bundles).

Per-device failure in the user fan-out, in `encryptAndSendUserMsg`:

```js
return o("WALogger").WARN(c||(c=...(["encryptAndSendUserMsg: encryption fail for ",": ",""])),String(n),e),
  o("WAWebSendMsgCommonApi").isPrimaryDevice(n)&&o("WALogger").ERROR(d||(d=...(["encryptAndSendUserMsg: encryption fail for primary device: ",""])),e)
    .tags("messaging").sendLogs("encryption-fail-for-primary-device"),null
```

and then, over the settled tasks:

```js
Q=yield Promise.all(K),X=T(Q),...,ne=X.successNodes;
...
if(ne.length>0||Y.length>0||J.length>0){ ... return {deviceEncs:te,body:ne.length>0?o("WAWap").wap("participants",null,ne):null, ...} }
return S.reject(r("err")("[messaging] encryptAndSendUserMsg: encryption fail for all devices"))
```

with `T` filtering `t != null`. Every device is caught individually, a failure yields `null`, the nulls are filtered, `<participants>` is built from the survivors, and the promise rejects only when all of them fail. That is what this library already does, and it is why this PR does not turn a partial fan-out into an error.

`isPrimaryDevice` is `function C(e){return e.device==null||e.device===o("WAJids").DEFAULT_DEVICE_ID}` in `WAWebSendMsgCommonApi`, load-bearing in two places. One is the catch above: WARN for any device, ERROR plus a dedicated `sendLogs("encryption-fail-for-primary-device")` when the failed device is the primary. The other is `ensureE2ESessions`, and it is a behaviour gate, not a log level:

```js
catch(e){ if(e instanceof o("WAWebBackendErrors").ServerStatusCodeError && e.statusCode===y
  && x.every(function(e){return e.device!=null&&e.device!==o("WAJids").DEFAULT_DEVICE_ID}))
    ... D=x,S.resolve();
  else throw ... }
```

reached from `if(N.length>0) throw N[0]`, where `N` is `fetchPrekeys`'s per-user `errors`. A named rejection with the primary in the batch fails the whole thing. That is the source of the 406 gate here. Note also what `fetchPrekeys` does *not* put in `errors`: a `<user>` the server simply omits is neither a bundle nor an error, so a missing bundle stays a partial fan-out in WA Web too, which is exactly the reporter's case and exactly what `RecipientFanout` is for.

Recovery is by phash, never by the return value:

```js
Promise.resolve().then(function(){ if(!S.isLid()) return o("WAWebFetchResendMissingKeyJob").fetchResendMissingKeys([S,R]).catch(...) })
  .then(function(){ return o("WAWebSyncDeviceAdvDeviceListJob").syncDeviceListJob([S,R],"message",D) })
  .then(function(){ return g({ackTime:x,chatId:r,excludeList:E,...}) })
```

where `g` persists a `resendUserMsg` job carrying the `excludeList` of devices that already hold a copy. Nothing in any of this reaches UI state or an error code: a partial send is WARN, ERROR and telemetry, and that is all.

On `c.us`, `WAWebWid` settles the namespace question: it stores `this.server === "c.us"` for a phone user, `isUser()` accepts it, and serialization maps it out (`this.server==="c.us"?"s.whatsapp.net":this.server`). `c.us` is the official client's canonical in-memory spelling, which is why the fix here normalizes rather than rejects.

So on the partial fan-out the global condition is the same as ours, and that part is a library-contract decision rather than a parity one. A client with an interface renders the bubble with no check mark and repairs behind the user's back; a library returns `Ok` and its caller writes "delivered" to a database. The caller needs the number the client keeps to itself.

## Design

`SendResult` gains `recipient_fanout: Option<RecipientFanout>`, populated for a DM and `None` for group, status, peer and newsletter plaintext.

```rust
pub struct RecipientFanout {
    pub addressed: usize,
    pub encrypted: usize,
    pub skipped_primary: bool,
    pub had_unregistered_device: bool,
}
impl RecipientFanout { pub fn is_partial(&self) -> bool { self.encrypted < self.addressed } }
```

Counts rather than a `Vec<Jid>` in the caller-facing type, because the caller's decision is "was this delivered" and not "to whom": a list would buy a name the caller cannot act on. `skipped_primary` is separate from the counts because a recipient's phone holds the chat whether or not they have a companion linked and open. `had_unregistered_device` is the flag the DM was already receiving and discarding.

The dropped devices *are* named internally, for the repair: `EncryptFanoutSummary::dropped_devices`, surfaced as `PreparedDmStanza::unreached_devices`. That vector is built only when the encrypted count differs from the addressed count, so a complete fan-out allocates nothing and scans nothing, which is the allocation #1131 removed on purpose.

On `SendResult` rather than a new `Event`, because the question is per message and the caller asks it at the point it decides what to record. `stats()` already covers the aggregate.

Erroring by default on a partial fan-out stays out, and stays the caller's policy.

`canonical_user_server` rewrites `Legacy` to `Pn` at the send entry, and only that: rejecting would refuse the spelling the official client considers canonical, and leaving it alone is what produced the bug. `is_self_dm_recipient` reads `Legacy` alongside `Pn` for the same reason, as defence in depth for the device-registry callers that do not go through the entry.

`SendError::PrimaryDeviceRejected` is a new variant rather than a `NoRecipientDeviceError` one, because the fetch layer can name our own primary as easily as the peer's and "no recipient device" would be the wrong sentence for that.

The delta resend is armed by handing the phash waiter the `Arc<ResolvedDmDevices>` the send already holds plus the (normally empty) unreached list. That is a refcount bump and an empty `Vec`, and it is the only per-send cost of the feature. The message id is read off the ack on the mismatch path rather than stored on the waiter, so the common path pays nothing at all. It cannot loop: the retransmission is pairwise and registers no phash waiter of its own. The exclude list is **addressed minus unreached**, not addressed: a device the fan-out named and could not encrypt for holds no copy, and excluding it would skip the repair on exactly the send this branch exists to make visible.

## Cost

**Send path.** `prepare_dm_stanza` through the real fan-out, three recipient devices and one own companion, release build, 2000 iterations after 50 warmup, three runs each:

| | per send |
| --- | --- |
| before | 2.473 ms, 2.478 ms, 2.512 ms |
| after | 2.462 ms, 2.442 ms, 2.436 ms |

The difference is inside the run-to-run spread and the sign is wrong for a regression: the send is dominated by Signal encryption. The happy path executes `encrypted_devices < devices.len()`, which is false, and short-circuits the scans and the allocation. No allocation is added on any complete send: the exclude list is an `Arc` clone of the memo entry plus a `Vec::new()`, and `canonical_user_server` is a field compare on a value the caller already owns.

**Binary size.** The first draft of the delta resend blew the size gate, and it was worth chasing rather than labelling. `.text` on the demo example, release with symbols kept:

| | .text |
| --- | --- |
| visibility commit (gate: pass) | 8,662,326 |
| first draft of the resend | 8,782,966 (+117.8 KiB) |
| current | 8,678,198 (+15.5 KiB) |

`cargo bloat` named the cause rather than leaving it to guesswork: a third ~66 KiB copy of `<waproto::whatsapp::Message as Clone>::clone`, instantiated for a per-device clone, plus the public `retransmit_message` wrapper becoming reachable from the read loop for the first time. Neither was buying anything. The wrapper validates a caller-supplied request and queries group metadata; every jid the resend passes it was built from our own resolved device list a few lines earlier, and the route is known to be `Direct`, so it now goes straight to the prepared form and keeps only the session-address resolution that route does need. The clone became a single read of the cached bytes plus a decode per device, which is code the retry cache already instantiates.

## Compatibility

Nothing changes for a caller that ignores the new field. `SendResult` is `#[non_exhaustive]`. `PreparedDmStanza` and `EncryptFanoutSummary` gained fields and are now sealed with `#[non_exhaustive]` themselves, so this is the last release in which adding one costs a downstream compile error; both are return types nothing outside the fan-out constructs.

`Client::send_message_impl` now returns `Result<Option<RecipientFanout>>` instead of `Result<()>`. It is `pub(crate)`, and fifteen of its seventeen call sites already discarded the value with `?;`.

Two behaviour changes a caller can observe:

- A pre-key fetch whose response names a device 0 with a `406` now fails instead of returning zero established sessions. The send fails against device lists this call has just refreshed, so the useful retry is immediate. A companion's 406, and any non-406 code including on a primary, behave exactly as before.
- A DM phash mismatch now issues a usync device query and may resend the message pairwise to newly discovered or unreached devices, under the original id. Previously it only dropped caches. Receivers deduplicate on the message id, and this is what WA Web does with the same ack.

A caller that treats `Ok` as delivery keeps behaving as before on the partial-fan-out path: the change there is additive and the policy shift is opt-in.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib            # 1537 passed
cargo test -p whatsapp-rust --lib     # 1817 passed
cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings
CARGO_PROFILE_RELEASE_STRIP=false cargo bloat --release --example demo
```

`cargo clippy --workspace` does not build in this environment: `alsa-sys` fails for want of ALSA headers, which predates this branch. Full matrix left to CI.

New tests, happy and failure path for each behaviour: `a_dm_that_lost_the_recipients_phone_says_so` (the named regression), `a_dm_that_reached_every_device_reports_no_loss`, `a_self_chat_reports_an_empty_recipient_fanout`, `a_dm_result_carries_its_recipient_fanout`, `a_status_reaction_reports_no_recipient_fanout`, `a_legacy_namespace_recipient_is_sent_as_a_phone_user`, `self_dm_legacy_recipient_matches_own_pn`, `non_self_legacy_recipient_is_not_self_dm`, `canonical_user_server_rewrites_only_legacy`, `a_406_naming_the_primary_fails_the_fetch`, `a_406_naming_only_a_companion_does_not_fail_the_fetch`, `a_non_406_rejection_of_the_primary_does_not_fail_the_fetch`, `only_the_devices_a_refresh_adds_are_resent`, `a_device_the_fanout_could_not_encrypt_for_is_still_resent`, `a_dm_phash_mismatch_re_resolves_the_peer_device_list`, `a_group_phash_mismatch_arms_no_dm_resend`.

The two regressions cannot compile against the old code (they read fields that did not exist), so each was also checked to be load-bearing rather than tautological: hardcoding `skipped_primary = false` fails `a_dm_that_lost_the_recipients_phone_says_so`, and making `canonical_user_server` the identity fails `a_legacy_namespace_recipient_is_sent_as_a_phone_user`.

Two existing tests changed, both contract changes rather than convenience:

- `a_rejected_device_is_counted_on_the_stats_snapshot` used device 0, which the new 406 gate now fails. It counts a companion instead, keeping its own subject (the counter), and the primary gate has three tests of its own.
- `prepared_dm_stanza_exposes_generated_message_secret` built a `PreparedDmStanza` literal and asserted on the field it had just assigned. Sealing the struct made the literal illegal from this crate, and it was asserting nothing about the code under test, so it now asserts on the token's own secret.

`Semver Checks (informational)` was red on the first two pushes and is red on merged PRs too (e.g. #1360): it compares against published `0.7.0` and lists accumulated drift (`enum_missing`, `feature_missing`, `pub_module_level_const_missing`, waproto's generated `constructible_struct_adds_field`). None of this PR's types appear in it.

Fixes #1361