### PR TITLE
fix(tests): move the harness version bump ahead of the IQ answer

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -3672,8 +3672,6 @@ mod send_patch_response_tests {
                 Some(code) => collection_error_result(&id, response_collection, code),
                 None => empty_sync_result(&id, response_collection),
             };
-            let clean_resync = attempt == 0 && verdict.is_none();
-            crate::test_utils::answer_iq(client, &id, &response).await;
             // A re-sync the server answers cleanly is one that found it ahead of
             // us, so it moves the base -- which is what makes the next patch a
             // different request rather than the same one. The real
@@ -3682,7 +3680,14 @@ mod send_patch_response_tests {
             // this the mock says "your base is stale" and then "nothing new",
             // which no server does, and the retry it provoked was measuring an
             // impossible sequence.
-            if clean_resync {
+            //
+            // Moved before the answer on purpose. `answer_iq` releases the
+            // waiter, so the sender resumes and `absorb_conflicting_patches`
+            // reads the base to decide whether the recovery moved it. Bumping
+            // afterwards races that read: lose it and the absorb sees the base
+            // it started from, calls the recovery failed and breaks the retry
+            // loop early. A real server has already moved before it answers.
+            if attempt == 0 && verdict.is_none() {
                 let backend = client.persistence_manager.backend();
                 let current = backend
                     .get_version(COLLECTION)
@@ -3700,6 +3705,7 @@ mod send_patch_response_tests {
                     .await
                     .expect("the test backend should accept a version");
             }
+            crate::test_utils::answer_iq(client, &id, &response).await;
             frame += 1;
         }
     }


### PR DESCRIPTION
Follow-up to #1367. That one turned `Build & Test` green, and `Build & Lint (all features)` got far enough to reach a second, unrelated failure that was hidden behind it.

## What fails

On `main` at `ff0813b`, `Build & Lint (all features)` fails one test out of 2289:

```
client::app_state::send_patch_response_tests::unresolvable_conflict_is_not_reported_as_success
assertion `left == right` failed: the send must exhaust its rebuild attempts before giving up
  left: 3
 right: 5
```

Not a feature-gating problem. It passes in isolation under `--all-features`, and it is not this crate's send path either. It is a race in the test harness that only opens up when the machine is busy, which is why the wider job trips it and `Build & Test` does not.

## The race

`serve_iqs` answers a clean re-sync and *then* bumps the collection's version:

```rust
crate::test_utils::answer_iq(client, &id, &response).await;
if clean_resync { /* get_version, set_version(version + 1) */ }
```

`answer_iq` releases the waiter, so the sender resumes inside `absorb_conflicting_patches`, which reads the base to decide whether the recovery moved it:

```rust
if base_after == base_before { return Recovery::Failed(...) }
```

That read races the bump. Lose it and the absorb sees the base it started from, calls the recovery failed, and `send_app_state_patch` breaks out of its retry loop early. Three patches reach the wire instead of five.

## The change

Bump before answering. The window closes, and the ordering is the more faithful one anyway: a real server's state has already moved by the time it replies. Production code is untouched.

## Verification

Reproduced first, with eight spinners against four cores:

```
before:  15 failures in 40 runs
after:    0 failures in 60 runs
```

Then the module under the same load (0 in 25), and the full checks:

```
cargo nextest run --profile ci -p whatsapp-rust --all-features --lib
    2216 passed, 0 failed, 1 skipped
cargo clippy -p whatsapp-rust --all-features --all-targets -- -D warnings   clean
cargo fmt --all --check                                                     clean
```

`Semver Checks` is still red on `main` and left alone: it is `continue-on-error: true` and advisory, and it fails on the base commit too. Its likely cause is worth a separate look — #1365 added the public `bootstrapped` field to `HashState` without `#[non_exhaustive]`, which breaks struct-literal construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMK63xtJKB2GYUNUd1ivtf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMK63xtJKB2GYUNUd1ivtf)_