### PR TITLE
fix(send): resend to the devices the fan-out named but never reached

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1074,6 +1074,11 @@ pub(crate) struct PhashWaiter {
     /// devices a refreshed list holds and this one does not, which is what the
     /// `excludeList` in WA Web's `resendUserMsg` job amounts to.
     pub(crate) dm_devices: Option<Arc<wacore::send::ResolvedDmDevices>>,
+    /// Of those, the ones that produced no `<enc>`. Empty on a complete
+    /// fan-out, so the common send stores nothing: a device the stanza named
+    /// but could not encrypt for holds no copy, and the repair has to resend
+    /// to it rather than count it as already covered.
+    pub(crate) dm_unreached: Vec<Jid>,
     /// Sweep epoch this waiter was registered in. Expiry is counted in sweeps
     /// rather than seconds: a wall deadline is subject to clock jumps (see
     /// wacore::time) and would have to be derived from an instant sampled well

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -396,6 +396,7 @@ impl Client {
         jid: Jid,
         invalidate_group_cache: bool,
         dm_devices: Option<Arc<wacore::send::ResolvedDmDevices>>,
+        dm_unreached: Vec<Jid>,
     ) {
         let mut waiters = self.response_waiters_guard();
         // Stamped with the sweep epoch under the lock the insert already holds:
@@ -409,6 +410,7 @@ impl Client {
                 jid,
                 invalidate_group_cache,
                 dm_devices,
+                dm_unreached,
                 registered_epoch,
             }),
         );

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1680,11 +1680,13 @@ impl Client {
             .is_some()
             .then(|| node.get_attr("id").map(|id| id.as_str().to_string()))
             .flatten();
+        let unreached = waiter.dm_unreached;
         self.runtime.spawn_detached(Box::pin(async move {
             let resend = match (message_id.as_deref(), waiter.dm_devices) {
-                (Some(message_id), Some(covered)) => Some(crate::send::DmDeltaResend {
+                (Some(message_id), Some(addressed)) => Some(crate::send::DmDeltaResend {
                     message_id,
-                    covered,
+                    addressed,
+                    unreached,
                 }),
                 _ => None,
             };

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -386,6 +386,30 @@ impl Client {
         }
     }
 
+    /// The canonical bytes of a sent message still held for retry, or `None`
+    /// when neither the cache nor the DB has it any more.
+    ///
+    /// `peek_recent_message` misses in DB-only mode (`recent_messages` capacity
+    /// 0), where the row exists and no L1 entry does, so this takes and re-adds
+    /// the way the retry path does rather than reporting the message gone on
+    /// every default cache config. Returns bytes because its callers want a
+    /// fresh `wa::Message` per device: decoding N times is cheaper in
+    /// instantiated code than one `Message::clone`, which is ~66 KiB of it.
+    pub(crate) async fn recent_message_bytes(
+        &self,
+        to: &Jid,
+        id: &str,
+    ) -> Option<std::sync::Arc<Vec<u8>>> {
+        if let Some((msg, _)) = self.peek_recent_message(to, id).await {
+            return Some(std::sync::Arc::new(waproto::codec::message_to_vec(&msg)));
+        }
+        let (msg, _) = self.take_recent_message(to, id).await?;
+        let bytes = std::sync::Arc::new(waproto::codec::message_to_vec(&msg));
+        self.add_recent_message(to, id, &msg, Some(std::sync::Arc::clone(&bytes)))
+            .await;
+        Some(bytes)
+    }
+
     /// Store a sent message for retry handling. Always writes to DB; when L1 cache
     /// is enabled (capacity > 0) also stores in-memory for fast retrieval.
     /// In DB-only mode (capacity = 0), the DB write is awaited to guarantee persistence.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5272,6 +5272,7 @@ fn phash_waiter_sweep_drops_only_entries_that_lived_through_a_sweep() {
             jid: "13135550100@s.whatsapp.net".parse().expect("valid jid"),
             invalidate_group_cache: false,
             dm_devices: None,
+            dm_unreached: Vec::new(),
             registered_epoch,
         })
     };

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -237,6 +237,8 @@ struct SendBranchOutput {
     /// DM branch only: the device set the stanza covered, shared with the memo
     /// entry it came from. Handed to the phash waiter as its exclude list.
     dm_devices: Option<std::sync::Arc<wacore::send::ResolvedDmDevices>>,
+    /// Of those, the ones that produced no `<enc>`. Empty on a complete fan-out.
+    dm_unreached: Vec<Jid>,
 }
 
 struct GroupBranchRequest<'a> {
@@ -337,6 +339,7 @@ impl SendBranchOutput {
             ack_phash: None,
             recipient_fanout: None,
             dm_devices: None,
+            dm_unreached: Vec::new(),
         }
     }
 }
@@ -500,12 +503,12 @@ pub(crate) struct SendPipelineOptions<'a> {
 /// The other direction is deliberately not reported: a device the send covered
 /// and the refresh dropped has already received its copy, and the refresh is
 /// the whole repair it needs.
-fn devices_missed_by_send(covered: &[Jid], fresh: &[Jid]) -> Vec<Jid> {
-    // Linear scan rather than a set: both sides are one user's devices plus our
+fn devices_missed_by_send(addressed: &[Jid], unreached: &[Jid], fresh: &[Jid]) -> Vec<Jid> {
+    // Linear scans rather than sets: both sides are one user's devices plus our
     // own, which is single digits, and this runs only on a mismatch.
     fresh
         .iter()
-        .filter(|device| !covered.contains(device))
+        .filter(|device| !addressed.contains(device) || unreached.contains(device))
         .cloned()
         .collect()
 }
@@ -514,7 +517,9 @@ fn devices_missed_by_send(covered: &[Jid], fresh: &[Jid]) -> Vec<Jid> {
 /// stanza missed: the id to resend under, and the set it already covered.
 pub(crate) struct DmDeltaResend<'a> {
     pub(crate) message_id: &'a str,
-    pub(crate) covered: std::sync::Arc<wacore::send::ResolvedDmDevices>,
+    pub(crate) addressed: std::sync::Arc<wacore::send::ResolvedDmDevices>,
+    /// The subset of `addressed` that produced no `<enc>`, so holds no copy.
+    pub(crate) unreached: Vec<Jid>,
 }
 
 /// Result of a successfully sent message.
@@ -1427,7 +1432,7 @@ impl Client {
             .optional_string("phash")
             .map(|s| wacore_binary::CompactString::from(s.as_ref()));
         if let Some(phash) = ack.clone() {
-            self.register_phash_waiter(&request_id, phash, to.clone(), true, None);
+            self.register_phash_waiter(&request_id, phash, to.clone(), true, None, Vec::new());
         }
 
         if let Err(e) = self.send_node(stanza).await {
@@ -1878,10 +1883,11 @@ impl Client {
     ) {
         let DmDeltaResend {
             message_id,
-            covered,
+            addressed,
+            unreached,
         } = resend;
         let device_snapshot = self.persistence_manager.get_device_snapshot();
-        let Some(own_jid) = device_snapshot.pn.clone() else {
+        let Some(own_jid) = device_snapshot.pn.as_ref() else {
             return;
         };
         let recipient_bare = self.resolve_dm_wire_jid(chat).await;
@@ -1889,7 +1895,7 @@ impl Client {
             .resolve_dm_devices_memoized(
                 chat,
                 &recipient_bare,
-                &own_jid,
+                own_jid,
                 device_snapshot.lid.as_ref(),
                 crate::cache::Freshness::Refresh,
             )
@@ -1905,7 +1911,7 @@ impl Client {
             }
         };
 
-        let uncovered = devices_missed_by_send(covered.devices(), fresh.devices());
+        let uncovered = devices_missed_by_send(addressed.devices(), &unreached, fresh.devices());
         if uncovered.is_empty() {
             // The set disagreed with the server's without gaining a device:
             // the divergence was a device we sent to and the server no longer
@@ -1922,20 +1928,31 @@ impl Client {
             chat.observe(),
             uncovered.len()
         );
+        // Read once, after the refresh: repairing the device list is worth
+        // doing even when the plaintext has aged out of the retry cache.
+        let Some(bytes) = self.recent_message_bytes(chat, message_id).await else {
+            log::debug!(
+                "phash mismatch for {}: message {message_id} is no longer held; \
+                 the device list is refreshed, so the next send reaches everyone",
+                chat.observe()
+            );
+            return;
+        };
+
         for device in uncovered {
-            // Decoded per device rather than cloned once and copied: a
-            // `wa::Message` clone is its own ~66 KiB of instantiated code, and
-            // this path runs only on a mismatch, so the decode the retry cache
-            // already does is the cheaper of the two to pay for. Read inside
-            // the loop for the same reason, which also keeps the device-list
-            // refresh above worth doing when the plaintext has aged out.
-            let Some((owned, _)) = self.peek_recent_message(chat, message_id).await else {
-                log::debug!(
-                    "phash mismatch for {}: message {message_id} is no longer cached; \
-                     the device list is refreshed, so the next send reaches everyone",
-                    chat.observe()
-                );
-                return;
+            // Decoded per device rather than cloned: a `wa::Message` clone is
+            // its own ~66 KiB of instantiated code, while the decode is code
+            // the retry cache already instantiates, and this runs only on a
+            // mismatch.
+            let owned = match waproto::codec::message_decode(bytes.as_slice()) {
+                Ok(message) => message,
+                Err(e) => {
+                    log::warn!(
+                        "phash mismatch for {}: cached {message_id} does not decode: {e}",
+                        chat.observe()
+                    );
+                    return;
+                }
             };
             // Our own companion needs the chat named as the recipient, or the
             // copy it receives has no destination to file itself under; a peer
@@ -1964,7 +1981,7 @@ impl Client {
                     retry_count: 1,
                     recipient: is_own.then(|| chat.clone()),
                     group_info: None,
-                    pre_encoded: None,
+                    pre_encoded: Some(std::sync::Arc::clone(&bytes)),
                 })
                 .await;
             if let Err(e) = outcome {
@@ -2081,6 +2098,7 @@ impl Client {
             ack_phash,
             recipient_fanout,
             dm_devices: covered_dm_devices,
+            dm_unreached,
         } = if peer && !to.is_group() {
             box_send_branch(self.send_peer_branch(to, message, request_id)).await?
         } else if to.is_group() {
@@ -2144,6 +2162,7 @@ impl Client {
                 tc_issue_target.clone(),
                 invalidate_group,
                 covered_dm_devices,
+                dm_unreached,
             );
             Some(request_id)
         } else {
@@ -2635,6 +2654,7 @@ impl Client {
             ack_phash: group_ack_phash,
             recipient_fanout: None,
             dm_devices: None,
+            dm_unreached: Vec::new(),
         })
     }
 
@@ -2799,6 +2819,11 @@ impl Client {
             // status message rather than to the device it names.
             recipient_fanout: (!is_status_addon).then_some(prepared.recipient_fanout),
             dm_devices: (!is_status_addon).then_some(dm_devices),
+            dm_unreached: if is_status_addon {
+                Vec::new()
+            } else {
+                prepared.unreached_devices
+            },
         })
     }
 
@@ -7563,7 +7588,7 @@ mod tests {
     }
 
     /// The exclude list: only what the refresh added is resent. A device the
-    /// send covered has its copy, and one the refresh dropped is not worth a
+    /// send reached has its copy, and one the refresh dropped is not worth a
     /// second attempt, so neither belongs in the delta.
     #[test]
     fn only_the_devices_a_refresh_adds_are_resent() {
@@ -7572,7 +7597,7 @@ mod tests {
         let peer_gone: Jid = "5511900000090:9@s.whatsapp.net".parse().unwrap();
         let own_companion: Jid = "5511900000091:2@s.whatsapp.net".parse().unwrap();
 
-        let covered = [peer_primary.clone(), peer_gone.clone()];
+        let addressed = [peer_primary.clone(), peer_gone.clone()];
         let fresh = [
             peer_primary.clone(),
             peer_new.clone(),
@@ -7580,17 +7605,40 @@ mod tests {
         ];
 
         assert_eq!(
-            devices_missed_by_send(&covered, &fresh),
+            devices_missed_by_send(&addressed, &[], &fresh),
             vec![peer_new, own_companion],
-            "a device the send covered stays out, and one it lost is not chased"
+            "a device the send reached stays out, and one it lost is not chased"
         );
         assert!(
-            devices_missed_by_send(&covered, &covered).is_empty(),
+            devices_missed_by_send(&addressed, &[], &addressed).is_empty(),
             "an unchanged list resends nothing"
         );
         assert!(
-            devices_missed_by_send(&fresh, &[]).is_empty(),
+            devices_missed_by_send(&fresh, &[], &[]).is_empty(),
             "a refresh that found nothing resends nothing"
+        );
+    }
+
+    /// Addressed is not reached. A device the fan-out named but could not
+    /// encrypt for holds no copy of the message, so excluding it from the
+    /// delta would leave it with nothing on exactly the send this PR exists
+    /// to make visible.
+    #[test]
+    fn a_device_the_fanout_could_not_encrypt_for_is_still_resent() {
+        let peer_primary: Jid = "5511900000092:0@s.whatsapp.net".parse().unwrap();
+        let peer_companion: Jid = "5511900000092:5@s.whatsapp.net".parse().unwrap();
+
+        let addressed = [peer_primary.clone(), peer_companion.clone()];
+        let unreached = [peer_primary.clone()];
+
+        assert_eq!(
+            devices_missed_by_send(&addressed, &unreached, &addressed),
+            vec![peer_primary],
+            "the device that never got ciphertext is the one to resend to"
+        );
+        assert!(
+            devices_missed_by_send(&addressed, &[], &addressed).is_empty(),
+            "and it is excluded again once it has encrypted"
         );
     }
 

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -176,6 +176,11 @@ pub struct PreparedDmStanza {
     pub node: Node,
     /// What the recipient half of the fan-out reached. See [`RecipientFanout`].
     pub recipient_fanout: RecipientFanout,
+    /// Every device, either half, that was addressed and produced no `<enc>`.
+    /// Empty on a complete fan-out. These hold no copy of the message, so a
+    /// repair driven by a later device-list disagreement has to treat them as
+    /// unreached even though the send named them.
+    pub unreached_devices: Vec<Jid>,
     /// Locally computed phash from the sent device set. Not sent on the
     /// wire (WA Web only sends phash for groups). Used by the caller to
     /// compare against the server's ACK phash for device-list drift detection.
@@ -295,6 +300,7 @@ pub async fn prepare_dm_stanza(
     let mut participant_nodes = Vec::with_capacity(total_devices);
     let mut includes_prekey_message = false;
     let mut recipient_fanout = RecipientFanout::default();
+    let mut unreached_devices: Vec<Jid> = Vec::new();
 
     let hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit, message);
 
@@ -327,6 +333,7 @@ pub async fn prepare_dm_stanza(
             skipped_primary: summary.skipped_primary,
             had_unregistered_device: summary.had_unregistered_device,
         };
+        unreached_devices = summary.dropped_devices;
         // The recipient half wrote into an empty buffer, so an emptiness test
         // here is a recipient-node count without walking anything. Bailing
         // before the own half also keeps a companion's sender chain from
@@ -358,6 +365,7 @@ pub async fn prepare_dm_stanza(
         )
         .await?;
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;
+        unreached_devices.extend(summary.dropped_devices);
     }
 
     // Only reachable for a self-chat now (the recipient half returns above):
@@ -420,6 +428,7 @@ pub async fn prepare_dm_stanza(
     Ok(PreparedDmStanza {
         node: stanza,
         recipient_fanout,
+        unreached_devices,
         phash,
         message_secret: reporting_result.map(|r| r.message_secret),
     })

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -467,6 +467,12 @@ pub struct EncryptFanoutSummary {
     /// recipient's own phone, so the stanza reaches the server, gets acked, and
     /// arrives nowhere the recipient can read it.
     pub skipped_primary: bool,
+    /// The devices that were addressed and produced no node, by name. Empty
+    /// whenever the fan-out was complete, which is every send until one is
+    /// not, so the common path allocates nothing. Named rather than counted
+    /// because a repair has to tell a device that holds the message from one
+    /// that was only addressed.
+    pub dropped_devices: Vec<Jid>,
     /// First failure of the fan-out (session, prekey fetch or spawn), or `None`
     /// when every device produced a node. Already collected for the group
     /// path's detailed attempt, so a caller that turns "nothing encrypted"
@@ -511,10 +517,17 @@ pub async fn encrypt_for_devices_into(
 
     let encrypted_devices = raw.devices.len();
     // Gated on the counts disagreeing so the send that keyed everyone -- every
-    // send, until one does not -- pays a single comparison and neither scan.
-    let skipped_primary = encrypted_devices < devices.len()
-        && !raw.devices.iter().any(|one| one.device_jid.device == 0)
-        && devices.iter().any(|jid| jid.device == 0);
+    // send, until one does not -- pays a single comparison, no scan and no
+    // allocation.
+    let mut dropped_devices = Vec::new();
+    if encrypted_devices < devices.len() {
+        dropped_devices = devices
+            .iter()
+            .filter(|jid| !raw.devices.iter().any(|one| one.device_jid == **jid))
+            .cloned()
+            .collect();
+    }
+    let skipped_primary = dropped_devices.iter().any(|jid| jid.device == 0);
 
     participant_nodes.reserve(raw.devices.len());
     for one in raw.devices {
@@ -530,6 +543,7 @@ pub async fn encrypt_for_devices_into(
         had_unregistered_device: raw.had_unregistered_device,
         encrypted_devices,
         skipped_primary,
+        dropped_devices,
         first_error,
     })
 }

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -5857,6 +5857,11 @@ mod local_identity_change_on_send {
                 "the one device whose absence means undelivered must be named"
             );
             assert!(fanout.is_partial());
+            assert_eq!(
+                prepared.unreached_devices,
+                vec![recipient_primary],
+                "a repair has to know which device holds no copy, not just how many"
+            );
         }
 
         /// The happy path answers the same question, and answers it "nobody was
@@ -5900,6 +5905,10 @@ mod local_identity_change_on_send {
             assert!(!fanout.is_partial());
             assert!(!fanout.skipped_primary);
             assert!(!fanout.had_unregistered_device);
+            assert!(
+                prepared.unreached_devices.is_empty(),
+                "a complete fan-out names nobody, and allocates for nobody"
+            );
         }
 
         /// A note to self has no recipient half, so the fan-out it reports is


### PR DESCRIPTION
## Summary

Three review findings that landed on #1362 after it was already merged. Each one leaves the delta resend it added doing less than it says, and the first two make it wrong rather than merely incomplete.

## The exclude list was the addressed set, not the reached one

`handle_phash_mismatch` stored the whole pre-encryption `ResolvedDmDevices` snapshot as "already covered". A device the fan-out named and could not encrypt for holds no copy of the message, so treating it as covered drops it from the delta on exactly the send #1362 exists to make visible: the recipient's primary fails to encrypt, the phash disagrees, and the repair skips the one device that needed it.

The fan-out now names the devices it dropped rather than only counting them (`EncryptFanoutSummary::dropped_devices`, surfaced as `PreparedDmStanza::unreached_devices`), and the exclude list is addressed minus those. `skipped_primary` is derived from that list rather than recomputed, so the two can no longer disagree.

The list is built only when the encrypted count differs from the addressed count. A complete fan-out still allocates nothing and scans nothing, which is the per-fan-out allocation #1131 removed on purpose.

## The resend never fired on a default cache config

`peek_recent_message` returns `None` in DB-only mode (`recent_messages` capacity 0, the default), where the row exists and no L1 entry does. Its own doc comment says so and tells the caller to fall back to take + re-add, which is what the retry path does and what the resend did not. So on a default configuration the mismatch refreshed the device list and then reported the message gone, every time.

It goes through a new `Client::recent_message_bytes`, which peeks, falls back to take + re-add, and hands the canonical bytes on as `pre_encoded` so the retransmission does not re-encode. Reading bytes once and decoding per device also keeps `wa::Message::clone` out of the path, which is what the size fix in #1362's last commit was about: the clone is ~66 KiB of instantiated code, the decode is code the retry cache already instantiates, and the delta is normally one device.

## `own_jid` was cloned out of the device snapshot

Borrowed now, per the snapshot rule in AGENTS.md. The function already holds the `Arc` and borrows `lid` from it correctly two lines further down.

## Cost

`.text` on the demo example, release with symbols kept: 8,662,326 before the resend existed, 8,678,198 with this. The CI gate measures it against the new main and reports +5.31 KiB, well inside the 32 KiB budget.

Nothing changes on a complete send: the unreached list is a `Vec::new()`, the exclude list an `Arc` clone of the memo entry, and the whole path runs only on a phash mismatch.

## Tests

- `a_device_the_fanout_could_not_encrypt_for_is_still_resent` - the regression: a device in the addressed set that produced no `<enc>` is in the delta, and drops out again once it encrypts.
- `only_the_devices_a_refresh_adds_are_resent` - updated for the third argument; the exclude-list semantics it pinned are unchanged.
- `a_dm_that_lost_the_recipients_phone_says_so` and `a_dm_that_reached_every_device_reports_no_loss` now also assert on `unreached_devices`, so the named list and the counts are checked against each other on both the partial and the complete path.

```
cargo fmt --all
cargo test -p wacore --lib            # 1537 passed
cargo test -p whatsapp-rust --lib     # 1817 passed
cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings
```

`cargo clippy --workspace` does not build in this environment (`alsa-sys` wants ALSA headers); full matrix left to CI, which is green here.

`Semver Checks (informational)` is red, as it is on merged PRs (#1360, #1362): it compares against published `0.7.0` and reports nine categories of accumulated drift (`enum_missing`, `feature_missing`, `pub_module_level_const_missing`, `function_parameter_count_changed`, waproto's generated `constructible_struct_adds_field`, and others). None of this PR's types appear anywhere in its output.

## Follow-up worth its own issue

CodeRabbit notes, correctly, that the resend is one-shot: a client that dies mid-repair leaves the remaining devices unrepaired until some later send re-resolves them. WA Web enqueues `resendUserMsg` as a *persisted* job for exactly that reason. Making our repair durable is a real gap, but it is a separate change with its own storage question, not something to fold in here.

Follow-up to #1362, and to the review threads on it from codex and coderabbit.