### PR TITLE
Let a call be placed where there is no UDP socket

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -87,8 +87,7 @@ jobs:
           fi
       # The sans-IO VoIP core (wacore::voip: the CallEngine, the portable run_call driver,
       # the RelayTransport seam, the MLow codec, SRTP/SFrame crypto) must stay wasm-buildable
-      # so the WASM bridge can drive 1:1 calls. whatsapp-rust's `voip` feature compile-errors on
-      # wasm (it pulls webrtc-rs + libopus FFI), so the guard is on the pure core here.
+      # so a browser front end can drive 1:1 calls.
       - name: Build wacore VoIP core for wasm32 (release)
         env:
           RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
@@ -96,3 +95,16 @@ jobs:
           cargo build -p wacore --lib --release
           --target wasm32-unknown-unknown
           --no-default-features --features "voip,js"
+      # And the half above it: signaling, the facade, `CallHandle` -- everything a consumer
+      # actually places a call through. It builds here because `voip-runtime` no longer carries the
+      # native relay dialer (that is `voip-relay-native`, and it is the one thing that still
+      # compile_error!s on this target), so what a page supplies is a `RelayTransportProvider` and
+      # not a reimplementation of the call flow. Without this step that split silently regresses the
+      # first time something in the facade reaches for a socket or a clock.
+      - name: Build whatsapp-rust VoIP runtime for wasm32 (release)
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: >
+          cargo build -p whatsapp-rust --lib --release
+          --target wasm32-unknown-unknown
+          --no-default-features --features voip-mlow

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,9 +189,21 @@ tokio-runtime = ["dep:tokio"]
 signal = ["tokio-runtime", "tokio/signal"]
 sqlite-storage = ["whatsapp-rust-sqlite-storage"]
 tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
-# Shared native VoIP runtime. Public profiles below select which codec implementation is linked.
-voip-runtime = [
-    "wacore/voip",
+# The portable half of the VoIP runtime: call signaling, the facade, and the orchestration around
+# `wacore`'s sans-IO engine. It owns no socket and names no clock, so it builds wherever `wacore`
+# does -- wasm32 included. What it does NOT bring is a way onto the wire; see `voip-relay-native`.
+#
+# It does not pull `tokio-runtime` either. The executor a call is driven on is the client's own
+# `Arc<dyn Runtime>`, and the only thing in this half that ever named Tokio was one `run_call_tokio`
+# call in the facade -- every clock and every timeout already went through `wacore::runtime`. A
+# native build gets `tokio-runtime` back through `voip-relay-native`, which genuinely needs it.
+voip-runtime = ["wacore/voip"]
+# The native relay media transport: one UDP socket per call, DTLS, SCTP, and the pre-negotiated
+# DataChannel over them. This is the half that cannot exist on wasm32 or espidf, so it is the half
+# that is its own feature -- a page supplies its own `RelayTransportFactory` (an `RTCPeerConnection`
+# reaches the same relay) through `Client::set_relay_transport_factory`, and needs none of this.
+voip-relay-native = [
+    "voip-runtime",
     "tokio-runtime",
     "tokio/net",
     "dep:rtc-dtls",
@@ -199,8 +211,9 @@ voip-runtime = [
     "dep:rtc-datachannel",
     "dep:rtc-shared",
 ]
-# Backwards-compatible full profile: preserves both codec adapters from the former single feature.
-voip = ["voip-mlow", "voip-libopus"]
+# Backwards-compatible full profile: preserves both codec adapters from the former single feature,
+# and the native relay every consumer of `voip` has always been getting.
+voip = ["voip-mlow", "voip-libopus", "voip-relay-native"]
 # Codec-bypass profile: raw MLOW/Opus payloads supplied by the application, no codec linked.
 voip-encoded = ["voip-runtime"]
 # Explicit spelling for consumers that assemble feature sets instead of using `voip`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,8 +200,8 @@ tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
 voip-runtime = ["wacore/voip"]
 # The native relay media transport: one UDP socket per call, DTLS, SCTP, and the pre-negotiated
 # DataChannel over them. This is the half that cannot exist on wasm32 or espidf, so it is the half
-# that is its own feature -- a page supplies its own `RelayTransportFactory` (an `RTCPeerConnection`
-# reaches the same relay) through `Client::set_relay_transport_factory`, and needs none of this.
+# that is its own feature -- a page supplies its own `RelayTransportProvider` (an `RTCPeerConnection`
+# reaches the same relay) through `Client::set_relay_transport_provider`, and needs none of this.
 voip-relay-native = [
     "voip-runtime",
     "tokio-runtime",

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -294,8 +294,16 @@ Scope caveats: the hook covers tasks spawned *by the client* through the
 future (`Bot::spawn` reaches it via `Runtime::spawn`), so the read loop is
 covered on either launch path. Work executed on the caller's own task (e.g.
 awaiting `send_message`) belongs to the caller — instrument that side
-yourself if you need it. The `voip` feature's media tasks (call driver,
-relay I/O) currently spawn directly on Tokio and are not instrumented.
+yourself if you need it.
+
+VoIP media tasks: the **call driver** is covered. It runs on the client's own
+`Arc<dyn Runtime>` — it has to, since that is the only executor a browser build
+has — so an installed instrument meters it like any other client task. Do not
+add separate attribution for it, or the work is counted twice. What is still
+outside the hook is the native relay transport's own I/O
+(`voip-relay-native`: the UDP socket's read task and the DTLS/SCTP retransmit
+timers), which spawns on Tokio directly. A platform that installs its own
+`RelayTransportProvider` decides that side for itself.
 
 ## `Client::resource_report()` — out-of-client resource attribution (on demand)
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -299,11 +299,16 @@ yourself if you need it.
 VoIP media tasks: the **call driver** is covered. It runs on the client's own
 `Arc<dyn Runtime>` — it has to, since that is the only executor a browser build
 has — so an installed instrument meters it like any other client task. Do not
-add separate attribution for it, or the work is counted twice. What is still
-outside the hook is the native relay transport's own I/O
-(`voip-relay-native`: the UDP socket's read task and the DTLS/SCTP retransmit
-timers), which spawns on Tokio directly. A platform that installs its own
-`RelayTransportProvider` decides that side for itself.
+add separate attribution for it, or the work is counted twice.
+
+The native relay transport's own I/O is covered too, which this section used to
+deny: `voip-relay-native`'s UDP read task and DTLS/SCTP retransmit timers run
+under `relay_driver`, and `connect_relay_media` spawns it through the runtime
+`RelayMediaChannelFactory` was built with — the client's own, both before and
+after the transport-provider split. So an installed instrument already meters
+the relay, and attributing it separately double-counts it. The only VoIP work
+outside the hook is a transport an installed `RelayTransportProvider` supplies,
+which spawns wherever its author chose.
 
 ## `Client::resource_report()` — out-of-client resource attribution (on demand)
 

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -91,21 +91,36 @@ Asked often enough to write down: the runtime-free VoIP core already exists, and
 it is not what `voip-runtime` gates.
 
 `wacore::voip` is sans-IO. Its feature is `["dep:aes-gcm", "dep:zerocopy"]`,
-`tokio` appears only under wacore's `[dev-dependencies]`, and the four mentions
-of tokio or webrtc under `wacore/src/voip/` are doc comments describing what the
-native side injects. The executor is the `wacore::runtime::Runtime` trait, with
-a `Send` native shape and a non-`Send` wasm one; the socket is the
+`tokio` appears only under wacore's `[dev-dependencies]`, and the mentions of
+tokio or webrtc under `wacore/src/voip/` are doc comments describing what a
+platform injects. The executor is the `wacore::runtime::Runtime` trait, with a
+`Send` native shape and a non-`Send` wasm one; the socket is the
 `RelayTransport` seam. CI builds it for `wasm32-unknown-unknown` with
 `--no-default-features --features "voip,js"` on every PR, which is what keeps
 that true.
 
-What `voip-runtime` gates in this crate is the native media plane: the webrtc-rs
-DTLS/SCTP DataChannel, the libopus FFI and the task orchestration around them.
-That is runtime-bound by construction, and `src/voip/mod.rs` has a
-`compile_error!` pointing wasm32 and espidf builds at `wacore/voip` instead.
-Making it runtime-agnostic would not be a refactor of this code, it would be
-replacing webrtc-rs, and there is no consumer waiting for it: the one a split
-was supposed to free is already served by `wacore::voip`.
+What `voip-runtime` gates in this crate is no longer the native media plane. It
+used to, and the split that changed it is worth stating plainly, because this
+section previously said the opposite and a boundary decision made from the old
+text would be made backwards:
+
+- **`voip-runtime`** is the portable half — signaling, the facade, `CallHandle`,
+  and the orchestration around `wacore`'s engine. It owns no socket and reads no
+  clock (every timeout goes through `wacore::runtime`, and the driver runs on the
+  client's own `Arc<dyn Runtime>`), so it builds wherever `wacore` does. CI
+  builds it for `wasm32-unknown-unknown` with `--features voip-mlow`.
+- **`voip-relay-native`** is the half that cannot: one UDP endpoint per call with
+  the webrtc-rs DTLS/SCTP DataChannel over it. It carries the `compile_error!`
+  for wasm32 and espidf, and it is the only VoIP feature that does.
+- **`voip-libopus`** is the other native-only one, and for the other reason: it
+  is C. MLow (`voip-mlow`) is pure Rust and is what a portable build uses.
+
+So "make it runtime-agnostic" is no longer a question about replacing webrtc-rs.
+A target without a UDP socket keeps the whole call flow and supplies its own way
+onto the wire through `Client::set_relay_transport_provider`; in a browser that
+is an `RTCPeerConnection`, which is the same DTLS/SCTP/DataChannel stack with the
+browser assembling it. The consumer that was said not to exist is the web front
+end, and it is the reason the split was made.
 
 `voip-runtime` is one test away from cuttable, and the three sites that keep it
 coupled are all the same shape: a `pub(crate)` helper whose only caller is VoIP.

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -137,8 +137,9 @@ loop:
 They are deliberately distinct: one is a codec problem and the other is transport, and conflating
 them is how #1105 was mis-triaged for months. `voip::tap::PacketTap` is public: decorating a
 `RelayTransportFactory` with `TappedFactory` puts every relay datagram in both directions through
-your sink. The runtime does not yet expose a factory injection point for a live call, so that is
-reachable from a shell building its own transport rather than from a `CallHandle`.
+your sink. `Client::set_relay_transport_provider` is the injection point for a live call, so a tap
+-- or any other decorated factory -- now reaches one placed through `CallHandle` rather than only a
+shell that builds its own transport.
 
 A build with no decoder for the negotiated codec does not pretend. It reports `AudioSilent` with
 `NoDecoderForNegotiatedCodec`, which is the one silence reason a consumer can act on.
@@ -147,14 +148,44 @@ A build with no decoder for the negotiated codec does not pretend. It reports `A
 
 | Feature | Contents |
 | --- | --- |
-| `voip-encoded` | Native relay/runtime and encoded I/O; no audio codec |
+| `voip-runtime` | Signaling, the facade and `CallHandle`; no transport, no codec |
+| `voip-relay-native` | The UDP/DTLS/SCTP relay dialer. Native only |
+| `voip-encoded` | Runtime and encoded I/O; no audio codec |
 | `voip-mlow` | Runtime plus the pure-Rust PCM/MLOW adapter |
 | `voip-libopus` | Encoded runtime plus the optional libopus adapter |
-| `voip` | Compatibility aggregate: MLOW + libopus |
+| `voip` | Compatibility aggregate: MLOW + libopus + the native relay |
 | `wacore/voip` | Runtime-agnostic media engine and encoded I/O |
 | `wacore/voip-mlow` | Core media engine plus MLOW |
 
 An application that already produces raw Opus packets needs only `voip-encoded`.
+
+## Calls off the native stack
+
+`voip-relay-native` is the only VoIP feature that does not build on wasm32 or espidf, and it is the
+only one that owns a socket: one UDP endpoint per call, with DTLS, SCTP and a pre-negotiated
+DataChannel over it. Everything above it -- the offer, the answer, the engine, `CallHandle` -- is
+portable, drives `wacore`'s sans-IO engine over the client's own `Arc<dyn Runtime>`, and reads no
+clock of its own.
+
+So a target without a UDP socket does not lose calls; it supplies the way onto the wire:
+
+```rust
+client.set_relay_transport_provider(Arc::new(MyProvider));
+```
+
+A `RelayTransportProvider` is asked for a `RelayTransportFactory` per relay address, because the
+relay is named by the server per call. A browser's implementation is an `RTCPeerConnection` with a
+synthetic SDP answer naming that address and the same pre-negotiated `id=0` DataChannel
+(`ordered=false`, `maxRetransmits=0`) the native stack assembles by hand -- which is what WhatsApp
+Web itself does, and the reason the native transport's own doc comment describes the stack as "the
+synthetic-SDP / wrtc dance".
+
+The codec is not a blocker there either: MLOW is pure Rust (`wacore/voip-mlow`) and builds
+everywhere. libopus is the C one, so `voip-libopus` stays native; a browser that wants Opus supplies
+it through `ForeignAudioCodecFactory` (WebCodecs `AudioEncoder`/`AudioDecoder`).
+
+A build with neither a native dialer nor an installed provider fails a call at setup with a sentence
+saying so, rather than refusing to compile.
 
 ## Encoded API
 

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -175,8 +175,14 @@ client.set_relay_transport_provider(Arc::new(MyProvider));
 
 A `RelayTransportProvider` is asked for a `RelayTransportFactory` per relay endpoint, because the
 relay is named by the server per call. What it is handed is a `RelayEndpointParams`: the address,
-plus the `ice-ufrag` (the relay token, base64) and `ice-pwd` (the relay `<key>`, in the ASCII form
-it arrived in) that a synthetic SDP answer has to carry. The address alone is enough for a stack
+plus the `ice-ufrag` and `ice-pwd` that a synthetic SDP answer has to carry.
+
+Which credential is which matters, and the two are easy to swap. `ice-ufrag` is the selected
+endpoint's `<auth_token>`, indexed by its `auth_token_id`; `ice-pwd` is the relay `<key>` in the
+ASCII base64 form it arrived in. The `<token>` beside them -- indexed by `token_id` -- is the STUN
+allocation credential and goes on the wire as `RELAY-TOKEN`, never as a ufrag. A ufrag built from
+the wrong one is refused at the browser's first connectivity check, which surfaces as a call that
+will not connect rather than as a bad credential. The address alone is enough for a stack
 that dials UDP itself; it is not enough for a browser, where ICE is not optional and the relay
 validates the credentials.
 

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -173,12 +173,17 @@ So a target without a UDP socket does not lose calls; it supplies the way onto t
 client.set_relay_transport_provider(Arc::new(MyProvider));
 ```
 
-A `RelayTransportProvider` is asked for a `RelayTransportFactory` per relay address, because the
-relay is named by the server per call. A browser's implementation is an `RTCPeerConnection` with a
-synthetic SDP answer naming that address and the same pre-negotiated `id=0` DataChannel
-(`ordered=false`, `maxRetransmits=0`) the native stack assembles by hand -- which is what WhatsApp
-Web itself does, and the reason the native transport's own doc comment describes the stack as "the
-synthetic-SDP / wrtc dance".
+A `RelayTransportProvider` is asked for a `RelayTransportFactory` per relay endpoint, because the
+relay is named by the server per call. What it is handed is a `RelayEndpointParams`: the address,
+plus the `ice-ufrag` (the relay token, base64) and `ice-pwd` (the relay `<key>`, in the ASCII form
+it arrived in) that a synthetic SDP answer has to carry. The address alone is enough for a stack
+that dials UDP itself; it is not enough for a browser, where ICE is not optional and the relay
+validates the credentials.
+
+A browser's implementation is an `RTCPeerConnection` with that synthetic SDP answer and the same
+pre-negotiated `id=0` DataChannel (`ordered=false`, `maxRetransmits=0`) the native stack assembles
+by hand -- which is what WhatsApp Web itself does, and the reason the native transport's own doc
+comment describes the stack as "the synthetic-SDP / wrtc dance".
 
 The codec is not a blocker there either: MLOW is pure Rust (`wacore/voip-mlow`) and builds
 everywhere. libopus is the C one, so `voip-libopus` stays native; a browser that wants Opus supplies

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -161,9 +161,11 @@ An application that already produces raw Opus packets needs only `voip-encoded`.
 
 ## Calls off the native stack
 
-`voip-relay-native` is the only VoIP feature that does not build on wasm32 or espidf, and it is the
-only one that owns a socket: one UDP endpoint per call, with DTLS, SCTP and a pre-negotiated
-DataChannel over it. Everything above it -- the offer, the answer, the engine, `CallHandle` -- is
+`voip-relay-native` is the only VoIP feature that owns a socket: one UDP endpoint per call, with
+DTLS, SCTP and a pre-negotiated DataChannel over it. It is native-only for that reason, and it is
+not the only native-only one -- `voip-libopus` is too, because libopus is C (see below). What
+separates them is that a portable target has an answer for the codec and needs one supplied for the
+transport. Everything above it -- the offer, the answer, the engine, `CallHandle` -- is
 portable, drives `wacore`'s sans-IO engine over the client's own `Arc<dyn Runtime>`, and reads no
 clock of its own.
 

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -157,7 +157,12 @@ A build with no decoder for the negotiated codec does not pretend. It reports `A
 | `wacore/voip` | Runtime-agnostic media engine and encoded I/O |
 | `wacore/voip-mlow` | Core media engine plus MLOW |
 
-An application that already produces raw Opus packets needs only `voip-encoded`.
+An application that already produces raw Opus packets needs `voip-encoded` for
+the codec side and, on a native target, `voip-relay-native` for the transport --
+`voip-encoded` expands to `voip-runtime`, which carries no dialer, so on its own
+every call fails at setup with "no relay media transport". The alternative to
+that feature is installing a `RelayTransportProvider`, which is what a target
+with no UDP socket does instead.
 
 ## Calls off the native stack
 

--- a/examples/voip-cli/Cargo.toml
+++ b/examples/voip-cli/Cargo.toml
@@ -34,6 +34,12 @@ whatsapp-rust = { path = "../..", features = [
     "tokio-transport",
     "ureq-client",
     "tokio-native",
+    # The way onto the media wire. It used to arrive with the codec profiles above, and no longer
+    # does: `voip-runtime` is the portable half and the UDP relay dialler is its own feature, so a
+    # native shell that does not install a provider of its own has to ask for it. Here rather than
+    # in each codec feature, because it is not a property of the codec -- and a CLI that skipped it
+    # would build fine and then fail every call at "no relay media transport".
+    "voip-relay-native",
 ] }
 
 [lints]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -902,11 +902,13 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Runtime-agnostic: the hook wraps whatever runtime the client uses, so
     /// every task spawned through the `Runtime` trait is covered, and
     /// [`Bot::run`] meters the main run loop itself — the read loop reports
-    /// on either launch path. The VoIP **call driver** is covered too: it runs
-    /// on the client's runtime, so do not attribute it separately or its work
-    /// is counted twice. What is not covered is the native relay transport's
-    /// own socket and timer tasks (`voip-relay-native`), which spawn on Tokio
-    /// directly. Pass a
+    /// on either launch path. The VoIP **call driver** is covered too, and so is
+    /// the native relay transport's own socket and timer work
+    /// (`voip-relay-native`): `RelayMediaChannelFactory` is constructed with the
+    /// client's `Arc<dyn Runtime>` and spawns its driver through it. So do not
+    /// attribute either separately, or the work is counted twice. A platform
+    /// that installs its own `RelayTransportProvider` decides that side for
+    /// itself. Pass a
     /// [`CpuMeter`](wacore::stats::CpuMeter) for per-session CPU accounting
     /// (keep a clone to read snapshots), or a custom hook to scope
     /// allocator-attribution or platform samplers to this client's work.

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -49,9 +49,14 @@ type DefaultHttpState = Provided;
 #[cfg(not(feature = "ureq-client"))]
 type DefaultHttpState = MissingHttpClient;
 
-#[cfg(feature = "tokio-runtime")]
+// The target as well as the feature, because `default_runtime` below answers on both: `TokioRuntime`
+// spawns through `tokio::spawn`, which wasm32 does not have, so a builder that read `Provided` from
+// the feature alone would offer `build()` on a page and then reach `build_graph`'s
+// `unreachable!("typestate guarantees...")` at run time. A page supplies its own runtime, and the
+// type system is where it should be told to.
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 type DefaultRuntimeState = Provided;
-#[cfg(not(feature = "tokio-runtime"))]
+#[cfg(not(all(feature = "tokio-runtime", not(target_arch = "wasm32"))))]
 type DefaultRuntimeState = MissingRuntime;
 
 #[cfg(feature = "tokio-transport")]
@@ -897,8 +902,11 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Runtime-agnostic: the hook wraps whatever runtime the client uses, so
     /// every task spawned through the `Runtime` trait is covered, and
     /// [`Bot::run`] meters the main run loop itself — the read loop reports
-    /// on either launch path (`voip` media tasks spawn directly on Tokio and
-    /// are not covered). Pass a
+    /// on either launch path. The VoIP **call driver** is covered too: it runs
+    /// on the client's runtime, so do not attribute it separately or its work
+    /// is counted twice. What is not covered is the native relay transport's
+    /// own socket and timer tasks (`voip-relay-native`), which spawn on Tokio
+    /// directly. Pass a
     /// [`CpuMeter`](wacore::stats::CpuMeter) for per-session CPU accounting
     /// (keep a clone to read snapshots), or a custom hook to scope
     /// allocator-attribution or platform samplers to this client's work.

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -74,11 +74,14 @@ fn default_http_client() -> Option<Arc<dyn crate::http::HttpClient>> {
     None
 }
 
-#[cfg(feature = "tokio-runtime")]
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 fn default_runtime() -> Option<Arc<dyn Runtime>> {
     Some(Arc::new(crate::runtime_impl::TokioRuntime))
 }
-#[cfg(not(feature = "tokio-runtime"))]
+/// No default anywhere `TokioRuntime` is absent -- which on wasm32 is the whole point: the page
+/// supplies its own single-threaded runtime, and a default that panicked on first spawn would be
+/// found out one call into a session rather than at assembly.
+#[cfg(not(all(feature = "tokio-runtime", not(target_arch = "wasm32"))))]
 fn default_runtime() -> Option<Arc<dyn Runtime>> {
     None
 }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -436,8 +436,9 @@ impl Client {
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn relay_transport_factory(
         &self,
-        relay: std::net::SocketAddr,
+        relay: &wacore::voip::RelayEndpointParams,
     ) -> Result<Arc<dyn wacore::voip::RelayTransportFactory>, CallError> {
+        let addr = relay.addr;
         let installed = self
             .voip_state()
             .relay_transport_provider
@@ -448,18 +449,18 @@ impl Client {
             return provider
                 .factory(relay)
                 .await
-                .map_err(|e| CallError::Setup(format!("relay transport for {relay}: {e}")));
+                .map_err(|e| CallError::Setup(format!("relay transport for {addr}: {e}")));
         }
         #[cfg(feature = "voip-relay-native")]
         {
             Ok(Arc::new(
-                crate::voip::transport::RelayMediaChannelFactory::new(relay, self.runtime.clone()),
+                crate::voip::transport::RelayMediaChannelFactory::new(addr, self.runtime.clone()),
             ))
         }
         #[cfg(not(feature = "voip-relay-native"))]
         {
             Err(CallError::Setup(format!(
-                "no relay media transport for {relay}: this build has no native relay dialler \
+                "no relay media transport for {addr}: this build has no native relay dialler \
                  (`voip-relay-native`), so it needs one installed with \
                  `Client::set_relay_transport_provider`"
             )))

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -403,6 +403,69 @@ impl Client {
         self.voip_state().call_registry.clone()
     }
 
+    /// Install the platform's way onto the media wire.
+    ///
+    /// A relay endpoint is a `SocketAddr` the server names per call, and what dials it is the
+    /// platform's business: on a `voip-relay-native` build the default is this crate's own
+    /// UDP/DTLS/SCTP/DataChannel dialer, and nothing else needs to say so. Everywhere else -- a
+    /// browser above all, where there is no UDP socket to open and an `RTCPeerConnection` reaches
+    /// the same relay over the same pre-negotiated DataChannel -- this is how the transport gets
+    /// in.
+    ///
+    /// Call it before placing or answering a call; a call already running keeps the transport it
+    /// dialled with. Installing one on a native build replaces the default rather than racing it,
+    /// which is also how a packet tap or an in-memory transport gets used against a real client.
+    #[cfg(feature = "voip-runtime")]
+    pub fn set_relay_transport_provider(
+        &self,
+        provider: Arc<dyn wacore::voip::RelayTransportProvider>,
+    ) {
+        *self
+            .voip_state()
+            .relay_transport_provider
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(provider);
+    }
+
+    /// The factory that dials `relay`, from the installed provider or this build's default.
+    ///
+    /// The error is `CallError::Setup` rather than a panic or a `compile_error!`, because "this
+    /// build has no way onto the media wire" is a fact about a deployment: a page that has not
+    /// installed a provider yet is in exactly the state a page with no `RTCPeerConnection` is in
+    /// permanently, and both deserve a sentence rather than a crash.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn relay_transport_factory(
+        &self,
+        relay: std::net::SocketAddr,
+    ) -> Result<Arc<dyn wacore::voip::RelayTransportFactory>, CallError> {
+        let installed = self
+            .voip_state()
+            .relay_transport_provider
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(provider) = installed {
+            return provider
+                .factory(relay)
+                .await
+                .map_err(|e| CallError::Setup(format!("relay transport for {relay}: {e}")));
+        }
+        #[cfg(feature = "voip-relay-native")]
+        {
+            Ok(Arc::new(
+                crate::voip::transport::RelayMediaChannelFactory::new(relay, self.runtime.clone()),
+            ))
+        }
+        #[cfg(not(feature = "voip-relay-native"))]
+        {
+            Err(CallError::Setup(format!(
+                "no relay media transport for {relay}: this build has no native relay dialler \
+                 (`voip-relay-native`), so it needs one installed with \
+                 `Client::set_relay_transport_provider`"
+            )))
+        }
+    }
+
     #[cfg(feature = "voip-runtime")]
     fn begin_call_link_join(&self) -> PendingCallLinkJoinGuard {
         let mut state = self

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -46,6 +46,14 @@ use super::{Client, ClientError};
 
 #[cfg(feature = "voip-runtime")]
 const CALL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long an installed [`RelayTransportProvider`](wacore::voip::RelayTransportProvider) has to
+/// hand back a factory before the call gives up on it.
+///
+/// Generous, because building one may involve a real device or a permission prompt, and short
+/// enough that a provider which never answers fails the call instead of parking its setup task
+/// forever.
+#[cfg(feature = "voip-runtime")]
+const RELAY_PROVIDER_TIMEOUT: Duration = Duration::from_secs(15);
 #[cfg(feature = "voip-runtime")]
 const WAITING_ROOM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(feature = "voip-runtime")]
@@ -446,10 +454,33 @@ impl Client {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
         if let Some(provider) = installed {
-            return provider
-                .factory(relay)
-                .await
-                .map_err(|e| CallError::Setup(format!("relay transport for {addr}: {e}")));
+            // Bounded, because this await is new and a stalled one is worse than it looks. The
+            // native dialer this replaced was a synchronous constructor, so nothing on the call
+            // setup path could park here; an installed provider is somebody else's code doing
+            // somebody else's I/O -- a browser building an `RTCPeerConnection` is a call into JS --
+            // and one that never resolves leaves the outgoing relay waiter holding a pending call
+            // it has already removed from the map, where a hangup can no longer find it to end it.
+            //
+            // A timeout rather than a race against the call's own `ended`: this is the one place
+            // every path goes through, so bounding it here covers the answer, the group join and
+            // the call-link join as well as the outgoing waiter that made it visible. It also
+            // mirrors what the native factory already does one layer down with
+            // `RELAY_CONNECT_TIMEOUT`, rather than inventing a second shape for the same problem.
+            return match wacore::runtime::timeout(
+                &*self.runtime,
+                RELAY_PROVIDER_TIMEOUT,
+                provider.factory(relay),
+            )
+            .await
+            {
+                Ok(built) => {
+                    built.map_err(|e| CallError::Setup(format!("relay transport for {addr}: {e}")))
+                }
+                Err(_) => Err(CallError::Setup(format!(
+                    "the installed relay transport provider did not answer for {addr} within \
+                     {RELAY_PROVIDER_TIMEOUT:?}"
+                ))),
+            };
         }
         #[cfg(feature = "voip-relay-native")]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,10 @@ pub(crate) mod signal_flush;
 pub use request::{IqError, RejectionStanza};
 #[cfg(feature = "tokio-runtime")]
 pub mod runtime_impl;
-#[cfg(feature = "tokio-runtime")]
+// The module is the feature's; the type inside it is the target's (`tokio::spawn` needs threads).
+// Re-exporting on the feature alone made `--features tokio-runtime` on wasm32 an unresolved import
+// rather than a runtime the target simply does not have.
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 pub use runtime_impl::TokioRuntime;
 pub use wacore::runtime::Runtime;
 pub mod send;
@@ -278,7 +281,7 @@ pub mod prelude {
         UntypedClientPlugin,
     };
     pub use crate::request::{IqError, RejectionStanza};
-    #[cfg(feature = "tokio-runtime")]
+    #[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
     pub use crate::runtime_impl::TokioRuntime;
     pub use crate::send::{EditOptions, SendError, SendOptions, SendResult};
     #[cfg(feature = "signal")]

--- a/src/voip/driver.rs
+++ b/src/voip/driver.rs
@@ -2,20 +2,46 @@
 //! runtime so the call orchestration itself stays in the sans-IO core. This is the whole "native
 //! driver" -- the engine does the work; this only supplies a runtime for the timer.
 
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use std::sync::Arc;
 
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use wacore::runtime::Runtime;
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use wacore::voip::engine::CallEngine;
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use wacore::voip::transport::{RelayTransport, RelayTransportEvent};
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use wacore::voip::{CallChannels, run_call};
 
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 use crate::runtime_impl::TokioRuntime;
 
-pub use crate::voip::transport::RandTxIds;
+/// OS-RNG-backed STUN transaction ids for production calls. The core's `SequentialTxIds` is
+/// deterministic (test-only); real calls need unpredictable ids for consent freshness.
+///
+/// Here rather than beside the native relay, where it was: it reads an RNG and nothing else, so
+/// binding it to the one transport that owns a UDP socket left a page with no way to name a
+/// transaction id at all.
+#[derive(Default)]
+pub struct RandTxIds;
+
+impl wacore::voip::engine::TxIdSource for RandTxIds {
+    fn next_tx_id(&mut self) -> [u8; 12] {
+        rand::random()
+    }
+}
 
 /// Drive one call to completion on the Tokio runtime. Returns when the relay disconnects, a send
 /// fails, or the event stream closes. Spawn it with the client/bot runtime and keep the
 /// [`AbortHandle`](wacore::runtime::AbortHandle) (e.g. in a `CallRegistry`) to tear the call down.
+///
+/// The facade no longer goes through this -- it drives `run_call` on the client's own runtime,
+/// which is the only shape a page can satisfy -- so this is the convenience for a consumer that
+/// has a Tokio runtime and would rather not name one. Absent where `TokioRuntime` is: it spawns
+/// through `tokio::spawn`, which on wasm32 compiles and then panics, and a function that is only
+/// there to trap is worse than one that is not there.
+#[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
 pub async fn run_call_tokio(
     transport: Arc<dyn RelayTransport>,
     relay_events: async_channel::Receiver<RelayTransportEvent>,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2208,6 +2208,39 @@ fn publish_setup_failure(events: &async_channel::Sender<CallEvent>, reason: Stri
     let _ = events.force_send(CallEvent::MediaSetupFailed(reason));
 }
 
+/// Why a setup path stopped, which is not the same question as what went wrong.
+///
+/// [`CallEvent::MediaSetupFailed`] means the media never came up *and nobody asked for that*, so
+/// it may not be published for a call that was hung up while its media was still being built:
+/// there the person who pressed the button would be told the setup they cancelled had failed, and
+/// a front end drawing the event has nothing to tell the two apart with. The distinction is only
+/// in what is published -- every stop here is still an `Err` to whoever is awaiting it, because a
+/// cancelled setup did not produce a call either.
+enum SetupStop {
+    /// Nothing came up: no relay in the ack, an engine that would not build, a provider that
+    /// refused or never answered. Published, because this is the whole reason the event exists.
+    Failed(CallError),
+    /// The call ended underneath the setup -- a local hangup, a peer `<terminate>`, a disconnect.
+    /// Not published: whoever ended it already knows, and the ordinary end is not a failure.
+    Cancelled(CallError),
+}
+
+impl SetupStop {
+    /// The error to propagate, having published the reason if there was one to publish.
+    ///
+    /// Takes the sender rather than being called beside `publish_setup_failure` so the choice is
+    /// made once, at the one exit both kinds leave through.
+    fn into_error(self, events: &async_channel::Sender<CallEvent>) -> CallError {
+        match self {
+            Self::Failed(e) => {
+                publish_setup_failure(events, e.to_string());
+                e
+            }
+            Self::Cancelled(e) => e,
+        }
+    }
+}
+
 fn fail_pending_outgoing(client: &Client, call_id: &str, generation: u64) {
     fail_pending_outgoing_with(client, call_id, generation, None);
 }
@@ -2377,15 +2410,15 @@ pub(crate) async fn attach_outgoing_relay(
             pending.call_key.clone(),
             relay,
         )
-        .map_err(|e| CallError::Setup(e.to_string()))?;
+        .map_err(|e| SetupStop::Failed(CallError::Setup(e.to_string())))?;
         config.audio = pending.audio.config();
         config.enable_video = pending.video.is_some();
         // Read the dial endpoint off the config before CallEngine::new consumes it (no second relay
         // walk).
-        let relay_endpoint = relay_endpoint_from_config(&config)?;
+        let relay_endpoint = relay_endpoint_from_config(&config).map_err(SetupStop::Failed)?;
         let engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
-            .map_err(|e| CallError::Setup(e.to_string()))?;
+            .map_err(|e| SetupStop::Failed(CallError::Setup(e.to_string())))?;
         // Raced against the call's own ending, not merely bounded by
         // `RELAY_PROVIDER_TIMEOUT`. The timeout is the floor -- it stops a provider that never
         // answers from parking any setup path -- but this one path can be *cancelled* rather than
@@ -2401,19 +2434,22 @@ pub(crate) async fn attach_outgoing_relay(
         )
         .await
         {
-            futures::future::Either::Left((built, _)) => built?,
+            futures::future::Either::Left((built, _)) => built.map_err(SetupStop::Failed)?,
+            // Cancelled, not failed: the call ended underneath us. Still an `Err`, because no
+            // engine attached -- but `MediaSetupFailed` here would tell whoever hung up that the
+            // setup they had just stopped was broken.
             futures::future::Either::Right(((), _)) => {
-                return Err(CallError::Connect(
+                return Err(SetupStop::Cancelled(CallError::Connect(
                     "the call ended while the relay transport was being built".into(),
-                ));
+                )));
             }
         };
-        Ok::<_, CallError>((engine, factory))
+        Ok::<_, SetupStop>((engine, factory))
     }
     .await;
     let (engine, factory) = match build {
         Ok(pair) => pair,
-        Err(e) => {
+        Err(stop) => {
             client
                 .call_registry()
                 .remove_if_current(call_id, pending.generation);
@@ -2425,10 +2461,13 @@ pub(crate) async fn attach_outgoing_relay(
             // path a browser with no WebRTC takes on every outgoing call, which is precisely the
             // one the event exists for.
             //
+            // Whether there is anything to say is `SetupStop`'s to answer: a call hung up while
+            // its transport was being built stops here too, and is not a setup failure.
+            //
             // Before `ended`, for the reason it is ordered that way there: a caller racing
             // `wait_ended()` against the stream would otherwise see the call end and then the
             // explanation.
-            publish_setup_failure(&pending.ev_tx, e.to_string());
+            let e = stop.into_error(&pending.ev_tx);
             pending.ended.notify();
             return Err(e);
         }
@@ -2968,10 +3007,19 @@ async fn attach_engine(
                 .call_registry()
                 .remove_if_current(call_id, generation);
         }
-        ended.notify();
-        return Err(CallError::Setup(
+        // Every exit below that *fails* says why through `ev_tx`, and the one that is merely
+        // cancelled does not. It has to be said here: for an outgoing call
+        // `attach_outgoing_relay` removed the `PendingOutgoing` before calling this, so the
+        // relay waiter's `fail_pending_outgoing_with` finds nothing and drops the reason with
+        // the sender it needed -- this function is the last owner of it. A caller that awaits
+        // the `Err` directly gets the reason twice and pays one queued event for it; a dormant
+        // outgoing handle gets it once instead of never.
+        let e = CallError::Setup(
             "group relay WARP tag length changed during media attachment".to_string(),
-        ));
+        );
+        publish_setup_failure(&ev_tx, e.to_string());
+        ended.notify();
+        return Err(e);
     }
     let group_ctl = Some(group_rx);
     // The registry entry already exists. Re-check is_connected NOW (after insert, before connect) so a
@@ -2985,8 +3033,10 @@ async fn attach_engine(
                 .call_registry()
                 .remove_if_current(call_id, generation);
         }
+        let e = CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into());
+        publish_setup_failure(&ev_tx, e.to_string());
         ended.notify();
-        return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
+        return Err(e);
     }
 
     // Connect failure leaves the call already visible (registry entry inserted before connect; for an
@@ -3029,25 +3079,35 @@ async fn attach_engine(
                         .call_registry()
                         .remove_if_current(call_id, generation);
                 }
-                ended.notify();
-                return Err(CallError::Connect(format!(
+                let e = CallError::Connect(format!(
                     "the relay transport did not connect within {RELAY_DIAL_CEILING:?}"
-                )));
+                ));
+                publish_setup_failure(&ev_tx, e.to_string());
+                ended.notify();
+                return Err(e);
             }
         }
     };
     let (transport, relay_events) = match dialed {
         Some(Ok(pair)) => pair,
-        Some(Err(e)) => {
+        Some(Err(dial_err)) => {
             if failure_cleanup == FailureCleanup::Here {
                 client
                     .call_registry()
                     .remove_if_current(call_id, generation);
             }
+            let e = CallError::Connect(dial_err.to_string());
+            publish_setup_failure(&ev_tx, e.to_string());
             ended.notify();
-            return Err(CallError::Connect(e.to_string()));
+            return Err(e);
         }
         // The generation was already reaped by whoever ended us; reap defensively and stop.
+        //
+        // No `MediaSetupFailed` on this one arm, and it is the reason the two are told apart at
+        // all: reaching here means `ended` won the race above, so the call was hung up,
+        // terminated by the peer, or disconnected while the dial was in flight. That is an
+        // ordinary ending, and publishing a terminal setup failure for it would tell whoever
+        // ended the call that its media had broken.
         None => {
             client
                 .call_registry()
@@ -6299,7 +6359,7 @@ mod tests {
         );
     }
 
-    /// A hangup during relay setup cancels the provider rather than waiting it out.    /// A hangup during relay setup cancels the provider rather than waiting it out.
+    /// A hangup during relay setup cancels the provider rather than waiting it out.
     ///
     /// The timeout beside this is the floor and not the answer: `attach_outgoing_relay` takes the
     /// pending entry out of the map on its way in, so a hangup arriving while the provider is
@@ -6348,7 +6408,129 @@ mod tests {
         );
     }
 
-    /// A provider that never answers fails the call rather than parking its setup forever.    /// A provider that never answers fails the call rather than parking its setup forever.
+    /// A hangup while the transport is being built is not a media setup failure.
+    ///
+    /// The two stop the same way -- no engine attaches and the caller gets a `Connect` error --
+    /// and they are not the same event. `MediaSetupFailed` is terminal and means the media never
+    /// came up *and nobody asked for that*, so publishing it for a call somebody just hung up
+    /// tells the person who pressed the button that the setup they cancelled had broken, with
+    /// nothing on the stream to tell them apart. `SetupStop` is that distinction; this is the arm
+    /// that must stay silent.
+    #[tokio::test]
+    async fn a_hangup_during_relay_setup_is_not_a_setup_failure() {
+        /// Never answers, so the hangup is what ends the setup.
+        struct NeverAnswers;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for NeverAnswers {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                std::future::pending().await
+            }
+        }
+
+        let (client, _count) = make_sending_client().await;
+        let (handle, call_id) = place_dormant_outgoing(&client).await;
+        client.set_relay_transport_provider(Arc::new(NeverAnswers));
+
+        let attaching = {
+            let client = client.clone();
+            let call_id = call_id.clone();
+            tokio::spawn(
+                async move { attach_outgoing_relay(&client, &call_id, &sample_relay()).await },
+            )
+        };
+        tokio::task::yield_now().await;
+        handle.hangup_local().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(2), attaching)
+            .await
+            .expect("the hangup must end the attach")
+            .expect("task");
+        assert!(
+            matches!(result, Err(CallError::Connect(_))),
+            "a call that ended during setup is still a Connect error, got {result:?}"
+        );
+
+        // Whatever the stream carries, none of it may claim the media setup failed.
+        while let Ok(event) = handle.events().try_recv() {
+            assert!(
+                !matches!(event, CallEvent::MediaSetupFailed(_)),
+                "a hangup published a setup failure: {event:?}"
+            );
+        }
+    }
+
+    /// A dial that fails reaches a dormant outgoing handle, rather than only its caller.
+    ///
+    /// `attach_outgoing_relay` removes the `PendingOutgoing` on its way in, so by the time
+    /// `attach_engine` gives up on the dial there is no pending entry left for the relay waiter's
+    /// `fail_pending_outgoing_with` to publish through -- it finds nothing and drops the reason
+    /// with the sender it needed. `attach_engine` is the last owner of `ev_tx`, so the reason is
+    /// said there or nowhere, and every exit of it that *fails* says one.
+    ///
+    /// Through a `connect()` that refuses rather than one that stalls, deliberately. The stalling
+    /// version tests `RELAY_DIAL_CEILING` and cannot be written here: under a paused clock this
+    /// path carries a shorter timer of its own, which fires first, ends the call, and sends the
+    /// dial into its *cancelled* arm -- so the test would pass or fail on a mechanism it is not
+    /// about. The ceiling has its own test through `spawn_call`
+    /// (`a_factory_that_never_connects_fails_the_call`); what is under test here is the
+    /// publication, and a refusing dial reaches the same exit with no clock involved.
+    #[tokio::test]
+    async fn a_failed_dial_reaches_a_dormant_handle() {
+        struct RefusesToConnect;
+        #[async_trait]
+        impl RelayTransportFactory for RefusesToConnect {
+            async fn connect(
+                &self,
+            ) -> anyhow::Result<(
+                Arc<dyn RelayTransport>,
+                async_channel::Receiver<RelayTransportEvent>,
+            )> {
+                anyhow::bail!("ICE gathering produced no candidates")
+            }
+        }
+        /// Hands back a factory promptly; it is the dial behind it that refuses.
+        struct Hands;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for Hands {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                Ok(Arc::new(RefusesToConnect))
+            }
+        }
+
+        let (client, _count) = make_sending_client().await;
+        let (handle, call_id) = place_dormant_outgoing(&client).await;
+        client.set_relay_transport_provider(Arc::new(Hands));
+
+        let res = attach_outgoing_relay(&client, &call_id, &sample_relay()).await;
+        assert!(
+            matches!(res, Err(CallError::Connect(_))),
+            "a dial that refuses must fail the attach, got {res:?}"
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(2), handle.events().recv())
+            .await
+            .expect("the dial's reason must reach the handle, not only its caller")
+            .expect("the event stream must carry it before it closes");
+        match event {
+            CallEvent::MediaSetupFailed(reason) => assert!(
+                reason.contains("ICE gathering produced no candidates"),
+                "the dial's own reason has to survive to the caller, got: {reason}"
+            ),
+            other => panic!("expected MediaSetupFailed, got {other:?}"),
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
+            .await
+            .expect("and the call must still end rather than hang");
+    }
+
+    /// A provider that never answers fails the call rather than parking its setup forever.
     ///
     /// The await this bounds is new: the native dialer it replaced was a synchronous constructor,
     /// so nothing on the setup path could stall here. An installed provider is somebody else's I/O,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2097,23 +2097,33 @@ fn spawn_outgoing_relay_waiter(
     runtime
         .clone()
         .spawn(Box::pin(async move {
+            // Three outcomes and not two. They used to collapse into one `None`, which was fine
+            // while the only consumer was a log line saying "(timeout or absent)" -- and is not,
+            // now that the reason reaches the caller: an ack that arrived carrying no relay and an
+            // ack that never arrived are different faults, and telling somebody the server's reply
+            // lacked something when there was no reply sends them looking in the wrong place.
             let relay =
                 match wacore::runtime::timeout(&*runtime, OFFER_ACK_RELAY_TIMEOUT, ack_rx).await {
                     // The ack node re-encoded as OwnedNodeRef; find its <relay> child and parse it (same
                     // path the incoming offer uses). handle_ack_response already removed our waiter entry.
                     Ok(Ok(ack)) => wacore::stanza::call::find_relay(ack.get())
-                        .and_then(wacore::voip::relay_parse::parse_relay_data),
+                        .and_then(wacore::voip::relay_parse::parse_relay_data)
+                        .ok_or("the server acked the offer but carried no relay"),
                     // Sender dropped (disconnect cleared the waiter map) or the timeout elapsed:
                     // handle_ack_response never ran, so our still-registered waiter entry must be dropped
                     // here or send_keepalive suppresses pings for the life of the connection.
-                    Ok(Err(_)) | Err(_) => {
+                    Ok(Err(_)) => {
                         client.response_waiters_guard().remove(&offer_stanza_id);
-                        None
+                        Err("the connection dropped before the server acked the offer")
+                    }
+                    Err(_) => {
+                        client.response_waiters_guard().remove(&offer_stanza_id);
+                        Err("the server did not ack the offer in time")
                     }
                 };
 
             match relay {
-                Some(relay) => {
+                Ok(relay) => {
                     if let Err(e) = attach_outgoing_relay(&client, &call_id, &relay).await {
                         warn!("voip: failed to attach outgoing relay for {call_id}: {e}");
                         fail_pending_outgoing_with(
@@ -2124,15 +2134,13 @@ fn spawn_outgoing_relay_waiter(
                         );
                     }
                 }
-                None => {
-                    warn!(
-                        "voip: no relay in offer ack for {call_id} (timeout or absent); call failed"
-                    );
+                Err(reason) => {
+                    warn!("voip: {reason} for {call_id}; call failed");
                     fail_pending_outgoing_with(
                         &client,
                         &call_id,
                         generation,
-                        Some("the server's offer ack carried no relay".to_string()),
+                        Some(reason.to_string()),
                     );
                 }
             }
@@ -2178,6 +2186,20 @@ fn take_pending_if_current(
     }
 }
 
+/// Put the reason a call never started onto its handle's stream.
+///
+/// `force_send` rather than `try_send`, which is what every other publish onto this queue uses and
+/// is wrong for this one: a full queue would drop the one event that explains the teardown, and it
+/// is the *last* event either way -- so if something has to go, the oldest diagnostic is a better
+/// loss than the reason the call failed. Never blocks; a teardown cannot wait on a consumer.
+///
+/// The queue is empty in every case reachable today, since a dormant outgoing call has no driver
+/// publishing to it -- which is exactly why this is `force_send` rather than that assumption
+/// written down as a comment.
+fn publish_setup_failure(events: &async_channel::Sender<CallEvent>, reason: String) {
+    let _ = events.force_send(CallEvent::MediaSetupFailed(reason));
+}
+
 fn fail_pending_outgoing(client: &Client, call_id: &str, generation: u64) {
     fail_pending_outgoing_with(client, call_id, generation, None);
 }
@@ -2215,9 +2237,7 @@ fn fail_pending_outgoing_with(
         .remove_if_current(call_id, generation);
     if let Some(pending) = pending {
         if let Some(reason) = reason {
-            // `try_send`, like every other publish onto this queue: the channel is bounded and a
-            // consumer that is not reading must not hold a teardown open.
-            let _ = pending.ev_tx.try_send(CallEvent::MediaSetupFailed(reason));
+            publish_setup_failure(&pending.ev_tx, reason);
         }
         pending.ended.notify();
     }
@@ -2381,9 +2401,7 @@ pub(crate) async fn attach_outgoing_relay(
             // Before `ended`, for the reason it is ordered that way there: a caller racing
             // `wait_ended()` against the stream would otherwise see the call end and then the
             // explanation.
-            let _ = pending
-                .ev_tx
-                .try_send(CallEvent::MediaSetupFailed(e.to_string()));
+            publish_setup_failure(&pending.ev_tx, e.to_string());
             pending.ended.notify();
             return Err(e);
         }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2278,17 +2278,23 @@ fn socket_addr_from_config(config: &CallConfig) -> Result<SocketAddr, CallError>
 /// Everything the platform's transport needs to reach this call's relay.
 ///
 /// The two ICE fields are read off the config rather than looked up again, because the config is
-/// what the relay walk already resolved: `relay_token` is the token this call allocates with, and
-/// `integrity_key` is the relay `<key>` in the ASCII base64 form it arrived in, which is both the
-/// STUN MESSAGE-INTEGRITY key and the `a=ice-pwd` a synthetic SDP answer carries. A native dialer
-/// ignores both; a browser cannot build an `RTCPeerConnection` without them, and looking them up
-/// from the transport would mean handing every transport the call's whole `RelayData`.
+/// what the relay walk already resolved: `auth_token` is the selected endpoint's `<auth_token>`,
+/// and `integrity_key` is the relay `<key>` in the ASCII base64 form it arrived in, which is both
+/// the STUN MESSAGE-INTEGRITY key and the `a=ice-pwd` a synthetic SDP answer carries. A native
+/// dialer ignores both; a browser cannot build an `RTCPeerConnection` without them, and looking
+/// them up from the transport would mean handing every transport the call's whole `RelayData`.
+///
+/// `auth_token` and **not** `relay_token`, which is the neighbouring field and the wrong one: they
+/// are two indexed sets, selected by `auth_token_id` and `token_id` respectively, and where those
+/// differ a ufrag built from the allocate token is one the relay refuses the browser's very first
+/// connectivity check over. `token_to_ice_ufrag`'s own doc has always named its input the auth
+/// token.
 fn relay_endpoint_from_config(
     config: &CallConfig,
 ) -> Result<wacore::voip::RelayEndpointParams, CallError> {
     Ok(wacore::voip::RelayEndpointParams {
         addr: socket_addr_from_config(config)?,
-        ice_ufrag: wacore::voip::relay_parse::token_to_ice_ufrag(&config.relay_token),
+        ice_ufrag: wacore::voip::relay_parse::token_to_ice_ufrag(&config.auth_token),
         // Lossy rather than fallible: the relay key is base64 text in every offer that has one, and
         // a call is not worth failing over a byte that is not. A relay that then refuses the
         // credential says so in the ICE check, which is a far more legible failure than "the
@@ -2364,6 +2370,20 @@ pub(crate) async fn attach_outgoing_relay(
             client
                 .call_registry()
                 .remove_if_current(call_id, pending.generation);
+            // Said here rather than left to the waiter's `fail_pending_outgoing_with`, which is
+            // where it looks like it belongs and is where it cannot happen: this function took the
+            // pending entry out of the map on its way in, so by the time the waiter tries to
+            // publish, `take_pending_if_current` finds nothing and the reason is dropped with the
+            // sender it needed. This is the last place that still holds `ev_tx` -- and it is the
+            // path a browser with no WebRTC takes on every outgoing call, which is precisely the
+            // one the event exists for.
+            //
+            // Before `ended`, for the reason it is ordered that way there: a caller racing
+            // `wait_ended()` against the stream would otherwise see the call end and then the
+            // explanation.
+            let _ = pending
+                .ev_tx
+                .try_send(CallEvent::MediaSetupFailed(e.to_string()));
             pending.ended.notify();
             return Err(e);
         }
@@ -6106,7 +6126,10 @@ mod tests {
         .expect("config");
         config.relay_ip = "198.51.100.9".to_string();
         config.relay_port = 3480;
-        config.relay_token = vec![0xaa, 0xbb, 0xcc];
+        // Deliberately different, because the two are separate indexed sets and building the
+        // ufrag from the allocate token is a call the relay refuses at the first ICE check.
+        config.relay_token = vec![0x11, 0x22, 0x33];
+        config.auth_token = vec![0xaa, 0xbb, 0xcc];
         config.integrity_key = b"EBESExQVFhcYGRobHB0eHw==".to_vec();
 
         let endpoint = relay_endpoint_from_config(&config).expect("endpoint");
@@ -6114,7 +6137,12 @@ mod tests {
         assert_eq!(
             endpoint.ice_ufrag,
             wacore::voip::relay_parse::token_to_ice_ufrag(&[0xaa, 0xbb, 0xcc]),
-            "ice-ufrag is the relay token, base64"
+            "ice-ufrag is the endpoint's auth token, base64 -- not the allocate token beside it"
+        );
+        assert_ne!(
+            endpoint.ice_ufrag,
+            wacore::voip::relay_parse::token_to_ice_ufrag(&[0x11, 0x22, 0x33]),
+            "and never the relay token"
         );
         assert_eq!(
             endpoint.ice_pwd, "EBESExQVFhcYGRobHB0eHw==",
@@ -9646,6 +9674,57 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("a setup error must resolve the handle's wait_ended, not hang it");
+    }
+
+    /// A refusing transport provider reaches the handle, not only the log.
+    ///
+    /// The regression this pins is subtle and was live: publishing the reason from
+    /// `fail_pending_outgoing_with` looks right and cannot work, because `attach_outgoing_relay`
+    /// takes the pending entry out of the map on its way in -- so by the time the relay waiter
+    /// tries, the `ev_tx` it needs has already been dropped with the entry. The event has to be
+    /// sent from inside `attach_outgoing_relay`, which is the last place that still holds it.
+    ///
+    /// It matters most on the path this whole feature exists for: a browser with no
+    /// `RTCPeerConnection` refuses here on *every* outgoing call, and without the event a caller
+    /// cannot tell that from the peer hanging up.
+    #[tokio::test]
+    async fn a_refused_transport_provider_reaches_the_handle() {
+        struct Refuses;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for Refuses {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                anyhow::bail!("this browser has no WebRTC")
+            }
+        }
+
+        let (client, _count) = make_sending_client().await;
+        let (handle, call_id) = place_dormant_outgoing(&client).await;
+        client.set_relay_transport_provider(Arc::new(Refuses));
+
+        let res = attach_outgoing_relay(&client, &call_id, &sample_relay()).await;
+        assert!(
+            matches!(res, Err(CallError::Setup(_))),
+            "a refusing provider must surface as a Setup error, got {res:?}"
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(2), handle.events().recv())
+            .await
+            .expect("the reason must reach the handle rather than only the log")
+            .expect("the event stream must carry it before it closes");
+        match event {
+            CallEvent::MediaSetupFailed(reason) => assert!(
+                reason.contains("this browser has no WebRTC"),
+                "the provider's own reason has to survive to the caller, got: {reason}"
+            ),
+            other => panic!("expected MediaSetupFailed, got {other:?}"),
+        }
+
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
+            .await
+            .expect("and the call must still end rather than hang");
     }
 
     // Finding M: if hangup() races the relay ack -- removing the registry entry while

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2078,6 +2078,14 @@ const GROUP_CONTROL_CHANNEL_CAPACITY: usize = 64;
 /// Returned by `CallError::Connect` when the socket drops mid-setup, before the engine is attached.
 const ERR_DISCONNECTED_DURING_SETUP: &str = "connection dropped during call setup";
 
+/// How long *any* relay factory has to hand back a connected transport.
+///
+/// Above the native dialer's own `RELAY_CONNECT_TIMEOUT`, deliberately: that one is more specific
+/// and names the endpoints it tried, so it should be the error a native call gets. This is the
+/// backstop for a factory an installed provider returned, which carries whatever bound its author
+/// gave it and, in a browser whose ICE never settles, may carry none.
+const RELAY_DIAL_CEILING: Duration = Duration::from_secs(20);
+
 /// Spawn the task that turns the offer's `<ack>` into a connected media engine: await the ack-waiter
 /// (bounded), and on a node carrying a `<relay>` attach the engine via [`attach_outgoing_relay`]
 /// (reusing its for_outgoing + generation handling). On timeout / no relay / closed channel the call
@@ -2989,30 +2997,64 @@ async fn attach_engine(
     // Race the dial against the call ending. A hangup, a peer <terminate>, or a disconnect landing in
     // this window all remove our registry entry, and its `on_terminal` hook notifies `ended` even
     // though no media task exists yet -- so selecting on `ended` drops the in-flight connect future to
-    // abort the unwanted DTLS/SCTP dial instead of letting it run to success or the 12s timeout while
-    // wait_ended() stays parked.
-    let dial = factory.connect();
-    let (transport, relay_events) =
-        match futures::future::select(dial, std::pin::pin!(ended.wait())).await {
-            futures::future::Either::Left((Ok(pair), _)) => pair,
-            futures::future::Either::Left((Err(e), _)) => {
+    // abort the unwanted DTLS/SCTP dial instead of letting it run to success while wait_ended() stays
+    // parked.
+    //
+    // And bounded, which the race alone is not. The native factory carries its own
+    // `RELAY_CONNECT_TIMEOUT` and so needed nothing here; a factory an installed provider returned
+    // carries whatever its author gave it, and a browser whose ICE never settles gives it nothing.
+    // Ending is not a floor either -- an incoming `accept()` or a group `start()` is *awaited* by
+    // its caller, so with no peer terminate there is nothing to notify `ended` and the call would
+    // hang rather than fail. This ceiling sits above the native one, so a native dial still fails
+    // with its own more specific message and only a stalled provider reaches this.
+    // Scoped, because the pinned `ended.wait()` borrows a flag this function later moves into the
+    // driver task's guard: what leaves the block is the dial's own answer, or nothing.
+    let dialed = {
+        let dial = factory.connect();
+        let ending = ended.wait();
+        futures::pin_mut!(ending);
+        match wacore::runtime::timeout(
+            &*client.runtime,
+            RELAY_DIAL_CEILING,
+            futures::future::select(dial, ending),
+        )
+        .await
+        {
+            Ok(futures::future::Either::Left((result, _))) => Some(result),
+            // Ended mid-dial: the loser `dial` future drops here, aborting the connect.
+            Ok(futures::future::Either::Right(((), _dial))) => None,
+            Err(_) => {
                 if failure_cleanup == FailureCleanup::Here {
                     client
                         .call_registry()
                         .remove_if_current(call_id, generation);
                 }
                 ended.notify();
-                return Err(CallError::Connect(e.to_string()));
+                return Err(CallError::Connect(format!(
+                    "the relay transport did not connect within {RELAY_DIAL_CEILING:?}"
+                )));
             }
-            // Ended mid-dial: the loser `dial` future drops here, aborting the connect. The generation
-            // was already reaped by whoever ended us; reap defensively and stop.
-            futures::future::Either::Right(((), _dial)) => {
+        }
+    };
+    let (transport, relay_events) = match dialed {
+        Some(Ok(pair)) => pair,
+        Some(Err(e)) => {
+            if failure_cleanup == FailureCleanup::Here {
                 client
                     .call_registry()
                     .remove_if_current(call_id, generation);
-                return Err(CallError::Connect("call ended during relay connect".into()));
             }
-        };
+            ended.notify();
+            return Err(CallError::Connect(e.to_string()));
+        }
+        // The generation was already reaped by whoever ended us; reap defensively and stop.
+        None => {
+            client
+                .call_registry()
+                .remove_if_current(call_id, generation);
+            return Err(CallError::Connect("call ended during relay connect".into()));
+        }
+    };
 
     // Only the selected I/O pair stays open. Closed inactive channels make their driver select arms
     // retire immediately without per-frame branching or idle tasks.
@@ -6203,7 +6245,61 @@ mod tests {
         assert!(printed.contains("UFRAG"), "got: {printed}");
     }
 
-    /// A hangup during relay setup cancels the provider rather than waiting it out.
+    /// A factory whose `connect()` never resolves fails the call rather than hanging it.
+    ///
+    /// The native dialer carries its own `RELAY_CONNECT_TIMEOUT`, so nothing here needed a ceiling
+    /// before a provider could supply a factory. One that an installed provider returns carries
+    /// whatever bound its author gave it -- a browser whose ICE never settles gives it none -- and
+    /// racing `ended` is not a floor on this path: an `accept()` is *awaited* by its caller, so
+    /// with no peer terminate there is nothing to notify `ended` and the await would never return.
+    #[tokio::test(start_paused = true)]
+    async fn a_factory_that_never_connects_fails_the_call() {
+        struct NeverConnects;
+        #[async_trait]
+        impl RelayTransportFactory for NeverConnects {
+            async fn connect(
+                &self,
+            ) -> anyhow::Result<(
+                Arc<dyn RelayTransport>,
+                async_channel::Receiver<RelayTransportEvent>,
+            )> {
+                std::future::pending().await
+            }
+        }
+        // Through `spawn_call` rather than the outgoing relay waiter, deliberately: that path also
+        // carries `OFFER_ACK_RELAY_TIMEOUT`, which under a paused clock fires first and ends the
+        // call before this ceiling can. Real, and a different mechanism -- what is under test here
+        // is the one that has to hold when nothing else ends the call, which is exactly an
+        // `accept()` awaiting its own setup.
+        let client = make_client().await;
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+
+        let error = match spawn_call(
+            &client,
+            mk_session(),
+            engine(),
+            &NeverConnects,
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
+            None,
+        )
+        .await
+        {
+            Ok(_) => panic!("a factory that never connects must not succeed"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("did not connect within"),
+            "the ceiling has to say what it gave up on, got: {error}"
+        );
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "and the generation it registered must not be left behind"
+        );
+    }
+
+    /// A hangup during relay setup cancels the provider rather than waiting it out.    /// A hangup during relay setup cancels the provider rather than waiting it out.
     ///
     /// The timeout beside this is the floor and not the answer: `attach_outgoing_relay` takes the
     /// pending entry out of the map on its way in, so a hangup arriving while the provider is

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -356,7 +356,7 @@ impl<'a> AcceptCall<'a> {
             &preaccept_id,
             &accept_id,
         )?;
-        let (mut engine, built_call_id, addr) = send_preaccept_then_prepare(
+        let (mut engine, built_call_id, relay_endpoint) = send_preaccept_then_prepare(
             self.client,
             &registration,
             &mut teardown,
@@ -383,7 +383,7 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         registration.ensure_current()?;
-        let factory = self.client.relay_transport_factory(addr).await?;
+        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
         // Final acceptance waits until media setup succeeded and the registered generation is still
         // current; only then may the caller apply the participant keys and enter the call.
         send_answer_node(self.client, &registration, &mut teardown, accept).await?;
@@ -423,7 +423,7 @@ impl<'a> AcceptCall<'a> {
         enable_video: bool,
         audio: AudioConfig,
         group: Option<GroupCallUpdate>,
-    ) -> Result<(CallEngine, String, SocketAddr), CallError> {
+    ) -> Result<(CallEngine, String, wacore::voip::RelayEndpointParams), CallError> {
         let CallAction::Offer {
             call_id,
             call_creator,
@@ -453,7 +453,7 @@ impl<'a> AcceptCall<'a> {
             .map_err(|error| CallError::Setup(error.to_string()))?;
             config.audio = audio;
             config.enable_video = enable_video;
-            let addr = socket_addr_from_config(&config)?;
+            let relay_endpoint = relay_endpoint_from_config(&config)?;
             let mut engine = CallEngine::new(config, Box::new(RandTxIds))
                 .map(with_platform_audio_codec)
                 .map_err(|error| CallError::Setup(error.to_string()))?;
@@ -465,7 +465,7 @@ impl<'a> AcceptCall<'a> {
                     direct_peer: None,
                 })
                 .map_err(|error| CallError::Setup(error.to_string()))?;
-            return Ok((engine, call_id.clone(), addr));
+            return Ok((engine, call_id.clone(), relay_endpoint));
         }
 
         let media = self
@@ -508,11 +508,11 @@ impl<'a> AcceptCall<'a> {
         config.audio = audio;
         config.enable_video = enable_video;
         // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
-        let addr = socket_addr_from_config(&config)?;
+        let relay_endpoint = relay_endpoint_from_config(&config)?;
         let engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|e| CallError::Setup(e.to_string()))?;
-        Ok((engine, call_id.clone(), addr))
+        Ok((engine, call_id.clone(), relay_endpoint))
     }
 }
 
@@ -932,7 +932,7 @@ impl<'a> OutgoingGroupCall<'a> {
         .map_err(|error| CallError::Setup(error.to_string()))?;
         config.audio = audio.config();
         config.enable_video = video.is_some();
-        let addr = socket_addr_from_config(&config)?;
+        let relay_endpoint = relay_endpoint_from_config(&config)?;
         let mut engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|error| CallError::Setup(error.to_string()))?;
@@ -963,7 +963,7 @@ impl<'a> OutgoingGroupCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = self.client.relay_transport_factory(addr).await?;
+        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
         let handle =
             spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
@@ -1142,7 +1142,7 @@ impl<'a> CallLinkCall<'a> {
         .map_err(|error| CallError::Setup(error.to_string()))?;
         config.audio = audio.config();
         config.enable_video = video.is_some();
-        let addr = socket_addr_from_config(&config)?;
+        let relay_endpoint = relay_endpoint_from_config(&config)?;
         let mut engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|error| CallError::Setup(error.to_string()))?;
@@ -1158,7 +1158,7 @@ impl<'a> CallLinkCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = self.client.relay_transport_factory(addr).await?;
+        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
         let handle =
             spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
@@ -2234,6 +2234,28 @@ fn socket_addr_from_config(config: &CallConfig) -> Result<SocketAddr, CallError>
         .map_err(|_| CallError::Media("relay address is not a valid socket addr"))
 }
 
+/// Everything the platform's transport needs to reach this call's relay.
+///
+/// The two ICE fields are read off the config rather than looked up again, because the config is
+/// what the relay walk already resolved: `relay_token` is the token this call allocates with, and
+/// `integrity_key` is the relay `<key>` in the ASCII base64 form it arrived in, which is both the
+/// STUN MESSAGE-INTEGRITY key and the `a=ice-pwd` a synthetic SDP answer carries. A native dialer
+/// ignores both; a browser cannot build an `RTCPeerConnection` without them, and looking them up
+/// from the transport would mean handing every transport the call's whole `RelayData`.
+fn relay_endpoint_from_config(
+    config: &CallConfig,
+) -> Result<wacore::voip::RelayEndpointParams, CallError> {
+    Ok(wacore::voip::RelayEndpointParams {
+        addr: socket_addr_from_config(config)?,
+        ice_ufrag: wacore::voip::relay_parse::token_to_ice_ufrag(&config.relay_token),
+        // Lossy rather than fallible: the relay key is base64 text in every offer that has one, and
+        // a call is not worth failing over a byte that is not. A relay that then refuses the
+        // credential says so in the ICE check, which is a far more legible failure than "the
+        // integrity key was not UTF-8".
+        ice_pwd: String::from_utf8_lossy(&config.integrity_key).into_owned(),
+    })
+}
+
 /// Build the engine from a relay that arrived for a pending OUTGOING call and start the driver,
 /// reusing the dormant handle's shared state. Returns `Ok(false)` when no pending outgoing call
 /// matches `call_id` (so the caller can fall through to normal handling).
@@ -2283,12 +2305,16 @@ pub(crate) async fn attach_outgoing_relay(
         .map_err(|e| CallError::Setup(e.to_string()))?;
         config.audio = pending.audio.config();
         config.enable_video = pending.video.is_some();
-        // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
-        let addr = socket_addr_from_config(&config)?;
+        // Read the dial endpoint off the config before CallEngine::new consumes it (no second relay
+        // walk).
+        let relay_endpoint = relay_endpoint_from_config(&config)?;
         let engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|e| CallError::Setup(e.to_string()))?;
-        Ok::<_, CallError>((engine, client.relay_transport_factory(addr).await?))
+        Ok::<_, CallError>((
+            engine,
+            client.relay_transport_factory(&relay_endpoint).await?,
+        ))
     }
     .await;
     let (engine, factory) = match build {
@@ -5967,16 +5993,20 @@ mod tests {
 
     /// A provider that hands out a [`MockFactory`] and records the relay it was asked about.
     struct RecordingProvider {
-        asked: Arc<Mutex<Vec<SocketAddr>>>,
+        asked: Arc<Mutex<Vec<(SocketAddr, String, String)>>>,
     }
 
     #[async_trait]
     impl wacore::voip::RelayTransportProvider for RecordingProvider {
         async fn factory(
             &self,
-            relay: SocketAddr,
+            relay: &wacore::voip::RelayEndpointParams,
         ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
-            self.asked.lock().unwrap().push(relay);
+            self.asked.lock().unwrap().push((
+                relay.addr,
+                relay.ice_ufrag.clone(),
+                relay.ice_pwd.clone(),
+            ));
             let (_tx, rx) = async_channel::unbounded();
             Ok(Arc::new(MockFactory {
                 sent: Arc::new(Mutex::new(Vec::new())),
@@ -6001,17 +6031,70 @@ mod tests {
             asked: asked.clone(),
         }));
 
-        let relay: SocketAddr = "203.0.113.7:3478".parse().expect("addr");
+        let addr: SocketAddr = "203.0.113.7:3478".parse().expect("addr");
+        let endpoint = wacore::voip::RelayEndpointParams {
+            addr,
+            ice_ufrag: "UFRAG".to_string(),
+            ice_pwd: "PWD".to_string(),
+        };
         client
-            .relay_transport_factory(relay)
+            .relay_transport_factory(&endpoint)
             .await
             .expect("the installed provider answers");
 
         assert_eq!(
             asked.lock().unwrap().as_slice(),
-            &[relay],
-            "the provider is asked about the relay the call named, not a default"
+            &[(addr, "UFRAG".to_string(), "PWD".to_string())],
+            "the provider is asked about the relay the call named, with the ICE credentials a \
+             synthetic SDP answer needs -- an address alone cannot build an RTCPeerConnection"
         );
+    }
+
+    /// The ICE credentials a browser signs its connectivity checks with are the call's own, read
+    /// off the config the relay walk already resolved. Getting either wrong is a call that dials
+    /// the right host and is refused by it, which looks like a network fault and is not one.
+    #[test]
+    fn a_relay_endpoint_carries_the_call_ice_credentials() {
+        let mut config = CallConfig::for_outgoing(
+            "CID-ICE",
+            "111:0@lid",
+            "222:0@lid",
+            vec![7u8; 32],
+            &sample_relay(),
+        )
+        .expect("config");
+        config.relay_ip = "198.51.100.9".to_string();
+        config.relay_port = 3480;
+        config.relay_token = vec![0xaa, 0xbb, 0xcc];
+        config.integrity_key = b"EBESExQVFhcYGRobHB0eHw==".to_vec();
+
+        let endpoint = relay_endpoint_from_config(&config).expect("endpoint");
+        assert_eq!(endpoint.addr.to_string(), "198.51.100.9:3480");
+        assert_eq!(
+            endpoint.ice_ufrag,
+            wacore::voip::relay_parse::token_to_ice_ufrag(&[0xaa, 0xbb, 0xcc]),
+            "ice-ufrag is the relay token, base64"
+        );
+        assert_eq!(
+            endpoint.ice_pwd, "EBESExQVFhcYGRobHB0eHw==",
+            "ice-pwd is the relay <key> in the ASCII form it arrived in"
+        );
+    }
+
+    /// The redaction is the point of the manual Debug: a transport implementation reaching for a
+    /// `{:?}` must not put the relay key in a log.
+    #[test]
+    fn a_relay_endpoint_does_not_print_its_password() {
+        let printed = format!(
+            "{:?}",
+            wacore::voip::RelayEndpointParams {
+                addr: "203.0.113.7:3480".parse().expect("addr"),
+                ice_ufrag: "UFRAG".to_string(),
+                ice_pwd: "SECRET-RELAY-KEY".to_string(),
+            }
+        );
+        assert!(!printed.contains("SECRET-RELAY-KEY"), "got: {printed}");
+        assert!(printed.contains("UFRAG"), "got: {printed}");
     }
 
     /// A provider that refuses fails the call with its reason, rather than falling back to a dialer
@@ -6024,7 +6107,7 @@ mod tests {
         impl wacore::voip::RelayTransportProvider for Refuses {
             async fn factory(
                 &self,
-                _relay: SocketAddr,
+                _relay: &wacore::voip::RelayEndpointParams,
             ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
                 anyhow::bail!("this browser has no WebRTC")
             }
@@ -6032,11 +6115,13 @@ mod tests {
 
         let client = make_client().await;
         client.set_relay_transport_provider(Arc::new(Refuses));
+        let endpoint = wacore::voip::RelayEndpointParams {
+            addr: "203.0.113.7:3478".parse().expect("addr"),
+            ice_ufrag: String::new(),
+            ice_pwd: String::new(),
+        };
         // `expect_err` wants the Ok side to be Debug, and `dyn RelayTransportFactory` is not.
-        let error = match client
-            .relay_transport_factory("203.0.113.7:3478".parse().expect("addr"))
-            .await
-        {
+        let error = match client.relay_transport_factory(&endpoint).await {
             Ok(_) => panic!("a refusing provider must not fall through to the native dialer"),
             Err(error) => error,
         };

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -37,7 +37,7 @@ use wacore::voip::{
     AudioCodec, AudioConfig, AudioFormat, AudioRtpProfile, CallChannels, CallConfig, CallDirection,
     CallEngine, CallEvent, CallPhase, CodecDecisionSource, EncodedAudioFrame, GroupEngineConfig,
     VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame, VideoUpgradeToken,
-    video_control_channel,
+    run_call, video_control_channel,
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
@@ -47,8 +47,7 @@ use crate::client::{CallError, Client, ResponseWaiter};
 use crate::voip::audio::{
     AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource, WA_FRAME_SAMPLES,
 };
-use crate::voip::driver::{RandTxIds, run_call_tokio};
-use crate::voip::transport::RelayMediaChannelFactory;
+use crate::voip::driver::RandTxIds;
 use crate::voip::video::{VideoSink, VideoSource};
 
 enum AudioEndpoints {
@@ -384,7 +383,7 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         registration.ensure_current()?;
-        let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
+        let factory = self.client.relay_transport_factory(addr).await?;
         // Final acceptance waits until media setup succeeded and the registered generation is still
         // current; only then may the caller apply the participant keys and enter the call.
         send_answer_node(self.client, &registration, &mut teardown, accept).await?;
@@ -393,7 +392,7 @@ impl<'a> AcceptCall<'a> {
             &mut registration,
             teardown,
             engine,
-            &factory,
+            &*factory,
             audio,
             video,
         )
@@ -964,9 +963,9 @@ impl<'a> OutgoingGroupCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
+        let factory = self.client.relay_transport_factory(addr).await?;
         let handle =
-            spawn_registered_call(self.client, &registration, engine, &factory, audio, video)
+            spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
         registration.disarm();
         teardown.disarm();
@@ -1159,9 +1158,9 @@ impl<'a> CallLinkCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
+        let factory = self.client.relay_transport_factory(addr).await?;
         let handle =
-            spawn_registered_call(self.client, &registration, engine, &factory, audio, video)
+            spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
         registration.disarm();
         teardown.disarm();
@@ -2273,7 +2272,7 @@ pub(crate) async fn attach_outgoing_relay(
     // call would otherwise leak its registry generation and a parked wait_ended() would hang forever
     // (no pending entry left for a later hangup to drain). Build everything in a fallible block and, on
     // any early-return error in this window, reap the generation and notify `ended` before propagating.
-    let build = (|| {
+    let build = async {
         let mut config = CallConfig::for_outgoing(
             call_id,
             &pending.self_lid,
@@ -2289,11 +2288,9 @@ pub(crate) async fn attach_outgoing_relay(
         let engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|e| CallError::Setup(e.to_string()))?;
-        Ok::<_, CallError>((
-            engine,
-            RelayMediaChannelFactory::new(addr, client.runtime.clone()),
-        ))
-    })();
+        Ok::<_, CallError>((engine, client.relay_transport_factory(addr).await?))
+    }
+    .await;
     let (engine, factory) = match build {
         Ok(pair) => pair,
         Err(e) => {
@@ -2311,7 +2308,7 @@ pub(crate) async fn attach_outgoing_relay(
         pending.generation,
         FailureCleanup::Here,
         engine,
-        &factory,
+        &*factory,
         pending.audio,
         pending.video,
         pending.video_shared,
@@ -2976,13 +2973,18 @@ async fn attach_engine(
     let ended_guard = scopeguard::guard(ended, |e| {
         e.notify();
     });
+    // The driver's runtime is the client's own, not a hardcoded Tokio one. `run_call` has always
+    // been portable and taken the runtime as an argument; naming Tokio here was what put the one
+    // remaining executor assumption in the call path, and it is exactly the assumption a page
+    // cannot satisfy.
+    let driver_runtime = client.runtime.clone();
     let task = client.runtime.spawn(Box::pin(async move {
         // All are captured (moved in), so any teardown -- even an abort before the first poll --
         // drops them: the feeds are aborted and `ended` is notified.
         let _ended_guard = ended_guard;
         let _audio_feed = audio_feed;
         let _video_out_feed = video_out_feed;
-        run_call_tokio(transport, relay_events, channels, engine).await;
+        run_call(driver_runtime, transport, relay_events, channels, engine).await;
         // A locally-ended call gets no <terminate>; drop our own entry so the registry doesn't grow.
         // The call's `ring_devices` live on the session, so this also drops the sibling-dismiss
         // tracking -- no separate map to clean up.
@@ -5961,6 +5963,87 @@ mod tests {
                 rx,
             ))
         }
+    }
+
+    /// A provider that hands out a [`MockFactory`] and records the relay it was asked about.
+    struct RecordingProvider {
+        asked: Arc<Mutex<Vec<SocketAddr>>>,
+    }
+
+    #[async_trait]
+    impl wacore::voip::RelayTransportProvider for RecordingProvider {
+        async fn factory(
+            &self,
+            relay: SocketAddr,
+        ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+            self.asked.lock().unwrap().push(relay);
+            let (_tx, rx) = async_channel::unbounded();
+            Ok(Arc::new(MockFactory {
+                sent: Arc::new(Mutex::new(Vec::new())),
+                relay_rx: Mutex::new(Some(rx)),
+                connects: Arc::new(AtomicUsize::new(0)),
+            }))
+        }
+    }
+
+    /// An installed provider is what dials, and it is told which relay to dial.
+    ///
+    /// This is the seam a page reaches a call through: with no provider a native build falls back
+    /// to its own UDP dialer, and a build without one -- wasm32, where there is no UDP socket to
+    /// open -- has nothing to fall back to. Guarding it here rather than only in the wasm CI build
+    /// is what makes "the browser transport is used" a fact this test suite can hold, since the
+    /// browser half itself cannot run in this test suite at all.
+    #[tokio::test]
+    async fn an_installed_relay_transport_provider_is_what_dials() {
+        let client = make_client().await;
+        let asked = Arc::new(Mutex::new(Vec::new()));
+        client.set_relay_transport_provider(Arc::new(RecordingProvider {
+            asked: asked.clone(),
+        }));
+
+        let relay: SocketAddr = "203.0.113.7:3478".parse().expect("addr");
+        client
+            .relay_transport_factory(relay)
+            .await
+            .expect("the installed provider answers");
+
+        assert_eq!(
+            asked.lock().unwrap().as_slice(),
+            &[relay],
+            "the provider is asked about the relay the call named, not a default"
+        );
+    }
+
+    /// A provider that refuses fails the call with its reason, rather than falling back to a dialer
+    /// the platform may not have. A browser with no `RTCPeerConnection` is exactly this case, and
+    /// the reason is the only thing a person ever sees of it.
+    #[tokio::test]
+    async fn a_refusing_provider_fails_the_call_with_its_reason() {
+        struct Refuses;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for Refuses {
+            async fn factory(
+                &self,
+                _relay: SocketAddr,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                anyhow::bail!("this browser has no WebRTC")
+            }
+        }
+
+        let client = make_client().await;
+        client.set_relay_transport_provider(Arc::new(Refuses));
+        // `expect_err` wants the Ok side to be Debug, and `dyn RelayTransportFactory` is not.
+        let error = match client
+            .relay_transport_factory("203.0.113.7:3478".parse().expect("addr"))
+            .await
+        {
+            Ok(_) => panic!("a refusing provider must not fall through to the native dialer"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("this browser has no WebRTC"),
+            "the provider's own reason has to survive to the caller, got: {error}"
+        );
     }
 
     // spawn_call: connects via the injected factory, registers the call, emits the STUN allocate,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -383,7 +383,7 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         registration.ensure_current()?;
-        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
+        let factory = relay_factory_or_ended(self.client, &registration, &relay_endpoint).await?;
         // Final acceptance waits until media setup succeeded and the registered generation is still
         // current; only then may the caller apply the participant keys and enter the call.
         send_answer_node(self.client, &registration, &mut teardown, accept).await?;
@@ -963,7 +963,7 @@ impl<'a> OutgoingGroupCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
+        let factory = relay_factory_or_ended(self.client, &registration, &relay_endpoint).await?;
         let handle =
             spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
@@ -1158,7 +1158,7 @@ impl<'a> CallLinkCall<'a> {
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
-        let factory = self.client.relay_transport_factory(&relay_endpoint).await?;
+        let factory = relay_factory_or_ended(self.client, &registration, &relay_endpoint).await?;
         let handle =
             spawn_registered_call(self.client, &registration, engine, &*factory, audio, video)
                 .await?;
@@ -2238,6 +2238,40 @@ impl SetupStop {
             }
             Self::Cancelled(e) => e,
         }
+    }
+}
+
+/// The provider await, *cancelled* by the call ending rather than merely bounded by
+/// `RELAY_PROVIDER_TIMEOUT`.
+///
+/// The timeout is the floor and not the answer. A peer `<terminate>`, a decline from another
+/// device, or a connection cleanup removes the registration and fires `ended` while an installed
+/// provider is still building its factory — and these three callers are *awaited* by whoever
+/// called `accept()` or `start()`, so a wait that watched only the timeout would be their wait
+/// too: up to `RELAY_PROVIDER_TIMEOUT` holding the engine, the audio endpoints and the call key
+/// for a call that is already over.
+///
+/// `attach_outgoing_relay` already races this same flag on the dormant 1:1 path, and
+/// `attach_engine` races it around the dial. This is that rule for the paths a `RegisteredCall`
+/// owns, which were the three that still only had the ceiling.
+///
+/// Cancellation, not failure: the error says the call ended, and the caller drops its endpoints
+/// on the way out rather than publishing a media setup failure for an ordinary ending.
+async fn relay_factory_or_ended(
+    client: &Client,
+    registration: &RegisteredCall,
+    endpoint: &wacore::voip::RelayEndpointParams,
+) -> Result<Arc<dyn RelayTransportFactory>, CallError> {
+    match futures::future::select(
+        std::pin::pin!(client.relay_transport_factory(endpoint)),
+        std::pin::pin!(registration.ended.wait()),
+    )
+    .await
+    {
+        futures::future::Either::Left((built, _)) => built,
+        futures::future::Either::Right(((), _)) => Err(CallError::Connect(
+            "the call ended while the relay transport was being built".into(),
+        )),
     }
 }
 
@@ -6528,6 +6562,64 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("and the call must still end rather than hang");
+    }
+
+    /// A peer `<terminate>` cancels the provider await on a call that is already registered.
+    ///
+    /// `RELAY_PROVIDER_TIMEOUT` is the floor and not the answer here. `accept()` and the group
+    /// starts are *awaited* by their callers, so a wait that watched only the ceiling would be
+    /// the caller's wait too — up to fifteen seconds holding the engine, the audio endpoints and
+    /// the call key for a call the peer has already hung up. The dormant 1:1 path got this race
+    /// when the provider seam landed; the three paths a `RegisteredCall` owns did not, which is
+    /// the hole this closes.
+    ///
+    /// On a real clock deliberately: under `start_paused` the fifteen-second ceiling
+    /// auto-advances and fires, so the test would pass without the race and prove nothing. Two
+    /// seconds is far inside it, so only the cancellation can satisfy this.
+    #[tokio::test]
+    async fn a_peer_terminate_cancels_a_registered_call_s_provider_await() {
+        struct NeverAnswers;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for NeverAnswers {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                std::future::pending().await
+            }
+        }
+
+        let (client, _sent) = make_sending_client().await;
+        let incoming = incoming_offer(false);
+        let registration = register_answer(&client, &incoming).await;
+        client.set_relay_transport_provider(Arc::new(NeverAnswers));
+        let endpoint = wacore::voip::RelayEndpointParams {
+            addr: "203.0.113.9:3478".parse().expect("addr"),
+            ice_ufrag: String::new(),
+            ice_pwd: String::new(),
+        };
+
+        let awaiting = relay_factory_or_ended(&client, &registration, &endpoint);
+        let end_peer = async {
+            tokio::task::yield_now().await;
+            terminate_call(&client, incoming.action.call_id());
+        };
+
+        let (result, ()) = tokio::time::timeout(
+            Duration::from_secs(2),
+            futures::future::join(awaiting, end_peer),
+        )
+        .await
+        .expect("the peer's terminate must end the await, not leave it on the provider");
+
+        let error = match result {
+            Ok(_) => panic!("a provider that never answers must not resolve"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("the call ended"),
+            "the reason has to name the ending rather than the ceiling, got: {error}"
+        );
     }
 
     /// A provider that never answers fails the call rather than parking its setup forever.

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -6184,6 +6184,44 @@ mod tests {
         assert!(printed.contains("UFRAG"), "got: {printed}");
     }
 
+    /// A provider that never answers fails the call rather than parking its setup forever.
+    ///
+    /// The await this bounds is new: the native dialer it replaced was a synchronous constructor,
+    /// so nothing on the setup path could stall here. An installed provider is somebody else's I/O,
+    /// and on the outgoing path the pending entry has already been taken out of the map by the time
+    /// it is awaited -- so a hangup can no longer find the call to end it, and `wait_ended()` would
+    /// wait on the provider rather than on the call.
+    #[tokio::test(start_paused = true)]
+    async fn a_provider_that_never_answers_does_not_park_the_call() {
+        struct NeverAnswers;
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for NeverAnswers {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                std::future::pending().await
+            }
+        }
+
+        let client = make_client().await;
+        client.set_relay_transport_provider(Arc::new(NeverAnswers));
+        let endpoint = wacore::voip::RelayEndpointParams {
+            addr: "203.0.113.7:3478".parse().expect("addr"),
+            ice_ufrag: String::new(),
+            ice_pwd: String::new(),
+        };
+
+        let error = match client.relay_transport_factory(&endpoint).await {
+            Ok(_) => panic!("a provider that never answers must not resolve"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("did not answer"),
+            "the timeout has to say what it gave up on, got: {error}"
+        );
+    }
+
     /// A provider that refuses fails the call with its reason, rather than falling back to a dialer
     /// the platform may not have. A browser with no `RTCPeerConnection` is exactly this case, and
     /// the reason is the only thing a person ever sees of it.

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2116,14 +2116,24 @@ fn spawn_outgoing_relay_waiter(
                 Some(relay) => {
                     if let Err(e) = attach_outgoing_relay(&client, &call_id, &relay).await {
                         warn!("voip: failed to attach outgoing relay for {call_id}: {e}");
-                        fail_pending_outgoing(&client, &call_id, generation);
+                        fail_pending_outgoing_with(
+                            &client,
+                            &call_id,
+                            generation,
+                            Some(e.to_string()),
+                        );
                     }
                 }
                 None => {
                     warn!(
                         "voip: no relay in offer ack for {call_id} (timeout or absent); call failed"
                     );
-                    fail_pending_outgoing(&client, &call_id, generation);
+                    fail_pending_outgoing_with(
+                        &client,
+                        &call_id,
+                        generation,
+                        Some("the server's offer ack carried no relay".to_string()),
+                    );
                 }
             }
         }))
@@ -2169,6 +2179,32 @@ fn take_pending_if_current(
 }
 
 fn fail_pending_outgoing(client: &Client, call_id: &str, generation: u64) {
+    fail_pending_outgoing_with(client, call_id, generation, None);
+}
+
+/// The same teardown, with the reason the media path never came up.
+///
+/// `wait_ended()` resolving is all a caller used to get from this, which says a call is over and
+/// not that it never started -- so a setup failure was indistinguishable from an ordinary remote
+/// hangup, and the reason lived only in a log line. That was survivable while the failures here
+/// were a missing `<relay>` or an engine that would not build, both rare; it is not once a
+/// platform's transport provider is one of them, because a browser with no WebRTC fails *every*
+/// outgoing call this way and the person placing it deserves to be told which.
+///
+/// [`CallEvent::MediaSetupFailed`] and not `RelayAllocateFailed`, which carries a STUN error code:
+/// there is no relay answering here, and dressing "the browser has no WebRTC" as a STUN class
+/// would be a worse lie than saying nothing. Sent before `ended` is notified, because a caller
+/// racing the two would otherwise see the call end and then the explanation -- the same ordering
+/// rule the terminal events in the drive loop follow.
+///
+/// A terminal stanza (`<reject>`, `<terminate>`) passes `None`: that is a call the peer ended, not
+/// a relay that failed, and dressing it as one would be a worse lie than saying nothing.
+fn fail_pending_outgoing_with(
+    client: &Client,
+    call_id: &str,
+    generation: u64,
+    reason: Option<String>,
+) {
     let pending = take_pending_if_current(
         &client.voip_state().pending_outgoing_calls,
         call_id,
@@ -2178,6 +2214,11 @@ fn fail_pending_outgoing(client: &Client, call_id: &str, generation: u64) {
         .call_registry()
         .remove_if_current(call_id, generation);
     if let Some(pending) = pending {
+        if let Some(reason) = reason {
+            // `try_send`, like every other publish onto this queue: the channel is bounded and a
+            // consumer that is not reading must not hold a teardown open.
+            let _ = pending.ev_tx.try_send(CallEvent::MediaSetupFailed(reason));
+        }
         pending.ended.notify();
     }
 }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2378,10 +2378,29 @@ pub(crate) async fn attach_outgoing_relay(
         let engine = CallEngine::new(config, Box::new(RandTxIds))
             .map(with_platform_audio_codec)
             .map_err(|e| CallError::Setup(e.to_string()))?;
-        Ok::<_, CallError>((
-            engine,
-            client.relay_transport_factory(&relay_endpoint).await?,
-        ))
+        // Raced against the call's own ending, not merely bounded by
+        // `RELAY_PROVIDER_TIMEOUT`. The timeout is the floor -- it stops a provider that never
+        // answers from parking any setup path -- but this one path can be *cancelled* rather than
+        // waited out, and it is the path that most needs to be: this function took the pending
+        // entry out of the map on its way in, so a hangup arriving now finds no call to end and
+        // the task would sit on the provider for the rest of the timeout holding the audio, the
+        // video and the call key. `attach_engine` already races its own dial against this same
+        // flag, three functions along; the provider await was the one step in front of it that
+        // did not.
+        let factory = match futures::future::select(
+            std::pin::pin!(client.relay_transport_factory(&relay_endpoint)),
+            std::pin::pin!(pending.ended.wait()),
+        )
+        .await
+        {
+            futures::future::Either::Left((built, _)) => built?,
+            futures::future::Either::Right(((), _)) => {
+                return Err(CallError::Connect(
+                    "the call ended while the relay transport was being built".into(),
+                ));
+            }
+        };
+        Ok::<_, CallError>((engine, factory))
     }
     .await;
     let (engine, factory) = match build {
@@ -6184,7 +6203,56 @@ mod tests {
         assert!(printed.contains("UFRAG"), "got: {printed}");
     }
 
-    /// A provider that never answers fails the call rather than parking its setup forever.
+    /// A hangup during relay setup cancels the provider rather than waiting it out.
+    ///
+    /// The timeout beside this is the floor and not the answer: `attach_outgoing_relay` takes the
+    /// pending entry out of the map on its way in, so a hangup arriving while the provider is
+    /// still building finds no call to end -- and without the race the task would hold the audio,
+    /// the video and the call key for the rest of `RELAY_PROVIDER_TIMEOUT`.
+    #[tokio::test]
+    async fn a_hangup_during_relay_setup_stops_waiting_for_the_provider() {
+        /// Answers only when told to, so the test owns the ordering.
+        struct Gated {
+            release: async_channel::Receiver<()>,
+        }
+        #[async_trait]
+        impl wacore::voip::RelayTransportProvider for Gated {
+            async fn factory(
+                &self,
+                _relay: &wacore::voip::RelayEndpointParams,
+            ) -> anyhow::Result<Arc<dyn RelayTransportFactory>> {
+                let _ = self.release.recv().await;
+                anyhow::bail!("released")
+            }
+        }
+
+        let (client, _count) = make_sending_client().await;
+        let (handle, call_id) = place_dormant_outgoing(&client).await;
+        let (_release_tx, release) = async_channel::bounded::<()>(1);
+        client.set_relay_transport_provider(Arc::new(Gated { release }));
+
+        // The attach parks in the provider; the hangup is what has to end it.
+        let attaching = {
+            let client = client.clone();
+            let call_id = call_id.clone();
+            tokio::spawn(
+                async move { attach_outgoing_relay(&client, &call_id, &sample_relay()).await },
+            )
+        };
+        tokio::task::yield_now().await;
+        handle.hangup_local().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(2), attaching)
+            .await
+            .expect("the hangup must end the attach, not leave it on the provider")
+            .expect("task");
+        assert!(
+            matches!(result, Err(CallError::Connect(_))),
+            "a call that ended during setup is a Connect error, got {result:?}"
+        );
+    }
+
+    /// A provider that never answers fails the call rather than parking its setup forever.    /// A provider that never answers fails the call rather than parking its setup forever.
     ///
     /// The await this bounds is new: the native dialer it replaced was a synchronous constructor,
     /// so nothing on the setup path could stall here. An installed provider is somebody else's I/O,

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -5,17 +5,17 @@
 //!
 //! Everything here except [`transport`] is portable: it drives `wacore`'s sans-IO engine over an
 //! injected [`Runtime`](wacore::runtime::Runtime) and an injected
-//! [`RelayTransportFactory`](wacore::voip::transport::RelayTransportFactory), so it names no clock
+//! [`wacore::voip::transport::RelayTransportFactory`], so it names no clock
 //! and opens no descriptor. That half is `voip-runtime`, and it builds wherever `wacore` does.
 //!
 //! [`transport`] is the other half -- a UDP socket per call with DTLS, SCTP and the pre-negotiated
 //! DataChannel over it -- and it is `voip-relay-native`, because a UDP socket is exactly what
 //! wasm32 and espidf do not have. A page reaches the same relay through an `RTCPeerConnection`,
-//! which is a factory it supplies with [`Client::set_relay_transport_factory`]; it needs no part of
+//! which is a factory it supplies with [`Client::set_relay_transport_provider`]; it needs no part of
 //! this module's native half, and asking for one used to be a `compile_error!` across the whole
 //! feature rather than across the socket.
 //!
-//! [`Client::set_relay_transport_factory`]: crate::client::Client::set_relay_transport_factory
+//! [`Client::set_relay_transport_provider`]: crate::client::Client::set_relay_transport_provider
 
 // Fail fast with an actionable message instead of a confusing link error further down. Narrowed to
 // the transport: `voip-runtime` alone is portable, and the message now names the way forward
@@ -27,7 +27,7 @@
 compile_error!(
     "`voip-relay-native` drives the relay media stack over a Tokio UDP socket and does not build \
      on wasm32/espidf. Enable `voip-mlow` (or `voip-encoded`) without it and supply your own \
-     `RelayTransportFactory` through `Client::set_relay_transport_factory` -- in a browser an \
+     `RelayTransportProvider` through `Client::set_relay_transport_provider` -- in a browser an \
      `RTCPeerConnection` with a pre-negotiated DataChannel reaches the same relay."
 );
 
@@ -37,7 +37,9 @@ pub mod facade;
 pub mod registry;
 pub mod session;
 mod state;
-#[cfg(feature = "voip-relay-native")]
+// Not gated, though nearly all of it is: `RandTxIds` and the packet demux are reachable here and
+// need no socket, so the module stays and its native stack is what carries the feature. See its
+// own docs.
 pub mod transport;
 pub mod video;
 
@@ -58,9 +60,9 @@ pub use wacore::voip::{
 };
 pub use wacore::voip::{CallEvent, GroupCallState, GroupStateApply, VideoUpgradeToken};
 // The platform transport seam, beside the facade that consults it: a consumer installing one
-// through `Client::set_relay_transport_provider` reaches for all three, and having to name `wacore`
-// for them while naming `whatsapp_rust` for the call is a paper cut on the one path this crate now
-// asks a platform to implement.
+// through `Client::set_relay_transport_provider` reaches for the whole set below, and having to
+// name `wacore` for them while naming `whatsapp_rust` for the call is a paper cut on the one path
+// this crate now asks a platform to implement.
 pub use wacore::voip::{
     RelayEndpointParams, RelayTransport, RelayTransportEvent, RelayTransportFactory,
     RelayTransportProvider,

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -57,6 +57,14 @@ pub use wacore::voip::{
     OpusMlowPacketError, depacketize_opus_from_mlow, packetize_opus_for_mlow,
 };
 pub use wacore::voip::{CallEvent, GroupCallState, GroupStateApply, VideoUpgradeToken};
+// The platform transport seam, beside the facade that consults it: a consumer installing one
+// through `Client::set_relay_transport_provider` reaches for all three, and having to name `wacore`
+// for them while naming `whatsapp_rust` for the call is a paper cut on the one path this crate now
+// asks a platform to implement.
+pub use wacore::voip::{
+    RelayEndpointParams, RelayTransport, RelayTransportEvent, RelayTransportFactory,
+    RelayTransportProvider,
+};
 // `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
 pub use wacore::types::call::VideoState;
 pub use wacore::types::group_call::{

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -37,9 +37,7 @@ pub mod facade;
 pub mod registry;
 pub mod session;
 mod state;
-// Not gated, though nearly all of it is: `RandTxIds` and the packet demux are reachable here and
-// need no socket, so the module stays and its native stack is what carries the feature. See its
-// own docs.
+// Not gated, and its own docs say why.
 pub mod transport;
 pub mod video;
 

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -1,20 +1,34 @@
-//! VoIP calls media plane (Tokio runtime side): the DTLS/SCTP DataChannel transport
-//! over the WhatsApp relay, encoded audio, the call state machine, and the media pipeline.
-//! Pure protocol/crypto lives in `wacore::voip`.
+//! VoIP calls media plane: the call state machine, the media pipeline, encoded audio, and the
+//! relay transport that carries them. Pure protocol/crypto lives in `wacore::voip`.
 //!
-//! This module drives the media stack over a Tokio UDP socket, which does not exist on wasm32 or
-//! espidf. The wasm/esp32-safe subset is `wacore`'s `voip` feature (pure-Rust crypto and encoded
-//! transport); add `wacore/voip-mlow` for its pure-Rust MLOW codec.
+//! # Two halves, and only one of them owns a socket
+//!
+//! Everything here except [`transport`] is portable: it drives `wacore`'s sans-IO engine over an
+//! injected [`Runtime`](wacore::runtime::Runtime) and an injected
+//! [`RelayTransportFactory`](wacore::voip::transport::RelayTransportFactory), so it names no clock
+//! and opens no descriptor. That half is `voip-runtime`, and it builds wherever `wacore` does.
+//!
+//! [`transport`] is the other half -- a UDP socket per call with DTLS, SCTP and the pre-negotiated
+//! DataChannel over it -- and it is `voip-relay-native`, because a UDP socket is exactly what
+//! wasm32 and espidf do not have. A page reaches the same relay through an `RTCPeerConnection`,
+//! which is a factory it supplies with [`Client::set_relay_transport_factory`]; it needs no part of
+//! this module's native half, and asking for one used to be a `compile_error!` across the whole
+//! feature rather than across the socket.
+//!
+//! [`Client::set_relay_transport_factory`]: crate::client::Client::set_relay_transport_factory
 
-// Fail fast with an actionable message instead of a confusing link error further down.
+// Fail fast with an actionable message instead of a confusing link error further down. Narrowed to
+// the transport: `voip-runtime` alone is portable, and the message now names the way forward
+// rather than only the wall.
 #[cfg(all(
-    feature = "voip-runtime",
+    feature = "voip-relay-native",
     any(target_arch = "wasm32", target_os = "espidf")
 ))]
 compile_error!(
-    "the native VoIP features of `whatsapp-rust` drive the relay media stack over a Tokio UDP \
-     socket and do not build on wasm32/espidf. For those targets use `wacore/voip` for \
-     crypto/encoded transport and optionally `wacore/voip-mlow` for the pure-Rust MLOW codec."
+    "`voip-relay-native` drives the relay media stack over a Tokio UDP socket and does not build \
+     on wasm32/espidf. Enable `voip-mlow` (or `voip-encoded`) without it and supply your own \
+     `RelayTransportFactory` through `Client::set_relay_transport_factory` -- in a browser an \
+     `RTCPeerConnection` with a pre-negotiated DataChannel reaches the same relay."
 );
 
 pub mod audio;
@@ -23,6 +37,7 @@ pub mod facade;
 pub mod registry;
 pub mod session;
 mod state;
+#[cfg(feature = "voip-relay-native")]
 pub mod transport;
 pub mod video;
 

--- a/src/voip/state.rs
+++ b/src/voip/state.rs
@@ -113,6 +113,17 @@ pub(crate) struct VoipState {
     /// engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id arrives.
     pub(crate) pending_outgoing_calls:
         Arc<std::sync::Mutex<HashMap<String, super::facade::PendingOutgoing>>>,
+    /// How a relay endpoint becomes a media transport, when the platform supplies its own.
+    ///
+    /// `None` means "use whatever this build has": the UDP/DTLS/SCTP dialer on a `voip-relay-native`
+    /// build, and nothing at all anywhere else -- a page that has not installed one gets a call
+    /// that fails at setup with a reason, rather than a crate that would not compile.
+    ///
+    /// A `std` lock over one `Option`, taken for the length of a clone. It is written once during
+    /// assembly in every use anyone has, but making it a constructor argument would put a VoIP type
+    /// in `ClientBuilder` for every consumer that never places a call.
+    pub(crate) relay_transport_provider:
+        std::sync::Mutex<Option<Arc<dyn wacore::voip::RelayTransportProvider>>>,
 }
 
 impl Default for VoipState {
@@ -123,6 +134,7 @@ impl Default for VoipState {
             pending_call_link_join_lane: Mutex::new(()),
             answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            relay_transport_provider: std::sync::Mutex::new(None),
         }
     }
 }

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -38,7 +38,6 @@ use rtc_sctp::{
 };
 
 use wacore::runtime::{AbortHandle, Runtime};
-use wacore::voip::engine::TxIdSource;
 use wacore::voip::relay_parse::WEB_CLIENT_RELAY_PORT;
 use wacore::voip::transport::{
     RelayDisconnectReason, RelayTransport, RelayTransportEvent, RelayTransportFactory,
@@ -580,16 +579,10 @@ pub async fn connect_relay_media(
     }
 }
 
-/// OS-RNG-backed STUN transaction ids for production calls. The core's `SequentialTxIds` is
-/// deterministic (test-only); real calls need unpredictable ids for consent freshness.
-#[derive(Default)]
-pub struct RandTxIds;
-
-impl TxIdSource for RandTxIds {
-    fn next_tx_id(&mut self) -> [u8; 12] {
-        rand::random()
-    }
-}
+// `RandTxIds` used to live here, and had no business doing so: an OS-RNG transaction id needs no
+// socket. It moved to the portable driver when the native relay became its own feature, and is
+// re-exported so `whatsapp_rust::voip::transport::RandTxIds` keeps naming it.
+pub use crate::voip::driver::RandTxIds;
 
 #[async_trait]
 impl RelayTransport for RelayMediaChannel {

--- a/src/voip/transport/mod.rs
+++ b/src/voip/transport/mod.rs
@@ -1,14 +1,13 @@
 //! The relay media transport, and the paths that name it.
 //!
-//! Two things live here and only one of them owns a socket. The native relay stack -- a UDP
-//! endpoint per call with DTLS, SCTP and the pre-negotiated DataChannel over it -- is the
-//! `native` submodule, gated on `voip-relay-native`, because a UDP socket is exactly what wasm32
-//! and espidf do not have.
+//! The native relay stack -- a UDP endpoint per call with DTLS, SCTP and the pre-negotiated
+//! DataChannel over it -- is the `native` submodule, gated on `voip-relay-native`. Why that half
+//! is a feature of its own is in [`crate::voip`], and stays there.
 //!
-//! The module itself is not gated, and that is deliberate rather than tidy: `RandTxIds` and the
-//! packet demux have always been reachable at `whatsapp_rust::voip::transport::*`, neither one
-//! needs a socket, and gating the module around them would break every codec-only consumer that
-//! imports one -- a build with `voip-mlow` and no relay is exactly the build a browser makes.
+//! What is decided *here* is that the module around it is not gated: `RandTxIds` and the packet
+//! demux have always been reachable at `whatsapp_rust::voip::transport::*`, neither needs a
+//! socket, and gating the module for their sake would break every codec-only consumer that imports
+//! one -- a build with `voip-mlow` and no relay is exactly the build a browser makes.
 
 #[cfg(feature = "voip-relay-native")]
 mod native;

--- a/src/voip/transport/mod.rs
+++ b/src/voip/transport/mod.rs
@@ -1,0 +1,27 @@
+//! The relay media transport, and the paths that name it.
+//!
+//! Two things live here and only one of them owns a socket. The native relay stack -- a UDP
+//! endpoint per call with DTLS, SCTP and the pre-negotiated DataChannel over it -- is the
+//! `native` submodule, gated on `voip-relay-native`, because a UDP socket is exactly what wasm32
+//! and espidf do not have.
+//!
+//! The module itself is not gated, and that is deliberate rather than tidy: `RandTxIds` and the
+//! packet demux have always been reachable at `whatsapp_rust::voip::transport::*`, neither one
+//! needs a socket, and gating the module around them would break every codec-only consumer that
+//! imports one -- a build with `voip-mlow` and no relay is exactly the build a browser makes.
+
+#[cfg(feature = "voip-relay-native")]
+mod native;
+
+#[cfg(feature = "voip-relay-native")]
+pub use native::*;
+
+// `RandTxIds` used to be defined here and had no business being: an OS-RNG transaction id needs no
+// socket. It moved to the portable driver when the native relay became its own feature, and is
+// re-exported at its old path -- ungated, because the path was never the socket's.
+pub use crate::voip::driver::RandTxIds;
+
+// First-byte relay-packet demux, in the portable core; re-exported so the existing
+// `whatsapp_rust::voip::transport::{classify_relay_packet, RelayPacketKind}` paths stay stable on
+// every build that has ever had them.
+pub use wacore::voip::demux::{RelayPacketKind, classify_relay_packet};

--- a/src/voip/transport/native.rs
+++ b/src/voip/transport/native.rs
@@ -61,9 +61,7 @@ const MEDIA_CHANNEL_TYPE: ChannelType = ChannelType::PartialReliableRexmitUnorde
 /// The retransmit count [`MEDIA_CHANNEL_TYPE`] carries: never retransmit, abandon instead.
 const MEDIA_MAX_RETRANSMITS: u32 = 0;
 
-// First-byte relay-packet demux moved to the portable core; re-exported so the existing
-// `whatsapp_rust::voip::transport::{classify_relay_packet, RelayPacketKind}` paths stay stable.
-pub use wacore::voip::demux::{RelayPacketKind, classify_relay_packet};
+use wacore::voip::demux::{RelayPacketKind, classify_relay_packet};
 
 /// Why the media stack stopped. The driver branches on the variant: a peer close ends the call the
 /// way hanging up does, anything else is a transport failure the call surfaces as a read error.
@@ -578,11 +576,6 @@ pub async fn connect_relay_media(
         )),
     }
 }
-
-// `RandTxIds` used to live here, and had no business doing so: an OS-RNG transaction id needs no
-// socket. It moved to the portable driver when the native relay became its own feature, and is
-// re-exported so `whatsapp_rust::voip::transport::RandTxIds` keeps naming it.
-pub use crate::voip::driver::RandTxIds;
 
 #[async_trait]
 impl RelayTransport for RelayMediaChannel {

--- a/src/voip/transport/native.rs
+++ b/src/voip/transport/native.rs
@@ -1750,6 +1750,7 @@ mod udp_relay_e2e {
             ssrc: SSRC,
             audio: wacore::voip::AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
+            auth_token: vec![0xCD; 8],
             relay_ip: relay_addr.ip().to_string(),
             relay_port: relay_addr.port(),
             integrity_key: b"relay-key".to_vec(),

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -115,6 +115,7 @@ fn config_for(self_lid: &str, peer_lid: &str, ssrc: u32, direction: CallDirectio
         ssrc,
         audio: wacore::voip::AudioConfig::MLOW_PCM,
         relay_token: vec![0xAB; 16],
+        auth_token: vec![0xCD; 8],
         relay_ip: "203.0.113.7".into(),
         relay_port: 3478,
         integrity_key: b"relay-key".to_vec(),

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -2252,6 +2252,7 @@ mod tests {
             ssrc: 0x5741_0001,
             audio: crate::voip::AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
+            auth_token: vec![0xCD; 8],
             relay_ip: "203.0.113.7".into(),
             relay_port: 3478,
             integrity_key: b"relay-key".to_vec(),

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -537,6 +537,17 @@ pub enum CallEvent {
     RelayAllocateFailed(u16),
     /// The relay never acked the allocate within the deadline (wedged relay). Terminal.
     RelayAllocateTimedOut,
+    /// The media path was never built, and this is why. Terminal.
+    ///
+    /// Distinct from the two above, which are the relay *answering* badly. This one is everything
+    /// before there is a relay to answer: no `<relay>` in the offer ack, an engine that would not
+    /// build, or a platform whose transport provider refused -- the last of which is a browser
+    /// with no `RTCPeerConnection`, where it is not an edge case but every outgoing call.
+    ///
+    /// It exists because `wait_ended()` resolving says a call is *over*, not that it never
+    /// started, so without this a setup failure was indistinguishable from an ordinary remote
+    /// hangup and its reason lived only in a log line.
+    MediaSetupFailed(String),
     /// Replacing a migrated relay transport did not finish within the reconnect deadline.
     RelayReconnectTimedOut,
     /// The peer's `<video state=N>` signaling arrived (upgrade requested/accepted, stopped, ...).
@@ -716,6 +727,7 @@ impl CallEvent {
                         .map(|item| item.fci.capacity())
                         .sum::<usize>()
             }
+            Self::MediaSetupFailed(reason) => reason.capacity(),
             Self::RelayAllocated
             | Self::RelayAllocateFailed(_)
             | Self::RelayAllocateTimedOut

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -195,10 +195,15 @@ pub struct CallConfig {
     /// ([`relay_parse::token_to_ice_ufrag`](crate::voip::relay_parse::token_to_ice_ufrag)), which a
     /// platform whose transport is an `RTCPeerConnection` needs and the native dialer does not.
     ///
-    /// Empty when the offer carries none: every endpoint arriving with `auth_token_id = 0` is a
-    /// real shape (see `is_outbound_relay_candidate`, where that marks an endpoint as
-    /// relaylatency-ineligible rather than unusable) and such a call must still connect for media.
-    /// So this is best-effort, and a transport that cannot do without it is the one that says so.
+    /// `auth_token_id` is an ordinary index, exactly as `token_id` is: both default to 0 when the
+    /// attribute is absent, and slot 0 is a real slot. It is *not* a sentinel -- treating it as one
+    /// would blank the ufrag for every offer that omits the attribute, which is the common shape.
+    /// What `is_outbound_relay_candidate` does with `auth_token_id != 0` is pick relaylatency
+    /// probes, and that is a different question from which credential signs an ICE check.
+    ///
+    /// Empty when the offer genuinely carries no matching token, because such a call must still
+    /// connect for media (`get_media_relay_endpoint` says so). Best-effort, therefore, and the
+    /// transport that cannot do without it is the one that says so.
     pub auth_token: Vec<u8>,
     pub relay_ip: String,
     pub relay_port: u16,
@@ -218,7 +223,24 @@ pub struct CallConfig {
     pub enable_sframe: bool,
 }
 
-/// Group-media inputs layered onto a regular engine before it starts.
+/// The endpoint's `<auth_token>`, or empty when the relay carries no matching one.
+///
+/// Shared by the 1:1 and group paths, which index two different token sets the same way and used
+/// to disagree about whether the group one existed at all.
+///
+/// No special case for id 0: it is an ordinary index that both `token_id` and `auth_token_id`
+/// default to when the attribute is absent, so skipping it would blank the credential for the most
+/// common shape of offer. An empty or absent slot answers empty, which is the honest "there is no
+/// token here" and is what a transport needing one checks.
+fn select_auth_token(auth_tokens: &[Vec<u8>], auth_token_id: u32) -> Vec<u8> {
+    auth_tokens
+        .get(auth_token_id as usize)
+        .filter(|token| !token.is_empty())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Group-media inputs layered onto a regular engine before it starts./// Group-media inputs layered onto a regular engine before it starts.
 pub struct GroupEngineConfig {
     pub call_creator: Jid,
     pub self_jid: Jid,
@@ -325,16 +347,11 @@ impl CallConfig {
             .filter(|t| !t.is_empty())
             .cloned()
             .ok_or(SetupError::NoRelayToken(ep.token_id))?;
-        // Best-effort, unlike the token above: an offer whose endpoints all carry
-        // `auth_token_id = 0` has no auth token to select and must still connect for media, so a
-        // missing one is empty here rather than an error. Only a transport that builds a synthetic
-        // SDP reads it, and that is the layer with something to say about an empty one.
-        let auth_token = relay
-            .auth_tokens
-            .get(ep.auth_token_id as usize)
-            .filter(|t| !t.is_empty())
-            .cloned()
-            .unwrap_or_default();
+        // Best-effort, unlike the token above: an offer that carries no matching auth token must
+        // still connect for media, so a missing one is empty here rather than an error. Only a
+        // transport that builds a synthetic SDP reads it, and that is the layer with something to
+        // say about an empty one. Slot 0 is indexed like any other -- see the field's own note.
+        let auth_token = select_auth_token(&relay.auth_tokens, ep.auth_token_id);
         // The relay <key> is the STUN MESSAGE-INTEGRITY key; without it the allocate/binding-success
         // we sign can't authenticate, so fail here rather than dial with an empty key. Sign with the
         // base64 TEXT of <key> (relay_key_ascii), NOT its decoded bytes (relay.relay_key): the relay
@@ -460,9 +477,11 @@ impl CallConfig {
             ),
             audio: AudioConfig::MLOW_PCM,
             relay_token,
-            // A `GroupCallRelay` carries one indexed token set and no `<auth_token>`, so there is
-            // nothing to select here.
-            auth_token: Vec::new(),
+            // A `GroupCallRelay` carries its own `<auth_token>` set, indexed by the selected
+            // endpoint's `auth_token_id` exactly as the 1:1 offer's is. This said the opposite and
+            // was wrong: a browser joining a group call would have built its synthetic SDP with an
+            // empty `ice-ufrag`, which the relay refuses.
+            auth_token: select_auth_token(&relay.auth_tokens, endpoint.auth_token_id),
             relay_ip,
             relay_port,
             integrity_key: relay.key.clone(),

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -187,6 +187,19 @@ pub struct CallConfig {
     pub audio: AudioConfig,
     /// Relay endpoint allocate inputs.
     pub relay_token: Vec<u8>,
+    /// The selected endpoint's `<auth_token>`, which is a different indexed set from
+    /// [`Self::relay_token`] and is indexed by `auth_token_id` rather than `token_id`.
+    ///
+    /// Not used by the allocate -- that is `relay_token`, the STUN `RELAY-TOKEN` attribute. This is
+    /// what a synthetic SDP answer's `a=ice-ufrag` is built from
+    /// ([`relay_parse::token_to_ice_ufrag`](crate::voip::relay_parse::token_to_ice_ufrag)), which a
+    /// platform whose transport is an `RTCPeerConnection` needs and the native dialer does not.
+    ///
+    /// Empty when the offer carries none: every endpoint arriving with `auth_token_id = 0` is a
+    /// real shape (see `is_outbound_relay_candidate`, where that marks an endpoint as
+    /// relaylatency-ineligible rather than unusable) and such a call must still connect for media.
+    /// So this is best-effort, and a transport that cannot do without it is the one that says so.
+    pub auth_token: Vec<u8>,
     pub relay_ip: String,
     pub relay_port: u16,
     /// The relay `<key>` (ASCII) used as the STUN MESSAGE-INTEGRITY key.
@@ -236,6 +249,7 @@ impl core::fmt::Debug for CallConfig {
             .field("ssrc", &self.ssrc)
             .field("audio", &self.audio)
             .field("relay_token", &"[redacted]")
+            .field("auth_token", &"[redacted]")
             .field("relay_ip", &self.relay_ip)
             .field("relay_port", &self.relay_port)
             .field("integrity_key", &"[redacted]")
@@ -311,6 +325,16 @@ impl CallConfig {
             .filter(|t| !t.is_empty())
             .cloned()
             .ok_or(SetupError::NoRelayToken(ep.token_id))?;
+        // Best-effort, unlike the token above: an offer whose endpoints all carry
+        // `auth_token_id = 0` has no auth token to select and must still connect for media, so a
+        // missing one is empty here rather than an error. Only a transport that builds a synthetic
+        // SDP reads it, and that is the layer with something to say about an empty one.
+        let auth_token = relay
+            .auth_tokens
+            .get(ep.auth_token_id as usize)
+            .filter(|t| !t.is_empty())
+            .cloned()
+            .unwrap_or_default();
         // The relay <key> is the STUN MESSAGE-INTEGRITY key; without it the allocate/binding-success
         // we sign can't authenticate, so fail here rather than dial with an empty key. Sign with the
         // base64 TEXT of <key> (relay_key_ascii), NOT its decoded bytes (relay.relay_key): the relay
@@ -346,6 +370,7 @@ impl CallConfig {
             ssrc: our_ssrc,
             audio: AudioConfig::MLOW_PCM,
             relay_token,
+            auth_token,
             relay_ip,
             relay_port,
             integrity_key,
@@ -435,6 +460,9 @@ impl CallConfig {
             ),
             audio: AudioConfig::MLOW_PCM,
             relay_token,
+            // A `GroupCallRelay` carries one indexed token set and no `<auth_token>`, so there is
+            // nothing to select here.
+            auth_token: Vec::new(),
             relay_ip,
             relay_port,
             integrity_key: relay.key.clone(),
@@ -3927,6 +3955,7 @@ mod encoded_tests {
             ssrc: 0x5741_0001,
             audio: AudioConfig::encoded(AudioFormat::OPUS_16KHZ_60MS),
             relay_token: vec![0xAB; 16],
+            auth_token: vec![0xCD; 8],
             relay_ip: "203.0.113.7".into(),
             relay_port: 3478,
             integrity_key: b"relay-key".to_vec(),
@@ -6178,6 +6207,7 @@ mod tests {
             ssrc: SSRC,
             audio: AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
+            auth_token: vec![0xCD; 8],
             relay_ip: "203.0.113.7".into(),
             relay_port: 3478,
             integrity_key: b"relay-key".to_vec(),
@@ -6206,11 +6236,16 @@ mod tests {
             dbg.contains("relay_token: \"[redacted]\""),
             "relay_token not redacted"
         );
-        // The 0..32 callKey bytes, the b"relay-key" integrity key, and the 0xAB relay-token bytes
-        // must not appear.
+        assert!(
+            dbg.contains("auth_token: \"[redacted]\""),
+            "auth_token not redacted"
+        );
+        // The 0..32 callKey bytes, the b"relay-key" integrity key, the 0xAB relay-token bytes and
+        // the 0xCD auth-token bytes must not appear.
         assert!(!dbg.contains("[0, 1, 2, 3"), "callKey bytes leaked");
         assert!(!dbg.contains("114, 101, 108"), "integrity_key bytes leaked");
         assert!(!dbg.contains("[171, 171"), "relay_token bytes leaked");
+        assert!(!dbg.contains("[205, 205"), "auth_token bytes leaked");
         // Non-secret fields stay visible for diagnostics.
         assert!(dbg.contains("call_id: \"CID\""));
     }

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -86,8 +86,8 @@ pub use session::{
 };
 pub use tap::{InMemoryTap, PacketDir, PacketTap, TappedFactory, TappedTransport};
 pub use transport::{
-    RelayDisconnectReason, RelayTransport, RelayTransportEvent, RelayTransportFactory,
-    RelayTransportProvider,
+    RelayDisconnectReason, RelayEndpointParams, RelayTransport, RelayTransportEvent,
+    RelayTransportFactory, RelayTransportProvider,
 };
 
 // Internal crypto/framing primitives (`crypt_payload`, `derive_e2e_keys`, `SframeSession`,

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -87,6 +87,7 @@ pub use session::{
 pub use tap::{InMemoryTap, PacketDir, PacketTap, TappedFactory, TappedTransport};
 pub use transport::{
     RelayDisconnectReason, RelayTransport, RelayTransportEvent, RelayTransportFactory,
+    RelayTransportProvider,
 };
 
 // Internal crypto/framing primitives (`crypt_payload`, `derive_e2e_keys`, `SframeSession`,

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -77,20 +77,32 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
     /// Platforms that cannot redial return an error, causing the driver to end the call instead of
     /// silently sending allocation traffic to the retired relay.
     ///
-    /// # What an address is enough for
+    /// # What an address does not carry, and what that costs
     ///
-    /// Only the endpoint changes here, and that is the whole of what a migration is: the call's
-    /// relay `<key>` is per call, not per endpoint, so a transport that needed ICE credentials to
-    /// build its channel -- a browser's, whose synthetic SDP answer carries them -- already holds
-    /// the ones it was constructed with and should reuse them against this address rather than
-    /// refusing. Refusing is what ends a call over a routine migration.
+    /// This seam carries the new endpoint and nothing else, and a group call can rotate the
+    /// credentials that [`RelayEndpointParams`] calls ICE ones. A `<relay>` in a group update
+    /// may carry a new `<key>` (the `ice_pwd`) and new `tokens`/`auth_tokens` (the `ice_ufrag`),
+    /// and `group_relay_credential_refresh_rearms_allocation_on_the_same_endpoint` in
+    /// `wacore::voip::engine` is a test that rotates all three.
     ///
-    /// The one thing this seam does not carry is a change of `ice_ufrag`. That is the relay
-    /// *token*, which `RelayEndpoint::token_id` indexes per endpoint, so a migration that also
-    /// moves the token index is one an implementation cannot follow from here. It has not been
-    /// observed in a live migration, and closing it means carrying a whole
-    /// [`RelayEndpointParams`] out of the engine rather than a `SocketAddr` -- a change to the
-    /// engine's own `Output`, which is why it is written down here instead of guessed at.
+    /// The engine answers such an update by rebuilding its STUN allocate with the new key and
+    /// token, which is the whole of what a *native* transport needs: it ships opaque datagrams,
+    /// so the credentials only ever appear inside the payloads the engine builds. A transport
+    /// that instead bakes them into the channel itself -- a browser's, whose synthetic SDP answer
+    /// names `ice-ufrag` and `ice-pwd` -- is not so served, and there are two distinct gaps:
+    ///
+    /// - **Credentials rotate, endpoint unchanged.** No `Output::ReconnectRelay` is emitted at
+    ///   all (that same test asserts it: "unchanged relay coordinates must not reconnect the
+    ///   socket"), so this method is never called and such a transport is never told.
+    /// - **Endpoint and credentials both change.** This method is called with the address alone,
+    ///   so an implementation can only redial carrying whatever it was constructed with.
+    ///
+    /// So an implementation should reuse its existing credentials against the new address rather
+    /// than refusing -- refusing ends a call over a routine migration -- while knowing they may
+    /// be the retired relay's. Closing either gap means the engine saying more than a
+    /// `SocketAddr`: a whole [`RelayEndpointParams`] on this output, and a second output for the
+    /// refresh that emits none. Both are changes to `Output`'s contract, which is why this is
+    /// written down rather than guessed at here.
     async fn reconnect(
         &self,
         endpoint: SocketAddr,

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -87,6 +87,40 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
     }
 }
 
+/// Everything a platform needs to reach one relay endpoint.
+///
+/// The address alone is enough for a stack that dials UDP and handshakes DTLS itself, which is what
+/// the native transport does. It is not enough for a browser: there the media channel is an
+/// `RTCPeerConnection`, ICE is not optional, and a synthetic SDP answer describing the relay has to
+/// carry credentials the relay will actually validate -- so the two ICE fields travel with the
+/// address rather than being looked up from a `RelayData` no transport is handed.
+///
+/// Both are derived rather than invented: `ice_ufrag` is
+/// [`token_to_ice_ufrag`](crate::voip::relay_parse::token_to_ice_ufrag) of the relay token, and
+/// `ice_pwd` is the relay `<key>` in the ASCII base64 form it arrived in -- the same bytes the
+/// engine keys STUN MESSAGE-INTEGRITY with.
+#[derive(Clone)]
+pub struct RelayEndpointParams {
+    /// Where the relay is.
+    pub addr: SocketAddr,
+    /// `a=ice-ufrag` for a synthetic SDP answer.
+    pub ice_ufrag: String,
+    /// `a=ice-pwd` for a synthetic SDP answer. Live credential material.
+    pub ice_pwd: String,
+}
+
+// Manual Debug: `ice_pwd` is the relay key, and this struct is the kind of thing a `{:?}` in a
+// transport implementation reaches for. Matches the redaction `RelayData` and `CallConfig` apply.
+impl core::fmt::Debug for RelayEndpointParams {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RelayEndpointParams")
+            .field("addr", &self.addr)
+            .field("ice_ufrag", &self.ice_ufrag)
+            .field("ice_pwd", &"[redacted]")
+            .finish()
+    }
+}
+
 /// Chooses which [`RelayTransportFactory`] dials a given relay endpoint.
 ///
 /// A factory is bound to one address, and the address is not known until the server names the
@@ -107,7 +141,7 @@ pub trait RelayTransportProvider: crate::sync_marker::MaybeSendSync {
     /// Async because a platform may have to ask for something before it can build one -- a browser
     /// creating an `RTCPeerConnection` is a call into JS. Failing here fails the call with the
     /// reason, which is the honest answer for a page whose browser has no WebRTC at all.
-    async fn factory(&self, relay: SocketAddr) -> Result<Arc<dyn RelayTransportFactory>>;
+    async fn factory(&self, relay: &RelayEndpointParams) -> Result<Arc<dyn RelayTransportFactory>>;
 }
 
 /// Creates a [`RelayTransport`] connected to a relay endpoint, returning it alongside a push stream

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -110,10 +110,19 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
 /// carry credentials the relay will actually validate -- so the two ICE fields travel with the
 /// address rather than being looked up from a `RelayData` no transport is handed.
 ///
-/// Both are derived rather than invented: `ice_ufrag` is
-/// [`token_to_ice_ufrag`](crate::voip::relay_parse::token_to_ice_ufrag) of the relay token, and
-/// `ice_pwd` is the relay `<key>` in the ASCII base64 form it arrived in -- the same bytes the
-/// engine keys STUN MESSAGE-INTEGRITY with.
+/// Both are derived rather than invented, and *which* credential is which matters: the relay block
+/// carries two separately indexed token sets and swapping them is a call that will not connect.
+///
+/// - `ice_ufrag` is [`token_to_ice_ufrag`](crate::voip::relay_parse::token_to_ice_ufrag) of the
+///   selected endpoint's `<auth_token>`, indexed by its `auth_token_id`.
+/// - `ice_pwd` is the relay `<key>` in the ASCII base64 form it arrived in -- the same bytes the
+///   engine keys STUN MESSAGE-INTEGRITY with.
+///
+/// The `<token>` beside them, indexed by `token_id`, is the STUN *allocation* credential and goes
+/// on the wire as `RELAY-TOKEN`. It is never a ufrag. A ufrag built from it is refused at the
+/// browser's first connectivity check, which surfaces as a call that will not connect rather than
+/// as anything resembling a bad credential -- so it is worth naming here rather than leaving to be
+/// inferred from a neighbouring field name.
 #[derive(Clone)]
 pub struct RelayEndpointParams {
     /// Where the relay is.

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -76,6 +76,21 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
     ///
     /// Platforms that cannot redial return an error, causing the driver to end the call instead of
     /// silently sending allocation traffic to the retired relay.
+    ///
+    /// # What an address is enough for
+    ///
+    /// Only the endpoint changes here, and that is the whole of what a migration is: the call's
+    /// relay `<key>` is per call, not per endpoint, so a transport that needed ICE credentials to
+    /// build its channel -- a browser's, whose synthetic SDP answer carries them -- already holds
+    /// the ones it was constructed with and should reuse them against this address rather than
+    /// refusing. Refusing is what ends a call over a routine migration.
+    ///
+    /// The one thing this seam does not carry is a change of `ice_ufrag`. That is the relay
+    /// *token*, which `RelayEndpoint::token_id` indexes per endpoint, so a migration that also
+    /// moves the token index is one an implementation cannot follow from here. It has not been
+    /// observed in a live migration, and closing it means carrying a whole
+    /// [`RelayEndpointParams`] out of the engine rather than a `SocketAddr` -- a change to the
+    /// engine's own `Output`, which is why it is written down here instead of guessed at.
     async fn reconnect(
         &self,
         endpoint: SocketAddr,

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -87,6 +87,29 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
     }
 }
 
+/// Chooses which [`RelayTransportFactory`] dials a given relay endpoint.
+///
+/// A factory is bound to one address, and the address is not known until the server names the
+/// relay for a call -- so what a platform actually supplies is this: a way to make a factory once
+/// the address arrives. Native builds default to the UDP/DTLS/SCTP dialer behind
+/// `voip-relay-native`; a browser has no UDP socket and hands in an `RTCPeerConnection` instead,
+/// which reaches the same relay over the same pre-negotiated DataChannel the native stack builds
+/// by hand.
+///
+/// It is a trait rather than a boxed closure because an implementation carries state -- a page's
+/// carries the JS handles its peer connections are built from -- and a closure returning an `Arc`
+/// would have to own that anyway.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait RelayTransportProvider: crate::sync_marker::MaybeSendSync {
+    /// The factory that dials `relay`.
+    ///
+    /// Async because a platform may have to ask for something before it can build one -- a browser
+    /// creating an `RTCPeerConnection` is a call into JS. Failing here fails the call with the
+    /// reason, which is the honest answer for a page whose browser has no WebRTC at all.
+    async fn factory(&self, relay: SocketAddr) -> Result<Arc<dyn RelayTransportFactory>>;
+}
+
 /// Creates a [`RelayTransport`] connected to a relay endpoint, returning it alongside a push stream
 /// of inbound packets. Mirrors `wacore::net::TransportFactory`.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]


### PR DESCRIPTION
## What this changes

`src/voip` was one feature with two halves in it, and only one of them could not exist on `wasm32`: the relay transport, which opens a UDP socket per call and runs DTLS, SCTP and a pre-negotiated DataChannel over it. Everything above that — the offer, the answer, the engine, the facade, `CallHandle` — owns no descriptor and reads no clock, and was kept off the target only by the `compile_error!` standing in front of both.

So a browser front end was being told it had no audio codec. What it does not have is a *socket*; MLow is pure Rust and builds there already.

- **`voip-relay-native`** is now the socket's own feature and carries the `compile_error!`.
- **`voip-runtime`** is the portable half: signaling, facade, `CallHandle`.
- **`voip`** still means exactly what it meant (`voip-mlow + voip-libopus + voip-relay-native`), so no native consumer changes.

## What replaces the socket

`Client::set_relay_transport_provider` installs a `RelayTransportProvider`, asked for a `RelayTransportFactory` per relay **endpoint** — because the server names the relay per call, which is why a plain factory could never have been the injection point.

What it is handed is a `RelayEndpointParams`: the address, plus the `ice-ufrag` (the endpoint's `<auth_token>`) and `ice-pwd` (the relay `<key>`, in the ASCII form it arrived in) that a synthetic SDP answer has to carry. An address alone is enough for a stack that dials UDP itself and is not enough for a browser, where ICE is not optional and the relay validates the credentials. Its `Debug` redacts the password.

- A native build with none installed falls back to its own dialer exactly as before.
- A build with neither fails the call at setup with a sentence. That is the honest answer for a browser with no WebRTC, and a much better one than a crate that will not compile.

In a browser the provider is an `RTCPeerConnection` with a synthetic SDP answer naming that address and the same `id=0`, `ordered=false`, `maxRetransmits=0` DataChannel the native stack assembles by hand — which is what WhatsApp Web does, and what the native transport's own comment already called "the synthetic-SDP / wrtc dance".

## Three things that fell out of pulling the seam through

**`voip-runtime` no longer requires `tokio-runtime`.** Every timeout and sleep in the facade already went through `wacore::runtime`; the one remaining executor assumption was a `run_call_tokio` call, and `run_call` has always taken its runtime as an argument. It now gets the client's own. `run_call_tokio` stays for consumers who want it, and is absent where `TokioRuntime` is — it spawns through `tokio::spawn`, which on `wasm32` compiles and then panics, and a function that is only there to trap is worse than one that is not there.

Note for consumers assembling feature sets by hand: `voip-runtime` and the codec profiles no longer pull `tokio-runtime` with them. `voip` is unchanged and still does. `examples/voip-cli` was the one consumer in this repo that named the codec profiles directly, and it now asks for `voip-relay-native` outright — without it, it built fine and failed every call at "no relay media transport".

**`RandTxIds` moved to the portable driver.** It reads an RNG and nothing else, so living beside the one transport that owns a socket left a page with no way to name a STUN transaction id at all. `src/voip/transport` is a directory now: the module is ungated and holds the two things that never needed a socket (`RandTxIds`, the packet demux), and `native.rs` inside it carries the feature. Every old path still resolves on every feature set that has ever had it.

**`--features tokio-runtime` on `wasm32` was an unresolved import** rather than a runtime the target does not have: the module was gated on the feature and the type inside it on the target. The re-exports, `bot.rs`'s `default_runtime`, *and its typestate alias* now agree with the contents — without the last one a page got a `build()` it was allowed to call and an `unreachable!("typestate guarantees…")` at run time.

## A setup failure is no longer indistinguishable from a hangup

`wait_ended()` resolving says a call is over, not that it never started, so the reason lived only in a log line. Survivable while the failures were a missing `<relay>` or an engine that would not build; not once a platform's transport provider is one of them, because a browser with no WebRTC fails **every** outgoing call this way.

`CallEvent::MediaSetupFailed(String)` carries it — a new variant on an already-`#[non_exhaustive]` enum, and not `RelayAllocateFailed`, which carries a STUN error code: there is no relay answering here. Sent before `ended` is notified, and with `force_send`, because it is the last event either way and the oldest diagnostic is a better loss than the reason. The three sources each carry their own sentence: a refusing provider, an ack that arrived without a relay, and an ack that never arrived — the last two used to collapse into one message claiming the server's reply lacked something when there had been no reply.

The provider call is also bounded (`RELAY_PROVIDER_TIMEOUT`, 15s). That await is new — what it replaced was a synchronous constructor — and on the outgoing path the pending entry has already left the map by the time it runs, so a stalled provider left a hangup with no call to find.

## Verification

- `cargo test -p whatsapp-rust --lib --features voip` — 2078 passed, 0 failed (before the six new tests below).
- `cargo clippy --lib --features voip -- -D warnings` — clean.
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean.
- `cargo check` for each of `voip`, `voip-runtime`, `voip-encoded`, `voip-mlow`, `voip-libopus`, `voip-relay-native` individually — clean.
- **`cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features --features voip-mlow` — builds.** This is the whole point of the PR, and `.github/workflows/wasm.yml` now carries it as a step, because the split regresses silently the first time something in the facade reaches for a socket or a clock.

Six tests guard the seam, since the browser half cannot run in this suite at all: that the provider is consulted with the right endpoint, that its refusal is not papered over by a fallback, that the ufrag is the auth token and never the relay token beside it, that the endpoint does not print its password, that a refusal **reaches the handle**, and that a provider which never answers does not park the call. The fifth was verified the hard way — reverted the fix, watched it fail, restored it.

Also updates `agent_docs/voip_audio_codecs.md`, `agent_docs/observability.md` (the call driver is now covered by the task-instrument hook, so attributing it separately would double-count) and `agent_docs/subsystem_boundary.md`, which described `voip-runtime` as the native media plane that cannot be made runtime-agnostic and has no waiting consumer. All three now describe `voip-relay-native`, and the consumer is the web front end.

**Semver Checks (informational) is red and none of it is this PR's** — see [the comment](https://github.com/oxidezap/whatsapp-rust/pull/1364#issuecomment-5470372047): the baseline is the published 0.7.0 and every item named is outside this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXRWTrDqjsPYAZMHBgF7uZ)_