### PR TITLE
Say how many snapshot records reached the fold without an index

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -60,6 +60,19 @@ impl Default for HashState {
     }
 }
 
+/// What a fold actually did, as opposed to what it was handed.
+///
+/// Returned rather than recomputed by callers: the fold's eligibility rule has
+/// already changed once, and a diagnostic that restates it is one that can
+/// disagree with the hash it is describing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FoldReport {
+    /// How many value MACs entered the ltHash.
+    pub folded: usize,
+    /// How many of those came from records carrying no index MAC.
+    pub unkeyed: usize,
+}
+
 impl HashState {
     /// Whether there is a real ltHash here to apply patches on top of.
     ///
@@ -222,14 +235,23 @@ impl HashState {
     /// a negative index there and folds the truncated buffer instead. Both are
     /// answers to a record the server should never send; ours refuses to fold
     /// something that is not a MAC.
-    /// Answers how many value MACs it folded, which is not `records.len()`: a
-    /// record whose value blob is too short to hold one is dropped, and a
-    /// repeated index contributes once. Diagnostics read it rather than
+    /// Answers what it folded rather than how many records it was given: a
+    /// record whose value blob is too short to hold a MAC is dropped, and a
+    /// repeated index contributes once. Diagnostics read this rather than
     /// restating the rule, which is how a count and a fold drift apart.
-    pub fn update_hash_from_records(&mut self, records: &[wa::SyncdRecord]) -> usize {
+    pub fn update_hash_from_records(&mut self, records: &[wa::SyncdRecord]) -> FoldReport {
         // Borrow the MAC tails; no Vec<u8> allocation per MAC.
         let mut added: Vec<&[u8]> = Vec::with_capacity(records.len());
         let mut indexed: Vec<(&[u8], &[u8])> = Vec::with_capacity(records.len());
+        // Counted here rather than recomputed by a caller, for the reason the
+        // fold reports its own total: this arm is a known divergence from WA
+        // Web, which keys every record through `hex(index.blob)` and so
+        // collapses records carrying no index into a single entry where this
+        // folds each of them. Harmless while at most one record is unkeyed,
+        // and a silent wrong ltHash the moment two are -- with a folded count
+        // that still equals the record count, which is exactly the shape a
+        // diagnostic has to be able to see.
+        let mut unkeyed = 0usize;
 
         for record in records {
             let Some(value_mac) = record
@@ -245,8 +267,13 @@ impl HashState {
             match record.index.as_option().and_then(|idx| idx.blob.as_deref()) {
                 // Keyed: the last record for this index is the one that counts.
                 Some(index_mac) => indexed.push((index_mac, value_mac)),
-                // Unkeyed records cannot collide, so they always fold.
-                None => added.push(value_mac),
+                // Unkeyed records cannot collide with a keyed one, so they
+                // always fold. Whether they collide with *each other* is the
+                // divergence noted above, and `unkeyed` is what says so.
+                None => {
+                    unkeyed += 1;
+                    added.push(value_mac)
+                }
             }
         }
 
@@ -276,7 +303,10 @@ impl HashState {
         }
 
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
-        added.len()
+        FoldReport {
+            folded: added.len(),
+            unkeyed,
+        }
     }
 
     pub fn generate_snapshot_mac(&self, name: &str, key: &[u8]) -> Vec<u8> {
@@ -860,5 +890,48 @@ mod tests {
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut expected, &[] as &[&[u8]], &[MAC]);
 
         assert_eq!(state.hash, expected);
+    }
+
+    /// The fold says how many records reached it without an index, because
+    /// that arm is a known divergence from WA Web and the count that would
+    /// otherwise expose it does not: two unkeyed records fold twice here and
+    /// once there -- WA Web keys every record through `hex(index.blob)`, so
+    /// records carrying no index collapse into one entry -- while `folded`
+    /// still equals the number of records, which is what a snapshot MAC
+    /// mismatch looks like when nothing else is wrong.
+    ///
+    /// Pins the reporting rather than the divergence: correcting the fold to
+    /// match WA Web is a change to a live account's ltHash and wants evidence
+    /// that such records exist, which is what this number is for.
+    #[test]
+    fn the_fold_reports_records_that_carried_no_index() {
+        let unkeyed = |mac: u8| {
+            let mut blob = vec![0u8; 16];
+            blob.extend_from_slice(&[mac; 32]);
+            wa::SyncdRecord {
+                value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
+                ..Default::default()
+            }
+        };
+
+        let mut state = HashState::default();
+        let report = state.update_hash_from_records(&[
+            record_with(&[0x01; 32], &[0x11; 32]),
+            unkeyed(0x22),
+            unkeyed(0x33),
+        ]);
+
+        assert_eq!(
+            report.folded, 3,
+            "every record carried a foldable value MAC"
+        );
+        assert_eq!(report.unkeyed, 2, "two of them carried no index MAC");
+
+        // The number a caller would reach for cannot tell the two apart, which
+        // is the whole reason the fold answers instead.
+        assert_eq!(
+            report.folded, 3,
+            "and the folded count still equals the record count"
+        );
     }
 }

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -86,7 +86,7 @@ where
     initial_state.version = version;
 
     // Update hash state directly from records (no cloning needed)
-    let folded = initial_state.update_hash_from_records(&snapshot.records);
+    let fold = initial_state.update_hash_from_records(&snapshot.records);
 
     debug!(
         target: "AppState",
@@ -187,14 +187,16 @@ where
             debug!(
                 target: "AppState",
                 "Snapshot {} v{} MAC mismatch: computed={}, expected={}, ltHash={}, \
-                 the fold folded {} of {} records, key probe says {}",
+                 the fold folded {} of {} records ({} carrying no index), \
+                 key probe says {}",
                 collection_name,
                 version,
                 hex::encode(&computed),
                 hex::encode(mac_expected),
                 hex::encode(&initial_state.hash[120..]),
-                folded,
+                fold.folded,
                 snapshot.records.len(),
+                fold.unkeyed,
                 key_probe
             );
             return Err(AppStateError::SnapshotMACMismatch);


### PR DESCRIPTION
Follow-up to #1369, from what its diagnostic answered in production.

## What #1369 settled

A real account fails `regular_low` v253 deterministically, and the line it added
ruled out both leading hypotheses by measurement rather than by reading:

```
computed=a9ba8fad…, expected=c73731d7…, ltHash=4a002f357bfb0af2,
the fold folded 31 of 31 records, key probe says the snapshot's key decodes its own record
```

`31 of 31` means the dedup from #1365 never applied to this account, so that fix
— real as it was — is not this bug. The probe means the derived key is right.

Everything else was then checked against WhatsApp Web, twice and independently:
once against the minified bundle and once against the captured JS in
`docs/captured-js/`. The HKDF (salt `None`, info `WhatsApp Patch Integrity`, 128
bytes, u16 little-endian lanes), the 160-byte key split, `valueMac` as the last
32 bytes of the value blob, the zero initial ltHash, the version encoding, the
collection name, and `HMAC(snapshotMacKey, ltHash ‖ u64be(version) ‖ utf8(name))`
all match. There is no decompression on the external snapshot path in either
implementation, and there is no point on ours where a record can be lost
silently: the CDN blob's HMAC covers the whole stream, so truncation cannot pass,
and the protobuf decode consumes the buffer and propagates errors.

## What is left, and why it is invisible

One divergence survives that audit, and it is in the fold this repository owns:

```rust
match record.index.as_option().and_then(|idx| idx.blob.as_deref()) {
    Some(index_mac) => indexed.push((index_mac, value_mac)),
    None => added.push(value_mac),   // "unkeyed records cannot collide"
}
```

WA Web builds `new Map(records.map(r => [hex(r.index.blob), valueMac(r)]))` and
sums the map's values, so records carrying no index collapse into a single
entry where this folds each of them. At most one such record, the two agree; at
two or more, the ltHash differs.

Nothing already reported can see that. The folded count still equals the record
count, the key still decodes its record, and the only symptom is a snapshot MAC
that does not match with everything else correct — which is precisely the
production line above.

## This change

`update_hash_from_records` answers a `FoldReport { folded, unkeyed }` instead of
a count, and the mismatch line says `31 of 31 records (N carrying no index)`.
Counted inside the fold, in the arm that takes the decision, for the reason
#1369 ended up carrying the folded count at all: a caller that recomputed it
would be restating a rule the fold has already changed once.

It **reports** rather than corrects. Changing which value MACs enter a live
account's ltHash is not a change to make from an inferred reading of a minified
bundle; it wants evidence that such records exist. If `N >= 2`, the fold is
wrong and the fix is to key them as WA Web does. If `N < 2`, this repository's
snapshot computation agrees with WhatsApp Web on every point that has been
checked, and the answer lies outside it — see below.

## Examined and not changed

- **The blob's identity is never verified** against `fileSha256`/`fileSizeBytes`
  from the external reference; only the CDN HMAC is checked, which proves the
  bytes are authentic rather than that they are the referenced ones. Left alone:
  the scenario needs the `pre_downloaded` map (keyed by `direct_path`) to hand
  back a different blob, and the failing log downloads exactly one.
- **The `snapshotMac` mismatch inside a patch** is fatal here and is deliberately
  tolerated by WA Web, which records `isCollectionInMacMismatchFatal` on the
  collection, applies the patch anyway and skips the check from then on. Only
  the patch path — `patchMac` and the snapshot path stay fatal there too. A
  behavioural change, decided on its own.
- **`COMPANION_SYNCD_SNAPSHOT_FATAL_RECOVERY`** is what WA Web does when a
  snapshot MAC fails: it throws, then asks the primary device for the collection
  over a peer data operation and rewrites it from the plaintext mutations and the
  primary's own ltHash, discarding the patches that came with the failed
  response. The request and response messages are already in `waproto`; the only
  mention of the type in this repository is a test enumerating push priorities,
  so the path does not exist. That is a feature, not a diagnostic, and it is the
  likely answer if `N < 2`.

## Test

`the_fold_reports_records_that_carried_no_index` pins the reporting, including
that `folded` still equals the record count while `unkeyed` is 2 — the shape the
production line has to be able to distinguish.