### PR TITLE
fix(tests): seed app-state fixtures as bootstrapped

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -3549,7 +3549,11 @@ mod send_patch_response_tests {
     use wacore_binary::node::Node;
 
     /// Seed the client's store with an app-state key so `build_patch` can sign,
-    /// and give the collection a non-zero base so the IQ carries a `version`.
+    /// and give the collection a bootstrapped, non-zero base so the IQ carries a
+    /// `version`. The base has to say it bootstrapped: `send_app_state_patch`
+    /// syncs a collection that never completed one instead of building on it,
+    /// and these tests are about what the send does with the server's answer to
+    /// a patch, not about reaching that state.
     async fn seed_collection(client: &Arc<Client>, collection: &str) -> Vec<u8> {
         let backend = client.persistence_manager.backend();
         let key_id = b"send-patch-key".to_vec();
@@ -3568,6 +3572,7 @@ mod send_patch_response_tests {
                 collection,
                 wacore::appstate::hash::HashState {
                     version: 7,
+                    bootstrapped: true,
                     ..Default::default()
                 },
             )

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -990,6 +990,12 @@ where
             collection,
             wacore::appstate::hash::HashState {
                 version: 7,
+                // `send_app_state_patch` refuses to build on a collection whose
+                // bootstrap never completed and syncs it first, which the mock
+                // transport cannot answer. A verb test is about the mutation the
+                // verb writes, not about reaching that state, so the fixture
+                // starts from a collection that has bootstrapped.
+                bootstrapped: true,
                 ..Default::default()
             },
         )


### PR DESCRIPTION
Follow-up to #1366: `Build & Test` and `Build & Lint (all features)` have been red on `main` since #1365, and #1366 merged on top of that.

## What broke

#1365 added a bootstrap gate to `send_app_state_patch`: a collection whose bootstrap never completed gets synced first instead of being built on, because a patch over an empty ltHash is refused by construction.

Both app-state test fixtures seed their base with `HashState { version: 7, ..Default::default() }`. `bootstrapped` is new in #1365 and defaults to `false`, so every one of those tests took the sync branch and waited on an answer the mock transport never sends.

Fifteen tests, in two shapes:

- The seven driving `capture_app_state_mutation` (`app_state_settings`, `chat_actions`, `labels`, `quick_replies`) timed out at `frame 0 should reach the transport`. Only these appear in the CI log tail, which is why the count looked like seven.
- The eight in `client::app_state::send_patch_response_tests` counted zero patch IQs where they expect one, because the send gave up before writing anything.

## The change

The gate is correct and stays untouched. The fixtures are what went stale, so both now seed `bootstrapped: true`:

- `src/features/chat_actions.rs`, `capture_app_state_mutation`
- `src/client/app_state.rs`, `seed_collection`

A verb test is about the mutation a verb writes, and a send-response test about what the send does with the server's answer to a patch. Neither is about reaching a bootstrapped state, so both start from one.

## Verification

```
cargo test -p whatsapp-rust --lib   1828 passed, 0 failed
cargo test -p wacore --lib          1540 passed, 0 failed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   clean
cargo fmt --all --check             clean
```

The seven timing-out tests now finish in 0.27s instead of burning 5s each on the timeout.

`Semver Checks` is left alone: it is `continue-on-error: true` and advisory by design, since the workspace is pre-1.0 and breaks API between minors on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMK63xtJKB2GYUNUd1ivtf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMK63xtJKB2GYUNUd1ivtf)_