### PR TITLE
diag(appstate): say whether a snapshot MAC mismatch is the key or the fold

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -222,7 +222,11 @@ impl HashState {
     /// a negative index there and folds the truncated buffer instead. Both are
     /// answers to a record the server should never send; ours refuses to fold
     /// something that is not a MAC.
-    pub fn update_hash_from_records(&mut self, records: &[wa::SyncdRecord]) {
+    /// Answers how many value MACs it folded, which is not `records.len()`: a
+    /// record whose value blob is too short to hold one is dropped, and a
+    /// repeated index contributes once. Diagnostics read it rather than
+    /// restating the rule, which is how a count and a fold drift apart.
+    pub fn update_hash_from_records(&mut self, records: &[wa::SyncdRecord]) -> usize {
         // Borrow the MAC tails; no Vec<u8> allocation per MAC.
         let mut added: Vec<&[u8]> = Vec::with_capacity(records.len());
         let mut indexed: Vec<(&[u8], &[u8])> = Vec::with_capacity(records.len());
@@ -272,6 +276,7 @@ impl HashState {
         }
 
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
+        added.len()
     }
 
     pub fn generate_snapshot_mac(&self, name: &str, key: &[u8]) -> Vec<u8> {

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -120,6 +120,32 @@ where
         let keys = get_keys(key_id)?;
         let computed = initial_state.generate_snapshot_mac(collection_name, &keys.snapshot_mac);
         if computed != *mac_expected {
+            // Two things can produce this, and they need opposite fixes: the key
+            // we derived is wrong, or the ltHash we folded is. They are
+            // indistinguishable from the MACs alone, and the MAC is checked
+            // before any record is decoded -- so nothing downstream ever gets to
+            // disagree. Decoding one record answers it: the value MAC inside it
+            // is derived from the same expanded key, so a record that decodes
+            // proves the key is right and points at the fold.
+            let key_probe = snapshot
+                .records
+                .first()
+                .map(|rec| {
+                    decode_record(
+                        wa::syncd_mutation::SyncdOperation::SET,
+                        rec,
+                        &keys,
+                        key_id,
+                        true,
+                    )
+                })
+                .map(|r| match r {
+                    Ok(_) => "the key is right, so the fold is what differs",
+                    Err(_) => "the key does not decode this snapshot either",
+                })
+                .unwrap_or("the snapshot carries no records to probe");
+            let distinct_indices = last_record_per_index(&snapshot.records).len();
+
             // The identifying line stays at warn, because a collection that
             // strands itself has to be visible without turning logging up. The
             // MACs and the ltHash do not: a snapshot MAC is HMAC output under
@@ -136,12 +162,16 @@ where
             );
             debug!(
                 target: "AppState",
-                "Snapshot {} v{} MAC mismatch: computed={}, expected={}, ltHash={}",
+                "Snapshot {} v{} MAC mismatch: computed={}, expected={}, ltHash={}, \
+                 {} of {} records carry a distinct index, key probe says {}",
                 collection_name,
                 version,
                 hex::encode(&computed),
                 hex::encode(mac_expected),
-                hex::encode(&initial_state.hash[120..])
+                hex::encode(&initial_state.hash[120..]),
+                distinct_indices,
+                snapshot.records.len(),
+                key_probe
             );
             return Err(AppStateError::SnapshotMACMismatch);
         }

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -8,7 +8,7 @@ use crate::AppStateError;
 use crate::decode::{Mutation, decode_record};
 use crate::hash::{HashState, generate_patch_mac};
 use crate::keys::ExpandedAppStateKeys;
-use log::{debug, trace, warn};
+use log::{Level, debug, log_enabled, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -127,24 +127,38 @@ where
             // disagree. Decoding one record answers it: the value MAC inside it
             // is derived from the same expanded key, so a record that decodes
             // proves the key is right and points at the fold.
-            let key_probe = snapshot
-                .records
-                .first()
-                .map(|rec| {
-                    decode_record(
-                        wa::syncd_mutation::SyncdOperation::SET,
-                        rec,
-                        &keys,
-                        key_id,
-                        true,
-                    )
-                })
-                .map(|r| match r {
-                    Ok(_) => "the key is right, so the fold is what differs",
-                    Err(_) => "the key does not decode this snapshot either",
-                })
-                .unwrap_or("the snapshot carries no records to probe");
-            let distinct_indices = last_record_per_index(&snapshot.records).len();
+            // Only when someone is reading: decoding a record costs an AES pass, a
+            // MAC and a protobuf parse, and this arm is reached on every page of
+            // a collection that is failing.
+            let (key_probe, distinct_indices) = if log_enabled!(target: "AppState", Level::Debug) {
+                // The record's own key id, not the snapshot's. The two are
+                // allowed to differ, and the normal decode loop below reads each
+                // record's -- probing with the snapshot's would report a key
+                // failure for a record the key never claimed to cover, sending
+                // the reader after the one answer this line exists to rule out.
+                let probe = match snapshot.records.first() {
+                    None => "the snapshot carries no records to probe",
+                    Some(rec) => match rec.key_id.id.as_deref() {
+                        None => "the first record names no key id",
+                        Some(rec_key_id) => match get_keys(rec_key_id) {
+                            Err(_) => "the first record's key id is not one we hold",
+                            Ok(rec_keys) => match decode_record(
+                                wa::syncd_mutation::SyncdOperation::SET,
+                                rec,
+                                &rec_keys,
+                                rec_key_id,
+                                true,
+                            ) {
+                                Ok(_) => "its records decode, so the fold is what differs",
+                                Err(_) => "its records do not decode either, so look at the key",
+                            },
+                        },
+                    },
+                };
+                (probe, last_record_per_index(&snapshot.records).len())
+            } else {
+                ("not probed", 0)
+            };
 
             // The identifying line stays at warn, because a collection that
             // strands itself has to be visible without turning logging up. The

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -130,34 +130,46 @@ where
             // Only when someone is reading: decoding a record costs an AES pass, a
             // MAC and a protobuf parse, and this arm is reached on every page of
             // a collection that is failing.
-            let (key_probe, distinct_indices) = if log_enabled!(target: "AppState", Level::Debug) {
-                // The record's own key id, not the snapshot's. The two are
-                // allowed to differ, and the normal decode loop below reads each
-                // record's -- probing with the snapshot's would report a key
-                // failure for a record the key never claimed to cover, sending
-                // the reader after the one answer this line exists to rule out.
-                let probe = match snapshot.records.first() {
-                    None => "the snapshot carries no records to probe",
-                    Some(rec) => match rec.key_id.id.as_deref() {
-                        None => "the first record names no key id",
-                        Some(rec_key_id) => match get_keys(rec_key_id) {
-                            Err(_) => "the first record's key id is not one we hold",
-                            Ok(rec_keys) => match decode_record(
-                                wa::syncd_mutation::SyncdOperation::SET,
-                                rec,
-                                &rec_keys,
-                                rec_key_id,
-                                true,
-                            ) {
-                                Ok(_) => "its records decode, so the fold is what differs",
-                                Err(_) => "its records do not decode either, so look at the key",
-                            },
-                        },
+            let (key_probe, folded, total) = if log_enabled!(target: "AppState", Level::Debug) {
+                let total = snapshot.records.len();
+                // What the fold actually kept: one record per index MAC, plus
+                // every record carrying no index blob, since those cannot
+                // collide. Not "distinct indices" -- nothing here has decoded or
+                // validated an index, so this counts blobs, and comparing it
+                // against `total` is what says whether the dedup applied at all.
+                let folded = last_record_per_index(&snapshot.records).len();
+                // The question is whether *this* key is right, and `computed` was
+                // made with the snapshot's. A record keyed with some other id
+                // answers about that other key: decoding it proves nothing here,
+                // and failing to decode it accuses a key the snapshot never
+                // claimed. Across an app-state key rotation a snapshot may carry
+                // both, so the record has to be chosen, not taken.
+                let probe = match snapshot
+                    .records
+                    .iter()
+                    .find(|rec| rec.key_id.id.as_deref() == Some(key_id))
+                {
+                    None => "inconclusive: no record is keyed with the snapshot's own key id"
+                        .to_string(),
+                    Some(rec) => match decode_record(
+                        wa::syncd_mutation::SyncdOperation::SET,
+                        rec,
+                        &keys,
+                        key_id,
+                        true,
+                    ) {
+                        Ok(_) => "the snapshot's key decodes its own record, so the fold differs"
+                            .to_string(),
+                        // The class, not just the fact: `decode_record` refuses
+                        // for a bad content MAC, a failed decryption, a malformed
+                        // value and a missing index MAC, and only some of those
+                        // are about the key.
+                        Err(e) => format!("the snapshot's key failed on its own record: {e}"),
                     },
                 };
-                (probe, last_record_per_index(&snapshot.records).len())
+                (probe, folded, total)
             } else {
-                ("not probed", 0)
+                ("not probed".to_string(), 0, 0)
             };
 
             // The identifying line stays at warn, because a collection that
@@ -177,14 +189,14 @@ where
             debug!(
                 target: "AppState",
                 "Snapshot {} v{} MAC mismatch: computed={}, expected={}, ltHash={}, \
-                 {} of {} records carry a distinct index, key probe says {}",
+                 the fold kept {} of {} records, key probe says {}",
                 collection_name,
                 version,
                 hex::encode(&computed),
                 hex::encode(mac_expected),
                 hex::encode(&initial_state.hash[120..]),
-                distinct_indices,
-                snapshot.records.len(),
+                folded,
+                total,
                 key_probe
             );
             return Err(AppStateError::SnapshotMACMismatch);

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -86,7 +86,7 @@ where
     initial_state.version = version;
 
     // Update hash state directly from records (no cloning needed)
-    initial_state.update_hash_from_records(&snapshot.records);
+    let folded = initial_state.update_hash_from_records(&snapshot.records);
 
     debug!(
         target: "AppState",
@@ -130,21 +130,17 @@ where
             // Only when someone is reading: decoding a record costs an AES pass, a
             // MAC and a protobuf parse, and this arm is reached on every page of
             // a collection that is failing.
-            let (key_probe, folded, total) = if log_enabled!(target: "AppState", Level::Debug) {
-                let total = snapshot.records.len();
-                // What the fold actually kept: one record per index MAC, plus
-                // every record carrying no index blob, since those cannot
-                // collide. Not "distinct indices" -- nothing here has decoded or
-                // validated an index, so this counts blobs, and comparing it
-                // against `total` is what says whether the dedup applied at all.
-                let folded = last_record_per_index(&snapshot.records).len();
+            // Only when someone is reading: decoding a record costs an AES pass, a
+            // MAC and a protobuf parse, and this arm is reached on every page of
+            // a collection that is failing.
+            let key_probe = if log_enabled!(target: "AppState", Level::Debug) {
                 // The question is whether *this* key is right, and `computed` was
                 // made with the snapshot's. A record keyed with some other id
                 // answers about that other key: decoding it proves nothing here,
                 // and failing to decode it accuses a key the snapshot never
                 // claimed. Across an app-state key rotation a snapshot may carry
                 // both, so the record has to be chosen, not taken.
-                let probe = match snapshot
+                match snapshot
                     .records
                     .iter()
                     .find(|rec| rec.key_id.id.as_deref() == Some(key_id))
@@ -158,18 +154,20 @@ where
                         key_id,
                         true,
                     ) {
-                        Ok(_) => "the snapshot's key decodes its own record, so the fold differs"
-                            .to_string(),
+                        // Says what it proved and no more. The key validating one
+                        // record does not make the fold the culprit: a stale or
+                        // truncated expected MAC produces this same mismatch with
+                        // a fold that is perfectly correct.
+                        Ok(_) => "the snapshot's key decodes its own record".to_string(),
                         // The class, not just the fact: `decode_record` refuses
                         // for a bad content MAC, a failed decryption, a malformed
                         // value and a missing index MAC, and only some of those
                         // are about the key.
                         Err(e) => format!("the snapshot's key failed on its own record: {e}"),
                     },
-                };
-                (probe, folded, total)
+                }
             } else {
-                ("not probed".to_string(), 0, 0)
+                "not probed".to_string()
             };
 
             // The identifying line stays at warn, because a collection that
@@ -189,14 +187,14 @@ where
             debug!(
                 target: "AppState",
                 "Snapshot {} v{} MAC mismatch: computed={}, expected={}, ltHash={}, \
-                 the fold kept {} of {} records, key probe says {}",
+                 the fold folded {} of {} records, key probe says {}",
                 collection_name,
                 version,
                 hex::encode(&computed),
                 hex::encode(mac_expected),
                 hex::encode(&initial_state.hash[120..]),
                 folded,
-                total,
+                snapshot.records.len(),
                 key_probe
             );
             return Err(AppStateError::SnapshotMACMismatch);


### PR DESCRIPTION
## Why

A production log taken after #1365 shows `regular_low` still refusing to sync:

```
[DEBUG] Client/AppState: regular_low has never synced; syncing before building a patch on it
[DEBUG] Client/AppState: Parsed patch list for RegularLow: has_snapshot_ref=true has_more_patches=false patches_count=6
[DEBUG] Client/AppState: Downloaded external snapshot (7096 bytes)
[DEBUG] AppState: Snapshot regular_low v253: 31 records, ltHash ends with ...4a002f357bfb0af2
[WARN]  AppState: Snapshot regular_low v253 MAC mismatch over 31 records
[DEBUG] AppState: Snapshot regular_low v253 MAC mismatch: computed=a9ba8f..., expected=c73731...
[WARN]  oxidezap_session::whatsapp: Failed to mark chat …@lid as read: snapshot MAC mismatch
```

The index dedup #1365 landed is a real divergence from WA Web and stays fixed, but it was not this account's cause: over 31 records it only changes the fold if some of those indices repeat, and the collection fails either way.

Two candidates remain and they want opposite fixes — the key we derived is wrong, or the ltHash we folded is. Nothing in the current logs separates them, and nothing downstream can: the MAC is validated *before* any record is decoded, so a wrong key never reaches a place where it would fail visibly.

## What this adds

On the mismatch path only, the debug line now carries:

- **A key probe.** One record is decoded with the same expanded key. Its value MAC is derived from that key, so a record that decodes proves the key is right and points at the fold; one that does not says the key does not decode this snapshot either.
- **Distinct indices against total records.** Says outright whether dedup applies to this snapshot at all — if the two numbers match, the fold is over exactly what it was before #1365.

Both are on the failure path, at debug, so nothing is paid on a healthy sync.

## What it does not do

It does not fix the account. The next log from it should say which half to fix, which is the thing the current one cannot.

Checked while writing this and ruled out: the LTHash operand derivation (`hkdf(None, valueMac, "WhatsApp Patch Integrity", 128)`, with `pre_keyed_extract_matches_plain_hkdf` proving the optimized path equals the reference), the version encoding, the collection name, and the order of fold-then-MAC.
