### PR TITLE
perf(bench): measure jid identity and the caches keyed by it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,6 +335,13 @@ name = "client_group_send"
 harness = false
 required-features = ["bench-harness"]
 
+# The `Cache<Jid, _>` lookup shape `chat_lanes` runs per inbound message. No
+# `required-features`: it reaches only the public cache, so it builds (and is
+# regression-gated) in a plain `cargo bench`.
+[[bench]]
+name = "jid_keyed_cache"
+harness = false
+
 [profile.release]
 opt-level = 3
 debug = false

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -137,7 +137,13 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
 /// is in.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    static FULL: OnceLock<Vec<(Cache<Jid, Arc<()>>, AtomicUsize)>> = OnceLock::new();
+    /// A cache held at capacity, plus the next unused chat index.
+    struct AtCapacity {
+        cache: Cache<Jid, Arc<()>>,
+        next: AtomicUsize,
+    }
+
+    static FULL: OnceLock<Vec<AtCapacity>> = OnceLock::new();
     let built = FULL.get_or_init(|| {
         CHAT_COUNTS
             .iter()
@@ -151,11 +157,14 @@ fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
                         cache.insert(chat_jid(i), Arc::new(())).await;
                     }
                 });
-                (cache, AtomicUsize::new(n))
+                AtCapacity {
+                    cache,
+                    next: AtomicUsize::new(n),
+                }
             })
             .collect()
     });
-    let (cache, next) = &built[CHAT_COUNTS
+    let AtCapacity { cache, next } = &built[CHAT_COUNTS
         .iter()
         .position(|&n| n == count)
         .expect("known chat count")];

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -50,15 +50,40 @@ fn block_on<F: Future>(future: F) -> F::Output {
 }
 
 /// Live-chat counts worth distinguishing. The default `chat_lanes_capacity` is
-/// 5000, so none of these evict; what changes across them is how deep the map
-/// is when the lookup lands.
+/// 5000, so none of these evict on the lookup benches; what changes across them
+/// is how deep the map is when the lookup lands.
 const CHAT_COUNTS: [usize; 3] = [16, 256, 4096];
 
 /// Lookups per measured iteration.
 const BATCH: usize = 1024;
 
+/// Fixed-width so every key costs the same to hash and compare, whichever
+/// rotation a bench is on. Six digits covers the largest fixture with room to
+/// spare, and never widens mid-run.
 fn chat_jid(i: usize) -> Jid {
     Jid::pn(format!("5511999{i:06}"))
+}
+
+/// `count + 1` keys per chat count, built once. One more than the cache holds,
+/// so a rotation through them always lands on the key that is currently absent
+/// -- which is what lets the creation bench stay on the miss path without
+/// building a key inside the measured loop.
+fn keys(count: usize) -> &'static [Jid] {
+    static KEYS: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
+    let built = KEYS.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| (0..=n).map(chat_jid).collect())
+            .collect()
+    });
+    &built[index_of(count)]
+}
+
+fn index_of(count: usize) -> usize {
+    CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")
 }
 
 /// A warm cache plus the two probes into it, one of each outcome.
@@ -92,10 +117,7 @@ fn fixture(count: usize) -> &'static Probed {
             })
             .collect()
     });
-    &built[CHAT_COUNTS
-        .iter()
-        .position(|&n| n == count)
-        .expect("known chat count")]
+    &built[index_of(count)]
 }
 
 /// The per-message path: an existing chat resolves its lane.
@@ -124,55 +146,76 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
     });
 }
 
-/// Creating the lane, which is what a miss leads to.
-///
-/// A separate fixture from the lookups above, and built at `max_capacity =
-/// count` on purpose: inserting a key the cache already holds takes an
-/// overwrite branch that returns before `insert_new` and measures none of what
-/// creating a lane costs -- the key clone, the FIFO bookkeeping, the capacity
-/// check, the new map entry. Every key here is new, so every iteration goes
-/// through that path, and the cache sits at capacity so each insert also pays
-/// the eviction it triggers. That is the steady state of a client with more
-/// live chats than `chat_lanes_capacity`, which is the state a long-lived one
-/// is in.
-#[divan::bench(args = CHAT_COUNTS)]
-fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    /// A cache held at capacity, plus the next unused chat index.
-    struct AtCapacity {
-        cache: Cache<Jid, Arc<()>>,
-        next: AtomicUsize,
-    }
+/// A cache held at capacity, and the rotation position that is absent from it.
+struct AtCapacity {
+    cache: Cache<Jid, Arc<()>>,
+    next: AtomicUsize,
+    /// Values kept alive so `evict_guard` refuses them, standing in for lanes
+    /// whose `enqueue_lock` is still held by message processing. Never read;
+    /// holding the `Arc` is the whole point.
+    _protected: Vec<Arc<()>>,
+}
 
-    static FULL: OnceLock<Vec<AtCapacity>> = OnceLock::new();
+/// Creating a lane, which is what a first message from a chat actually does.
+///
+/// Driven through `get_with_by_ref`, not `insert`, because that is what
+/// `handlers::message` calls: the miss path behind it hashes and acquires a
+/// per-key init lock, re-checks under it, converts the borrowed key to an owned
+/// one, inserts, clones the value out and reclaims the lock. A bare `insert`
+/// measures none of that, and an `insert` of a key already present measures
+/// less still -- it returns from the overwrite branch before `insert_new`.
+///
+/// The cache is built at `max_capacity = count` and the keys rotate through
+/// `count + 1` prebuilt values, so every iteration lands on the one key FIFO
+/// eviction has just removed: always a miss, always the same key width, and no
+/// allocation inside the measured loop.
+///
+/// `PROTECTED` picks whether some entries are ineligible for eviction. That is
+/// the guard `chat_lanes` actually runs -- a lane whose lock is held must be
+/// skipped -- and it makes the eviction scan walk past entries instead of
+/// taking the first FIFO candidate, which is the depth-dependent part.
+#[divan::bench(args = CHAT_COUNTS, consts = [0usize, 8usize])]
+fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count: usize) {
+    static FULL: OnceLock<Vec<Vec<AtCapacity>>> = OnceLock::new();
     let built = FULL.get_or_init(|| {
-        CHAT_COUNTS
+        [0usize, 8usize]
             .iter()
-            .map(|&n| {
-                let cache: Cache<Jid, Arc<()>> = Cache::builder()
-                    .max_capacity(n as u64)
-                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
-                    .build();
-                block_on(async {
-                    for i in 0..n {
-                        cache.insert(chat_jid(i), Arc::new(())).await;
-                    }
-                });
-                AtCapacity {
-                    cache,
-                    next: AtomicUsize::new(n),
-                }
+            .map(|&protected| {
+                CHAT_COUNTS
+                    .iter()
+                    .map(|&n| {
+                        let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                            .max_capacity(n as u64)
+                            .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                            .build();
+                        let mut held = Vec::new();
+                        block_on(async {
+                            for (i, key) in keys(n).iter().take(n).enumerate() {
+                                let value = Arc::new(());
+                                if i < protected {
+                                    held.push(Arc::clone(&value));
+                                }
+                                cache.insert(key.clone(), value).await;
+                            }
+                        });
+                        AtCapacity {
+                            cache,
+                            next: AtomicUsize::new(n),
+                            _protected: held,
+                        }
+                    })
+                    .collect()
             })
             .collect()
     });
-    let AtCapacity { cache, next } = &built[CHAT_COUNTS
-        .iter()
-        .position(|&n| n == count)
-        .expect("known chat count")];
+    let slot = if PROTECTED == 0 { 0 } else { 1 };
+    let AtCapacity { cache, next, .. } = &built[slot][index_of(count)];
+    let keys = keys(count);
 
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            let key = chat_jid(next.fetch_add(1, Ordering::Relaxed));
-            block_on(cache.insert(black_box(key), Arc::new(())));
+            let i = next.fetch_add(1, Ordering::Relaxed) % keys.len();
+            block_on(cache.get_with_by_ref(black_box(&keys[i]), async { Arc::new(()) }));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -1,0 +1,137 @@
+//! The `Cache<Jid, _>` lookup every inbound message performs.
+//!
+//! `chat_lanes` (`src/client.rs`) is the hottest structure this repository
+//! keys by `Jid`: `handlers::message` resolves one lane per incoming message
+//! before anything else happens, so its cost is paid per message rather than
+//! per send. The lane itself cannot be driven from a bench target -- `ChatLane`
+//! and the field holding it are crate-private, and reaching them needs a
+//! connected `Client` -- so what is measured here is the cache it lives in,
+//! built the same way (`max_capacity` + `evict_guard`) and keyed the same way,
+//! with a value cheap enough that what is left on the clock is the `Jid` hash,
+//! the `Jid` equality on a hit, and the cache's own bookkeeping.
+//!
+//! Driven on a bare poll loop rather than a Tokio runtime: the cache's locks
+//! are `async_lock` primitives that resolve without yielding when uncontended,
+//! so every future here completes on its first poll, and a runtime in the loop
+//! would put its own scheduling on the clock instead of the lookup's.
+//!
+//! Fixtures are built once and leaked, and each iteration works a batch: a
+//! single lookup is a few nanoseconds, below this repository's documented
+//! wall-clock noise on cloud hardware. See the same note in
+//! `wacore/binary/benches/jid_benchmark.rs`.
+
+use divan::black_box;
+use divan::counter::ItemsCount;
+use std::future::Future;
+use std::pin::pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll, Waker};
+use wacore_binary::jid::Jid;
+use whatsapp_rust::cache::Cache;
+
+fn main() {
+    divan::main();
+}
+
+/// Drive a future to completion by polling it. Every future in this file
+/// resolves on the first poll, so the busy loop is a fallback that never runs;
+/// it is here so a future that did park would hang visibly rather than return
+/// a wrong answer.
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    loop {
+        if let Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+        std::hint::spin_loop();
+    }
+}
+
+/// Live-chat counts worth distinguishing. The default `chat_lanes_capacity` is
+/// 5000, so none of these evict; what changes across them is how deep the map
+/// is when the lookup lands.
+const CHAT_COUNTS: [usize; 3] = [16, 256, 4096];
+
+/// Lookups per measured iteration.
+const BATCH: usize = 1024;
+
+fn chat_jid(i: usize) -> Jid {
+    Jid::pn(format!("5511999{i:06}"))
+}
+
+/// A warm cache plus the two probes into it, one of each outcome.
+struct Probed {
+    cache: Cache<Jid, Arc<()>>,
+    hit: Jid,
+    miss: Jid,
+}
+
+/// One warm cache per chat count, plus a key that hits and one that misses.
+fn fixture(count: usize) -> &'static Probed {
+    static BUILT: OnceLock<Vec<Probed>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                    .max_capacity(5_000)
+                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                    .build();
+                block_on(async {
+                    for i in 0..n {
+                        cache.insert(chat_jid(i), Arc::new(())).await;
+                    }
+                });
+                Probed {
+                    cache,
+                    hit: chat_jid(n / 2),
+                    miss: Jid::pn("5511000000000"),
+                }
+            })
+            .collect()
+    });
+    &built[CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")]
+}
+
+/// The per-message path: an existing chat resolves its lane.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, hit, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for _ in 0..BATCH {
+            found += block_on(cache.get(black_box(hit))).is_some() as usize;
+        }
+        black_box(found)
+    });
+}
+
+/// First message from a chat: the lookup misses and a lane has to be created.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, miss, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut absent = 0usize;
+        for _ in 0..BATCH {
+            absent += block_on(cache.get(black_box(miss))).is_none() as usize;
+        }
+        black_box(absent)
+    });
+}
+
+/// Creating the lane, which is what a miss leads to. Overwrites one key rather
+/// than growing the cache, so the arms stay comparable and nothing evicts.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, hit, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        for _ in 0..BATCH {
+            block_on(cache.insert(black_box(hit).clone(), Arc::new(())));
+        }
+        black_box(cache.entry_count())
+    });
+}

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -200,7 +200,7 @@ fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count
                         });
                         AtCapacity {
                             cache,
-                            next: AtomicUsize::new(n),
+                            next: AtomicUsize::new(n - protected),
                             _protected: held,
                         }
                     })
@@ -210,12 +210,16 @@ fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count
     });
     let slot = if PROTECTED == 0 { 0 } else { 1 };
     let AtCapacity { cache, next, .. } = &built[slot][index_of(count)];
-    let keys = keys(count);
+    // The protected keys are pinned in the cache forever, so probing one is a
+    // hit, not a creation. Rotate only over the evictable tail: the cache holds
+    // `PROTECTED` pinned plus `count - PROTECTED` of these, one short of the
+    // set, so the rotation still lands on the absent key every time.
+    let rotating = &keys(count)[PROTECTED..];
 
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            let i = next.fetch_add(1, Ordering::Relaxed) % keys.len();
-            block_on(cache.get_with_by_ref(black_box(&keys[i]), async { Arc::new(()) }));
+            let i = next.fetch_add(1, Ordering::Relaxed) % rotating.len();
+            block_on(cache.get_with_by_ref(black_box(&rotating[i]), async { Arc::new(()) }));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -24,6 +24,7 @@ use divan::black_box;
 use divan::counter::ItemsCount;
 use std::future::Future;
 use std::pin::pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll, Waker};
 use wacore_binary::jid::Jid;
@@ -123,14 +124,46 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
     });
 }
 
-/// Creating the lane, which is what a miss leads to. Overwrites one key rather
-/// than growing the cache, so the arms stay comparable and nothing evicts.
+/// Creating the lane, which is what a miss leads to.
+///
+/// A separate fixture from the lookups above, and built at `max_capacity =
+/// count` on purpose: inserting a key the cache already holds takes an
+/// overwrite branch that returns before `insert_new` and measures none of what
+/// creating a lane costs -- the key clone, the FIFO bookkeeping, the capacity
+/// check, the new map entry. Every key here is new, so every iteration goes
+/// through that path, and the cache sits at capacity so each insert also pays
+/// the eviction it triggers. That is the steady state of a client with more
+/// live chats than `chat_lanes_capacity`, which is the state a long-lived one
+/// is in.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, hit, .. } = fixture(count);
+    static FULL: OnceLock<Vec<(Cache<Jid, Arc<()>>, AtomicUsize)>> = OnceLock::new();
+    let built = FULL.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                    .max_capacity(n as u64)
+                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                    .build();
+                block_on(async {
+                    for i in 0..n {
+                        cache.insert(chat_jid(i), Arc::new(())).await;
+                    }
+                });
+                (cache, AtomicUsize::new(n))
+            })
+            .collect()
+    });
+    let (cache, next) = &built[CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")];
+
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            block_on(cache.insert(black_box(hit).clone(), Arc::new(())));
+            let key = chat_jid(next.fetch_add(1, Ordering::Relaxed));
+            block_on(cache.insert(black_box(key), Arc::new(())));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -64,6 +64,11 @@ fn chat_jid(i: usize) -> Jid {
     Jid::pn(format!("5511999{i:06}"))
 }
 
+/// A key of the same width that no fixture ever inserts, for the miss probes.
+fn absent_jid(i: usize) -> Jid {
+    Jid::pn(format!("5511000{i:06}"))
+}
+
 /// `count + 1` keys per chat count, built once. One more than the cache holds,
 /// so a rotation through them always lands on the key that is currently absent
 /// -- which is what lets the creation bench stay on the miss path without
@@ -86,14 +91,21 @@ fn index_of(count: usize) -> usize {
         .expect("known chat count")
 }
 
-/// A warm cache plus the two probes into it, one of each outcome.
+/// A warm cache plus a set of probes into it for each outcome.
+///
+/// Both sets are cycled rather than repeated, for the reason
+/// `bench_jid_hashmap_get` cycles its own: the cache hashes with a per-process
+/// `RandomState`, so one fixed probe measures whichever bucket and collision
+/// chain that process happened to draw. Repeating it a thousand times only
+/// amplifies the draw, and CodSpeed compares two separate processes -- the
+/// baseline could differ from the branch with no code change at all.
 struct Probed {
     cache: Cache<Jid, Arc<()>>,
-    hit: Jid,
-    miss: Jid,
+    hits: Vec<Jid>,
+    misses: Vec<Jid>,
 }
 
-/// One warm cache per chat count, plus a key that hits and one that misses.
+/// One warm cache per chat count, plus the probe sets that hit and miss it.
 fn fixture(count: usize) -> &'static Probed {
     static BUILT: OnceLock<Vec<Probed>> = OnceLock::new();
     let built = BUILT.get_or_init(|| {
@@ -111,8 +123,8 @@ fn fixture(count: usize) -> &'static Probed {
                 });
                 Probed {
                     cache,
-                    hit: chat_jid(n / 2),
-                    miss: Jid::pn("5511000000000"),
+                    hits: (0..n).map(chat_jid).collect(),
+                    misses: (0..n).map(absent_jid).collect(),
                 }
             })
             .collect()
@@ -123,11 +135,12 @@ fn fixture(count: usize) -> &'static Probed {
 /// The per-message path: an existing chat resolves its lane.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, hit, .. } = fixture(count);
+    let Probed { cache, hits, .. } = fixture(count);
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut found = 0usize;
-        for _ in 0..BATCH {
-            found += block_on(cache.get(black_box(hit))).is_some() as usize;
+        for i in 0..BATCH {
+            let key = &hits[i % hits.len()];
+            found += block_on(cache.get(black_box(key))).is_some() as usize;
         }
         black_box(found)
     });
@@ -136,11 +149,12 @@ fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
 /// First message from a chat: the lookup misses and a lane has to be created.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, miss, .. } = fixture(count);
+    let Probed { cache, misses, .. } = fixture(count);
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut absent = 0usize;
-        for _ in 0..BATCH {
-            absent += block_on(cache.get(black_box(miss))).is_none() as usize;
+        for i in 0..BATCH {
+            let key = &misses[i % misses.len()];
+            absent += block_on(cache.get(black_box(key))).is_none() as usize;
         }
         black_box(absent)
     });

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -57,3 +57,180 @@ fn bench_jid_push_phash_form(bencher: divan::Bencher) {
             black_box(buf.as_bytes());
         });
 }
+
+// ---------------------------------------------------------------------------
+// Identity: `PartialEq`, `Hash`, and the maps keyed by them.
+//
+// Every incoming message looks a `Jid` up in at least one hash map (the chat
+// lane, the session lock, the device memo), and every fan-out compares JIDs
+// pairwise while deduplicating. Neither operation had a bench, so a change to
+// `identity_agent` -- which both go through -- had no way to be costed: the
+// send/receive benches bury it under crypto and marshalling, and the binary
+// size gate only moves on dependency deltas.
+//
+// Two things about the shape of these, both forced by how small the operation
+// is relative to the instruments measuring it:
+//
+// - **Every fixture is built once and leaked.** `with_inputs` runs per
+//   iteration and, while divan excludes it from the wall clock, an
+//   instruction-count profile still counts it -- and building a `Jid` costs
+//   more than comparing two, which would leave the profile measuring setup.
+// - **Each iteration works a whole batch**, reported through `ItemsCount`. A
+//   single comparison is a few nanoseconds, well under this repository's
+//   documented wall-clock noise on cloud hardware, and under callgrind divan's
+//   own per-iteration bookkeeping costs ~335k instructions. Batching amortises
+//   both to nothing, so `ns/item` and `Ir/item` are both readable.
+// ---------------------------------------------------------------------------
+
+use divan::counter::ItemsCount;
+use std::collections::HashMap;
+use std::hash::{BuildHasher, RandomState};
+use std::sync::OnceLock;
+use wacore_binary::jid::Server;
+
+/// Items per measured iteration. Large enough that the per-iteration overhead
+/// of either instrument is below the per-item cost being read.
+const BATCH: usize = 4096;
+
+/// Fan-out sizes worth distinguishing: a DM's own devices, a small group, and
+/// a large one. Below the first the map cost is noise; above the last the
+/// server splits the fan-out anyway.
+const FANOUT_SIZES: [usize; 3] = [8, 64, 512];
+
+fn pn_device(user: &str, device: u16) -> Jid {
+    let mut jid = Jid::pn(user);
+    jid.device = device;
+    jid
+}
+
+fn interop_agent(agent: u8) -> Jid {
+    Jid {
+        user: "5511999990000".into(),
+        server: Server::Interop,
+        agent,
+        device: 0,
+        integrator: 0,
+    }
+}
+
+/// The four comparisons `==` resolves differently: an equal pair (the full
+/// field walk), a mismatch caught on the first field, a mismatch caught only on
+/// `server`, and a pair carrying a non-zero `agent`, which is the one case that
+/// reaches the `identity_agent` normalisation instead of the raw equal-agents
+/// shortcut.
+const EQ_CASES: [&str; 4] = ["equal", "user_differs", "server_differs", "agent_nonzero"];
+
+fn eq_pair(case: &str) -> &'static (Jid, Jid) {
+    static PAIRS: OnceLock<HashMap<&'static str, (Jid, Jid)>> = OnceLock::new();
+    &PAIRS.get_or_init(|| {
+        HashMap::from([
+            (
+                "equal",
+                (pn_device("5511999990000", 7), pn_device("5511999990000", 7)),
+            ),
+            (
+                "user_differs",
+                (pn_device("5511999990000", 7), pn_device("5511999990001", 7)),
+            ),
+            ("server_differs", {
+                let mut right = Jid::lid("5511999990000");
+                right.device = 7;
+                (pn_device("5511999990000", 7), right)
+            }),
+            ("agent_nonzero", (interop_agent(3), interop_agent(4))),
+        ])
+    })[case]
+}
+
+#[divan::bench(args = EQ_CASES)]
+fn bench_jid_eq(bencher: divan::Bencher, case: &str) {
+    let (left, right) = eq_pair(case);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut equal = 0usize;
+        for _ in 0..BATCH {
+            equal += (black_box(left) == black_box(right)) as usize;
+        }
+        black_box(equal)
+    });
+}
+
+#[divan::bench]
+fn bench_jid_hash(bencher: divan::Bencher) {
+    static STATE: OnceLock<(RandomState, Jid)> = OnceLock::new();
+    let (state, jid) = STATE.get_or_init(|| (RandomState::new(), pn_device("5511999990000", 7)));
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut acc = 0u64;
+        for _ in 0..BATCH {
+            acc ^= state.hash_one(black_box(jid));
+        }
+        black_box(acc)
+    });
+}
+
+fn fanout(size: usize) -> &'static [Jid] {
+    static SETS: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
+    let sets = SETS.get_or_init(|| {
+        FANOUT_SIZES
+            .iter()
+            .map(|&n| {
+                (0..n)
+                    .map(|i| pn_device(&format!("5511999{i:06}"), (i % 8) as u16))
+                    .collect()
+            })
+            .collect()
+    });
+    &sets[FANOUT_SIZES
+        .iter()
+        .position(|&n| n == size)
+        .expect("known fan-out size")]
+}
+
+/// Building the map from scratch: the cost a cold fan-out pays once per send.
+/// One item is one inserted device, so the arms are comparable across sizes.
+#[divan::bench(args = FANOUT_SIZES)]
+fn bench_jid_hashmap_insert(bencher: divan::Bencher, size: usize) {
+    let jids = fanout(size);
+    bencher.counter(ItemsCount::new(size)).bench(|| {
+        let mut map = HashMap::with_capacity(jids.len());
+        for jid in jids {
+            map.insert(jid.clone(), ());
+        }
+        black_box(map.len())
+    });
+}
+
+/// A warm map plus the two probes into it, one of each outcome.
+struct Probed {
+    map: HashMap<Jid, ()>,
+    hit: Jid,
+    miss: Jid,
+}
+
+/// The per-message shape: one lookup into a warm map. Hit and miss are separate
+/// because a miss stops at the hash and a hit pays the `==` on top of it.
+#[divan::bench(args = FANOUT_SIZES, consts = [true, false])]
+fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) {
+    static MAPS: OnceLock<Vec<Probed>> = OnceLock::new();
+    let built = MAPS.get_or_init(|| {
+        FANOUT_SIZES
+            .iter()
+            .map(|&n| Probed {
+                map: fanout(n).iter().map(|j| (j.clone(), ())).collect(),
+                hit: fanout(n)[n / 2].clone(),
+                miss: pn_device("5511000000000", 1),
+            })
+            .collect()
+    });
+    let probed = &built[FANOUT_SIZES
+        .iter()
+        .position(|&n| n == size)
+        .expect("known fan-out size")];
+    let (map, probe) = (&probed.map, if HIT { &probed.hit } else { &probed.miss });
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for _ in 0..BATCH {
+            found += map.get(black_box(probe)).is_some() as usize;
+        }
+        black_box(found)
+    });
+}

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -221,15 +221,22 @@ fn bench_jid_hashmap_insert(bencher: divan::Bencher, size: usize) {
     });
 }
 
-/// A warm map plus the two probes into it, one of each outcome.
+/// A warm map plus a full set of probes for each outcome.
 struct Probed {
     map: HashMap<Jid, ()>,
-    hit: Jid,
-    miss: Jid,
+    hits: Vec<Jid>,
+    misses: Vec<Jid>,
 }
 
 /// The per-message shape: one lookup into a warm map. Hit and miss are separate
 /// because a miss stops at the hash and a hit pays the `==` on top of it.
+///
+/// Each batch cycles through every key rather than repeating one. `HashMap`'s
+/// default hasher is seeded per process, so a single probe's bucket and
+/// collision chain are drawn fresh on every run: repeating it would let the
+/// same code measure differently between a baseline and a PR, and batching
+/// would only amplify whichever path that one draw happened to pick. Averaging
+/// over the whole key set makes the layout wash out instead.
 #[divan::bench(args = FANOUT_SIZES, consts = [true, false])]
 fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) {
     static MAPS: OnceLock<Vec<Probed>> = OnceLock::new();
@@ -238,8 +245,12 @@ fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) 
             .iter()
             .map(|&n| Probed {
                 map: fanout(n).iter().map(|j| (j.clone(), ())).collect(),
-                hit: fanout(n)[n / 2].clone(),
-                miss: pn_device("5511000000000", 1),
+                hits: fanout(n).to_vec(),
+                // Same shape and width as the hits, so a miss differs only in
+                // being absent.
+                misses: (0..n)
+                    .map(|i| pn_device(&format!("5511000{i:06}"), (i % 8) as u16))
+                    .collect(),
             })
             .collect()
     });
@@ -247,11 +258,12 @@ fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) 
         .iter()
         .position(|&n| n == size)
         .expect("known fan-out size")];
-    let (map, probe) = (&probed.map, if HIT { &probed.hit } else { &probed.miss });
+    let map = &probed.map;
+    let probes: &[Jid] = if HIT { &probed.hits } else { &probed.misses };
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut found = 0usize;
-        for _ in 0..BATCH {
-            found += map.get(black_box(probe)).is_some() as usize;
+        for i in 0..BATCH {
+            found += map.get(black_box(&probes[i % probes.len()])).is_some() as usize;
         }
         black_box(found)
     });

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -113,12 +113,21 @@ fn interop_agent(agent: u8) -> Jid {
     }
 }
 
-/// The four comparisons `==` resolves differently: an equal pair (the full
-/// field walk), a mismatch caught on the first field, a mismatch caught only on
-/// `server`, and a pair carrying a non-zero `agent`, which is the one case that
-/// reaches the `identity_agent` normalisation instead of the raw equal-agents
-/// shortcut.
-const EQ_CASES: [&str; 4] = ["equal", "user_differs", "server_differs", "agent_nonzero"];
+/// The five comparisons `==` resolves differently: an equal pair (the full field
+/// walk), a mismatch caught on the first field, a mismatch caught only on
+/// `server`, and the two shapes that miss the raw equal-agents shortcut and go
+/// through `identity_agent`. Those two are separate because the normalisation
+/// does different work in each: on `@interop` it renders the agent, so it
+/// confirms a real difference, while on the phone namespace it suppresses it, so
+/// it is what makes two JIDs equal that the raw compare would have split. The
+/// second is the case the function exists for.
+const EQ_CASES: [&str; 5] = [
+    "equal",
+    "user_differs",
+    "server_differs",
+    "agent_nonzero",
+    "agent_normalised",
+];
 
 fn eq_pair(case: &str) -> &'static (Jid, Jid) {
     static PAIRS: OnceLock<HashMap<&'static str, (Jid, Jid)>> = OnceLock::new();
@@ -138,6 +147,19 @@ fn eq_pair(case: &str) -> &'static (Jid, Jid) {
                 (pn_device("5511999990000", 7), right)
             }),
             ("agent_nonzero", (interop_agent(3), interop_agent(4))),
+            // Different raw agents, equal identity: the phone namespace does
+            // not render the agent, so both normalise to 0 and the pair is one
+            // device.
+            (
+                "agent_normalised",
+                (
+                    pn_device("5511999990000", 7),
+                    Jid {
+                        agent: 1,
+                        ..pn_device("5511999990000", 7)
+                    },
+                ),
+            ),
         ])
     })[case]
 }


### PR DESCRIPTION
## Summary

`Jid` is the key of the hottest maps in this repository and the subject of the pairwise comparison every fan-out runs while deduplicating, and none of it was benchmarked. `jid_benchmark` covered parsing and formatting only; `PartialEq`/`Hash` not at all. That is a coverage gap on its own, and it is also the reason a change to `identity_agent` — which equality, `Hash`, `sort_dedup_by_device` and the display path all route through — currently has no way to be priced: the send/receive benches bury it under crypto and marshalling, and the binary size gate moves on dependency deltas, not on a branch inside an inline function.

This adds the instrument. No behaviour changes; the numbers below are the baseline a follow-up ([#1371](https://github.com/oxidezap/whatsapp-rust/pull/1371), collapsing the legacy `@c.us` spelling into the phone-user identity) is measured against.

## What was added

**`wacore/binary/benches/jid_benchmark.rs`** — `bench_jid_eq` across the five shapes `==` resolves differently (equal; mismatched user; mismatched server; and the two that miss the raw equal-agents shortcut and go through `identity_agent` — on `@interop`, where the agent is rendered and the normalisation only confirms a difference, and on the phone namespace, where it is suppressed and the normalisation is what makes two JIDs one device). Plus `bench_jid_hash`, and `bench_jid_hashmap_insert` / `bench_jid_hashmap_get` (hit and miss) at DM, small-group and large-group fan-out sizes.

**`benches/jid_keyed_cache.rs`** (new target, client crate) — the `Cache` shape `chat_lanes` runs per inbound message. `handlers::message` resolves one lane per incoming message before anything else happens, so its cost is per message rather than per send.

`chat_lanes` itself is not directly drivable from a bench target: `ChatLane` and the field holding it are `pub(crate)` and reaching them needs a connected `Client`. What the target does instead is build the same cache the same way (`max_capacity` + `evict_guard`, via the public `whatsapp_rust::cache::Cache`) with a trivial value, which leaves the `Jid` hash, the `Jid` equality on a hit, and the cache's own bookkeeping on the clock.

Lane *creation* is driven through `get_with_by_ref`, because that is the call `handlers::message` makes: the miss path behind it hashes and acquires a per-key init lock, re-checks under it, converts the borrowed key to an owned one, inserts, clones the value out and reclaims the lock. It runs against a cache at `max_capacity = count` with keys rotating through a prebuilt set of `count + 1`, so FIFO eviction always leaves exactly the next key absent — every iteration is a real miss, at constant key width, with no allocation in the measured loop. A second arm holds live clones of some values so `evict_guard` must refuse them, which is the behaviour that distinguishes `chat_lanes`: a lane whose `enqueue_lock` is held cannot be evicted, so the scan has to walk past it.

## Shaping

Three things about how these are written, all forced by how small the operation is relative to the instruments:

- **Fixtures are built once and leaked.** `with_inputs` runs per iteration, and while divan excludes it from the wall clock, an instruction-count profile still counts it — building a `Jid` costs more than comparing two, so a `with_inputs`-shaped bench measures its own setup.
- **Each iteration works a batch**, reported through `ItemsCount`. A single comparison is a few nanoseconds, well under this repository's documented wall-clock noise on cloud hardware (`agent_docs/build_flags.md`), and under callgrind divan's own per-iteration bookkeeping is ~335k instructions — measured here, by differencing Ir at two sample sizes on a bench body that does one hash. Batching puts both instruments an order of magnitude below the per-item cost.
- **Every lookup arm cycles its whole key set** rather than repeating one probe, in both targets. `HashMap` and `PortableCache` both seed their hasher per process, so a single probe's bucket and collision chain are drawn fresh each run — the same code could then measure differently between a baseline and a PR, with batching amplifying whichever draw it got. A repeated probe also stays hot in cache regardless of map depth, which hides exactly the depth-dependence these arms exist to show.

The client target drives the async cache on a bare noop-waker poll loop rather than a Tokio runtime. Every future involved resolves on its first poll (the cache's locks are `async_lock` primitives, uncontended here), so a runtime would only put its own scheduling on the clock.

## Cost (baseline)

Measured on the session's dev VM, `--threads 1`, `fastest` column. Wall clock, because the repo's documented Ir procedure does not resolve at this scale: divan's per-iteration overhead under callgrind dwarfs the operation, and the two-point difference cancels fixed setup but not per-iteration overhead.

**Noise floor, stated before the numbers.** Every arm was run at least three times. On an otherwise idle box `fastest` reproduced to within **±1%**; a rep that overlapped background work moved a single arm by up to **2.5×** and is discarded as contended — its `slowest` column gives it away, hundreds of microseconds against tens. So differences under ~5% between two runs of this suite on this hardware are not real, and every number below is from a quiet rep.

| bench | per item |
| --- | --- |
| `jid_eq/equal` | 3.5 ns |
| `jid_eq/user_differs` | 3.1 ns |
| `jid_eq/server_differs` | 3.1 ns |
| `jid_eq/agent_nonzero` | 4.5 ns |
| `jid_eq/agent_normalised` | 4.5 ns |
| `jid_hash` | 28.1 ns |
| `hashmap_get` hit, 8 / 64 / 512 | 37.7 / 37.9 / 38.4 ns |
| `hashmap_get` miss, 8 / 64 / 512 | 35.3 / 36.1 / 36.9 ns |
| `hashmap_insert`, 8 / 64 / 512 | 48 / 41 / 40 ns |
| `chat_lane_get_hit`, 16 / 256 / 4096 chats | 95 / 97 / 100 ns |
| `chat_lane_get_miss`, 16 / 256 / 4096 | 73 / 75 / 75 ns |
| `chat_lane_create`, 16 / 256 / 4096 | 833 / 847 / 896 ns |
| `chat_lane_create` w/ 8 protected | 1133 / 1191 / 1254 ns |

Four things worth reading off it. Both `identity_agent` arms are ~28% slower than the plain equal case — that is where a change to the normalisation would land, and it now has a number. A chat-lane *lookup* is ~95 ns against the 28 ns the `Jid` hash inside it costs, so most of it is the async map's own overhead; it carries only a mild depth trend, and the miss arm is flat. **Creating** a lane is ~9× a lookup, and it is the per-first-message cost the client actually pays. And the guarded-eviction arm is both ~40% dearer and steeper in depth (1133 → 1191 → 1254 ns against 833 → 847 → 896), which is the scan past held lanes that nothing was measuring.

The authoritative series is CodSpeed's, not this table: it reports instruction counts, deterministically, and the new targets ride the existing shards (`wacore-binary` in `proto-signal`, the client target in `client`) with no workflow change. The client target carries no `required-features` deliberately, so it also builds in a plain `cargo bench` and `cargo build --all-targets`.

## Review follow-ups

Seven bot findings, all real, all fixed — and between them they moved most of the numbers above, which is the point of having reviewed the instrument rather than just the code.

- **Lane creation used `insert`, not `get_with_by_ref`** (Codex). The client's actual call runs an init lock, a double-checked lookup, an owned-key conversion and a value clone. Driven properly, creation costs ~830 ns against the ~205 ns the old shape reported.
- **Nothing exercised `evict_guard`** (Codex). Every value had a strong count of one, so the guard took the first FIFO candidate every time. The protected arm shows the scan is not free and grows with depth.
- **The protected keys were inside the rotation** (Codex, second round). Eight of the seventeen probes were therefore hits rather than misses, and the arm read 654 ns at the shallowest depth — faster than the unprotected arm it was supposed to be slower than, which is what gave it away. Rotating only the unprotected tail puts it at 1133 ns.
- **The measured loop allocated its own keys** (Codex), via `format!` per insert, with an unbounded index that would eventually widen them mid-run. Keys are now prebuilt and rotated.
- **The hash-map lookup measured one bucket** (Codex). Now cycles the whole key set; the per-size spread that produced collapsed, which is the layout noise leaving.
- **The two cache lookup arms still measured one bucket** (Codex, third round) — the same finding, on the target where I had not applied it. Cycling them moved `get_hit` from a flat 93 / 93 / 94 ns to 95 / 97 / 100: the repeated probe was not only risking a bad draw, it was keeping one key hot in cache so the arm could not see map depth at all.
- **`bench_jid_eq` had no arm where the normalisation decides equality** (Greptile). `agent_nonzero` reaches `identity_agent` but on a server that renders the agent; `agent_normalised` adds the phone-namespace case, which is what the function exists for.

An earlier round also caught `bench_chat_lane_insert` overwriting an existing key, returning before `insert_new`; that bench is superseded by the creation one above.

CodeRabbit's docstring-coverage warning is a threshold heuristic over a file that is mostly prose; not acted on.

## Validation

```
cargo fmt --all
cargo clippy --workspace --all-targets -- -D warnings
cargo bench -p wacore-binary --bench jid_benchmark
cargo bench -p whatsapp-rust --bench jid_keyed_cache
```

Full matrix left to CI. The one red check is `Semver Checks (informational)`, which reports `failure` on `main` at this PR's base too and is `continue-on-error` by design — see the comment below.