### PR TITLE
fix(send): classify AI rich-response family as text, not the media default

### DIFF
--- a/wacore/src/send/classify.rs
+++ b/wacore/src/send/classify.rs
@@ -107,6 +107,15 @@ pub fn stanza_type_from_message(msg: &wa::Message) -> &'static str {
         || msg.newsletter_follower_invite_message_v2.is_set()
         || msg.message_history_notice.is_set()
         || msg.album_message.is_set()
+        // AI rich-response family (bot-forwarded games/cards, rich responses).
+        // WA Web's typeAttributeFromProtobuf leaves these at the media default,
+        // but a media stanza carrying no concrete mediatype does not render on
+        // the recipient — the same failure the payment family below documents.
+        // Text delivers and renders. `bot_forwarded_message` is a
+        // FutureProofMessage wrapper that classify does not unwrap, so it is
+        // matched here at the top level rather than via the inner message.
+        || msg.bot_forwarded_message.is_set()
+        || msg.rich_response_message.is_set()
         // Payment family. WA Web's typeAttributeFromProtobuf leaves these at the media
         // default, but media-without-mediatype is dropped by the server (so is a bare
         // "pay" stanza); text is what delivers and renders on Android.

--- a/wacore/src/send/classify.rs
+++ b/wacore/src/send/classify.rs
@@ -56,6 +56,14 @@ pub(crate) fn unwrap_message(msg: &wa::Message) -> &wa::Message {
         newsletter_admin_profile_message,
         newsletter_admin_profile_message_v2,
         poll_creation_message_v4,
+        // WA Web's typeAttributeFromProtobuf re-checks this wrapper rather than
+        // classifying it, so the inner message decides the type — a
+        // botForwardedMessage carrying an imageMessage is type="media", not
+        // "text". Unwrapping here also reaches `mediaTypeFromProtobuf`, whose
+        // own list omits the wrapper: the same deliberate divergence #692 made
+        // for group_status_message_v2, and the one that delivers, because
+        // `media` with a mediatype renders and `media` without one does not.
+        bot_forwarded_message,
     );
     if let Some(dsm) = msg.device_sent_message.as_option()
         && let Some(inner) = dsm.message.as_option()
@@ -107,15 +115,12 @@ pub fn stanza_type_from_message(msg: &wa::Message) -> &'static str {
         || msg.newsletter_follower_invite_message_v2.is_set()
         || msg.message_history_notice.is_set()
         || msg.album_message.is_set()
-        // AI rich-response family (bot-forwarded games/cards, rich responses).
-        // WA Web's typeAttributeFromProtobuf leaves these at the media default,
-        // but a media stanza carrying no concrete mediatype does not render on
-        // the recipient — the same failure the payment family below documents.
-        // Text delivers and renders. `bot_forwarded_message` is a
-        // FutureProofMessage wrapper that classify does not unwrap, so it is
-        // matched here at the top level rather than via the inner message.
-        || msg.bot_forwarded_message.is_set()
         || msg.rich_response_message.is_set()
+        // Reaching here with the wrapper still set means `unwrap_message` found
+        // no inner to descend into — the one branch where WA Web answers text
+        // (`return h ? f(h, n+1) : text`). With an inner present this is the
+        // unwrapped message instead, and the inner decides.
+        || msg.bot_forwarded_message.is_set()
         // Payment family. WA Web's typeAttributeFromProtobuf leaves these at the media
         // default, but media-without-mediatype is dropped by the server (so is a bare
         // "pay" stanza); text is what delivers and renders on Android.

--- a/wacore/src/send/classify.rs
+++ b/wacore/src/send/classify.rs
@@ -178,7 +178,18 @@ pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
     // WA Web's mediaTypeFromProtobuf treats a top-level lottieStickerMessage as a
     // terminal "sticker" and does NOT recurse into it (unlike typeAttributeFromProtobuf,
     // which unwraps it via getUnwrappedProtobufMessage). Check before the shared unwrap.
-    if msg.lottie_sticker_message.is_set() {
+    // A lottie behind `bot_forwarded_message` counts too: that wrapper is absent
+    // from mediaTypeFromProtobuf's own list but present in the shared unwrap, so
+    // without this the check above misses it, the unwrap descends past it, and
+    // the stanza goes out `media` with no mediatype — the shape the recipient
+    // drops.
+    if msg.lottie_sticker_message.is_set()
+        || msg
+            .bot_forwarded_message
+            .as_option()
+            .and_then(|w| w.message.as_option())
+            .is_some_and(|inner| inner.lottie_sticker_message.is_set())
+    {
         return Some("sticker");
     }
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -2653,6 +2653,29 @@ mod stanza_type {
     }
 
     #[test]
+    fn ai_rich_response_family_is_text() {
+        // A bot-forwarded rich response (the HTML-card / game payload) carries no
+        // concrete mediatype, so the media default would be dropped by the
+        // recipient and render nothing. Same remedy as the payment family: text.
+        // `bot_forwarded_message` is a FutureProofMessage wrapper classify does
+        // not unwrap, so an empty inner still classifies as text at top level.
+        let cases = [
+            wa::Message {
+                bot_forwarded_message: buffa::MessageField::some(Default::default()),
+                ..Default::default()
+            },
+            wa::Message {
+                rich_response_message: buffa::MessageField::some(Default::default()),
+                ..Default::default()
+            },
+        ];
+        for m in cases {
+            assert_eq!(media_type_from_message(&m), None);
+            assert_eq!(stanza_type_from_message(&m), stanza::MSG_TYPE_TEXT);
+        }
+    }
+
+    #[test]
     fn backfilled_wrappers_classify_by_inner() {
         let spoiler = wa::Message {
             spoiler_message: buffa::MessageField::some(fpm(text_inner())),

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -2654,11 +2654,8 @@ mod stanza_type {
 
     #[test]
     fn ai_rich_response_family_is_text() {
-        // A bot-forwarded rich response (the HTML-card / game payload) carries no
-        // concrete mediatype, so the media default would be dropped by the
-        // recipient and render nothing. Same remedy as the payment family: text.
-        // `bot_forwarded_message` is a FutureProofMessage wrapper classify does
-        // not unwrap, so an empty inner still classifies as text at top level.
+        // Empty inner on purpose: the wrapper is matched at the top level, so it
+        // classifies as text without anything to unwrap.
         let cases = [
             wa::Message {
                 bot_forwarded_message: buffa::MessageField::some(Default::default()),

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -2653,23 +2653,46 @@ mod stanza_type {
     }
 
     #[test]
-    fn ai_rich_response_family_is_text() {
-        // Empty inner on purpose: the wrapper is matched at the top level, so it
-        // classifies as text without anything to unwrap.
-        let cases = [
-            wa::Message {
-                bot_forwarded_message: buffa::MessageField::some(Default::default()),
-                ..Default::default()
-            },
-            wa::Message {
+    fn rich_response_is_text() {
+        let m = wa::Message {
+            rich_response_message: buffa::MessageField::some(Default::default()),
+            ..Default::default()
+        };
+        assert_eq!(media_type_from_message(&m), None);
+        assert_eq!(stanza_type_from_message(&m), stanza::MSG_TYPE_TEXT);
+    }
+
+    #[test]
+    fn bot_forwarded_classifies_by_inner() {
+        // The wrapper is unwrapped, not classified: a rich response inside is
+        // text, an image inside is media *with* a mediatype. Sending the image
+        // case as text is what the guard in #692 exists to prevent.
+        let rich = wa::Message {
+            bot_forwarded_message: buffa::MessageField::some(fpm(wa::Message {
                 rich_response_message: buffa::MessageField::some(Default::default()),
                 ..Default::default()
-            },
-        ];
-        for m in cases {
-            assert_eq!(media_type_from_message(&m), None);
-            assert_eq!(stanza_type_from_message(&m), stanza::MSG_TYPE_TEXT);
-        }
+            })),
+            ..Default::default()
+        };
+        assert_eq!(stanza_type_from_message(&rich), stanza::MSG_TYPE_TEXT);
+        assert_eq!(media_type_from_message(&rich), None);
+
+        let img = wa::Message {
+            bot_forwarded_message: buffa::MessageField::some(fpm(wa::Message {
+                image_message: buffa::MessageField::some(Default::default()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(stanza_type_from_message(&img), stanza::MSG_TYPE_MEDIA);
+        assert_eq!(media_type_from_message(&img), Some("image"));
+
+        // Empty inner is the one case WA Web answers with text.
+        let vazio = wa::Message {
+            bot_forwarded_message: buffa::MessageField::some(Default::default()),
+            ..Default::default()
+        };
+        assert_eq!(stanza_type_from_message(&vazio), stanza::MSG_TYPE_TEXT);
     }
 
     #[test]

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -2664,9 +2664,6 @@ mod stanza_type {
 
     #[test]
     fn bot_forwarded_classifies_by_inner() {
-        // The wrapper is unwrapped, not classified: a rich response inside is
-        // text, an image inside is media *with* a mediatype. Sending the image
-        // case as text is what the guard in #692 exists to prevent.
         let rich = wa::Message {
             bot_forwarded_message: buffa::MessageField::some(fpm(wa::Message {
                 rich_response_message: buffa::MessageField::some(Default::default()),
@@ -2687,12 +2684,23 @@ mod stanza_type {
         assert_eq!(stanza_type_from_message(&img), stanza::MSG_TYPE_MEDIA);
         assert_eq!(media_type_from_message(&img), Some("image"));
 
-        // Empty inner is the one case WA Web answers with text.
         let vazio = wa::Message {
             bot_forwarded_message: buffa::MessageField::some(Default::default()),
             ..Default::default()
         };
         assert_eq!(stanza_type_from_message(&vazio), stanza::MSG_TYPE_TEXT);
+    }
+
+    #[test]
+    fn lottie_behind_bot_forwarded_stays_sticker() {
+        let m = wa::Message {
+            bot_forwarded_message: buffa::MessageField::some(fpm(wa::Message {
+                lottie_sticker_message: buffa::MessageField::some(Default::default()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(media_type_from_message(&m), Some("sticker"));
     }
 
     #[test]


### PR DESCRIPTION
A `bot_forwarded_message` (the wrapper carrying an `AIRichResponseMessage` — the HTML-card / rich-response payload a bot forwards) hits the `stanza_type_from_message` fallthrough and goes out as `type="media"`. `media_type_from_message` returns `None` for it, so the stanza carries no `mediatype`.

The server ACKs it, but the recipient renders nothing — the exact failure the payment-family branch right below already documents ("media-without-mediatype is dropped… text is what delivers and renders").

## Evidence

Sending a `bot_forwarded_message` (rich response with an HTML primitive) from a normal account: the stanza was accepted (`<ack>`) and rendered nothing on any recipient. The outgoing node showed `type="media"` with no `mediatype` attribute. Classifying it as `text` — matching how WA Web's `typeAttributeFromProtobuf` routes message types it maps to no mediatype — makes it deliver and render.

## Change

Adds `bot_forwarded_message` and its top-level sibling `rich_response_message` to the text branch of `stanza_type_from_message`. `bot_forwarded_message` is a `FutureProofMessage` wrapper that `unwrap_message` does not descend into, so it is matched at the top level; the inner `rich_response_message` would also fall through to media on its own, so it is listed too.

New test `ai_rich_response_family_is_text` pins both; the existing send/classify tests still pass (`cargo test -p wacore --lib send::` → 150 passed).