### PR TITLE
fix(jid): treat the legacy phone-user spelling as one identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,6 +335,13 @@ name = "client_group_send"
 harness = false
 required-features = ["bench-harness"]
 
+# The `Cache<Jid, _>` lookup shape `chat_lanes` runs per inbound message. No
+# `required-features`: it reaches only the public cache, so it builds (and is
+# regression-gated) in a plain `cargo bench`.
+[[bench]]
+name = "jid_keyed_cache"
+harness = false
+
 [profile.release]
 opt-level = 3
 debug = false

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -137,7 +137,13 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
 /// is in.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    static FULL: OnceLock<Vec<(Cache<Jid, Arc<()>>, AtomicUsize)>> = OnceLock::new();
+    /// A cache held at capacity, plus the next unused chat index.
+    struct AtCapacity {
+        cache: Cache<Jid, Arc<()>>,
+        next: AtomicUsize,
+    }
+
+    static FULL: OnceLock<Vec<AtCapacity>> = OnceLock::new();
     let built = FULL.get_or_init(|| {
         CHAT_COUNTS
             .iter()
@@ -151,11 +157,14 @@ fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
                         cache.insert(chat_jid(i), Arc::new(())).await;
                     }
                 });
-                (cache, AtomicUsize::new(n))
+                AtCapacity {
+                    cache,
+                    next: AtomicUsize::new(n),
+                }
             })
             .collect()
     });
-    let (cache, next) = &built[CHAT_COUNTS
+    let AtCapacity { cache, next } = &built[CHAT_COUNTS
         .iter()
         .position(|&n| n == count)
         .expect("known chat count")];

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -50,15 +50,40 @@ fn block_on<F: Future>(future: F) -> F::Output {
 }
 
 /// Live-chat counts worth distinguishing. The default `chat_lanes_capacity` is
-/// 5000, so none of these evict; what changes across them is how deep the map
-/// is when the lookup lands.
+/// 5000, so none of these evict on the lookup benches; what changes across them
+/// is how deep the map is when the lookup lands.
 const CHAT_COUNTS: [usize; 3] = [16, 256, 4096];
 
 /// Lookups per measured iteration.
 const BATCH: usize = 1024;
 
+/// Fixed-width so every key costs the same to hash and compare, whichever
+/// rotation a bench is on. Six digits covers the largest fixture with room to
+/// spare, and never widens mid-run.
 fn chat_jid(i: usize) -> Jid {
     Jid::pn(format!("5511999{i:06}"))
+}
+
+/// `count + 1` keys per chat count, built once. One more than the cache holds,
+/// so a rotation through them always lands on the key that is currently absent
+/// -- which is what lets the creation bench stay on the miss path without
+/// building a key inside the measured loop.
+fn keys(count: usize) -> &'static [Jid] {
+    static KEYS: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
+    let built = KEYS.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| (0..=n).map(chat_jid).collect())
+            .collect()
+    });
+    &built[index_of(count)]
+}
+
+fn index_of(count: usize) -> usize {
+    CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")
 }
 
 /// A warm cache plus the two probes into it, one of each outcome.
@@ -92,10 +117,7 @@ fn fixture(count: usize) -> &'static Probed {
             })
             .collect()
     });
-    &built[CHAT_COUNTS
-        .iter()
-        .position(|&n| n == count)
-        .expect("known chat count")]
+    &built[index_of(count)]
 }
 
 /// The per-message path: an existing chat resolves its lane.
@@ -124,55 +146,76 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
     });
 }
 
-/// Creating the lane, which is what a miss leads to.
-///
-/// A separate fixture from the lookups above, and built at `max_capacity =
-/// count` on purpose: inserting a key the cache already holds takes an
-/// overwrite branch that returns before `insert_new` and measures none of what
-/// creating a lane costs -- the key clone, the FIFO bookkeeping, the capacity
-/// check, the new map entry. Every key here is new, so every iteration goes
-/// through that path, and the cache sits at capacity so each insert also pays
-/// the eviction it triggers. That is the steady state of a client with more
-/// live chats than `chat_lanes_capacity`, which is the state a long-lived one
-/// is in.
-#[divan::bench(args = CHAT_COUNTS)]
-fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    /// A cache held at capacity, plus the next unused chat index.
-    struct AtCapacity {
-        cache: Cache<Jid, Arc<()>>,
-        next: AtomicUsize,
-    }
+/// A cache held at capacity, and the rotation position that is absent from it.
+struct AtCapacity {
+    cache: Cache<Jid, Arc<()>>,
+    next: AtomicUsize,
+    /// Values kept alive so `evict_guard` refuses them, standing in for lanes
+    /// whose `enqueue_lock` is still held by message processing. Never read;
+    /// holding the `Arc` is the whole point.
+    _protected: Vec<Arc<()>>,
+}
 
-    static FULL: OnceLock<Vec<AtCapacity>> = OnceLock::new();
+/// Creating a lane, which is what a first message from a chat actually does.
+///
+/// Driven through `get_with_by_ref`, not `insert`, because that is what
+/// `handlers::message` calls: the miss path behind it hashes and acquires a
+/// per-key init lock, re-checks under it, converts the borrowed key to an owned
+/// one, inserts, clones the value out and reclaims the lock. A bare `insert`
+/// measures none of that, and an `insert` of a key already present measures
+/// less still -- it returns from the overwrite branch before `insert_new`.
+///
+/// The cache is built at `max_capacity = count` and the keys rotate through
+/// `count + 1` prebuilt values, so every iteration lands on the one key FIFO
+/// eviction has just removed: always a miss, always the same key width, and no
+/// allocation inside the measured loop.
+///
+/// `PROTECTED` picks whether some entries are ineligible for eviction. That is
+/// the guard `chat_lanes` actually runs -- a lane whose lock is held must be
+/// skipped -- and it makes the eviction scan walk past entries instead of
+/// taking the first FIFO candidate, which is the depth-dependent part.
+#[divan::bench(args = CHAT_COUNTS, consts = [0usize, 8usize])]
+fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count: usize) {
+    static FULL: OnceLock<Vec<Vec<AtCapacity>>> = OnceLock::new();
     let built = FULL.get_or_init(|| {
-        CHAT_COUNTS
+        [0usize, 8usize]
             .iter()
-            .map(|&n| {
-                let cache: Cache<Jid, Arc<()>> = Cache::builder()
-                    .max_capacity(n as u64)
-                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
-                    .build();
-                block_on(async {
-                    for i in 0..n {
-                        cache.insert(chat_jid(i), Arc::new(())).await;
-                    }
-                });
-                AtCapacity {
-                    cache,
-                    next: AtomicUsize::new(n),
-                }
+            .map(|&protected| {
+                CHAT_COUNTS
+                    .iter()
+                    .map(|&n| {
+                        let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                            .max_capacity(n as u64)
+                            .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                            .build();
+                        let mut held = Vec::new();
+                        block_on(async {
+                            for (i, key) in keys(n).iter().take(n).enumerate() {
+                                let value = Arc::new(());
+                                if i < protected {
+                                    held.push(Arc::clone(&value));
+                                }
+                                cache.insert(key.clone(), value).await;
+                            }
+                        });
+                        AtCapacity {
+                            cache,
+                            next: AtomicUsize::new(n),
+                            _protected: held,
+                        }
+                    })
+                    .collect()
             })
             .collect()
     });
-    let AtCapacity { cache, next } = &built[CHAT_COUNTS
-        .iter()
-        .position(|&n| n == count)
-        .expect("known chat count")];
+    let slot = if PROTECTED == 0 { 0 } else { 1 };
+    let AtCapacity { cache, next, .. } = &built[slot][index_of(count)];
+    let keys = keys(count);
 
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            let key = chat_jid(next.fetch_add(1, Ordering::Relaxed));
-            block_on(cache.insert(black_box(key), Arc::new(())));
+            let i = next.fetch_add(1, Ordering::Relaxed) % keys.len();
+            block_on(cache.get_with_by_ref(black_box(&keys[i]), async { Arc::new(()) }));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -1,0 +1,137 @@
+//! The `Cache<Jid, _>` lookup every inbound message performs.
+//!
+//! `chat_lanes` (`src/client.rs`) is the hottest structure this repository
+//! keys by `Jid`: `handlers::message` resolves one lane per incoming message
+//! before anything else happens, so its cost is paid per message rather than
+//! per send. The lane itself cannot be driven from a bench target -- `ChatLane`
+//! and the field holding it are crate-private, and reaching them needs a
+//! connected `Client` -- so what is measured here is the cache it lives in,
+//! built the same way (`max_capacity` + `evict_guard`) and keyed the same way,
+//! with a value cheap enough that what is left on the clock is the `Jid` hash,
+//! the `Jid` equality on a hit, and the cache's own bookkeeping.
+//!
+//! Driven on a bare poll loop rather than a Tokio runtime: the cache's locks
+//! are `async_lock` primitives that resolve without yielding when uncontended,
+//! so every future here completes on its first poll, and a runtime in the loop
+//! would put its own scheduling on the clock instead of the lookup's.
+//!
+//! Fixtures are built once and leaked, and each iteration works a batch: a
+//! single lookup is a few nanoseconds, below this repository's documented
+//! wall-clock noise on cloud hardware. See the same note in
+//! `wacore/binary/benches/jid_benchmark.rs`.
+
+use divan::black_box;
+use divan::counter::ItemsCount;
+use std::future::Future;
+use std::pin::pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll, Waker};
+use wacore_binary::jid::Jid;
+use whatsapp_rust::cache::Cache;
+
+fn main() {
+    divan::main();
+}
+
+/// Drive a future to completion by polling it. Every future in this file
+/// resolves on the first poll, so the busy loop is a fallback that never runs;
+/// it is here so a future that did park would hang visibly rather than return
+/// a wrong answer.
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    loop {
+        if let Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+        std::hint::spin_loop();
+    }
+}
+
+/// Live-chat counts worth distinguishing. The default `chat_lanes_capacity` is
+/// 5000, so none of these evict; what changes across them is how deep the map
+/// is when the lookup lands.
+const CHAT_COUNTS: [usize; 3] = [16, 256, 4096];
+
+/// Lookups per measured iteration.
+const BATCH: usize = 1024;
+
+fn chat_jid(i: usize) -> Jid {
+    Jid::pn(format!("5511999{i:06}"))
+}
+
+/// A warm cache plus the two probes into it, one of each outcome.
+struct Probed {
+    cache: Cache<Jid, Arc<()>>,
+    hit: Jid,
+    miss: Jid,
+}
+
+/// One warm cache per chat count, plus a key that hits and one that misses.
+fn fixture(count: usize) -> &'static Probed {
+    static BUILT: OnceLock<Vec<Probed>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                    .max_capacity(5_000)
+                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                    .build();
+                block_on(async {
+                    for i in 0..n {
+                        cache.insert(chat_jid(i), Arc::new(())).await;
+                    }
+                });
+                Probed {
+                    cache,
+                    hit: chat_jid(n / 2),
+                    miss: Jid::pn("5511000000000"),
+                }
+            })
+            .collect()
+    });
+    &built[CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")]
+}
+
+/// The per-message path: an existing chat resolves its lane.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, hit, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for _ in 0..BATCH {
+            found += block_on(cache.get(black_box(hit))).is_some() as usize;
+        }
+        black_box(found)
+    });
+}
+
+/// First message from a chat: the lookup misses and a lane has to be created.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, miss, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut absent = 0usize;
+        for _ in 0..BATCH {
+            absent += block_on(cache.get(black_box(miss))).is_none() as usize;
+        }
+        black_box(absent)
+    });
+}
+
+/// Creating the lane, which is what a miss leads to. Overwrites one key rather
+/// than growing the cache, so the arms stay comparable and nothing evicts.
+#[divan::bench(args = CHAT_COUNTS)]
+fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
+    let Probed { cache, hit, .. } = fixture(count);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        for _ in 0..BATCH {
+            block_on(cache.insert(black_box(hit).clone(), Arc::new(())));
+        }
+        black_box(cache.entry_count())
+    });
+}

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -200,7 +200,7 @@ fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count
                         });
                         AtCapacity {
                             cache,
-                            next: AtomicUsize::new(n),
+                            next: AtomicUsize::new(n - protected),
                             _protected: held,
                         }
                     })
@@ -210,12 +210,16 @@ fn bench_chat_lane_create<const PROTECTED: usize>(bencher: divan::Bencher, count
     });
     let slot = if PROTECTED == 0 { 0 } else { 1 };
     let AtCapacity { cache, next, .. } = &built[slot][index_of(count)];
-    let keys = keys(count);
+    // The protected keys are pinned in the cache forever, so probing one is a
+    // hit, not a creation. Rotate only over the evictable tail: the cache holds
+    // `PROTECTED` pinned plus `count - PROTECTED` of these, one short of the
+    // set, so the rotation still lands on the absent key every time.
+    let rotating = &keys(count)[PROTECTED..];
 
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            let i = next.fetch_add(1, Ordering::Relaxed) % keys.len();
-            block_on(cache.get_with_by_ref(black_box(&keys[i]), async { Arc::new(()) }));
+            let i = next.fetch_add(1, Ordering::Relaxed) % rotating.len();
+            block_on(cache.get_with_by_ref(black_box(&rotating[i]), async { Arc::new(()) }));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -24,6 +24,7 @@ use divan::black_box;
 use divan::counter::ItemsCount;
 use std::future::Future;
 use std::pin::pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll, Waker};
 use wacore_binary::jid::Jid;
@@ -123,14 +124,46 @@ fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
     });
 }
 
-/// Creating the lane, which is what a miss leads to. Overwrites one key rather
-/// than growing the cache, so the arms stay comparable and nothing evicts.
+/// Creating the lane, which is what a miss leads to.
+///
+/// A separate fixture from the lookups above, and built at `max_capacity =
+/// count` on purpose: inserting a key the cache already holds takes an
+/// overwrite branch that returns before `insert_new` and measures none of what
+/// creating a lane costs -- the key clone, the FIFO bookkeeping, the capacity
+/// check, the new map entry. Every key here is new, so every iteration goes
+/// through that path, and the cache sits at capacity so each insert also pays
+/// the eviction it triggers. That is the steady state of a client with more
+/// live chats than `chat_lanes_capacity`, which is the state a long-lived one
+/// is in.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_insert(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, hit, .. } = fixture(count);
+    static FULL: OnceLock<Vec<(Cache<Jid, Arc<()>>, AtomicUsize)>> = OnceLock::new();
+    let built = FULL.get_or_init(|| {
+        CHAT_COUNTS
+            .iter()
+            .map(|&n| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                    .max_capacity(n as u64)
+                    .evict_guard(|v: &Arc<()>| Arc::strong_count(v) <= 1)
+                    .build();
+                block_on(async {
+                    for i in 0..n {
+                        cache.insert(chat_jid(i), Arc::new(())).await;
+                    }
+                });
+                (cache, AtomicUsize::new(n))
+            })
+            .collect()
+    });
+    let (cache, next) = &built[CHAT_COUNTS
+        .iter()
+        .position(|&n| n == count)
+        .expect("known chat count")];
+
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         for _ in 0..BATCH {
-            block_on(cache.insert(black_box(hit).clone(), Arc::new(())));
+            let key = chat_jid(next.fetch_add(1, Ordering::Relaxed));
+            block_on(cache.insert(black_box(key), Arc::new(())));
         }
         black_box(cache.entry_count())
     });

--- a/benches/jid_keyed_cache.rs
+++ b/benches/jid_keyed_cache.rs
@@ -64,6 +64,11 @@ fn chat_jid(i: usize) -> Jid {
     Jid::pn(format!("5511999{i:06}"))
 }
 
+/// A key of the same width that no fixture ever inserts, for the miss probes.
+fn absent_jid(i: usize) -> Jid {
+    Jid::pn(format!("5511000{i:06}"))
+}
+
 /// `count + 1` keys per chat count, built once. One more than the cache holds,
 /// so a rotation through them always lands on the key that is currently absent
 /// -- which is what lets the creation bench stay on the miss path without
@@ -86,14 +91,21 @@ fn index_of(count: usize) -> usize {
         .expect("known chat count")
 }
 
-/// A warm cache plus the two probes into it, one of each outcome.
+/// A warm cache plus a set of probes into it for each outcome.
+///
+/// Both sets are cycled rather than repeated, for the reason
+/// `bench_jid_hashmap_get` cycles its own: the cache hashes with a per-process
+/// `RandomState`, so one fixed probe measures whichever bucket and collision
+/// chain that process happened to draw. Repeating it a thousand times only
+/// amplifies the draw, and CodSpeed compares two separate processes -- the
+/// baseline could differ from the branch with no code change at all.
 struct Probed {
     cache: Cache<Jid, Arc<()>>,
-    hit: Jid,
-    miss: Jid,
+    hits: Vec<Jid>,
+    misses: Vec<Jid>,
 }
 
-/// One warm cache per chat count, plus a key that hits and one that misses.
+/// One warm cache per chat count, plus the probe sets that hit and miss it.
 fn fixture(count: usize) -> &'static Probed {
     static BUILT: OnceLock<Vec<Probed>> = OnceLock::new();
     let built = BUILT.get_or_init(|| {
@@ -111,8 +123,8 @@ fn fixture(count: usize) -> &'static Probed {
                 });
                 Probed {
                     cache,
-                    hit: chat_jid(n / 2),
-                    miss: Jid::pn("5511000000000"),
+                    hits: (0..n).map(chat_jid).collect(),
+                    misses: (0..n).map(absent_jid).collect(),
                 }
             })
             .collect()
@@ -123,11 +135,12 @@ fn fixture(count: usize) -> &'static Probed {
 /// The per-message path: an existing chat resolves its lane.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, hit, .. } = fixture(count);
+    let Probed { cache, hits, .. } = fixture(count);
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut found = 0usize;
-        for _ in 0..BATCH {
-            found += block_on(cache.get(black_box(hit))).is_some() as usize;
+        for i in 0..BATCH {
+            let key = &hits[i % hits.len()];
+            found += block_on(cache.get(black_box(key))).is_some() as usize;
         }
         black_box(found)
     });
@@ -136,11 +149,12 @@ fn bench_chat_lane_get_hit(bencher: divan::Bencher, count: usize) {
 /// First message from a chat: the lookup misses and a lane has to be created.
 #[divan::bench(args = CHAT_COUNTS)]
 fn bench_chat_lane_get_miss(bencher: divan::Bencher, count: usize) {
-    let Probed { cache, miss, .. } = fixture(count);
+    let Probed { cache, misses, .. } = fixture(count);
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut absent = 0usize;
-        for _ in 0..BATCH {
-            absent += block_on(cache.get(black_box(miss))).is_none() as usize;
+        for i in 0..BATCH {
+            let key = &misses[i % misses.len()];
+            absent += block_on(cache.get(black_box(key))).is_none() as usize;
         }
         black_box(absent)
     });

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -7537,16 +7537,19 @@ mod tests {
         let stanza = crate::test_utils::decode_sent_iq(&transport, 0).await;
         let stanza = stanza.get();
         assert_eq!(stanza.tag, "message");
-        let to = stanza
+        // The raw attribute, before parsing: `optional_jid` would resolve
+        // `@c.us` back to `Server::Pn` and pass on a stanza that still spelled
+        // it the old way, which is the regression this is here to catch.
+        let to_raw = stanza
             .attrs()
-            .optional_jid("to")
-            .expect("the stanza names its chat");
+            .optional_string("to")
+            .expect("the stanza names its chat")
+            .to_string();
         assert_eq!(
-            to.server,
-            Server::Pn,
-            "the legacy spelling must not reach the wire: {to}"
+            to_raw,
+            format!("{}@s.whatsapp.net", peer_pn.user),
+            "the legacy spelling must not reach the wire"
         );
-        assert_eq!(to.user, peer_pn.user, "and it must still be the same user");
     }
 
     /// The exclude list: only what the refresh added is resent. A device the

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1077,7 +1077,6 @@ impl Client {
         #[cfg(feature = "tracing")]
         self.record_identity_on_span(&tracing::Span::current());
 
-        let to = canonical_user_server(to);
         validate_extra_stanza_nodes(&options.extra_stanza_nodes)?;
         if options.message_id.as_ref().is_some_and(String::is_empty) {
             return Err(SendError::InvalidRequest(
@@ -2025,7 +2024,6 @@ impl Client {
             device_freshness,
             borrowed_message_id,
         } = options;
-        let to = canonical_user_server(to);
         // Callers that already stamped their message hand the instant down; the
         // rest sample here so the pipeline below still has exactly one.
         let sent_at = sent_at.unwrap_or_else(SendInstant::now);
@@ -2959,28 +2957,9 @@ pub(crate) fn is_self_dm_recipient(
 ) -> bool {
     match recipient_bare.server {
         Server::Lid => own_lid.is_some_and(|lid| recipient_bare.user == lid.user),
-        // `Legacy` alongside `Pn` for the same reason `canonical_user_server`
-        // exists: both name a phone user, and reading one as "not me" sends a
-        // note to self down the third-party path.
-        Server::Pn | Server::Legacy => recipient_bare.user == own_pn.user,
+        Server::Pn => recipient_bare.user == own_pn.user,
         _ => false,
     }
-}
-
-/// `@c.us` is not a namespace of its own: it is what WA Web calls a phone user
-/// in memory, mapped to `s.whatsapp.net` only when a wid is serialized
-/// (`WAWebWid`: `this.server==="c.us"?"s.whatsapp.net":this.server`). We take
-/// `Server::Pn` as the canonical spelling instead, so a `to` that arrives the
-/// other way is rewritten here rather than travelling the send path as a
-/// namespace nothing recognises: `is_pn()` is false for it, so it misses the
-/// self-chat check, the PN-to-LID usync, the LID resolution and, worst, the
-/// pre-key fetch, whose response is matched back by whole-`Jid` equality and
-/// so reports every bundle the server did return as absent.
-pub(crate) fn canonical_user_server(mut jid: Jid) -> Jid {
-    if jid.server == Server::Legacy {
-        jid.server = Server::Pn;
-    }
-    jid
 }
 
 /// The outer `<message to>`, the DeviceSentMessage destinationJid, and the
@@ -4617,45 +4596,28 @@ mod tests {
         assert!(is_self_dm_recipient(&recipient, &own_pn, None));
     }
 
-    /// A note to self addressed in the legacy namespace is still a note to
-    /// self. Read as a third party it takes the recipient path and asks the
-    /// server for our own pre-key bundles, which is the shape the reporter of
-    /// #1361 saw on every failing send.
+    /// A note to self addressed in the legacy spelling is still a note to self.
+    /// Read as a third party it takes the recipient path and asks the server
+    /// for our own pre-key bundles, which is the shape the reporter of #1361
+    /// saw on every failing send. Nothing here special-cases the spelling any
+    /// more: parsing resolves it to the phone namespace, and this asserts the
+    /// resolution actually reaches the check.
     #[test]
     fn self_dm_legacy_recipient_matches_own_pn() {
         let own_pn = Jid::pn_device(SELF_PN, SELF_DEVICE);
         let own_lid = Jid::lid_device(SELF_LID, SELF_DEVICE);
-        let recipient = Jid::new(SELF_PN, Server::Legacy);
+        let recipient: Jid = format!("{SELF_PN}@c.us").parse().unwrap();
 
+        assert_eq!(recipient.server, Server::Pn);
         assert!(is_self_dm_recipient(&recipient, &own_pn, Some(&own_lid)));
     }
 
     #[test]
     fn non_self_legacy_recipient_is_not_self_dm() {
         let own_pn = Jid::pn_device(SELF_PN, SELF_DEVICE);
-        let recipient = Jid::new(OTHER_PN, Server::Legacy);
+        let recipient: Jid = format!("{OTHER_PN}@c.us").parse().unwrap();
 
         assert!(!is_self_dm_recipient(&recipient, &own_pn, None));
-    }
-
-    /// `Legacy` is a spelling of the phone-user namespace, not a namespace of
-    /// its own, and only that one is rewritten: nothing else may be quietly
-    /// re-pointed at a different server.
-    #[test]
-    fn canonical_user_server_rewrites_only_legacy() {
-        assert_eq!(
-            canonical_user_server(Jid::new(OTHER_PN, Server::Legacy).with_device(3)),
-            Jid::pn_device(OTHER_PN, 3),
-            "the device survives the rewrite"
-        );
-        for untouched in [
-            Jid::pn(OTHER_PN),
-            Jid::lid(OTHER_LID),
-            Jid::group("120363000000000000"),
-            Jid::status_broadcast(),
-        ] {
-            assert_eq!(canonical_user_server(untouched.clone()), untouched);
-        }
     }
 
     #[test]
@@ -7548,16 +7510,16 @@ mod tests {
         );
     }
 
-    /// `@c.us` is the namespace WA Web keeps a phone user in; a caller that
-    /// spells a recipient that way is naming a PN user, and the send must treat
-    /// it as one. Left alone it misses `is_pn()` everywhere that matters, most
-    /// damagingly in the pre-key fetch, whose response is matched back by whole
-    /// jid and so reports every bundle as absent.
+    /// `@c.us` is a spelling of the phone namespace; a caller that names a
+    /// recipient that way is naming a PN user, and the send must treat it as
+    /// one end to end. Left alone it misses `is_pn()` everywhere that matters,
+    /// most damagingly in the pre-key fetch, whose response is matched back by
+    /// whole jid and so reports every bundle as absent.
     #[tokio::test]
     async fn a_legacy_namespace_recipient_is_sent_as_a_phone_user() {
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
-        let legacy = Jid::new(peer_pn.user.as_str(), Server::Legacy);
+        let legacy: Jid = format!("{}@c.us", peer_pn.user).parse().unwrap();
 
         let message_id = "LEGACYNSDM1";
         client
@@ -7579,9 +7541,9 @@ mod tests {
             .attrs()
             .optional_jid("to")
             .expect("the stanza names its chat");
-        assert_ne!(
+        assert_eq!(
             to.server,
-            Server::Legacy,
+            Server::Pn,
             "the legacy spelling must not reach the wire: {to}"
         );
         assert_eq!(to.user, peer_pn.user, "and it must still be the same user");

--- a/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/down.sql
+++ b/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/down.sql
@@ -1,0 +1,5 @@
+-- Not reversible, and not lossy either: the rows this migration rewrote are
+-- addressed by the same identity under either spelling, and the client that
+-- reads them can no longer produce the old one. Restoring it would recreate
+-- keys nothing looks up.
+SELECT 1;

--- a/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
+++ b/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
@@ -10,15 +10,28 @@
 -- spelling there, matching WA Web, and rewriting them would invalidate every
 -- established session.
 --
--- Where both spellings of one peer exist the rows collide on the primary key,
--- and which one survives matters. For the three caches below it decides what
--- the client believes about a peer, so the collision is resolved by freshness
--- first: the loser is deleted, then the rewrite cannot collide at all. Letting
--- `UPDATE OR REPLACE` pick would always keep the row being rewritten -- the
--- legacy one, which is by construction the older of the two -- and for
--- `device_registry` that means a stale device list replacing a current one,
--- which `get_devices` would then serve until the next refresh, dropping linked
--- devices from every send in between.
+-- One rule decides every collision: **a legacy row never displaces a canonical
+-- one.** Where both spellings of the same key exist, the legacy row is deleted
+-- and the canonical row is left exactly as it is; only an uncontested legacy
+-- row is rewritten.
+--
+-- That is not a coin toss between two candidates, it is the only choice that
+-- cannot lose information. The canonical row is the one the current client has
+-- been reading and writing all along, and the legacy row is already unreachable
+-- to it -- so deleting the legacy row costs nothing that is live today, while
+-- keeping it can only substitute stale state for current state. It is also why
+-- no per-table merge is attempted: every table below has its own freshness
+-- rule (`put_msg_secrets` keeps the later `expires_at` and a non-zero
+-- `message_ts`; `set_sender_key_status` must not let a stale `has_key = true`
+-- outlive a forget mark; `tc_tokens` advances `token_timestamp` and
+-- `sender_timestamp` independently), and a migration that tried to reproduce
+-- each of them would be a second implementation of every writer, drifting from
+-- the first. Preferring the canonical row defers to whatever those writers
+-- already decided.
+--
+-- Deleting first also means the rewrite cannot collide, so it needs no
+-- `OR REPLACE` and a surprise collision would surface as a failure rather than
+-- silently discarding a row.
 
 -- device_registry: the cached device list per peer.
 DELETE FROM device_registry
@@ -27,16 +40,7 @@ DELETE FROM device_registry
        SELECT 1 FROM device_registry AS canon
         WHERE canon.user_id =
               substr(device_registry.user_id, 1, length(device_registry.user_id) - 5) || '@s.whatsapp.net'
-          AND canon.device_id = device_registry.device_id
-          AND canon.updated_at >= device_registry.updated_at);
-
-DELETE FROM device_registry
- WHERE user_id NOT LIKE '%@c.us'
-   AND EXISTS (
-       SELECT 1 FROM device_registry AS legacy
-        WHERE legacy.user_id LIKE '%@c.us'
-          AND substr(legacy.user_id, 1, length(legacy.user_id) - 5) || '@s.whatsapp.net' = device_registry.user_id
-          AND legacy.device_id = device_registry.device_id);
+          AND canon.device_id = device_registry.device_id);
 
 UPDATE device_registry
    SET user_id = substr(user_id, 1, length(user_id) - 5) || '@s.whatsapp.net'
@@ -48,22 +52,16 @@ DELETE FROM tc_tokens
    AND EXISTS (
        SELECT 1 FROM tc_tokens AS canon
         WHERE canon.jid = substr(tc_tokens.jid, 1, length(tc_tokens.jid) - 5) || '@s.whatsapp.net'
-          AND canon.device_id = tc_tokens.device_id
-          AND canon.updated_at >= tc_tokens.updated_at);
-
-DELETE FROM tc_tokens
- WHERE jid NOT LIKE '%@c.us'
-   AND EXISTS (
-       SELECT 1 FROM tc_tokens AS legacy
-        WHERE legacy.jid LIKE '%@c.us'
-          AND substr(legacy.jid, 1, length(legacy.jid) - 5) || '@s.whatsapp.net' = tc_tokens.jid
-          AND legacy.device_id = tc_tokens.device_id);
+          AND canon.device_id = tc_tokens.device_id);
 
 UPDATE tc_tokens
    SET jid = substr(jid, 1, length(jid) - 5) || '@s.whatsapp.net'
  WHERE jid LIKE '%@c.us';
 
 -- sender_key_devices: which devices hold the current sender key for a group.
+-- `group_jid` is part of the key, so the counterpart must match on it too: a
+-- legacy row for a device in one group must not be deleted because that device
+-- has a canonical row in a different group.
 DELETE FROM sender_key_devices
  WHERE device_jid LIKE '%@c.us'
    AND EXISTS (
@@ -71,44 +69,81 @@ DELETE FROM sender_key_devices
         WHERE canon.device_jid =
               substr(sender_key_devices.device_jid, 1, length(sender_key_devices.device_jid) - 5) || '@s.whatsapp.net'
           AND canon.group_jid = sender_key_devices.group_jid
-          AND canon.device_id = sender_key_devices.device_id
-          AND canon.updated_at >= sender_key_devices.updated_at);
-
-DELETE FROM sender_key_devices
- WHERE device_jid NOT LIKE '%@c.us'
-   AND EXISTS (
-       SELECT 1 FROM sender_key_devices AS legacy
-        WHERE legacy.device_jid LIKE '%@c.us'
-          AND substr(legacy.device_jid, 1, length(legacy.device_jid) - 5) || '@s.whatsapp.net' = sender_key_devices.device_jid
-          AND legacy.group_jid = sender_key_devices.group_jid
-          AND legacy.device_id = sender_key_devices.device_id);
+          AND canon.device_id = sender_key_devices.device_id);
 
 UPDATE sender_key_devices
    SET device_jid = substr(device_jid, 1, length(device_jid) - 5) || '@s.whatsapp.net'
  WHERE device_jid LIKE '%@c.us';
 
--- The rest key on a message id as well as the chat, so a collision means the
--- same message stored under both spellings -- the same bytes either way, with
--- nothing to choose between them. `OR REPLACE` is enough, and is also the
--- backstop that keeps a collision from aborting the migration and leaving the
--- database unopenable.
-UPDATE OR REPLACE sent_messages
+-- sent_messages: the retry payload, keyed by chat and message id.
+DELETE FROM sent_messages
+ WHERE chat_jid LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM sent_messages AS canon
+        WHERE canon.chat_jid =
+              substr(sent_messages.chat_jid, 1, length(sent_messages.chat_jid) - 5) || '@s.whatsapp.net'
+          AND canon.message_id = sent_messages.message_id
+          AND canon.device_id = sent_messages.device_id);
+
+UPDATE sent_messages
    SET chat_jid = substr(chat_jid, 1, length(chat_jid) - 5) || '@s.whatsapp.net'
  WHERE chat_jid LIKE '%@c.us';
 
-UPDATE OR REPLACE msg_secrets
+-- msg_secrets: keyed by chat, sender and message id, so both jid columns move
+-- and either can collide. Deleted per column in turn, each against the shape
+-- the row would take after that column is rewritten.
+DELETE FROM msg_secrets
+ WHERE chat LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM msg_secrets AS canon
+        WHERE canon.chat = substr(msg_secrets.chat, 1, length(msg_secrets.chat) - 5) || '@s.whatsapp.net'
+          AND canon.sender = msg_secrets.sender
+          AND canon.msg_id = msg_secrets.msg_id
+          AND canon.device_id = msg_secrets.device_id);
+
+UPDATE msg_secrets
    SET chat = substr(chat, 1, length(chat) - 5) || '@s.whatsapp.net'
  WHERE chat LIKE '%@c.us';
 
-UPDATE OR REPLACE msg_secrets
+DELETE FROM msg_secrets
+ WHERE sender LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM msg_secrets AS canon
+        WHERE canon.sender = substr(msg_secrets.sender, 1, length(msg_secrets.sender) - 5) || '@s.whatsapp.net'
+          AND canon.chat = msg_secrets.chat
+          AND canon.msg_id = msg_secrets.msg_id
+          AND canon.device_id = msg_secrets.device_id);
+
+UPDATE msg_secrets
    SET sender = substr(sender, 1, length(sender) - 5) || '@s.whatsapp.net'
  WHERE sender LIKE '%@c.us';
 
-UPDATE OR REPLACE pending_inbound_messages
+-- pending_inbound_messages: the durability buffer, same two-column shape.
+DELETE FROM pending_inbound_messages
+ WHERE chat LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM pending_inbound_messages AS canon
+        WHERE canon.chat =
+              substr(pending_inbound_messages.chat, 1, length(pending_inbound_messages.chat) - 5) || '@s.whatsapp.net'
+          AND canon.sender = pending_inbound_messages.sender
+          AND canon.id = pending_inbound_messages.id
+          AND canon.device_id = pending_inbound_messages.device_id);
+
+UPDATE pending_inbound_messages
    SET chat = substr(chat, 1, length(chat) - 5) || '@s.whatsapp.net'
  WHERE chat LIKE '%@c.us';
 
-UPDATE OR REPLACE pending_inbound_messages
+DELETE FROM pending_inbound_messages
+ WHERE sender LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM pending_inbound_messages AS canon
+        WHERE canon.sender =
+              substr(pending_inbound_messages.sender, 1, length(pending_inbound_messages.sender) - 5) || '@s.whatsapp.net'
+          AND canon.chat = pending_inbound_messages.chat
+          AND canon.id = pending_inbound_messages.id
+          AND canon.device_id = pending_inbound_messages.device_id);
+
+UPDATE pending_inbound_messages
    SET sender = substr(sender, 1, length(sender) - 5) || '@s.whatsapp.net'
  WHERE sender LIKE '%@c.us';
 

--- a/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
+++ b/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
@@ -10,26 +10,92 @@
 -- spelling there, matching WA Web, and rewriting them would invalidate every
 -- established session.
 --
--- `UPDATE OR REPLACE` because these columns are primary keys: where both
--- spellings of the same peer exist, the rows collide, and the surviving one is
--- the row being rewritten. Everything touched here is a cache or a resendable
--- payload, so losing the older duplicate costs at most one refetch.
-UPDATE OR REPLACE device_registry
+-- Where both spellings of one peer exist the rows collide on the primary key,
+-- and which one survives matters. For the three caches below it decides what
+-- the client believes about a peer, so the collision is resolved by freshness
+-- first: the loser is deleted, then the rewrite cannot collide at all. Letting
+-- `UPDATE OR REPLACE` pick would always keep the row being rewritten -- the
+-- legacy one, which is by construction the older of the two -- and for
+-- `device_registry` that means a stale device list replacing a current one,
+-- which `get_devices` would then serve until the next refresh, dropping linked
+-- devices from every send in between.
+
+-- device_registry: the cached device list per peer.
+DELETE FROM device_registry
+ WHERE user_id LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM device_registry AS canon
+        WHERE canon.user_id =
+              substr(device_registry.user_id, 1, length(device_registry.user_id) - 5) || '@s.whatsapp.net'
+          AND canon.device_id = device_registry.device_id
+          AND canon.updated_at >= device_registry.updated_at);
+
+DELETE FROM device_registry
+ WHERE user_id NOT LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM device_registry AS legacy
+        WHERE legacy.user_id LIKE '%@c.us'
+          AND substr(legacy.user_id, 1, length(legacy.user_id) - 5) || '@s.whatsapp.net' = device_registry.user_id
+          AND legacy.device_id = device_registry.device_id);
+
+UPDATE device_registry
    SET user_id = substr(user_id, 1, length(user_id) - 5) || '@s.whatsapp.net'
  WHERE user_id LIKE '%@c.us';
 
-UPDATE OR REPLACE tc_tokens
+-- tc_tokens: the per-peer trusted-contact token.
+DELETE FROM tc_tokens
+ WHERE jid LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM tc_tokens AS canon
+        WHERE canon.jid = substr(tc_tokens.jid, 1, length(tc_tokens.jid) - 5) || '@s.whatsapp.net'
+          AND canon.device_id = tc_tokens.device_id
+          AND canon.updated_at >= tc_tokens.updated_at);
+
+DELETE FROM tc_tokens
+ WHERE jid NOT LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM tc_tokens AS legacy
+        WHERE legacy.jid LIKE '%@c.us'
+          AND substr(legacy.jid, 1, length(legacy.jid) - 5) || '@s.whatsapp.net' = tc_tokens.jid
+          AND legacy.device_id = tc_tokens.device_id);
+
+UPDATE tc_tokens
    SET jid = substr(jid, 1, length(jid) - 5) || '@s.whatsapp.net'
  WHERE jid LIKE '%@c.us';
 
+-- sender_key_devices: which devices hold the current sender key for a group.
+DELETE FROM sender_key_devices
+ WHERE device_jid LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM sender_key_devices AS canon
+        WHERE canon.device_jid =
+              substr(sender_key_devices.device_jid, 1, length(sender_key_devices.device_jid) - 5) || '@s.whatsapp.net'
+          AND canon.group_jid = sender_key_devices.group_jid
+          AND canon.device_id = sender_key_devices.device_id
+          AND canon.updated_at >= sender_key_devices.updated_at);
+
+DELETE FROM sender_key_devices
+ WHERE device_jid NOT LIKE '%@c.us'
+   AND EXISTS (
+       SELECT 1 FROM sender_key_devices AS legacy
+        WHERE legacy.device_jid LIKE '%@c.us'
+          AND substr(legacy.device_jid, 1, length(legacy.device_jid) - 5) || '@s.whatsapp.net' = sender_key_devices.device_jid
+          AND legacy.group_jid = sender_key_devices.group_jid
+          AND legacy.device_id = sender_key_devices.device_id);
+
+UPDATE sender_key_devices
+   SET device_jid = substr(device_jid, 1, length(device_jid) - 5) || '@s.whatsapp.net'
+ WHERE device_jid LIKE '%@c.us';
+
+-- The rest key on a message id as well as the chat, so a collision means the
+-- same message stored under both spellings -- the same bytes either way, with
+-- nothing to choose between them. `OR REPLACE` is enough, and is also the
+-- backstop that keeps a collision from aborting the migration and leaving the
+-- database unopenable.
 UPDATE OR REPLACE sent_messages
    SET chat_jid = substr(chat_jid, 1, length(chat_jid) - 5) || '@s.whatsapp.net'
  WHERE chat_jid LIKE '%@c.us';
 
-UPDATE OR REPLACE sender_key_devices
-   SET device_jid = substr(device_jid, 1, length(device_jid) - 5) || '@s.whatsapp.net'
- WHERE device_jid LIKE '%@c.us';
-
 UPDATE OR REPLACE msg_secrets
    SET chat = substr(chat, 1, length(chat) - 5) || '@s.whatsapp.net'
  WHERE chat LIKE '%@c.us';
@@ -46,6 +112,7 @@ UPDATE OR REPLACE pending_inbound_messages
    SET sender = substr(sender, 1, length(sender) - 5) || '@s.whatsapp.net'
  WHERE sender LIKE '%@c.us';
 
-UPDATE OR REPLACE device
+-- `device.pn` is not a key, so it cannot collide with anything.
+UPDATE device
    SET pn = substr(pn, 1, length(pn) - 5) || '@s.whatsapp.net'
  WHERE pn LIKE '%@c.us';

--- a/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
+++ b/storages/sqlite-storage/migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql
@@ -1,0 +1,51 @@
+-- `@c.us` and `@s.whatsapp.net` are two spellings of one namespace, and the
+-- client now resolves the first to the second while parsing, so nothing can
+-- write the legacy spelling again. Rows written before that point are keyed by
+-- a string that will never be looked up again: string comparison in SQLite does
+-- not go through Rust's `PartialEq`, so a `@c.us` key is simply a different key.
+--
+-- Only columns holding a rendered JID are rewritten, anchored on the suffix.
+-- The Signal address columns (`sessions`, `identities`, `sender_keys`,
+-- `base_keys`) are deliberately left alone: `@c.us` is the correct and current
+-- spelling there, matching WA Web, and rewriting them would invalidate every
+-- established session.
+--
+-- `UPDATE OR REPLACE` because these columns are primary keys: where both
+-- spellings of the same peer exist, the rows collide, and the surviving one is
+-- the row being rewritten. Everything touched here is a cache or a resendable
+-- payload, so losing the older duplicate costs at most one refetch.
+UPDATE OR REPLACE device_registry
+   SET user_id = substr(user_id, 1, length(user_id) - 5) || '@s.whatsapp.net'
+ WHERE user_id LIKE '%@c.us';
+
+UPDATE OR REPLACE tc_tokens
+   SET jid = substr(jid, 1, length(jid) - 5) || '@s.whatsapp.net'
+ WHERE jid LIKE '%@c.us';
+
+UPDATE OR REPLACE sent_messages
+   SET chat_jid = substr(chat_jid, 1, length(chat_jid) - 5) || '@s.whatsapp.net'
+ WHERE chat_jid LIKE '%@c.us';
+
+UPDATE OR REPLACE sender_key_devices
+   SET device_jid = substr(device_jid, 1, length(device_jid) - 5) || '@s.whatsapp.net'
+ WHERE device_jid LIKE '%@c.us';
+
+UPDATE OR REPLACE msg_secrets
+   SET chat = substr(chat, 1, length(chat) - 5) || '@s.whatsapp.net'
+ WHERE chat LIKE '%@c.us';
+
+UPDATE OR REPLACE msg_secrets
+   SET sender = substr(sender, 1, length(sender) - 5) || '@s.whatsapp.net'
+ WHERE sender LIKE '%@c.us';
+
+UPDATE OR REPLACE pending_inbound_messages
+   SET chat = substr(chat, 1, length(chat) - 5) || '@s.whatsapp.net'
+ WHERE chat LIKE '%@c.us';
+
+UPDATE OR REPLACE pending_inbound_messages
+   SET sender = substr(sender, 1, length(sender) - 5) || '@s.whatsapp.net'
+ WHERE sender LIKE '%@c.us';
+
+UPDATE OR REPLACE device
+   SET pn = substr(pn, 1, length(pn) - 5) || '@s.whatsapp.net'
+ WHERE pn LIKE '%@c.us';

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4171,17 +4171,19 @@ mod tests {
         );
     }
 
-    /// Both spellings of one peer collide on the primary key when the legacy one
-    /// is rewritten, and which row survives is not a detail: for the caches
-    /// keyed this way it decides what the client believes about a peer. The
-    /// freshest row has to win in *both* directions, and the collision must
-    /// never abort the migration, which would leave the database unopenable.
+    /// Both spellings of one key collide when the legacy one is rewritten, and
+    /// which row survives decides what the client believes. The rule is that a
+    /// legacy row never displaces a canonical one: the legacy row is dropped,
+    /// the canonical row is left untouched, and only an uncontested legacy row
+    /// is rewritten. The collision must also never abort the migration, which
+    /// would leave the database unopenable.
     ///
-    /// `UPDATE OR REPLACE` alone gets this wrong: it keeps the row being
-    /// rewritten, which is the legacy one, so a stale device list would replace
-    /// a current one and `get_devices` would serve it until the next refresh.
+    /// `UPDATE OR REPLACE` alone gets this backwards -- it keeps the row being
+    /// rewritten, which is the legacy one -- and that is the case with a real
+    /// consequence: a stale device list replacing a current one, which
+    /// `get_devices` would then serve until the next refresh.
     #[tokio::test]
-    async fn the_normalisation_migration_keeps_the_fresher_of_two_spellings() {
+    async fn the_normalisation_migration_never_lets_a_legacy_row_displace_a_canonical_one() {
         use diesel::connection::SimpleConnection;
 
         const NORMALISE: &str =
@@ -4190,24 +4192,30 @@ mod tests {
         let store = create_test_store().await;
         let mut conn = store.pool.get().expect("a connection");
 
-        // Peer 1: the canonical row is newer, so it survives.
-        // Peer 2: the legacy row is newer, so that one does.
-        // Peer 3: only the legacy row exists, so it is simply rewritten.
+        // Peer 1: both spellings, so the canonical row survives whole.
+        // Peer 2: legacy only, so it is rewritten.
+        // The device_registry pair is the one that matters in practice.
+        // sender_key_devices: the same device under both spellings in group A,
+        // and legacy-only in group B -- the second must survive, because
+        // `group_jid` is part of the key and a counterpart in another group is
+        // not a counterpart at all.
         conn.batch_execute(
             r#"INSERT INTO tc_tokens (jid, token, token_timestamp, device_id, updated_at)
-                    VALUES ('15550000001@c.us',           x'01', 0, 1, 10),
-                           ('15550000001@s.whatsapp.net', x'02', 0, 1, 20),
-                           ('15550000002@c.us',           x'03', 0, 1, 20),
-                           ('15550000002@s.whatsapp.net', x'04', 0, 1, 10),
-                           ('15550000003@c.us',           x'05', 0, 1, 5);
+                    VALUES ('15550000001@c.us',           x'01', 0, 1, 99),
+                           ('15550000001@s.whatsapp.net', x'02', 0, 1, 1),
+                           ('15550000002@c.us',           x'03', 0, 1, 5);
                INSERT INTO device_registry (user_id, devices_json, timestamp, device_id, updated_at)
-                    VALUES ('15550000001@c.us',           '["stale"]', 0, 1, 10),
-                           ('15550000001@s.whatsapp.net', '["fresh"]', 0, 1, 20);"#,
+                    VALUES ('15550000001@c.us',           '["stale"]', 0, 1, 99),
+                           ('15550000001@s.whatsapp.net', '["live"]',  0, 1, 1);
+               INSERT INTO sender_key_devices (group_jid, device_jid, has_key, device_id, updated_at)
+                    VALUES ('120363000000000001@g.us', '15550000001@c.us',           1, 1, 0),
+                           ('120363000000000001@g.us', '15550000001@s.whatsapp.net', 0, 1, 0),
+                           ('120363000000000002@g.us', '15550000001@c.us',           1, 1, 0);"#,
         )
-        .expect("seed both spellings of the same peers");
+        .expect("seed both spellings of the same keys");
 
         conn.batch_execute(NORMALISE)
-            .expect("a duplicate must not abort the migration");
+            .expect("a collision must not abort the migration");
 
         let scalar = |conn: &mut _, sql: &str| -> String {
             diesel::dsl::sql::<diesel::sql_types::Text>(sql)
@@ -4222,7 +4230,7 @@ mod tests {
 
         assert_eq!(
             count(&mut *conn, "SELECT count(*) FROM tc_tokens"),
-            3,
+            2,
             "one row per peer"
         );
         assert_eq!(
@@ -4239,7 +4247,7 @@ mod tests {
                 "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000001@s.whatsapp.net'"
             ),
             "02",
-            "the canonical row was newer and must survive"
+            "the canonical row survives even though the legacy one is newer"
         );
         assert_eq!(
             scalar(
@@ -4247,14 +4255,6 @@ mod tests {
                 "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000002@s.whatsapp.net'"
             ),
             "03",
-            "the legacy row was newer and must survive the rewrite"
-        );
-        assert_eq!(
-            scalar(
-                &mut *conn,
-                "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000003@s.whatsapp.net'"
-            ),
-            "05",
             "an uncontested legacy row is just rewritten"
         );
 
@@ -4266,8 +4266,33 @@ mod tests {
                 &mut *conn,
                 "SELECT devices_json FROM device_registry WHERE user_id = '15550000001@s.whatsapp.net'"
             ),
-            r#"["fresh"]"#,
-            "the newer device list must win"
+            r#"["live"]"#,
+            "the canonical device list must win"
+        );
+
+        // Both groups keep a row, and both are canonical. The colliding group
+        // keeps its canonical `has_key = 0`, so a forget mark is not undone by
+        // a stale `1`; the other group's legacy-only row is simply rewritten.
+        assert_eq!(
+            count(&mut *conn, "SELECT count(*) FROM sender_key_devices"),
+            2,
+            "a counterpart in another group is not a counterpart"
+        );
+        assert_eq!(
+            count(
+                &mut *conn,
+                "SELECT count(*) FROM sender_key_devices WHERE device_jid = '15550000001@s.whatsapp.net'"
+            ),
+            2,
+            "and both reference the canonical device"
+        );
+        assert_eq!(
+            count(
+                &mut *conn,
+                "SELECT has_key FROM sender_key_devices WHERE group_jid = '120363000000000001@g.us'"
+            ),
+            0,
+            "the canonical forget mark survives the collision"
         );
     }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4172,10 +4172,16 @@ mod tests {
     }
 
     /// Both spellings of one peer collide on the primary key when the legacy one
-    /// is rewritten. `UPDATE OR REPLACE` has to resolve that rather than abort
-    /// the migration, which would leave the database unopenable.
+    /// is rewritten, and which row survives is not a detail: for the caches
+    /// keyed this way it decides what the client believes about a peer. The
+    /// freshest row has to win in *both* directions, and the collision must
+    /// never abort the migration, which would leave the database unopenable.
+    ///
+    /// `UPDATE OR REPLACE` alone gets this wrong: it keeps the row being
+    /// rewritten, which is the legacy one, so a stale device list would replace
+    /// a current one and `get_devices` would serve it until the next refresh.
     #[tokio::test]
-    async fn the_normalisation_migration_survives_a_duplicated_peer() {
+    async fn the_normalisation_migration_keeps_the_fresher_of_two_spellings() {
         use diesel::connection::SimpleConnection;
 
         const NORMALISE: &str =
@@ -4184,22 +4190,85 @@ mod tests {
         let store = create_test_store().await;
         let mut conn = store.pool.get().expect("a connection");
 
+        // Peer 1: the canonical row is newer, so it survives.
+        // Peer 2: the legacy row is newer, so that one does.
+        // Peer 3: only the legacy row exists, so it is simply rewritten.
         conn.batch_execute(
-            "INSERT INTO tc_tokens (jid, token, token_timestamp, device_id, updated_at)
-                  VALUES ('15550000001@c.us', x'01', 0, 1, 0),
-                         ('15550000001@s.whatsapp.net', x'02', 0, 1, 0);",
+            r#"INSERT INTO tc_tokens (jid, token, token_timestamp, device_id, updated_at)
+                    VALUES ('15550000001@c.us',           x'01', 0, 1, 10),
+                           ('15550000001@s.whatsapp.net', x'02', 0, 1, 20),
+                           ('15550000002@c.us',           x'03', 0, 1, 20),
+                           ('15550000002@s.whatsapp.net', x'04', 0, 1, 10),
+                           ('15550000003@c.us',           x'05', 0, 1, 5);
+               INSERT INTO device_registry (user_id, devices_json, timestamp, device_id, updated_at)
+                    VALUES ('15550000001@c.us',           '["stale"]', 0, 1, 10),
+                           ('15550000001@s.whatsapp.net', '["fresh"]', 0, 1, 20);"#,
         )
-        .expect("seed both spellings of one peer");
+        .expect("seed both spellings of the same peers");
 
         conn.batch_execute(NORMALISE)
             .expect("a duplicate must not abort the migration");
 
-        let rows: i64 = diesel::dsl::sql::<diesel::sql_types::BigInt>(
-            "SELECT count(*) FROM tc_tokens WHERE jid = '15550000001@s.whatsapp.net'",
-        )
-        .get_result(&mut *conn)
-        .expect("one row");
-        assert_eq!(rows, 1, "one peer, one row");
+        let scalar = |conn: &mut _, sql: &str| -> String {
+            diesel::dsl::sql::<diesel::sql_types::Text>(sql)
+                .get_result::<String>(conn)
+                .expect("one row")
+        };
+        let count = |conn: &mut _, sql: &str| -> i64 {
+            diesel::dsl::sql::<diesel::sql_types::BigInt>(sql)
+                .get_result::<i64>(conn)
+                .expect("one row")
+        };
+
+        assert_eq!(
+            count(&mut *conn, "SELECT count(*) FROM tc_tokens"),
+            3,
+            "one row per peer"
+        );
+        assert_eq!(
+            count(
+                &mut *conn,
+                "SELECT count(*) FROM tc_tokens WHERE jid LIKE '%@c.us'"
+            ),
+            0,
+            "and none of them spelled the old way"
+        );
+        assert_eq!(
+            scalar(
+                &mut *conn,
+                "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000001@s.whatsapp.net'"
+            ),
+            "02",
+            "the canonical row was newer and must survive"
+        );
+        assert_eq!(
+            scalar(
+                &mut *conn,
+                "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000002@s.whatsapp.net'"
+            ),
+            "03",
+            "the legacy row was newer and must survive the rewrite"
+        );
+        assert_eq!(
+            scalar(
+                &mut *conn,
+                "SELECT hex(token) FROM tc_tokens WHERE jid = '15550000003@s.whatsapp.net'"
+            ),
+            "05",
+            "an uncontested legacy row is just rewritten"
+        );
+
+        // The case with a real consequence: a stale device list must not
+        // displace the current one.
+        assert_eq!(count(&mut *conn, "SELECT count(*) FROM device_registry"), 1);
+        assert_eq!(
+            scalar(
+                &mut *conn,
+                "SELECT devices_json FROM device_registry WHERE user_id = '15550000001@s.whatsapp.net'"
+            ),
+            r#"["fresh"]"#,
+            "the newer device list must win"
+        );
     }
 
     /// `delete_version` is how a rebuild is expressed, so what it does to a row

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4094,6 +4094,114 @@ mod tests {
             .expect("Failed to create test store")
     }
 
+    /// The legacy-spelling normalisation, run against the migration file itself
+    /// so the SQL under test cannot drift from the SQL that ships.
+    ///
+    /// Two halves matter equally: the JID-rendered keys move, and the Signal
+    /// address columns do not. `@c.us` is the correct, current spelling of a
+    /// Signal address (it is what WA Web uses, and `mapped_server` still writes
+    /// it), so rewriting one would orphan every established session -- the
+    /// opposite of what this migration is for.
+    #[tokio::test]
+    async fn the_normalisation_migration_moves_jids_and_leaves_signal_addresses() {
+        use diesel::connection::SimpleConnection;
+
+        const NORMALISE: &str =
+            include_str!("../migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql");
+
+        let store = create_test_store().await;
+        let pool = store.pool.clone();
+        let mut conn = pool.get().expect("a connection");
+
+        conn.batch_execute(
+            "INSERT INTO tc_tokens (jid, token, token_timestamp, device_id, updated_at)
+                  VALUES ('15550000001@c.us', x'01', 0, 1, 0),
+                         ('15550000002@s.whatsapp.net', x'02', 0, 1, 0),
+                         ('120363000000000000@g.us', x'03', 0, 1, 0);
+             INSERT INTO sent_messages (chat_jid, message_id, payload, device_id, created_at)
+                  VALUES ('15550000001@c.us', 'M1', x'01', 1, 0);
+             INSERT INTO device_registry (user_id, devices_json, timestamp, device_id, updated_at)
+                  VALUES ('15550000001@c.us', '[]', 0, 1, 0);
+             INSERT INTO sessions (address, record, device_id)
+                  VALUES ('15550000001@c.us.0', x'01', 1);
+             INSERT INTO sender_keys (address, record, device_id)
+                  VALUES ('120363000000000000@g.us:15550000001@c.us.0', x'01', 1);",
+        )
+        .expect("seed rows");
+
+        conn.batch_execute(NORMALISE).expect("the migration runs");
+
+        let scalar = |conn: &mut _, sql: &str| -> String {
+            diesel::dsl::sql::<diesel::sql_types::Text>(sql)
+                .get_result::<String>(conn)
+                .expect("one row")
+        };
+
+        assert_eq!(
+            scalar(&mut *conn, "SELECT jid FROM tc_tokens WHERE token = x'01'"),
+            "15550000001@s.whatsapp.net"
+        );
+        assert_eq!(
+            scalar(&mut *conn, "SELECT chat_jid FROM sent_messages"),
+            "15550000001@s.whatsapp.net"
+        );
+        assert_eq!(
+            scalar(&mut *conn, "SELECT user_id FROM device_registry"),
+            "15550000001@s.whatsapp.net"
+        );
+        // Untouched: a group is not in this namespace, and one already spelled
+        // the modern way must not be double-rewritten.
+        assert_eq!(
+            scalar(&mut *conn, "SELECT jid FROM tc_tokens WHERE token = x'02'"),
+            "15550000002@s.whatsapp.net"
+        );
+        assert_eq!(
+            scalar(&mut *conn, "SELECT jid FROM tc_tokens WHERE token = x'03'"),
+            "120363000000000000@g.us"
+        );
+        // The Signal addresses, both the plain one and the one that carries an
+        // address in the middle of a longer key.
+        assert_eq!(
+            scalar(&mut *conn, "SELECT address FROM sessions"),
+            "15550000001@c.us.0"
+        );
+        assert_eq!(
+            scalar(&mut *conn, "SELECT address FROM sender_keys"),
+            "120363000000000000@g.us:15550000001@c.us.0"
+        );
+    }
+
+    /// Both spellings of one peer collide on the primary key when the legacy one
+    /// is rewritten. `UPDATE OR REPLACE` has to resolve that rather than abort
+    /// the migration, which would leave the database unopenable.
+    #[tokio::test]
+    async fn the_normalisation_migration_survives_a_duplicated_peer() {
+        use diesel::connection::SimpleConnection;
+
+        const NORMALISE: &str =
+            include_str!("../migrations/2026-08-31-000000_normalize_legacy_user_server/up.sql");
+
+        let store = create_test_store().await;
+        let mut conn = store.pool.get().expect("a connection");
+
+        conn.batch_execute(
+            "INSERT INTO tc_tokens (jid, token, token_timestamp, device_id, updated_at)
+                  VALUES ('15550000001@c.us', x'01', 0, 1, 0),
+                         ('15550000001@s.whatsapp.net', x'02', 0, 1, 0);",
+        )
+        .expect("seed both spellings of one peer");
+
+        conn.batch_execute(NORMALISE)
+            .expect("a duplicate must not abort the migration");
+
+        let rows: i64 = diesel::dsl::sql::<diesel::sql_types::BigInt>(
+            "SELECT count(*) FROM tc_tokens WHERE jid = '15550000001@s.whatsapp.net'",
+        )
+        .get_result(&mut *conn)
+        .expect("one row");
+        assert_eq!(rows, 1, "one peer, one row");
+    }
+
     /// `delete_version` is how a rebuild is expressed, so what it does to a row
     /// that is not there, and to another device's row, is load-bearing.
     #[tokio::test]

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -57,3 +57,180 @@ fn bench_jid_push_phash_form(bencher: divan::Bencher) {
             black_box(buf.as_bytes());
         });
 }
+
+// ---------------------------------------------------------------------------
+// Identity: `PartialEq`, `Hash`, and the maps keyed by them.
+//
+// Every incoming message looks a `Jid` up in at least one hash map (the chat
+// lane, the session lock, the device memo), and every fan-out compares JIDs
+// pairwise while deduplicating. Neither operation had a bench, so a change to
+// `identity_agent` -- which both go through -- had no way to be costed: the
+// send/receive benches bury it under crypto and marshalling, and the binary
+// size gate only moves on dependency deltas.
+//
+// Two things about the shape of these, both forced by how small the operation
+// is relative to the instruments measuring it:
+//
+// - **Every fixture is built once and leaked.** `with_inputs` runs per
+//   iteration and, while divan excludes it from the wall clock, an
+//   instruction-count profile still counts it -- and building a `Jid` costs
+//   more than comparing two, which would leave the profile measuring setup.
+// - **Each iteration works a whole batch**, reported through `ItemsCount`. A
+//   single comparison is a few nanoseconds, well under this repository's
+//   documented wall-clock noise on cloud hardware, and under callgrind divan's
+//   own per-iteration bookkeeping costs ~335k instructions. Batching amortises
+//   both to nothing, so `ns/item` and `Ir/item` are both readable.
+// ---------------------------------------------------------------------------
+
+use divan::counter::ItemsCount;
+use std::collections::HashMap;
+use std::hash::{BuildHasher, RandomState};
+use std::sync::OnceLock;
+use wacore_binary::jid::Server;
+
+/// Items per measured iteration. Large enough that the per-iteration overhead
+/// of either instrument is below the per-item cost being read.
+const BATCH: usize = 4096;
+
+/// Fan-out sizes worth distinguishing: a DM's own devices, a small group, and
+/// a large one. Below the first the map cost is noise; above the last the
+/// server splits the fan-out anyway.
+const FANOUT_SIZES: [usize; 3] = [8, 64, 512];
+
+fn pn_device(user: &str, device: u16) -> Jid {
+    let mut jid = Jid::pn(user);
+    jid.device = device;
+    jid
+}
+
+fn interop_agent(agent: u8) -> Jid {
+    Jid {
+        user: "5511999990000".into(),
+        server: Server::Interop,
+        agent,
+        device: 0,
+        integrator: 0,
+    }
+}
+
+/// The four comparisons `==` resolves differently: an equal pair (the full
+/// field walk), a mismatch caught on the first field, a mismatch caught only on
+/// `server`, and a pair carrying a non-zero `agent`, which is the one case that
+/// reaches the `identity_agent` normalisation instead of the raw equal-agents
+/// shortcut.
+const EQ_CASES: [&str; 4] = ["equal", "user_differs", "server_differs", "agent_nonzero"];
+
+fn eq_pair(case: &str) -> &'static (Jid, Jid) {
+    static PAIRS: OnceLock<HashMap<&'static str, (Jid, Jid)>> = OnceLock::new();
+    &PAIRS.get_or_init(|| {
+        HashMap::from([
+            (
+                "equal",
+                (pn_device("5511999990000", 7), pn_device("5511999990000", 7)),
+            ),
+            (
+                "user_differs",
+                (pn_device("5511999990000", 7), pn_device("5511999990001", 7)),
+            ),
+            ("server_differs", {
+                let mut right = Jid::lid("5511999990000");
+                right.device = 7;
+                (pn_device("5511999990000", 7), right)
+            }),
+            ("agent_nonzero", (interop_agent(3), interop_agent(4))),
+        ])
+    })[case]
+}
+
+#[divan::bench(args = EQ_CASES)]
+fn bench_jid_eq(bencher: divan::Bencher, case: &str) {
+    let (left, right) = eq_pair(case);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut equal = 0usize;
+        for _ in 0..BATCH {
+            equal += (black_box(left) == black_box(right)) as usize;
+        }
+        black_box(equal)
+    });
+}
+
+#[divan::bench]
+fn bench_jid_hash(bencher: divan::Bencher) {
+    static STATE: OnceLock<(RandomState, Jid)> = OnceLock::new();
+    let (state, jid) = STATE.get_or_init(|| (RandomState::new(), pn_device("5511999990000", 7)));
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut acc = 0u64;
+        for _ in 0..BATCH {
+            acc ^= state.hash_one(black_box(jid));
+        }
+        black_box(acc)
+    });
+}
+
+fn fanout(size: usize) -> &'static [Jid] {
+    static SETS: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
+    let sets = SETS.get_or_init(|| {
+        FANOUT_SIZES
+            .iter()
+            .map(|&n| {
+                (0..n)
+                    .map(|i| pn_device(&format!("5511999{i:06}"), (i % 8) as u16))
+                    .collect()
+            })
+            .collect()
+    });
+    &sets[FANOUT_SIZES
+        .iter()
+        .position(|&n| n == size)
+        .expect("known fan-out size")]
+}
+
+/// Building the map from scratch: the cost a cold fan-out pays once per send.
+/// One item is one inserted device, so the arms are comparable across sizes.
+#[divan::bench(args = FANOUT_SIZES)]
+fn bench_jid_hashmap_insert(bencher: divan::Bencher, size: usize) {
+    let jids = fanout(size);
+    bencher.counter(ItemsCount::new(size)).bench(|| {
+        let mut map = HashMap::with_capacity(jids.len());
+        for jid in jids {
+            map.insert(jid.clone(), ());
+        }
+        black_box(map.len())
+    });
+}
+
+/// A warm map plus the two probes into it, one of each outcome.
+struct Probed {
+    map: HashMap<Jid, ()>,
+    hit: Jid,
+    miss: Jid,
+}
+
+/// The per-message shape: one lookup into a warm map. Hit and miss are separate
+/// because a miss stops at the hash and a hit pays the `==` on top of it.
+#[divan::bench(args = FANOUT_SIZES, consts = [true, false])]
+fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) {
+    static MAPS: OnceLock<Vec<Probed>> = OnceLock::new();
+    let built = MAPS.get_or_init(|| {
+        FANOUT_SIZES
+            .iter()
+            .map(|&n| Probed {
+                map: fanout(n).iter().map(|j| (j.clone(), ())).collect(),
+                hit: fanout(n)[n / 2].clone(),
+                miss: pn_device("5511000000000", 1),
+            })
+            .collect()
+    });
+    let probed = &built[FANOUT_SIZES
+        .iter()
+        .position(|&n| n == size)
+        .expect("known fan-out size")];
+    let (map, probe) = (&probed.map, if HIT { &probed.hit } else { &probed.miss });
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for _ in 0..BATCH {
+            found += map.get(black_box(probe)).is_some() as usize;
+        }
+        black_box(found)
+    });
+}

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -221,15 +221,22 @@ fn bench_jid_hashmap_insert(bencher: divan::Bencher, size: usize) {
     });
 }
 
-/// A warm map plus the two probes into it, one of each outcome.
+/// A warm map plus a full set of probes for each outcome.
 struct Probed {
     map: HashMap<Jid, ()>,
-    hit: Jid,
-    miss: Jid,
+    hits: Vec<Jid>,
+    misses: Vec<Jid>,
 }
 
 /// The per-message shape: one lookup into a warm map. Hit and miss are separate
 /// because a miss stops at the hash and a hit pays the `==` on top of it.
+///
+/// Each batch cycles through every key rather than repeating one. `HashMap`'s
+/// default hasher is seeded per process, so a single probe's bucket and
+/// collision chain are drawn fresh on every run: repeating it would let the
+/// same code measure differently between a baseline and a PR, and batching
+/// would only amplify whichever path that one draw happened to pick. Averaging
+/// over the whole key set makes the layout wash out instead.
 #[divan::bench(args = FANOUT_SIZES, consts = [true, false])]
 fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) {
     static MAPS: OnceLock<Vec<Probed>> = OnceLock::new();
@@ -238,8 +245,12 @@ fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) 
             .iter()
             .map(|&n| Probed {
                 map: fanout(n).iter().map(|j| (j.clone(), ())).collect(),
-                hit: fanout(n)[n / 2].clone(),
-                miss: pn_device("5511000000000", 1),
+                hits: fanout(n).to_vec(),
+                // Same shape and width as the hits, so a miss differs only in
+                // being absent.
+                misses: (0..n)
+                    .map(|i| pn_device(&format!("5511000{i:06}"), (i % 8) as u16))
+                    .collect(),
             })
             .collect()
     });
@@ -247,11 +258,12 @@ fn bench_jid_hashmap_get<const HIT: bool>(bencher: divan::Bencher, size: usize) 
         .iter()
         .position(|&n| n == size)
         .expect("known fan-out size")];
-    let (map, probe) = (&probed.map, if HIT { &probed.hit } else { &probed.miss });
+    let map = &probed.map;
+    let probes: &[Jid] = if HIT { &probed.hits } else { &probed.misses };
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         let mut found = 0usize;
-        for _ in 0..BATCH {
-            found += map.get(black_box(probe)).is_some() as usize;
+        for i in 0..BATCH {
+            found += map.get(black_box(&probes[i % probes.len()])).is_some() as usize;
         }
         black_box(found)
     });

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -113,12 +113,21 @@ fn interop_agent(agent: u8) -> Jid {
     }
 }
 
-/// The four comparisons `==` resolves differently: an equal pair (the full
-/// field walk), a mismatch caught on the first field, a mismatch caught only on
-/// `server`, and a pair carrying a non-zero `agent`, which is the one case that
-/// reaches the `identity_agent` normalisation instead of the raw equal-agents
-/// shortcut.
-const EQ_CASES: [&str; 4] = ["equal", "user_differs", "server_differs", "agent_nonzero"];
+/// The five comparisons `==` resolves differently: an equal pair (the full field
+/// walk), a mismatch caught on the first field, a mismatch caught only on
+/// `server`, and the two shapes that miss the raw equal-agents shortcut and go
+/// through `identity_agent`. Those two are separate because the normalisation
+/// does different work in each: on `@interop` it renders the agent, so it
+/// confirms a real difference, while on the phone namespace it suppresses it, so
+/// it is what makes two JIDs equal that the raw compare would have split. The
+/// second is the case the function exists for.
+const EQ_CASES: [&str; 5] = [
+    "equal",
+    "user_differs",
+    "server_differs",
+    "agent_nonzero",
+    "agent_normalised",
+];
 
 fn eq_pair(case: &str) -> &'static (Jid, Jid) {
     static PAIRS: OnceLock<HashMap<&'static str, (Jid, Jid)>> = OnceLock::new();
@@ -138,6 +147,19 @@ fn eq_pair(case: &str) -> &'static (Jid, Jid) {
                 (pn_device("5511999990000", 7), right)
             }),
             ("agent_nonzero", (interop_agent(3), interop_agent(4))),
+            // Different raw agents, equal identity: the phone namespace does
+            // not render the agent, so both normalise to 0 and the pair is one
+            // device.
+            (
+                "agent_normalised",
+                (
+                    pn_device("5511999990000", 7),
+                    Jid {
+                        agent: 1,
+                        ..pn_device("5511999990000", 7)
+                    },
+                ),
+            ),
         ])
     })[case]
 }

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -21,7 +21,7 @@
 use libfuzzer_sys::fuzz_target;
 use wacore_binary::jid::{Jid, Server, parse_jid_fast, parse_jid_ref};
 
-const SERVERS: [Server; 12] = [
+const SERVERS: [Server; 11] = [
     Server::Pn,
     Server::Lid,
     Server::Group,
@@ -32,7 +32,6 @@ const SERVERS: [Server; 12] = [
     Server::Messenger,
     Server::Interop,
     Server::Bot,
-    Server::Legacy,
     Server::Call,
 ];
 

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -993,6 +993,52 @@ mod tests {
         }
     }
 
+    /// The legacy spelling must not reach the wire by any encoding path, not
+    /// just the message send. `write_jid_owned`/`write_jid_ref` write
+    /// `server.as_str()` for a JID_PAIR with no guard, and `c.us` is not in the
+    /// token dictionary (`s.whatsapp.net` is), so emitting it would put a raw
+    /// string on the wire where WA Web sends a token -- and a server spelling
+    /// WA Web never sends at all, since its whole JID layer (`WAJids`) knows
+    /// only `s.whatsapp.net`. There is no guard because there is nothing left
+    /// to guard against: no `Server` renders it. This holds the bytes to that.
+    #[test]
+    fn the_legacy_spelling_never_reaches_the_wire() -> TestResult {
+        use crate::jid::{Jid, parse_jid_ref};
+
+        fn encode(jid: &Jid) -> Result<Vec<u8>> {
+            let mut buffer = Vec::new();
+            let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+            encoder.write_jid_owned(jid)?;
+            Ok(buffer)
+        }
+
+        for (legacy, modern) in [
+            ("5511999998888@c.us", "5511999998888@s.whatsapp.net"),
+            // AD_JID form: same domain byte, so the bytes match there too.
+            ("5511999998888:3@c.us", "5511999998888:3@s.whatsapp.net"),
+            // A dotted agent is inert on a phone user and encodes nothing.
+            ("5511999998888.2@c.us", "5511999998888@s.whatsapp.net"),
+        ] {
+            let legacy: Jid = legacy.parse().unwrap();
+            let modern: Jid = modern.parse().unwrap();
+            let bytes = encode(&legacy)?;
+            assert_eq!(bytes, encode(&modern)?, "{legacy} must encode as {modern}");
+            assert!(
+                !bytes.windows(4).any(|w| w == b"c.us"),
+                "{legacy} put the legacy spelling on the wire: {bytes:?}"
+            );
+
+            // The borrowed writer is a separate copy of the same branch.
+            let rendered = legacy.to_string();
+            let borrowed = parse_jid_ref(&rendered).unwrap();
+            let mut buffer = Vec::new();
+            let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+            encoder.write_jid_ref(&borrowed)?;
+            assert_eq!(buffer, bytes);
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_encode_node() -> TestResult {
         let node = Node::new(

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -297,7 +297,7 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         (user_combined, None)
     };
 
-    let user_end = if let Some(underscore_idx) = user_agent.find('_')
+    let mut user_end = if let Some(underscore_idx) = user_agent.find('_')
         && user_agent[underscore_idx + 1..].parse::<u8>().is_ok()
     {
         underscore_idx
@@ -306,6 +306,20 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
     };
 
     let server_kind = jid::Server::parse_known(server);
+    // A dotted agent is inert on the phone and hosted namespaces, so a parsed
+    // `Jid` drops it from the rendered form (`renders_agent`). Drop it here too,
+    // or the two public attribute paths address different users: `read_jid_pair`
+    // takes the user verbatim and never reads a `.2` back as an agent. `@lid`
+    // is excluded because a dot there is part of the user, and the servers that
+    // do render an agent keep it for the same reason -- it is theirs.
+    if matches!(
+        server_kind,
+        Some(jid::Server::Pn | jid::Server::Hosted | jid::Server::HostedLid)
+    ) && let Some(dot_idx) = user_agent[..user_end].rfind('.')
+        && user_agent[dot_idx + 1..user_end].parse::<u8>().is_ok()
+    {
+        user_end = dot_idx;
+    }
 
     // Single source of truth: only servers whose domain byte the decoder
     // round-trips back can use AD_JID. For everyone else drop the device
@@ -1074,6 +1088,20 @@ mod tests {
             assert!(
                 !buffer.windows(4).any(|w| w == b"c.us"),
                 "the string path leaked the legacy spelling of {raw}: {buffer:?}"
+            );
+
+            // A dotted agent in a string attribute must drop out the same way
+            // it does for a parsed `Jid`, or the two public paths address
+            // different users: `read_jid_pair` reads the user verbatim and
+            // never parses a `.2` back into an agent.
+            let dotted = format!("{}.2@c.us", legacy.user);
+            let mut buffer = Vec::new();
+            let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+            encoder.write_string(&dotted)?;
+            assert_eq!(
+                buffer,
+                encode(&modern.to_non_ad())?,
+                "{dotted} must encode as the bare user, like the parsed Jid does"
             );
 
             // Plan and write must agree on the canonical spelling too: the

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -201,6 +201,12 @@ struct ParsedJidMeta {
     server_start: u8,
     domain_type: u8,
     device: Option<u8>,
+    /// The resolved server, when the suffix is one we know. `JID_PAIR` writes
+    /// this rather than the caller's substring, so a string-valued attribute
+    /// (`.attr("to", "…@c.us")`) is spelled on the wire exactly as the
+    /// equivalent `Jid` would be. `None` keeps an unknown suffix verbatim,
+    /// which is the only way it can survive the round trip.
+    server: Option<jid::Server>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -304,6 +310,7 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         .and(device);
 
     Some(ParsedJidMeta {
+        server: server_kind,
         user_end: u8::try_from(user_end).ok()?,
         server_start: u8::try_from(server_start).ok()?,
         domain_type,
@@ -536,7 +543,11 @@ fn parsed_jid_encoded_size_with_cache(
     meta: ParsedJidMeta,
     hints: &mut StringHintCache,
 ) -> usize {
-    let (user, server) = split_jid_from_meta(jid, meta);
+    let (user, raw_server) = split_jid_from_meta(jid, meta);
+    // The same canonicalisation `write_jid_from_meta` applies. Sizing the
+    // caller's substring while the writer emits the resolved spelling is not a
+    // bad estimate, it is an `UnexpectedEof` on the send.
+    let server = meta.server.map_or(raw_server, |s| s.as_str());
     if meta.device.is_some() {
         3 + string_encoded_size_with_cache(user, hints)
     } else {
@@ -757,7 +768,8 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
 
     #[inline(always)]
     fn write_jid_from_meta(&mut self, jid: &str, meta: ParsedJidMeta) -> Result<()> {
-        let (user, server) = split_jid_from_meta(jid, meta);
+        let (user, raw_server) = split_jid_from_meta(jid, meta);
+        let server = meta.server.map_or(raw_server, |s| s.as_str());
         if let Some(device) = meta.device {
             self.write_u8(token::AD_JID)?;
             self.write_u8(meta.domain_type)?;
@@ -1012,20 +1024,47 @@ mod tests {
             Ok(buffer)
         }
 
-        for (legacy, modern) in [
+        for (raw, modern) in [
             ("5511999998888@c.us", "5511999998888@s.whatsapp.net"),
             // AD_JID form: same domain byte, so the bytes match there too.
             ("5511999998888:3@c.us", "5511999998888:3@s.whatsapp.net"),
             // A dotted agent is inert on a phone user and encodes nothing.
             ("5511999998888.2@c.us", "5511999998888@s.whatsapp.net"),
         ] {
-            let legacy: Jid = legacy.parse().unwrap();
+            let legacy: Jid = raw.parse().unwrap();
             let modern: Jid = modern.parse().unwrap();
             let bytes = encode(&legacy)?;
-            assert_eq!(bytes, encode(&modern)?, "{legacy} must encode as {modern}");
+            assert_eq!(bytes, encode(&modern)?, "{raw} must encode as {modern}");
             assert!(
                 !bytes.windows(4).any(|w| w == b"c.us"),
-                "{legacy} put the legacy spelling on the wire: {bytes:?}"
+                "{raw} put the legacy spelling on the wire: {bytes:?}"
+            );
+
+            // The string path: a caller that hands a JID as a node attribute
+            // (`.attr("to", "…@c.us")`) never builds a `Jid`, and the JID_PAIR
+            // branch there writes the server substring straight out of the
+            // input.
+            let mut buffer = Vec::new();
+            let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+            encoder.write_string(raw)?;
+            assert!(
+                !buffer.windows(4).any(|w| w == b"c.us"),
+                "the string path leaked the legacy spelling of {raw}: {buffer:?}"
+            );
+
+            // Plan and write must agree on the canonical spelling too: the
+            // exact marshal sizes its buffer from the estimator and then writes
+            // into it, so a mismatch is an `UnexpectedEof`, not a loose bound.
+            let node = NodeBuilder::new("message").attr("to", raw).build();
+            let exact = crate::marshal::marshal_exact(&node)?;
+            assert_eq!(
+                exact,
+                crate::marshal::marshal(&node)?,
+                "plan and writer disagree for {raw}"
+            );
+            assert!(
+                !exact.windows(4).any(|w| w == b"c.us"),
+                "a string-valued attribute leaked the legacy spelling of {raw}"
             );
 
             // The borrowed writer is a separate copy of the same branch.

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -194,12 +194,13 @@ impl EncodeNode for NodeRef<'_> {
 
 // u8 offsets keep StringHint small — the hint tape stores one per string —
 // and always fit: classify_string_hint only treats strings <= 48 bytes as
-// JID candidates.
+// JID candidates. The tape is one hint per string of the whole node, so a
+// byte added here is a byte times every string in the payload: keep the
+// resolved server and derive everything derivable from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ParsedJidMeta {
     user_end: u8,
     server_start: u8,
-    domain_type: u8,
     device: Option<u8>,
     /// The resolved server, when the suffix is one we know. `JID_PAIR` writes
     /// this rather than the caller's substring, so a string-valued attribute
@@ -207,6 +208,17 @@ struct ParsedJidMeta {
     /// equivalent `Jid` would be. `None` keeps an unknown suffix verbatim,
     /// which is the only way it can survive the round trip.
     server: Option<jid::Server>,
+}
+
+impl ParsedJidMeta {
+    /// The AD_JID domain byte, from the resolved server rather than a second
+    /// stored copy of the same fact — `device` is `Some` only for the servers
+    /// [`server_supports_ad_jid`] accepts, which are exactly the ones
+    /// [`server_to_domain_type`] maps.
+    #[inline]
+    fn domain_type(self) -> u8 {
+        self.server.map_or(0, server_to_domain_type)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,15 +306,8 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
     };
 
     let server_kind = jid::Server::parse_known(server);
-    let domain_type = match server_kind {
-        Some(jid::Server::Pn) => 0,
-        Some(jid::Server::Lid) => 1,
-        Some(jid::Server::Hosted) => 128,
-        Some(jid::Server::HostedLid) => 129,
-        _ => 0,
-    };
 
-    // Single source of truth: only servers whose `domain_type` the decoder
+    // Single source of truth: only servers whose domain byte the decoder
     // round-trips back can use AD_JID. For everyone else drop the device
     // and fall through to JID_PAIR (which preserves the server name).
     let device = server_kind
@@ -313,7 +318,6 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         server: server_kind,
         user_end: u8::try_from(user_end).ok()?,
         server_start: u8::try_from(server_start).ok()?,
-        domain_type,
         device,
     })
 }
@@ -334,11 +338,12 @@ fn split_jid_from_meta(input: &str, meta: ParsedJidMeta) -> (&str, &str) {
 ///   128 = hosted
 ///   129 = hosted.lid
 ///
-/// WARNING: This must stay in sync with the string-path mapping in
-/// `classify_string_hint` / `parse_jid_meta` and the inverse mapping in
-/// `decoder.rs read_ad_jid`. Writing `jid.agent` unconditionally here
-/// (instead of only as a fallback) was the root cause of a regression
-/// where LID group messages were silently rejected by the server (error 421).
+/// WARNING: This must stay in sync with the inverse mapping in
+/// `decoder.rs read_ad_jid`. The string path no longer keeps its own copy of
+/// this mapping — `ParsedJidMeta::domain_type` calls this. Writing `jid.agent`
+/// unconditionally here (instead of only as a fallback) was the root cause of a
+/// regression where LID group messages were silently rejected by the server
+/// (error 421).
 #[inline]
 fn server_to_domain_type(server: jid::Server) -> u8 {
     match server {
@@ -772,7 +777,7 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
         let server = meta.server.map_or(raw_server, |s| s.as_str());
         if let Some(device) = meta.device {
             self.write_u8(token::AD_JID)?;
-            self.write_u8(meta.domain_type)?;
+            self.write_u8(meta.domain_type())?;
             self.write_u8(device)?;
             self.write_string(user)?;
         } else {
@@ -1003,6 +1008,25 @@ mod tests {
                 "nibble table disagrees at {byte:#04x}"
             );
         }
+    }
+
+    /// The hint tape holds one `StringHint` per string in the payload, so its
+    /// width is multiplied by every tag, attribute key, attribute value and
+    /// string content of the node: a 2048-child stanza records ~12k hints, and
+    /// one byte added here is 16 KiB of peak allocation once the `SmallVec`
+    /// rounds up. Adding a field that duplicates something already derivable
+    /// (the AD_JID domain byte, from the resolved server) cost exactly that
+    /// before it was derived instead. Pinned so the next field has to justify
+    /// itself.
+    #[test]
+    fn the_hint_tape_stays_five_bytes_wide() {
+        assert_eq!(
+            size_of::<StringHint>(),
+            5,
+            "StringHint got wider; the tape is one per string, so this is \
+             peak memory times every string in the payload"
+        );
+        assert_eq!(size_of::<ParsedJidMeta>(), 5, "ParsedJidMeta got wider");
     }
 
     /// The legacy spelling must not reach the wire by any encoding path, not

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -1006,11 +1006,9 @@ impl FromStr for Jid {
             device = d_str.parse()?;
         }
 
-        // No phone-namespace carve-out: the dot is the agent position on every
-        // server this reaches, matching `parse_jid_scan` and WA Web. See the
-        // generic arm there.
-        if server != HIDDEN_USER_SERVER
-            && let Some((u, last_part)) = user.rsplit_once('.')
+        // No carve-out by server: the LID branch has already returned, and the
+        // dot is the agent position on everything else. See `parse_jid_scan`.
+        if let Some((u, last_part)) = user.rsplit_once('.')
             && let Ok(num_val) = last_part.parse::<u16>()
         {
             if num_val > u8::MAX as u16 {

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -79,8 +79,7 @@ fn parse_jid_scan(s: &str) -> Option<(ParsedJidParts<'_>, Option<Server>)> {
                 break;
             }
             b':' => colon_pos = Some(i),
-            // Dots after the first colon belong to the device, not the agent.
-            b'.' if colon_pos.is_none() => last_dot_pos = Some(i),
+            b'.' => last_dot_pos = Some(i),
             _ => {}
         }
     }
@@ -112,65 +111,36 @@ fn parse_jid_scan(s: &str) -> Option<(ParsedJidParts<'_>, Option<Server>)> {
                 server,
             ))
         }
-        // `s.whatsapp.net` has no agent in the string form; a trailing dotted
-        // number is the legacy device spelling.
-        Some(Server::Pn) => {
-            if let Some(pos) = colon_pos {
-                return Some((
-                    ParsedJidParts {
-                        user: &s[..pos],
-                        server: server_str,
-                        agent: 0,
-                        device: parse_u16_decimal(&s[pos + 1..at]).unwrap_or(0),
-                        integrator: 0,
-                    },
-                    server,
-                ));
-            }
-            if let Some(dot_pos) = last_dot_pos
-                && let Some(device_val) = parse_u16_decimal(&s[dot_pos + 1..at])
-            {
-                return Some((
-                    ParsedJidParts {
-                        user: &s[..dot_pos],
-                        server: server_str,
-                        agent: 0,
-                        device: device_val,
-                        integrator: 0,
-                    },
-                    server,
-                ));
-            }
-            Some((
-                ParsedJidParts {
-                    user: user_part,
-                    server: server_str,
-                    agent: 0,
-                    device: 0,
-                    integrator: 0,
-                },
-                server,
-            ))
-        }
-        // Everything else (including unknown servers): `user.agent:device`.
+        // Everything else, phone users included (and unknown servers):
+        // `user.agent:device`. The dot is the agent position on every server WA
+        // Web parses -- `WAJids.parseJidParts` splits `:` then `.` with no
+        // per-server carve-out, `fullFormDeviceJidString` writes it back as
+        // `user.<agent>:<device>@server`, and `stripAgentIdFromPhoneDeviceJid`
+        // exists precisely to drop it off a phone user. It is never a device
+        // there: the device only ever follows a colon. On the phone namespace
+        // the agent is inert (`renders_agent`), so a JID that carries one is
+        // still the same identity as the bare user, which is what makes reading
+        // it here safe rather than merely faithful.
         _ => {
             let (user_before_colon, device) = match colon_pos {
                 Some(pos) => (&s[..pos], parse_u16_decimal(&s[pos + 1..at]).unwrap_or(0)),
                 None => (user_part, 0),
             };
-            // Deliberately `rfind` on the pre-colon slice rather than reusing
-            // `last_dot_pos`: the two differ for pathological users that hold a
-            // second colon (`a:1.5:2`), and this branch is cold enough that
-            // matching the historical rule is worth the extra scan.
-            let (final_user, agent) = match user_before_colon.rfind('.') {
-                Some(dot_pos) => match parse_u16_decimal(&user_before_colon[dot_pos + 1..]) {
-                    Some(agent_val) if agent_val <= u8::MAX as u16 => {
-                        (&user_before_colon[..dot_pos], agent_val as u8)
-                    }
-                    _ => (user_before_colon, 0),
-                },
-                None => (user_before_colon, 0),
-            };
+            // The scan already found the last dot, so this needs no second
+            // pass -- but only a dot *before* the device separator is the
+            // agent, which is what the bound rules out. The two readings differ
+            // for a pathological user holding a second colon (`a:1.5:2`), and
+            // the pre-colon one is what the agent rule means.
+            let (final_user, agent) =
+                match last_dot_pos.filter(|&dot_pos| dot_pos < user_before_colon.len()) {
+                    Some(dot_pos) => match parse_u16_decimal(&user_before_colon[dot_pos + 1..]) {
+                        Some(agent_val) if agent_val <= u8::MAX as u16 => {
+                            (&user_before_colon[..dot_pos], agent_val as u8)
+                        }
+                        _ => (user_before_colon, 0),
+                    },
+                    None => (user_before_colon, 0),
+                };
             Some((
                 ParsedJidParts {
                     user: final_user,
@@ -221,7 +191,9 @@ pub enum Server {
     Messenger = 7,
     Interop = 8,
     Bot = 9,
-    Legacy = 10,
+    // 10 was the legacy `c.us` spelling of `Pn`, which `parse_known` now
+    // resolves. The gap is left rather than closed so no existing discriminant
+    // changes meaning.
     /// `@call` call-signaling JID; not an AD server, so it round-trips via JID_PAIR.
     Call = 11,
 }
@@ -285,7 +257,6 @@ impl Server {
             Self::Messenger => "msgr",
             Self::Interop => "interop",
             Self::Bot => "bot",
-            Self::Legacy => "c.us",
             Self::Call => "call",
         }
     }
@@ -322,7 +293,7 @@ impl Server {
     pub fn carries_phone_number(self) -> bool {
         matches!(
             self,
-            Self::Pn | Self::Hosted | Self::Legacy | Self::Messenger | Self::Interop
+            Self::Pn | Self::Hosted | Self::Messenger | Self::Interop
         )
     }
 }
@@ -363,7 +334,17 @@ impl Server {
             "msgr" => Self::Messenger,
             "interop" => Self::Interop,
             "bot" => Self::Bot,
-            "c.us" => Self::Legacy,
+            // `c.us` is not a namespace: it is the other spelling of the phone
+            // namespace, collapsed here so it cannot exist past parsing. WA Web
+            // collapses the same way and in the same place -- `createWid` does
+            // `t.replace("@s.whatsapp.net","@c.us")` before the constructor runs
+            // and caches under the collapsed key, so the two spellings can never
+            // reach two objects, two cache entries or two comparisons. This is
+            // the sole converter behind text (`FromStr`), the wire
+            // (`read_jid_pair`) and serde, so collapsing it here covers all
+            // three, and `Server` then has no variant that could render `c.us`
+            // back out.
+            "c.us" => Self::Pn,
             "call" => Self::Call,
             _ => return None,
         })
@@ -463,11 +444,11 @@ pub trait JidExt {
         self.server() == Server::Broadcast && self.user() == STATUS_BROADCAST_USER
     }
 
-    /// The system/announcements account (`0@s.whatsapp.net` / `0@c.us`).
+    /// The system/announcements account (`0@s.whatsapp.net`, however spelled).
     /// It never answers user-directed IQs, so requests must be short-circuited
     /// client-side (WA Web excludes it via `isPSA` before hitting the server).
     fn is_psa(&self) -> bool {
-        matches!(self.server(), Server::Pn | Server::Legacy) && self.user() == PSA_USER
+        self.server() == Server::Pn && self.user() == PSA_USER
     }
 
     fn is_bot(&self) -> bool {
@@ -504,6 +485,9 @@ pub trait JidExt {
 /// encodes an agent set there (`server_to_domain_type`), nothing prints it
 /// (`renders_agent`), and nothing hashes it (`push_phash_form_to` writes a literal `0`,
 /// matching WA Web). Two JIDs differing only there address the same device.
+/// A phone user parsed from `user.<n>@...` lands here: WA Web reads that
+/// position as the agent too and drops it (`stripAgentIdFromPhoneDeviceJid`),
+/// and this is what makes keeping it inert equivalent to dropping it.
 ///
 /// Letting it into equality anyway is what made a JID decoded from the wire
 /// unequal to the same JID read back from the store, which holds JIDs as text
@@ -1033,8 +1017,10 @@ impl FromStr for Jid {
             device = d_str.parse()?;
         }
 
-        if server != DEFAULT_USER_SERVER
-            && server != HIDDEN_USER_SERVER
+        // No phone-namespace carve-out: the dot is the agent position on every
+        // server this reaches, matching `parse_jid_scan` and WA Web. See the
+        // generic arm there.
+        if server != HIDDEN_USER_SERVER
             && let Some((u, last_part)) = user.rsplit_once('.')
             && let Ok(num_val) = last_part.parse::<u16>()
         {
@@ -1372,6 +1358,163 @@ impl TryFrom<String> for Jid {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    /// The regression the whole change is for, and the one a naive fix does not
+    /// pass. Relaxing `==` alone -- teaching it that the two spellings of the
+    /// phone namespace are one -- still leaves the two sides classified
+    /// differently by `identity_agent`, because the legacy spelling was not in
+    /// the set of servers that suppress the agent. Two JIDs equal in everything
+    /// but the spelling would then compare unequal whenever the agent is
+    /// non-zero, which is rare enough to pass CI and show up only on odd input
+    /// off the wire. Collapsing at the parser instead means there is no second
+    /// classification to get wrong.
+    #[test]
+    fn the_two_spellings_agree_when_the_agent_is_not_zero() {
+        let legacy: Jid = "12345678901.6@c.us".parse().unwrap();
+        let modern: Jid = "12345678901.6@s.whatsapp.net".parse().unwrap();
+
+        assert_eq!(legacy.agent, 6, "the dotted number is read, not discarded");
+        assert_eq!(legacy.device, 0, "and it is not a device");
+        assert_eq!(legacy, modern);
+        assert_eq!(hash_of(&legacy), hash_of(&modern));
+        // ...and both are the same identity as the bare user, since the agent
+        // is inert on the phone namespace.
+        assert_eq!(legacy, "12345678901@s.whatsapp.net".parse::<Jid>().unwrap());
+        assert_eq!(legacy.to_string(), "12345678901@s.whatsapp.net");
+    }
+
+    /// The dotted position on a phone user is the agent, not a device. WA Web's
+    /// `WAJids.parseJidParts` splits `user:device` then `user.agent` with no
+    /// per-server branch, `fullFormDeviceJidString` writes it back as
+    /// `user.<agent>:<device>@server`, and `stripAgentIdFromPhoneDeviceJid`
+    /// drops it; its `Wid` layer has no agent field at all and accepts only a
+    /// literal `.0` there. Reading it as a device -- which this parser did --
+    /// turned a bare user into a request addressed at device N.
+    #[test]
+    fn a_dotted_number_on_a_phone_user_is_the_inert_agent() {
+        let dotted: Jid = "5511999998888.2@s.whatsapp.net".parse().unwrap();
+        assert_eq!(dotted.user, "5511999998888");
+        assert_eq!(dotted.agent, 2);
+        assert_eq!(dotted.device, 0, "a device only ever follows a colon");
+        assert_eq!(dotted, Jid::pn("5511999998888"));
+
+        // The colon still is the device, and the two positions compose.
+        let both: Jid = "5511999998888.2:3@s.whatsapp.net".parse().unwrap();
+        assert_eq!(
+            (both.user.as_str(), both.agent, both.device),
+            ("5511999998888", 2, 3)
+        );
+        assert_eq!(both, Jid::pn_device("5511999998888", 3));
+        assert_ne!(both, dotted);
+
+        // The shape WA Web actually writes, `formatFull`'s `user.0:device`.
+        // The old phone-namespace carve-out returned early on the colon and
+        // never looked at the dot, so the `.0` stayed inside `user` and the
+        // result was not equal to the same device addressed without it.
+        let full: Jid = "5511999998888.0:3@s.whatsapp.net".parse().unwrap();
+        assert_eq!(
+            full.user, "5511999998888",
+            "the agent is not part of the user"
+        );
+        assert_eq!(full, Jid::pn_device("5511999998888", 3));
+        assert_eq!(full.to_string(), "5511999998888:3@s.whatsapp.net");
+    }
+
+    /// Text, wire and serde all resolve the server through `Server::parse_known`,
+    /// so the collapse has to hold for all three -- and none of them may
+    /// materialise the legacy spelling internally, because a `Server` that could
+    /// render it is a `Server` that could reach the wire.
+    #[test]
+    fn every_input_direction_collapses_the_legacy_spelling() {
+        let expected = Jid::pn("5511999998888");
+
+        // Text, both parsers.
+        assert_eq!("5511999998888@c.us".parse::<Jid>().unwrap(), expected);
+        assert_eq!(
+            parse_jid_ref("5511999998888@c.us").unwrap().to_owned(),
+            expected
+        );
+        // The fallback path (an empty user forces it) resolves it too.
+        assert_eq!("@c.us".parse::<Jid>().unwrap().server, Server::Pn);
+
+        // Wire: `read_jid_pair` classifies the server string with the same
+        // converter, so a JID_PAIR naming `c.us` decodes as a phone user.
+        assert_eq!(Server::try_from("c.us").unwrap(), Server::Pn);
+
+        // No spelling of the enum renders it back out.
+        for server in [
+            Server::Pn,
+            Server::Lid,
+            Server::Group,
+            Server::Broadcast,
+            Server::Newsletter,
+            Server::Hosted,
+            Server::HostedLid,
+            Server::Messenger,
+            Server::Interop,
+            Server::Bot,
+            Server::Call,
+        ] {
+            assert_ne!(
+                server.as_str(),
+                LEGACY_USER_SERVER,
+                "{server:?} must not render the legacy spelling"
+            );
+        }
+        assert_eq!(expected.to_string(), "5511999998888@s.whatsapp.net");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_collapses_the_legacy_spelling_too() {
+        let server: Server = serde_json::from_str("\"c.us\"").unwrap();
+        assert_eq!(server, Server::Pn);
+        assert_eq!(
+            serde_json::to_string(&server).unwrap(),
+            "\"s.whatsapp.net\""
+        );
+
+        let jid: Jid = serde_json::from_str(
+            r#"{"user":"5511999998888","server":"c.us","agent":0,"device":0,"integrator":0}"#,
+        )
+        .unwrap();
+        assert_eq!(jid, Jid::pn("5511999998888"));
+
+        // A server that is not a spelling of anything still fails.
+        assert!(serde_json::from_str::<Server>("\"nope\"").is_err());
+    }
+
+    /// A JID's identity must not depend on which spelling it arrived as, in any
+    /// of the derived keys built over it.
+    #[test]
+    fn the_two_spellings_share_every_derived_key() {
+        let legacy: Jid = "5511999998888:3@c.us".parse().unwrap();
+        let modern: Jid = "5511999998888:3@s.whatsapp.net".parse().unwrap();
+
+        assert_eq!(legacy, modern);
+        assert_eq!(hash_of(&legacy), hash_of(&modern));
+        assert_eq!(legacy.device_key(), modern.device_key());
+        assert!(legacy.is_same_chat_as(&modern));
+        assert!(legacy.device_eq(&modern));
+        assert!(legacy.display_eq_jid(&modern));
+        assert_eq!(legacy.to_string(), modern.to_string());
+        assert_eq!(legacy.to_non_ad_string(), modern.to_non_ad_string());
+        assert_eq!(legacy.to_phash_form_string(), modern.to_phash_form_string());
+        assert!(legacy.is_pn(), "a phone user however it is spelled");
+
+        // And a single map entry, which is the failure the batch is named for.
+        let mut map = std::collections::HashMap::new();
+        map.insert(legacy.clone(), ());
+        assert!(map.contains_key(&modern), "one person, one entry");
+    }
+
+    /// One fixed-key hasher, so two calls are comparable at all.
+    fn hash_of(jid: &Jid) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        jid.hash(&mut hasher);
+        hasher.finish()
+    }
 
     #[test]
     fn is_psa_matches_system_jid_in_both_user_namespaces() {
@@ -1858,17 +2001,20 @@ mod tests {
             ("123456789.4@interop", "123456789", 4, 0),
             // ...but an agent past u8 leaves the user whole instead.
             ("123.999@interop", "123.999", 0, 0),
-            // On s.whatsapp.net that same trailing number is the legacy device.
-            ("5511999998888.2@s.whatsapp.net", "5511999998888", 0, 2),
+            // s.whatsapp.net reads it the same way, as the agent. WA Web's
+            // `parseJidParts` splits `.` into `agent` with no per-server
+            // carve-out and the device only ever follows a colon; see
+            // `a_dotted_number_on_a_phone_user_is_the_inert_agent`.
+            ("5511999998888.2@s.whatsapp.net", "5511999998888", 2, 0),
             // Dots in a lid user are part of the user.
             ("12345.678@lid", "12345.678", 0, 0),
             ("12345.678:9@lid", "12345.678", 0, 9),
-            // `hosted.lid` and `c.us` are NOT in the lid family here — they take
-            // the generic rule, so a dotted number that fits in u8 becomes the
-            // agent. Pinned as the pre-existing behaviour, not endorsed as
-            // correct; changing it needs WA Web as ground truth, not this PR.
+            // `hosted.lid` is NOT in the lid family here — it takes the generic
+            // rule, so a dotted number that fits in u8 becomes the agent.
             ("12345.6@hosted.lid", "12345", 6, 0),
             ("12345.678@hosted.lid", "12345.678", 0, 0),
+            // ...and so does the legacy spelling of the phone namespace, which
+            // by then is the phone namespace.
             ("12345.6@c.us", "12345", 6, 0),
             // A second colon puts the last dot after the first one, which is
             // where reusing the scanned dot position would silently diverge.
@@ -2612,7 +2758,7 @@ mod tests {
             // Short user
             Case {
                 user: "1",
-                server: Server::Legacy,
+                server: Server::Call,
                 agent: 0,
                 device: 1,
             },

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -112,25 +112,19 @@ fn parse_jid_scan(s: &str) -> Option<(ParsedJidParts<'_>, Option<Server>)> {
             ))
         }
         // Everything else, phone users included (and unknown servers):
-        // `user.agent:device`. The dot is the agent position on every server WA
-        // Web parses -- `WAJids.parseJidParts` splits `:` then `.` with no
-        // per-server carve-out, `fullFormDeviceJidString` writes it back as
-        // `user.<agent>:<device>@server`, and `stripAgentIdFromPhoneDeviceJid`
-        // exists precisely to drop it off a phone user. It is never a device
-        // there: the device only ever follows a colon. On the phone namespace
-        // the agent is inert (`renders_agent`), so a JID that carries one is
-        // still the same identity as the bare user, which is what makes reading
-        // it here safe rather than merely faithful.
+        // `user.agent:device`, one rule. The dot is the agent on every server WA
+        // Web parses and never a device, which only ever follows a colon; the
+        // phone namespace had a carve-out reading it as one, and that turned a
+        // bare user into a request addressed at a device it never named.
         _ => {
             let (user_before_colon, device) = match colon_pos {
                 Some(pos) => (&s[..pos], parse_u16_decimal(&s[pos + 1..at]).unwrap_or(0)),
                 None => (user_part, 0),
             };
-            // The scan already found the last dot, so this needs no second
-            // pass -- but only a dot *before* the device separator is the
-            // agent, which is what the bound rules out. The two readings differ
-            // for a pathological user holding a second colon (`a:1.5:2`), and
-            // the pre-colon one is what the agent rule means.
+            // The scan already found the last dot, so no second pass is
+            // needed -- but only one before the device separator is the agent,
+            // which is what the bound enforces. The two readings differ for a
+            // user holding a second colon (`a:1.5:2`).
             let (final_user, agent) =
                 match last_dot_pos.filter(|&dot_pos| dot_pos < user_before_colon.len()) {
                     Some(dot_pos) => match parse_u16_decimal(&user_before_colon[dot_pos + 1..]) {
@@ -334,16 +328,11 @@ impl Server {
             "msgr" => Self::Messenger,
             "interop" => Self::Interop,
             "bot" => Self::Bot,
-            // `c.us` is not a namespace: it is the other spelling of the phone
-            // namespace, collapsed here so it cannot exist past parsing. WA Web
-            // collapses the same way and in the same place -- `createWid` does
-            // `t.replace("@s.whatsapp.net","@c.us")` before the constructor runs
-            // and caches under the collapsed key, so the two spellings can never
-            // reach two objects, two cache entries or two comparisons. This is
-            // the sole converter behind text (`FromStr`), the wire
-            // (`read_jid_pair`) and serde, so collapsing it here covers all
-            // three, and `Server` then has no variant that could render `c.us`
-            // back out.
+            // `c.us` is the other spelling of the phone namespace, not a
+            // namespace. Collapsing it in this converter -- the one text, the
+            // wire and serde all resolve through, and the same place WA Web
+            // collapses it -- is what leaves no variant able to render it back
+            // out, so one person cannot become two identities.
             "c.us" => Self::Pn,
             "call" => Self::Call,
             _ => return None,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -121,20 +121,27 @@ fn parse_jid_scan(s: &str) -> Option<(ParsedJidParts<'_>, Option<Server>)> {
                 Some(pos) => (&s[..pos], parse_u16_decimal(&s[pos + 1..at]).unwrap_or(0)),
                 None => (user_part, 0),
             };
-            // The scan already found the last dot, so no second pass is
-            // needed -- but only one before the device separator is the agent,
-            // which is what the bound enforces. The two readings differ for a
-            // user holding a second colon (`a:1.5:2`).
-            let (final_user, agent) =
-                match last_dot_pos.filter(|&dot_pos| dot_pos < user_before_colon.len()) {
-                    Some(dot_pos) => match parse_u16_decimal(&user_before_colon[dot_pos + 1..]) {
-                        Some(agent_val) if agent_val <= u8::MAX as u16 => {
-                            (&user_before_colon[..dot_pos], agent_val as u8)
-                        }
-                        _ => (user_before_colon, 0),
-                    },
-                    None => (user_before_colon, 0),
-                };
+            // The scan already found the last dot, so the common case needs no
+            // second pass. Only a dot before the device separator is the agent,
+            // though, and a malformed device can hold one of its own
+            // (`123.4:x.y`) -- there the scanned dot is not the agent and the
+            // earlier one still is, so that case falls back to a reverse scan
+            // of the user. Getting this wrong is not cosmetic: it would parse
+            // to a different identity than the rendered form reparses to.
+            let agent_dot = match last_dot_pos {
+                Some(pos) if pos < user_before_colon.len() => Some(pos),
+                Some(_) => user_before_colon.rfind('.'),
+                None => None,
+            };
+            let (final_user, agent) = match agent_dot {
+                Some(dot_pos) => match parse_u16_decimal(&user_before_colon[dot_pos + 1..]) {
+                    Some(agent_val) if agent_val <= u8::MAX as u16 => {
+                        (&user_before_colon[..dot_pos], agent_val as u8)
+                    }
+                    _ => (user_before_colon, 0),
+                },
+                None => (user_before_colon, 0),
+            };
             Some((
                 ParsedJidParts {
                     user: final_user,
@@ -2006,6 +2013,11 @@ mod tests {
             // A second colon puts the last dot after the first one, which is
             // where reusing the scanned dot position would silently diverge.
             ("a:1.5:2@bot", "a:1", 5, 2),
+            // A valid agent followed by a malformed device: the scan's last dot
+            // is the one inside `x.y`, which is not the agent. Recovering the
+            // earlier one matters because the device degrades to 0 rather than
+            // rejecting the JID, so this must render and reparse to itself.
+            ("123.4:x.y@interop", "123", 4, 0),
             // Unparsable device degrades to 0 rather than rejecting the JID.
             ("5511999998888:x@s.whatsapp.net", "5511999998888", 0, 0),
         ];

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -774,8 +774,8 @@ fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySy
 ///
 /// Parsing is left to `parse_jid_ref` rather than split by hand: it borrows
 /// (no allocation for the entries we discard) and it already knows the forms
-/// this field can take — the legacy `@c.us` spelling of the phone namespace,
-/// and both device suffixes, `user:3` and the legacy dotted `user.3`.
+/// this field can take, the legacy `@c.us` spelling included — it resolves that
+/// to the phone namespace, so nothing here has to name it.
 fn pushname_id_is(id: &str, own_user: &str) -> bool {
     if !id.contains('@') {
         // Pre-JID bare form, still accepted.
@@ -784,8 +784,7 @@ fn pushname_id_is(id: &str, own_user: &str) -> bool {
     let Some(jid) = wacore_binary::jid::parse_jid_ref(id) else {
         return false;
     };
-    (jid.server.is_pn_family() || jid.server == wacore_binary::jid::Server::Legacy)
-        && &*jid.user == own_user
+    jid.server.is_pn_family() && &*jid.user == own_user
 }
 
 /// History sync's placeholder for an entry that carries no push name. It is a
@@ -1015,16 +1014,16 @@ fn history_lid_mapping(
     lid_raw: &str,
     source: HistoryLidMappingSource,
 ) -> Option<HistoryLidMapping> {
-    use wacore_binary::{Jid, Server};
+    use wacore_binary::Jid;
 
     let pn: Jid = pn_raw.parse().ok()?;
     let lid: Jid = lid_raw.parse().ok()?;
     // Family predicates, not the exact-server ones: `@hosted` and `@hosted.lid`
     // are the PN and LID namespaces for hosted accounts, and the mapping and
-    // Signal-address code elsewhere already treats them as such. Legacy `@c.us`
-    // is the PN namespace under its old name (whatsmeow maps it to
-    // `@s.whatsapp.net` the same way); the user part is the phone either way.
-    if !(pn.server.is_pn_family() || pn.server == Server::Legacy) || !lid.server.is_lid_family() {
+    // Signal-address code elsewhere already treats them as such. The legacy
+    // `@c.us` spelling needs no arm of its own: it parses as the phone
+    // namespace.
+    if !pn.server.is_pn_family() || !lid.server.is_lid_family() {
         return None;
     }
     if pn.user_base().is_empty() || lid.user_base().is_empty() {
@@ -2079,9 +2078,7 @@ where
     let pn_jid = pn_jid.or_else(|| {
         chat_jid
             .as_ref()
-            .filter(|jid| {
-                jid.server.is_pn_family() || jid.server == wacore_binary::jid::Server::Legacy
-            })
+            .filter(|jid| jid.server.is_pn_family())
             .map(|_| chat_id)
     });
     let lid_jid = lid_jid.or_else(|| {

--- a/wacore/src/types/jid.rs
+++ b/wacore/src/types/jid.rs
@@ -264,6 +264,56 @@ mod tests {
         assert_eq!(jid.to_signal_address_string(), "15550000001@c.us");
     }
 
+    /// The Signal address is a stored key: every session, identity and sender
+    /// key ever written is filed under it, so a byte that moves here invalidates
+    /// them. It is built from `mapped_server`, not from `Server::as_str`, and
+    /// that is why collapsing the legacy spelling into the phone namespace does
+    /// not touch it -- both spellings produced `@c.us` before and both produce
+    /// `@c.us` now, for the bare user and the device form alike.
+    #[test]
+    fn the_signal_address_is_the_same_for_both_spellings() {
+        for (legacy, modern, expected) in [
+            (
+                "15550000001@c.us",
+                "15550000001@s.whatsapp.net",
+                "15550000001@c.us",
+            ),
+            (
+                "15550000001:33@c.us",
+                "15550000001:33@s.whatsapp.net",
+                "15550000001:33@c.us",
+            ),
+            // A dotted agent is inert on a phone user and stays out of the
+            // address, so a session is not filed twice.
+            (
+                "15550000001.2:33@c.us",
+                "15550000001:33@s.whatsapp.net",
+                "15550000001:33@c.us",
+            ),
+        ] {
+            let legacy = Jid::from_str(legacy).unwrap();
+            let modern = Jid::from_str(modern).unwrap();
+            assert_eq!(legacy.to_signal_address_string(), expected);
+            assert_eq!(modern.to_signal_address_string(), expected);
+            assert_eq!(
+                legacy.to_protocol_address_string(),
+                modern.to_protocol_address_string()
+            );
+            assert_eq!(
+                make_sender_key_name_for_jid(&Jid::group("120363000000000000"), &legacy),
+                make_sender_key_name_for_jid(&Jid::group("120363000000000000"), &modern)
+            );
+        }
+
+        // A LID address is untouched by any of this.
+        assert_eq!(
+            Jid::from_str("123456789@lid")
+                .unwrap()
+                .to_signal_address_string(),
+            "123456789@lid"
+        );
+    }
+
     #[test]
     fn test_protocol_address_format() {
         let jid = Jid::from_str("123456789:33@lid").unwrap();

--- a/wacore/tests/jid_test.rs
+++ b/wacore/tests/jid_test.rs
@@ -60,19 +60,34 @@ fn test_is_ad_logic() {
 
 #[test]
 fn test_legacy_and_agent_jid_parsing() {
-    // Test case 1: Legacy companion device JID (e.g., from an older WhatsApp Web)
-    // This is the primary failing case. The parser incorrectly identifies '.13' as an agent.
-    let legacy_jid_str = format!("1234567890.13@{}", SERVER_JID);
-    let legacy_jid = Jid::from_str(&legacy_jid_str).expect("test JID should be valid");
+    // A dotted number on a phone user is the agent, and the agent is inert
+    // there, so the JID still addresses the primary device.
+    //
+    // This block used to assert the opposite -- that `.13` was a companion
+    // device -- on the strength of a comment about "an older WhatsApp Web".
+    // Three things in the current bundle say otherwise, and one of them is
+    // decisive: WA Web's phoneDevice pattern requires the colon group
+    // (`(:[0-9]{1,2})` is not optional), so a dotted-only JID is a phoneUser
+    // and cannot be a device at all. `WAJids.parseJidParts` then splits `:`
+    // into `device` and `.` into `agent`, and `stripAgentIdFromPhoneDeviceJid`
+    // exists to drop exactly that field. This repository already agreed in one
+    // place: `push_phash_form_to` renders `user.0:device@server`, putting the
+    // agent before the colon and the device after it.
+    let dotted_jid_str = format!("1234567890.13@{}", SERVER_JID);
+    let dotted_jid = Jid::from_str(&dotted_jid_str).expect("test JID should be valid");
+    assert_eq!(dotted_jid.user, "1234567890", "the user stops at the dot");
+    assert_eq!(dotted_jid.agent, 13, "the dotted number is the agent");
+    assert_eq!(dotted_jid.device, 0, "a device only ever follows a colon");
     assert_eq!(
-        legacy_jid.user, "1234567890",
-        "Legacy JID user part is incorrect"
-    );
-    assert_eq!(legacy_jid.device, 13, "Legacy JID device part should be 13");
-    assert_eq!(legacy_jid.agent, 0, "Legacy JID agent part should be 0");
-    assert_eq!(
-        legacy_jid.server, SERVER_JID,
+        dotted_jid.server, SERVER_JID,
         "Legacy JID server part is incorrect"
+    );
+    // The agent is not rendered on the phone namespace, so this is the same
+    // identity as the bare user and addresses the same device.
+    assert!(!dotted_jid.is_ad(), "no device means not an AD jid");
+    assert_eq!(
+        dotted_jid,
+        Jid::from_str(&format!("1234567890@{SERVER_JID}")).expect("bare user parses")
     );
 
     // Test case 2: Modern companion device JID (for comparison)

--- a/wacore/tests/jid_test.rs
+++ b/wacore/tests/jid_test.rs
@@ -60,19 +60,10 @@ fn test_is_ad_logic() {
 
 #[test]
 fn test_legacy_and_agent_jid_parsing() {
-    // A dotted number on a phone user is the agent, and the agent is inert
-    // there, so the JID still addresses the primary device.
-    //
-    // This block used to assert the opposite -- that `.13` was a companion
-    // device -- on the strength of a comment about "an older WhatsApp Web".
-    // Three things in the current bundle say otherwise, and one of them is
-    // decisive: WA Web's phoneDevice pattern requires the colon group
-    // (`(:[0-9]{1,2})` is not optional), so a dotted-only JID is a phoneUser
-    // and cannot be a device at all. `WAJids.parseJidParts` then splits `:`
-    // into `device` and `.` into `agent`, and `stripAgentIdFromPhoneDeviceJid`
-    // exists to drop exactly that field. This repository already agreed in one
-    // place: `push_phash_form_to` renders `user.0:device@server`, putting the
-    // agent before the colon and the device after it.
+    // A dotted number on a phone user is the agent, not a companion device, so
+    // the JID still addresses the primary one. This block asserted the opposite
+    // until the parser was corrected; the rationale for the rule lives at that
+    // decision point, in `parse_jid_scan`.
     let dotted_jid_str = format!("1234567890.13@{}", SERVER_JID);
     let dotted_jid = Jid::from_str(&dotted_jid_str).expect("test JID should be valid");
     assert_eq!(dotted_jid.user, "1234567890", "the user stops at the dot");


### PR DESCRIPTION
> Contains [#1370](https://github.com/oxidezap/whatsapp-rust/pull/1370) (the benchmarks) underneath it — the Cost section needs a baseline that exists, and every CI workflow here is gated on `pull_request: branches: [main]`, so a stacked base gets no matrix at all. **The `perf(bench):` commits are #1370; review the `fix(jid):` and `refactor(jid):` ones on top.** Merge #1370 first and this rebases to just those.

## Summary

`@c.us` was a `Server` variant of its own, which put one person in two identities: two `HashMap` entries, two database rows, two device sets. `Server::renders_agent` excluded Pn/Lid/Hosted/HostedLid and not `Legacy`, so the legacy spelling was classified with `@bot` and `@interop` rather than with the phone namespace it names, while `is_psa` and `carries_phone_number` already grouped it with `Pn` — the type disagreed with itself.

WA Web has one representation and collapses at construction. This does the same, in the one converter that text, wire and serde all share, and removes the variant so no `Server` can render `c.us` at all. The dotted position on a phone user changes with it: WA Web reads a dot as the agent on every namespace, and our parser read it as a device on `s.whatsapp.net` only. #1362 is not undone — `canonical_user_server` becomes unreachable and goes, along with three other rediscoveries of the same rewrite.

## Audit

Everything below was checked against the current tree, not taken from the brief.

**Confirmed:**

- `Server::renders_agent` (`wacore/binary/src/jid.rs`) excluded `Pn | Lid | Hosted | HostedLid` and not `Legacy`, so `identity_agent(Legacy, 5) = 5` against `identity_agent(Pn, 5) = 0`.
- `Legacy` was absent from `is_pn_family`, from `JidExt::is_ad`, and from `with_device_hosting`, while `is_psa` and `carries_phone_number` already listed it beside `Pn`.
- The parser's dotted rule branched on the resolved server, and `Legacy` fell to the generic arm: `12345.6@c.us` gave agent 6 where `5511999998888.2@s.whatsapp.net` gave device 2. The test that pinned this (`fast_parse_pins_the_separator_rules_per_server`) said so in as many words — "pinned as the pre-existing behaviour, not endorsed as correct; changing it needs WA Web as ground truth, not this PR."
- `read_jid_pair` (`decoder.rs`) reads the server with the generic string reader and resolves it with `Server::try_from`, so a JID_PAIR naming `c.us` decoded. History sync carries it for real — the pushname and LID-mapping fixtures feed it — and `history_sync.rs` carried three ad-hoc `|| server == Legacy` disjuncts, one of them citing whatsmeow's identical mapping.
- `write_jid_ref` / `write_jid_owned` write `jid.server.as_str()` with no guard. `c.us` is **not** in `tokens.json`; `s.whatsapp.net` is. So we could emit a raw string spelling a server WA Web never sends.
- Text, wire and serde do all converge: `FromStr` → `parse_jid_ref` → `parse_jid_scan` → `parse_known` (and the fallback → `Server::try_from`), `read_jid_pair` → `try_from`, `Deserialize for Server` → `try_from`. One converter covers all three; only a literal in our own code escaped it.
- The two legitimate `c.us` string uses bypass the enum and are untouched: `mapped_server` (`wacore/src/types/jid.rs`) maps `DEFAULT_USER_SERVER` → `LEGACY_USER_SERVER` for the Signal address, and `RequestUtils::message_id_at` hashes a fixed `user@c.us` without reading `server`.
- `PartialEq for Jid` does compare `server` strictly, and the `self.agent == other.agent` shortcut is load-bearing on that, exactly as its comment says.

**Refuted / corrected:**

- **The hypothesis-D failure mode is real but does not apply to this design.** It is a trap for a fix that relaxes `==` while leaving the classification alone; collapsing at the parser means there is no second classification to disagree. `the_two_spellings_agree_when_the_agent_is_not_zero` is written to fail on the naive version anyway, so the trap stays closed.
- **The brief's reading of `WAWebWid` was backwards on direction.** `canonical_user_server`'s comment says the wid is "mapped to `s.whatsapp.net` only when a wid is serialized". Read literally that is right, but it implies `s.whatsapp.net` is WA Web's canonical form; it is the opposite. In memory the canonical spelling is `c.us` — see below. It does not change what to do, only which direction to describe it in.
- **One extra defect, found while measuring.** The phone-namespace arm returned early on the colon and never looked at the dot, so `5511999998888.0:3@s.whatsapp.net` — the shape WA Web's own `formatFull` writes — parsed with `user = "5511999998888.0"` and was **not equal** to the same device addressed without the agent. That is a second way one device became two, on the wire's own spelling.

## WA Web

Bundle set restored from `generated/bundles.lock.json` (`bundles-2.3000.1045368834-99a75bd7…`, the content-addressed release asset the lock names), read raw. The IR only carries the domain enum (`WAWebWidValidator.Domains`, which lists `C_US: "c.us"` beside `S_WHATSAPP_NET`), so the answers below are from `WAWebWid`, `WAWebWidFactory` and `WAJids` directly.

**One representation, collapsed at construction.** `WAWebWidFactory.createWid` rewrites the string before the constructor and caches under the collapsed key:

```js
var a=t; a=t.replace("@s.whatsapp.net","@c.us"),
n=r("WAWebWidStore").cache[a],
n||(n=new(r("WAWebWid"))(a,{intentionallyUsePrivateConstructor:!0}),r("WAWebWidStore").cache[a]=n)
```

and the constructor collapses again for good measure: `switch(p){case"s.whatsapp.net":_="c.us";break;default:_=p}`. So the two spellings can never reach two objects, two cache entries, or two comparisons — `equals` is just `this.toString()===n.toString()` over the already-collapsed form. Everything downstream tests the one spelling: `isUser()` is `server==="c.us"||"lid"||"bot"||"hosted"||"hosted.lid"`, `isPSA()` is `user==="0"&&server==="c.us"`.

**It never emits `c.us` on the wire.** Serialization goes through `toJid()`, which is `toString({legacy:!0})`, and `legacy` is the flag that swaps it back: `r=t.legacy&&this.server==="c.us"?"s.whatsapp.net":this.server`. `WAWebWidToJid` calls `toJid()` and hands the result to `WAJids.interpretAndValidateJid` — and `WAJids`, the whole JID/wire layer, contains **no `c.us` at all**: every phone regex is `@s.whatsapp.net`, and a `@c.us` string returns `jidType:"unknown"`.

So WA Web keeps `c.us` in memory and `s.whatsapp.net` on the wire. We do the reverse — one spelling, the wire one, everywhere — because ours is also what `Display` writes and what the store holds as text. What matters is that there is one, and that the collapse happens at construction.

**The dotted number is the agent, never a device.** At the JID layer:

```js
function Ae(e){  // parseJidParts
  var t=e.split("@"),n=t[0],r=t[1],o=n.split(":"),a=o[0],i=o[1],l=a.split("."),s=l[0],u=l[1];
  return{user:s,device:i,agent:u,server:r}
}
function Fe(e){  // fullFormDeviceJidString
  var t=Ae(e),n=t.agent,r=n===void 0?"0":n,o=t.device,a=o===void 0?"0":o, ...
  return l+"."+r+":"+a+"@"+i
}
```

`:` is the device, `.` is the agent, with no per-server branch, and `stripAgentIdFromPhoneDeviceJid` exists purely to drop it (`user+":"+device+"@"+server`). The `Wid` layer above it has no agent field at all: its phone regex is `^(0$|^(?!10)[1-9][0-9]{4,19})([.]0)?(?:[:]([0-9]{1,2}))?$` — a dot may be followed only by a literal `0`, and the capture is discarded; the device comes from the `:` group. Same shape for `@lid`.

That answers the blocking question, and it answers it against what we did: the dot was never a device on a phone user, and the `.0` WA Web writes is an agent position, not part of the user. Reading it as the agent — inert on the phone namespace — is the reading that makes both spellings and both device forms land on one identity.

## Design

**Where it normalises.** In `Server::parse_known`, `"c.us" => Self::Pn`. That is the sole converter behind all three input directions, so one line covers text, wire and serde; `every_input_direction_collapses_the_legacy_spelling` exercises each.

**The variant does not survive.** Keeping it would leave it reachable only by a literal in our own code, i.e. an invariant maintained by convention. Removing it makes it structural: no `Server` renders `c.us`, so nothing can emit it and nothing can name it. This is a breaking change to `wacore_binary::Server` — a `match` arm or a `Jid::new(x, Server::Legacy)` stops compiling, and the fix is to delete the arm or use `Server::Pn`. The discriminant `10` is left as a gap so no other variant changes value. `LEGACY_USER_SERVER` stays, because the Signal address still needs the string.

**`is_pn()` does not change meaning.** It is still `server == Server::Pn`. What changes is that a `@c.us` input now satisfies it, which is the bug, not a redefinition — so nothing downstream of `if jid.is_pn()` needed review.

**The dotted rule changes**, per the bundle: the phone-namespace arm is gone and phone users take the same `user.agent:device` rule as everything outside `@lid`. `a_dotted_number_on_a_phone_user_is_the_inert_agent` names the new meaning and cites the evidence. `@lid` keeps its own arm — WA Web's lid regexes are digits-only and this parser is deliberately more permissive there; narrowing it is a separate question.

**Identity itself is untouched.** `PartialEq`, `Hash`, `identity_agent`, `DeviceKey`, `sort_dedup_by_device`, `sort_dedup_by_user`, `cmp_for_lock_order`, `is_same_chat_as` and the `JidRef` mirrors are all unchanged, and that is the point of collapsing at the parser rather than in the comparison: there is no lockstep set to keep in step, and the `sort_dedup_by_device` docstring's promise that its key is exactly what equality compares stays true because neither moved.

**What became unreachable and went:** `canonical_user_server` and its two call sites, the `Legacy` arm of `is_self_dm_recipient`, the `Legacy` half of `is_psa` and of `carries_phone_number`, and the three disjuncts in `history_sync.rs`. #1362 was right about the direction and is not reverted; it just could not reach past the send path, which is why the same rewrite kept being rediscovered. Its two behavioural tests survive, re-expressed against a parsed `@c.us` rather than a constructed variant, which is what the fix now guarantees end to end.

## Cost

Re-measured after the last round of review fixes, paired in one session on one box: the same bench sources built at this branch's tip and at the bench-only baseline underneath it, `--threads 1`, `fastest` column, alternating reps.

**Noise floor, stated before the numbers.** Each arm was run at least three times per side. On a quiet box `fastest` reproduced to within **±1%**; a rep that overlapped background work moved a single arm by up to **2.5×** and was discarded as contended (its `slowest` column gives it away — hundreds of microseconds against tens). Nothing under ~5% below is a real difference, and it is reported as flat.

**Identity is flat, exactly as intended** — nothing in `==` or `Hash` moved, because the collapse happens in the parser and not in the comparison:

| bench | before | after | |
| --- | --- | --- | --- |
| `jid_eq/equal` | 3.54 ns | 3.54 ns | flat |
| `jid_eq/user_differs` | 3.12 | 3.11 | flat |
| `jid_eq/server_differs` | 3.12 | 3.12 | flat |
| `jid_eq/agent_nonzero` | 4.45 | 4.44 | flat |
| `jid_eq/agent_normalised` | 4.46 | 4.47 | flat |
| `jid_hash` | 28.1 | 28.1 | flat |
| `hashmap_get` hit, 8 / 64 / 512 | 37.7 / 37.9 / 38.4 | 39.0 / 38.3 / 38.4 | flat |
| `hashmap_get` miss, 8 / 64 / 512 | 35.3 / 36.1 / 36.9 | 35.3 / 36.1 / 36.8 | flat |
| `hashmap_insert`, 8 / 64 / 512 | 48 / 41 / 40 | 48 / 47 / 49 | flat (insert is the noisiest arm) |
| `chat_lane_get_hit`, 16 / 256 / 4096 | 95 / 97 / 100 | 95 / 97 / 100 | flat |
| `chat_lane_get_miss`, 16 / 256 / 4096 | 73 / 75 / 75 | 73 / 75 / 75 | flat |
| `chat_lane_create`, 16 / 256 / 4096 | 833 / 847 / 896 | 833 / 847 / 896 | flat |
| `chat_lane_create` w/ 8 protected | 1133 / 1191 / 1254 | 1133 / 1191 / 1254 | flat |

Parsing is where the change actually lands:

| bench | before | after | |
| --- | --- | --- | --- |
| `jid_parse` `…@s.whatsapp.net` | 16.1 ns | 16.1 ns | flat |
| `jid_parse` `…@lid` | 17.2 | 17.0 | flat |
| `jid_parse` `…@g.us` | 33.9 | 21.4 | **−37%** |
| `jid_parse` `…0:7@s.whatsapp.net` | 22.0 | 25.1 | **+14%**, and not comparable |

The two rows that moved are worth reading. Removing the phone-namespace arm first cost ~10 ns on every phone parse, because the generic arm re-scanned the user with `rfind('.')`. That is fixed rather than accepted: the forward scan already finds the last dot, so the generic arm uses the scanned position with a bound (`dot_pos < user_before_colon.len()`) and only a malformed device that hides a dot of its own (`123.4:x.y`) pays the reverse scan. Bare phone parse is back to baseline, and `@g.us` — which was paying that `rfind` all along — got materially faster.

The remaining `+14%` on `…0:7@s.whatsapp.net` is not a regression against a comparable measurement: at baseline that arm returned early on the colon and produced `user = "5511999990000.0"`. It now does the agent work and produces the correct `user`. Slower, and right.

CodSpeed's instruction counts are the authoritative series, and they agree closely and independently with the table above: `@g.us` at **+57.8%** efficiency against the −37% wall clock, and the dotted arm at **−12.1%** against the +14%. That dotted arm is the one benchmark CodSpeed flags as regressed on this branch, and it is exactly the deliberate one described in the paragraph above — it now does work it previously skipped, to produce a `user` it previously got wrong.

**The Memory instrument caught a second one, since fixed.** `server: Option<Server>` on `ParsedJidMeta` took it and `StringHint` from 5 bytes to 6, and `StringHintCache` holds one hint per string in the payload — on `bench_marshal_exact_many_children` that is a 16,384-entry tape, so one byte wider is exactly +16 KiB of peak allocation (119.2 → 135.2 KB). `9379fdc` derives the `AD_JID` domain byte from the resolved server through the existing `server_to_domain_type` instead of storing it, which puts both structs back at 5 bytes and peak allocation byte-identical to `main`. A test pins `size_of::<StringHint>()` at 5 so the next field added there has to justify itself.

## Data

I cannot query anyone's database, so what I measured is which columns can hold a rendered JID and which of those the legacy spelling could reach. Text columns keyed by `Jid::to_string()`: `device_registry.user_id`, `tc_tokens.jid`, `sent_messages.chat_jid`, `sender_key_devices.device_jid`, `msg_secrets.chat`/`.sender`, `pending_inbound_messages.chat`/`.sender`, `device.pn`. Not at risk: `group_metadata.group_jid` and `sender_key_devices.group_jid` (groups only), `lid_pn_mapping.phone_number` (bare user, no server).

Reachable, yes: before #1362 the send path stored the caller's spelling verbatim, so anyone who hit #1361 has rows keyed `…@c.us`. SQLite compares strings, not `Jid`s, so those keys are simply keys nothing will look up again.

The migration rewrites exactly those columns, anchored on the `@c.us` **suffix** so a Signal address that carries `@c.us.0` mid-string cannot match. Every one of them is a primary key, so both spellings of one peer collide on rewrite, and one rule decides every collision: **a legacy row never displaces a canonical one.** Where both exist the legacy row is deleted and the canonical row is left untouched; only an uncontested legacy row is rewritten. That is not a coin toss — the canonical row is the one the current client has been reading and writing all along, and the legacy row is already unreachable to it, so dropping the legacy row costs nothing live while keeping it could substitute stale state for current state. It is also why no per-table merge is attempted: each of these tables has its own freshness rule (`put_msg_secrets` keeps the later `expires_at`, `set_sender_key_status` must not let a stale `has_key = true` outlive a forget mark, `tc_tokens` advances its two timestamps independently), and a migration reproducing them would be a second implementation of every writer. Deleting first also means the rewrite itself cannot collide, so there is no `OR REPLACE` anywhere and a surprise collision would surface as a failure rather than silently discarding a row.

The four Signal address columns (`sessions`, `identities`, `sender_keys`, `base_keys`) are deliberately excluded: `@c.us` is their correct and current spelling. Two tests hold both halves — one that the JID columns move and the Signal ones do not, one that a legacy row never displaces a canonical one (covering canonical-wins, the uncontested rewrite, and the two-group `sender_key_devices` case where the same device JID is keyed under different groups) — and both run the migration file itself via `include_str!`, so the SQL under test cannot drift from the SQL that ships.

## Compatibility

- **`Server::Legacy` is gone.** Breaking for anyone matching on it or constructing with it; replace with `Server::Pn`. Pre-1.0.
- **`Display` never writes `@c.us`.** A JID parsed from the legacy spelling renders `@s.whatsapp.net`, and so does `SendResult.to`. The asymmetry the brief flags — `to` echoing a canonicalised spelling rather than the caller's — still exists in form, but no longer describes two things: under one identity the canonical rendering *is* the caller's JID.
- **Serde round-trips through the canonical spelling.** `"c.us"` deserializes to `Pn` and serializes back as `"s.whatsapp.net"`. A consumer diffing serialized JIDs across this version sees the phone namespace settle on one spelling.
- **`user.N@s.whatsapp.net` parses differently**: user `user`, agent N, device 0, where it was user `user`, device N. Anything relying on the old reading was addressing a device the peer never named.
- **Unchanged, and tested so:** the Signal address (byte for byte, for both spellings and for the dotted form), `message_id_at`, and every history-sync mapping the existing fixtures assert.

## Follow-ups

None of these is touched here; all are real and separate.

- **`StringHint` can go from 5 bytes to 4.** Folding device presence into the variant (`Jid` vs `AdJid`) instead of carrying an `Option` would save another 16 KiB on the `many_children` fixture — below `main`'s baseline, not just back to it. Left out because it duplicates a match across the encoder's size and write paths, which already carry a stay-in-sync warning, and that is a trade worth making on its own rather than inside a JID identity change. Raised in [the CodSpeedBot analysis](https://github.com/oxidezap/whatsapp-rust/pull/1371#issuecomment-5481319724) on this PR.
- **Public entry points that hand a `Jid` straight to the wire without canonicalising** — receipts, chatstate, presence, and the app-state mutation index. The central collapse resolves the `@c.us` half of this by construction (nothing can build the spelling any more), so no residue is left *for this bug*. The general shape — a caller-supplied JID reaching a sync key unvalidated — is its own question, and the app-state index is the sharp end of it since it is a cross-device key.
- **`resend_dm_to_uncovered_devices` (#1363) is untested.** The existing test only asserts the usync fired; the mock never returns a different device list, so the body never runs. Unrelated to JID identity.

## Validation

```
cargo fmt --all
cargo test --workspace --exclude e2e-tests --exclude bench-integration --tests
cargo test --doc
cargo clippy --workspace --all-targets -- -D warnings
cargo bench -p wacore-binary --bench jid_benchmark
cargo bench -p whatsapp-rust --bench jid_keyed_cache
```

All clean. (The full-workspace clippy needed `libasound2-dev` installed in the container for `alsa-sys`; that is an environment gap, not a diff one.)

No existing test needed a convenience adaptation. Five changed, each a contract change described above: `fast_parse_pins_the_separator_rules_per_server` (the dotted rule, with the bundle citation), the integration test in `wacore/tests/jid_test.rs` that asserted the old dotted reading, the two `is_self_dm_recipient` legacy tests and `a_legacy_namespace_recipient_is_sent_as_a_phone_user` (re-expressed against a parsed `@c.us` instead of a constructed variant, and asserting the raw spelling that reaches the wire, which is a stronger assertion), and `canonical_user_server_rewrites_only_legacy` removed with the function it tested.