### PR TITLE
Fold, key and encode app state the way WhatsApp Web actually does

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -284,7 +284,7 @@ impl HashState {
     /// it, and the server signed a snapshot that includes it. Dropping it here
     /// is the ltHash disagreeing with the MAC it will be checked against, which
     /// is a judgement about what a MAC ought to look like paid for with the
-    /// whole collection. [`value_mac_start`] is that slice; an empty blob folds
+    /// whole collection. `value_mac_start` is that slice; an empty blob folds
     /// an empty operand, which the ltHash's HKDF derives from perfectly well.
     ///
     /// Answers what it folded rather than how many records it was given: a

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -419,7 +419,7 @@ pub fn generate_patch_mac(patch: &wa::SyncdPatch, name: &str, key: &[u8], versio
 /// patch path used to require `blob.len() >= 32` and drop the mutation when it
 /// was not met, which made a patch carrying a short blob MAC as though that
 /// mutation were absent — for a single-mutation patch, the empty patch's MAC.
-fn value_mac_tail(blob: &[u8]) -> &[u8] {
+pub(crate) fn value_mac_tail(blob: &[u8]) -> &[u8] {
     &blob[value_mac_start(blob.len())..]
 }
 

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -80,6 +80,13 @@ pub struct FoldReport {
     /// only the last of them -- correct, and still worth seeing in a log,
     /// because nothing else in `folded` will ever hint at it.
     pub unkeyed: usize,
+    /// How many records carried no value blob at all and so folded nothing.
+    ///
+    /// Not a curiosity: WA Web reads `.byteLength` off the absent buffer and
+    /// the whole fold throws, so a snapshot holding one is a snapshot nobody
+    /// can agree about. Counted here rather than re-derived by a caller, and
+    /// answered by whoever decides what a malformed snapshot costs.
+    pub valueless: usize,
 }
 
 impl HashState {
@@ -214,12 +221,15 @@ impl HashState {
                 }
             };
             let is_set = op == wa::syncd_mutation::SyncdOperation::SET;
+            // The same slice `generate_patch_mac` feeds the MAC, and it has to
+            // be: the two describe one patch, so a rule applied to only one of
+            // them lets a patch authenticate against its own patchMac and then
+            // carry an ltHash the server's snapshotMac disagrees with.
             if is_set
                 && mutation.record.is_set()
                 && let Some(blob) = &mutation.record.value.blob
-                && blob.len() >= 32
             {
-                added.push(&blob[blob.len() - 32..]);
+                added.push(value_mac_tail(blob));
             }
             if let Some(index_mac) = index_mac_of(mutation) {
                 if is_set && removed_in_patch.contains(&index_mac) {
@@ -301,6 +311,7 @@ impl HashState {
         // fix it is invisible in `folded` — several of them contribute one
         // value MAC between them, exactly as they do at the far end.
         let mut unkeyed = 0usize;
+        let mut valueless = 0usize;
 
         for record in records {
             // A record with no value blob at all is the one place this still
@@ -309,6 +320,7 @@ impl HashState {
             // collection fails either way; skipping is the failure that leaves
             // a diagnosable state behind.
             let Some(blob) = record.value.blob.as_ref() else {
+                valueless += 1;
                 continue;
             };
             let value_mac = &blob[value_mac_start(blob.len())..];
@@ -359,6 +371,7 @@ impl HashState {
         FoldReport {
             folded: added.len(),
             unkeyed,
+            valueless,
         }
     }
 

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -69,7 +69,16 @@ impl Default for HashState {
 pub struct FoldReport {
     /// How many value MACs entered the ltHash.
     pub folded: usize,
-    /// How many of those came from records carrying no index MAC.
+    /// How many records reached the fold carrying no index MAC -- no index
+    /// message, no blob, or a blob that is present and empty, which WA Web's
+    /// `hex(index.blob)` key cannot tell apart.
+    ///
+    /// Not a subset of [`FoldReport::folded`], which is what makes it worth
+    /// reporting: they share one key, so however many there are they add at
+    /// most one value MAC between them. Any count above one is a snapshot
+    /// where something upstream dropped an index and the fold silently kept
+    /// only the last of them -- correct, and still worth seeing in a log,
+    /// because nothing else in `folded` will ever hint at it.
     pub unkeyed: usize,
 }
 
@@ -103,14 +112,41 @@ pub struct HashUpdateResult {
     pub has_missing_remove: bool,
 }
 
-/// Count of *records carrying an index* at or below which
+/// Count of *records with a value blob* at or below which
 /// [`HashState::update_hash_from_records`] dedups with a linear scan instead of
 /// a sort; above it the sort wins despite ordering every entry. Note this counts
 /// records, not distinct indices: a snapshot of 200 records over 100 indices
-/// takes the sorted branch. Mirrors `MAC_DEDUP_SCAN_LIMIT` in `wacore`'s
-/// appstate sync, which measured the same trade-off over the same kind of key
-/// (#856).
+/// takes the sorted branch. Unkeyed records are counted here too, since they
+/// go through the same dedup under the empty key rather than around it.
+///
+/// Mirrors `MAC_DEDUP_SCAN_LIMIT` in `wacore`'s appstate sync, which measured
+/// the same trade-off over the same kind of key (#856).
 const MAC_DEDUP_SCAN_LIMIT: usize = 64;
+
+/// Where a value blob's MAC starts, by WA Web's arithmetic rather than by ours.
+///
+/// `valueMacFromIndexAndValueCipherText` is
+/// `new Uint8Array(v).slice(t - MAC_LENGTH)` with `t = v.byteLength`
+/// (`WAWebSyncdCrypto`), and that subtraction goes negative on a blob shorter
+/// than a MAC — where `Array.prototype.slice` counts a negative start *from the
+/// end again*, so the length is subtracted twice. A 31-byte blob is therefore
+/// not folded whole; `slice(-1)` folds its last byte. The obvious reading —
+/// "a negative start means the whole buffer" — is right for exactly the lengths
+/// at or below 16, which is why it survived being written down once: 16 and 0
+/// agree with it and 31 does not.
+///
+/// Only reachable on a record the server should never send. Matching it anyway
+/// is the whole point: the ltHash is compared against a MAC computed by
+/// somebody running that arithmetic.
+fn value_mac_start(len: usize) -> usize {
+    if len >= 32 {
+        len - 32
+    } else {
+        // JS: `slice(k)` with `k < 0` starts at `max(0, len + k)`, and here
+        // `k` is `len - 32`.
+        (2 * len).saturating_sub(32)
+    }
+}
 
 impl HashState {
     pub fn update_hash<F>(
@@ -229,52 +265,69 @@ impl HashState {
     /// (`put_mutation_macs`, `on_conflict((name, index_mac, device_id))`), so
     /// before this the ltHash and the store disagreed about the same snapshot.
     ///
-    /// One deliberate difference from that Map: a record whose value blob is
-    /// shorter than a MAC is dropped before the dedup, so the winner is the last
-    /// *usable* record for an index rather than the last one. WA Web slices with
-    /// a negative index there and folds the truncated buffer instead. Both are
-    /// answers to a record the server should never send; ours refuses to fold
-    /// something that is not a MAC.
+    /// The key is `hex(index.blob)`, and hex of nothing is the empty string —
+    /// so a record with no index message, one whose index message carries no
+    /// blob, and one whose blob is present but empty are *one* key in that Map,
+    /// and only the last of them in list order survives it. Executed against
+    /// the bundle: `[unkeyed(aa), unkeyed(bb)]` folds to exactly `[unkeyed(bb)]`,
+    /// and reversing the pair folds to exactly `[unkeyed(aa)]`. Keying the
+    /// absent index on the empty slice is therefore not a convenience, it is
+    /// the oracle's own key spelled in bytes instead of hex; folding each
+    /// unkeyed record separately made the ltHash heavier by one value MAC per
+    /// extra unkeyed record, with the same permanent consequence as a repeated
+    /// index above.
+    ///
+    /// A value blob shorter than a MAC is folded rather than dropped, for the
+    /// same reason: `valueMacFromIndexAndValueCipherText` is
+    /// `new Uint8Array(v).slice(len - MAC_LENGTH)`, which neither throws nor
+    /// yields 32 bytes on a short buffer — it answers *something*, WA Web folds
+    /// it, and the server signed a snapshot that includes it. Dropping it here
+    /// is the ltHash disagreeing with the MAC it will be checked against, which
+    /// is a judgement about what a MAC ought to look like paid for with the
+    /// whole collection. [`value_mac_start`] is that slice; an empty blob folds
+    /// an empty operand, which the ltHash's HKDF derives from perfectly well.
+    ///
     /// Answers what it folded rather than how many records it was given: a
-    /// record whose value blob is too short to hold a MAC is dropped, and a
-    /// repeated index contributes once. Diagnostics read this rather than
+    /// repeated index contributes once, and every unkeyed record contributes
+    /// through the one key they share. Diagnostics read this rather than
     /// restating the rule, which is how a count and a fold drift apart.
     pub fn update_hash_from_records(&mut self, records: &[wa::SyncdRecord]) -> FoldReport {
         // Borrow the MAC tails; no Vec<u8> allocation per MAC.
         let mut added: Vec<&[u8]> = Vec::with_capacity(records.len());
         let mut indexed: Vec<(&[u8], &[u8])> = Vec::with_capacity(records.len());
         // Counted here rather than recomputed by a caller, for the reason the
-        // fold reports its own total: this arm is a known divergence from WA
-        // Web, which keys every record through `hex(index.blob)` and so
-        // collapses records carrying no index into a single entry where this
-        // folds each of them. Harmless while at most one record is unkeyed,
-        // and a silent wrong ltHash the moment two are -- with a folded count
-        // that still equals the record count, which is exactly the shape a
-        // diagnostic has to be able to see.
+        // fold reports its own total: an unkeyed record is what a snapshot
+        // looks like when something upstream lost the index, and after this
+        // fix it is invisible in `folded` — several of them contribute one
+        // value MAC between them, exactly as they do at the far end.
         let mut unkeyed = 0usize;
 
         for record in records {
-            let Some(value_mac) = record
-                .value
-                .blob
-                .as_ref()
-                .filter(|blob| blob.len() >= 32)
-                .map(|blob| &blob[blob.len() - 32..])
-            else {
+            // A record with no value blob at all is the one place this still
+            // diverges, and deliberately: WA Web reads `.byteLength` off it and
+            // the whole fold throws, so there is no ltHash to agree with. The
+            // collection fails either way; skipping is the failure that leaves
+            // a diagnosable state behind.
+            let Some(blob) = record.value.blob.as_ref() else {
                 continue;
             };
+            let value_mac = &blob[value_mac_start(blob.len())..];
 
-            match record.index.as_option().and_then(|idx| idx.blob.as_deref()) {
-                // Keyed: the last record for this index is the one that counts.
-                Some(index_mac) => indexed.push((index_mac, value_mac)),
-                // Unkeyed records cannot collide with a keyed one, so they
-                // always fold. Whether they collide with *each other* is the
-                // divergence noted above, and `unkeyed` is what says so.
-                None => {
-                    unkeyed += 1;
-                    added.push(value_mac)
-                }
+            // An index MAC is a 32-byte HMAC, so the empty slice is a key no
+            // real index can take -- which is what lets the absent index share
+            // the dedup with the keyed records instead of bypassing it. Absent
+            // index message, absent blob and empty blob all land here, because
+            // `hex()` of each of the three is the same empty string.
+            let index_mac = record
+                .index
+                .as_option()
+                .and_then(|idx| idx.blob.as_deref())
+                .unwrap_or_default();
+            if index_mac.is_empty() {
+                unkeyed += 1;
             }
+            // The last record for this key is the one that counts, keyed or not.
+            indexed.push((index_mac, value_mac));
         }
 
         if indexed.len() <= MAC_DEDUP_SCAN_LIMIT {
@@ -310,7 +363,7 @@ impl HashState {
     }
 
     pub fn generate_snapshot_mac(&self, name: &str, key: &[u8]) -> Vec<u8> {
-        let version_be = u64_to_be(self.version);
+        let version_be = version_to_64_bit_network_order(self.version);
         let mut mac =
             CryptographicMac::new("HmacSha256", key).expect("HmacSha256 is a valid algorithm");
         mac.update(&self.hash);
@@ -329,21 +382,76 @@ pub fn generate_patch_mac(patch: &wa::SyncdPatch, name: &str, key: &[u8], versio
         mac.update(sm);
     }
     for m in &patch.mutations {
+        // `m.record.is_set()` is a field-presence check (buffa's `MessageField`),
+        // not a filter on the SET operation: WA Web folds every mutation's value
+        // blob in, REMOVE included, so narrowing this to SET would change the MAC
+        // of every patch carrying a removal.
         if m.record.is_set()
             && let Some(blob) = &m.record.value.blob
-            && blob.len() >= 32
         {
-            mac.update(&blob[blob.len() - 32..]);
+            mac.update(value_mac_tail(blob));
         }
     }
-    mac.update(&u64_to_be(version));
+    mac.update(&version_to_64_bit_network_order(version));
     mac.update(name.as_bytes());
 
     mac.finalize()
 }
 
-fn u64_to_be(val: u64) -> [u8; 8] {
-    val.to_be_bytes()
+/// The trailing bytes WA Web feeds into a MAC for one value blob.
+///
+/// The arithmetic is [`value_mac_start`]'s, and deliberately not a second copy
+/// of it: the snapshot fold and the patch MAC ask the same question about the
+/// same blob, and two spellings of one rule are how they come to disagree. The
+/// patch path used to require `blob.len() >= 32` and drop the mutation when it
+/// was not met, which made a patch carrying a short blob MAC as though that
+/// mutation were absent — for a single-mutation patch, the empty patch's MAC.
+fn value_mac_tail(blob: &[u8]) -> &[u8] {
+    &blob[value_mac_start(blob.len())..]
+}
+
+/// Encodes an app-state collection version the way WA Web's
+/// `to64BitNetworkOrder` does — which, despite the name, is *not* a 64-bit
+/// big-endian integer:
+///
+/// ```js
+/// function m(e) {
+///     var t = new ArrayBuffer(8);
+///     return new DataView(t).setUint32(4, e, !1), t
+/// }
+/// ```
+///
+/// `setUint32` writes four bytes at offset 4 of an eight-byte buffer, and it
+/// takes its argument modulo 2^32 (WebIDL `unsigned long` conversion). So the
+/// top four bytes are always zero and the version rides in the low four:
+/// `version mod 2^32`, not the version. Same shape as the `octetLength` buffer
+/// in `generate_content_mac` below — eight zero bytes with only the tail
+/// written.
+///
+/// Verified by executing the bundle's own function: version `2^32` yields
+/// `0000000000000000` and `2^48-1` yields `00000000ffffffff`, so `2^32`
+/// produces byte-for-byte the same MAC as `0`.
+///
+/// Truncation is what the oracle does and so is what we do, but it is silently
+/// lossy, so a version that could not survive the round trip is logged rather
+/// than swallowed. It is not an error: refusing would desynchronize us from a
+/// server whose own client accepts the value, and the MAC we produce is still
+/// the correct one. Real collection versions are small (57, 88, 234, 253
+/// observed), so the branch is never taken in practice — it exists so that if
+/// it ever is, there is a line saying why the version in the log stopped
+/// agreeing with the version in the MAC.
+fn version_to_64_bit_network_order(version: u64) -> [u8; 8] {
+    if version > u64::from(u32::MAX) {
+        log::warn!(
+            "app-state version {version} exceeds 2^32-1; WA Web's to64BitNetworkOrder \
+             truncates it to {} for the MAC, making this version indistinguishable \
+             from that one",
+            version as u32
+        );
+    }
+    let mut out = [0u8; 8];
+    out[4..].copy_from_slice(&(version as u32).to_be_bytes());
+    out
 }
 
 pub fn generate_content_mac(
@@ -616,63 +724,261 @@ mod tests {
         assert_eq!(state.hash.as_slice(), expected.as_slice());
     }
 
-    /// Known-answer test for generate_patch_mac to guard byte ordering and input
-    /// concatenation.  The expected MAC was computed by feeding:
-    ///   snapshot_mac ‖ mutation1_tail(32) ‖ mutation2_tail(32)
-    ///   ‖ u64_to_be(42) ‖ b"regular_high"
-    /// into HMAC-SHA256 with key = [0xAA; 32].
+    /// Builds the patch shape `generate_patch_mac` is asked about from the
+    /// oracle's own hex, so a test reads as the vector it is anchored on.
+    /// `index` and `key_id` are set because the oracle's patches carry them; the
+    /// MAC does not read either.
+    fn patch_from_hex(
+        snapshot_mac: &str,
+        mutations: &[(wa::syncd_mutation::SyncdOperation, &str)],
+    ) -> wa::SyncdPatch {
+        wa::SyncdPatch {
+            snapshot_mac: Some(hex::decode(snapshot_mac).expect("vector hex")),
+            mutations: mutations
+                .iter()
+                .map(|(operation, blob)| wa::SyncdMutation {
+                    operation: Some((*operation).into()),
+                    record: buffa::MessageField::some(wa::SyncdRecord {
+                        index: buffa::MessageField::some(wa::SyncdIndex {
+                            blob: Some(vec![0u8; 32]),
+                        }),
+                        value: buffa::MessageField::some(wa::SyncdValue {
+                            blob: Some(hex::decode(blob).expect("vector hex")),
+                        }),
+                        key_id: buffa::MessageField::some(wa::KeyId {
+                            id: Some(b"test_key_id".to_vec()),
+                        }),
+                    }),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// The exact table `WAWebSyncdCrypto.valueMacFromIndexAndValueCipherText`
+    /// answers with, read off the running bundle. `slice(len - 32)` counts a
+    /// negative start from the end, so this is `blob[max(2*len - 32, 0)..]` and
+    /// not "the last 32 bytes, or nothing".
+    #[test]
+    fn value_mac_tail_matches_the_official_slice() {
+        let blob: Vec<u8> = (1..=64u8).collect();
+        for (len, expected_len) in [
+            (0usize, 0usize),
+            (1, 1),
+            (8, 8),
+            (15, 15),
+            (16, 16),
+            (17, 15),
+            (20, 12),
+            (31, 1),
+            (32, 32),
+            (33, 32),
+            (64, 32),
+        ] {
+            let tail = value_mac_tail(&blob[..len]);
+            assert_eq!(
+                tail.len(),
+                expected_len,
+                "wrong length for a {len}-byte blob"
+            );
+            assert_eq!(
+                tail,
+                &blob[len - expected_len..len],
+                "a {len}-byte blob must contribute its own last {expected_len} bytes"
+            );
+        }
+    }
+
+    /// Known-answer test for `generate_patch_mac`, anchored on the oracle rather
+    /// than on a manual replay of this function's own steps: the bytes are
+    /// vector `repo-known-answer-test-replica` of the 07-patch-mac conformance
+    /// suite, produced by executing WA Web's own
+    /// `WAWebSyncdEncryptionManager.generatePatchMac` out of the minified bundle.
     #[test]
     fn test_generate_patch_mac_known_answer() {
+        use wa::syncd_mutation::SyncdOperation::SET;
         let key = [0xAAu8; 32];
-        let name = "regular_high";
-        let version: u64 = 42;
-
-        // Build a patch with snapshot_mac and two mutations with >=32 byte blobs.
-        let snapshot_mac = vec![0x11u8; 32];
-        let mut blob1 = vec![0u8; 16]; // 16 prefix bytes
-        blob1.extend_from_slice(&[0x22u8; 32]); // 32-byte tail taken by generate_patch_mac
-        let mut blob2 = vec![0u8; 16];
-        blob2.extend_from_slice(&[0x33u8; 32]);
-
-        let patch = wa::SyncdPatch {
-            version: buffa::MessageField::some(wa::SyncdVersion {
-                version: Some(version),
-            }),
-            snapshot_mac: Some(snapshot_mac.clone()),
-            mutations: vec![
-                wa::SyncdMutation {
-                    operation: Some(wa::syncd_mutation::SyncdOperation::SET.into()),
-                    record: buffa::MessageField::some(wa::SyncdRecord {
-                        value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob1) }),
-                        ..Default::default()
-                    }),
-                },
-                wa::SyncdMutation {
-                    operation: Some(wa::syncd_mutation::SyncdOperation::SET.into()),
-                    record: buffa::MessageField::some(wa::SyncdRecord {
-                        value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob2) }),
-                        ..Default::default()
-                    }),
-                },
+        let patch = patch_from_hex(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            &[
+                (
+                    SET,
+                    "000000000000000000000000000000002222222222222222222222222222222222222222222222222222222222222222",
+                ),
+                (
+                    SET,
+                    "000000000000000000000000000000003333333333333333333333333333333333333333333333333333333333333333",
+                ),
             ],
-            ..Default::default()
-        };
-
-        // Compute expected MAC manually using the same HMAC-SHA256 inputs.
-        let mut expected_mac =
-            CryptographicMac::new("HmacSha256", &key).expect("HmacSha256 is a valid algorithm");
-        expected_mac.update(&snapshot_mac); // snapshot_mac
-        expected_mac.update(&[0x22u8; 32]); // mutation 1 tail
-        expected_mac.update(&[0x33u8; 32]); // mutation 2 tail
-        expected_mac.update(&42u64.to_be_bytes()); // version
-        expected_mac.update(b"regular_high"); // name
-        let expected = expected_mac.finalize();
-
-        let actual = generate_patch_mac(&patch, name, &key, version);
-        assert_eq!(
-            actual, expected,
-            "generate_patch_mac output must match manual HMAC-SHA256 computation"
         );
+
+        assert_eq!(
+            hex::encode(generate_patch_mac(&patch, "regular_high", &key, 42)),
+            "f0c524a5c5f1e2877788a6a14363816e829b5dc064bd96234bba5cb92727d3ec"
+        );
+    }
+
+    /// The same shape with a 16-byte blob wedged into the middle. WA Web folds
+    /// that mutation in whole (`slice(16 - 32)` is `slice(-16)`, the whole blob);
+    /// a `blob.len() >= 32` guard dropped it, and the MAC came out as though the
+    /// patch had only two mutations.
+    ///
+    /// Vector `repo-known-answer-shape-plus-short-blob-16`.
+    #[test]
+    fn a_short_blob_is_folded_in_rather_than_dropped() {
+        use wa::syncd_mutation::SyncdOperation::SET;
+        let key = [0xAAu8; 32];
+        let patch = patch_from_hex(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            &[
+                (
+                    SET,
+                    "000000000000000000000000000000002222222222222222222222222222222222222222222222222222222222222222",
+                ),
+                (SET, "44444444444444444444444444444444"),
+                (
+                    SET,
+                    "000000000000000000000000000000003333333333333333333333333333333333333333333333333333333333333333",
+                ),
+            ],
+        );
+
+        assert_eq!(
+            hex::encode(generate_patch_mac(&patch, "regular_high", &key, 42)),
+            "4a9e2c1ab1b4dbac593e4e88222a18d54bc5520946f8917d439a21108771dd04"
+        );
+    }
+
+    /// A patch whose *only* mutation carries a short blob. This is the shape the
+    /// old guard failed hardest on: dropping the one mutation made the answer
+    /// the empty patch's MAC
+    /// (`73750b1d…`, vector `empty-mutations`), so a tampered patch and an empty
+    /// one were indistinguishable.
+    ///
+    /// Vector `only-a-short-blob-16`.
+    #[test]
+    fn a_patch_of_one_short_blob_is_not_the_empty_patch() {
+        use wa::syncd_mutation::SyncdOperation::SET;
+        let key = hex::decode("c18e344692effe59af62f7e5f603feecf669620eada0ce0f40780dbaa044035c")
+            .expect("vector hex");
+        let snapshot_mac = "5a7fa4c9ee13385d82a7ccf1163b6085aacff4193e6388add2f71c41668bb0d5";
+
+        let patch = patch_from_hex(snapshot_mac, &[(SET, "c8ed12375c81a6cbf0153a5f84a9cef3")]);
+        let mac = hex::encode(generate_patch_mac(&patch, "regular_low", &key, 253));
+        assert_eq!(
+            mac,
+            "ecfe951c2f66815234e19c5919258790351f414a638eed6a1a37288829df0a91"
+        );
+
+        let empty = patch_from_hex(snapshot_mac, &[]);
+        assert_ne!(
+            mac,
+            hex::encode(generate_patch_mac(&empty, "regular_low", &key, 253)),
+            "a mutation must not vanish from the MAC"
+        );
+    }
+
+    /// A 31-byte blob contributes its last *one* byte, and a 0-byte blob nothing
+    /// — the two ends of the negative-slice rule, both between full-length
+    /// neighbours so a wrong length shifts the whole HMAC input.
+    ///
+    /// Vectors `short-blob-31-between-two-normal` and
+    /// `short-blob-0-between-two-normal`.
+    #[test]
+    fn short_blobs_contribute_the_official_number_of_bytes() {
+        use wa::syncd_mutation::SyncdOperation::SET;
+        let key = hex::decode("c18e344692effe59af62f7e5f603feecf669620eada0ce0f40780dbaa044035c")
+            .expect("vector hex");
+        let snapshot_mac = "5a7fa4c9ee13385d82a7ccf1163b6085aacff4193e6388add2f71c41668bb0d5";
+        let first = "03284d7297bce1062b50759abfe4092e01264b7095badf04294e7398bde2072c51769bc0e50a2f54799ec3e80d32577c";
+        let last = "03284d7297bce1062b50759abfe4092e02274c7196bbe0052a4f7499bee3082d52779cc1e60b30557a9fc4e90e33587d";
+
+        // 31 bytes: the oracle's value MAC for it is the single byte `1e`.
+        let patch = patch_from_hex(
+            snapshot_mac,
+            &[
+                (SET, first),
+                (
+                    SET,
+                    "c8ed12375c81a6cbf0153a5f84a9cef3183d6287acd1f61b40658aafd4f91e",
+                ),
+                (SET, last),
+            ],
+        );
+        assert_eq!(
+            hex::encode(generate_patch_mac(&patch, "regular_low", &key, 253)),
+            "0ca4713495777d8c3241c327a9def39c6e1d706a5796de78e6c43c0961e2d27e"
+        );
+
+        // 0 bytes: the one length that really does contribute nothing.
+        let patch = patch_from_hex(snapshot_mac, &[(SET, first), (SET, ""), (SET, last)]);
+        assert_eq!(
+            hex::encode(generate_patch_mac(&patch, "regular_low", &key, 253)),
+            "5e8e0a53184e51a82b015b83d53c801cbc31fafe6f5f6e5781e5c37f01cfccd1"
+        );
+    }
+
+    /// `m.record.is_set()` in `generate_patch_mac` is field presence, not the SET
+    /// operation: WA Web's loop reads `m.record.value.blob` off every mutation
+    /// and never looks at `m.operation`. Mistaking it for an operation filter
+    /// would change the MAC of every patch carrying a removal, which is most of
+    /// them.
+    ///
+    /// Vectors `mixed-set-and-remove` and `all-remove`.
+    #[test]
+    fn removals_are_folded_into_the_patch_mac_too() {
+        use wa::syncd_mutation::SyncdOperation::{REMOVE, SET};
+        let key = hex::decode("c18e344692effe59af62f7e5f603feecf669620eada0ce0f40780dbaa044035c")
+            .expect("vector hex");
+        let snapshot_mac = "5a7fa4c9ee13385d82a7ccf1163b6085aacff4193e6388add2f71c41668bb0d5";
+        let a = "03284d7297bce1062b50759abfe4092e01264b7095badf04294e7398bde2072c51769bc0e50a2f54799ec3e80d32577c";
+        let b = "03284d7297bce1062b50759abfe4092e02274c7196bbe0052a4f7499bee3082d52779cc1e60b30557a9fc4e90e33587d";
+        let c = "03284d7297bce1062b50759abfe4092e03284d7297bce1062b50759abfe4092e53789dc2e70c31567ba0c5ea0f34597e";
+        let d = "03284d7297bce1062b50759abfe4092e04294e7398bde2072c51769bc0e50a2f54799ec3e80d32577ca1c6eb10355a7f";
+
+        let mixed = patch_from_hex(
+            snapshot_mac,
+            &[(SET, a), (REMOVE, b), (REMOVE, c), (SET, d)],
+        );
+        assert_eq!(
+            hex::encode(generate_patch_mac(&mixed, "regular_low", &key, 253)),
+            "bc500ec7136ea2a921d6d4345a40378530ba0fb1d3a222365c912df5d893780c"
+        );
+
+        // Vector `all-remove`, which carries its own name, version and snapshot MAC.
+        let all_remove = patch_from_hex(
+            "082d52779cc1e60b30557a9fc4e90e33587da2c7ec11365b80a5caef14395e83",
+            &[
+                (
+                    REMOVE,
+                    "03284d7297bce1062b50759abfe4092e052a4f7499bee3082d52779cc1e60b30557a9fc4e90e33587da2c7ec11365b80",
+                ),
+                (
+                    REMOVE,
+                    "03284d7297bce1062b50759abfe4092e062b50759abfe4092e53789dc2e70c31567ba0c5ea0f34597ea3c8ed12375c81",
+                ),
+            ],
+        );
+        assert_eq!(
+            hex::encode(generate_patch_mac(
+                &all_remove,
+                "critical_unblock_low",
+                &key,
+                3
+            )),
+            "334e8d4731f4b3cec4a6ff70971358f84bfb785f218699e6142048678827e881"
+        );
+    }
+
+    /// A record with no index message at all, its value blob a 16-byte prefix
+    /// and the MAC tail, like `record_with`.
+    fn unkeyed_record(value_mac: &[u8]) -> wa::SyncdRecord {
+        let mut blob = vec![0u8; 16];
+        blob.extend_from_slice(value_mac);
+        wa::SyncdRecord {
+            value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
+            ..Default::default()
+        }
     }
 
     fn record_with(index_mac: &[u8], value_mac: &[u8]) -> wa::SyncdRecord {
@@ -871,67 +1177,438 @@ mod tests {
         assert_eq!(state.hash, expected);
     }
 
-    /// A record with no index cannot be keyed, so it folds unconditionally —
-    /// the arm the dedup must leave alone.
+    /// One record with no index folds, like any other. It is *two* that used to
+    /// be wrong: see `unkeyed_records_collapse_onto_the_last_of_them` below,
+    /// which is anchored on the bundle's own bytes.
     #[test]
     fn a_record_without_an_index_still_folds() {
         const MAC: &[u8] = &[0x44u8; 32];
-        let mut blob = vec![0u8; 16];
-        blob.extend_from_slice(MAC);
-        let record = wa::SyncdRecord {
-            value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
-            ..Default::default()
-        };
+        let record = unkeyed_record(MAC);
 
         let mut state = HashState::default();
-        state.update_hash_from_records(&[record]);
+        let report = state.update_hash_from_records(&[record]);
 
         let mut expected = [0u8; 128];
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut expected, &[] as &[&[u8]], &[MAC]);
 
         assert_eq!(state.hash, expected);
+        assert_eq!(report.folded, 1);
+        assert_eq!(report.unkeyed, 1);
     }
 
     /// The fold says how many records reached it without an index, because
-    /// that arm is a known divergence from WA Web and the count that would
-    /// otherwise expose it does not: two unkeyed records fold twice here and
-    /// once there -- WA Web keys every record through `hex(index.blob)`, so
-    /// records carrying no index collapse into one entry -- while `folded`
-    /// still equals the number of records, which is what a snapshot MAC
-    /// mismatch looks like when nothing else is wrong.
+    /// `folded` deliberately cannot: they share the empty key, so three of them
+    /// add one value MAC between them and `folded` reads exactly as it would
+    /// for one. A snapshot where something upstream dropped an index is
+    /// therefore silent in the hash and in the count, and this number is the
+    /// only place it shows.
     ///
-    /// Pins the reporting rather than the divergence: correcting the fold to
-    /// match WA Web is a change to a live account's ltHash and wants evidence
-    /// that such records exist, which is what this number is for.
+    /// It used to pin the opposite -- that each unkeyed record folded on its
+    /// own, "a known divergence from WA Web" left in place until somebody
+    /// proved such records exist. The proof arrived by executing the bundle,
+    /// and the vectors below are what it said.
     #[test]
     fn the_fold_reports_records_that_carried_no_index() {
-        let unkeyed = |mac: u8| {
-            let mut blob = vec![0u8; 16];
-            blob.extend_from_slice(&[mac; 32]);
-            wa::SyncdRecord {
-                value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
-                ..Default::default()
-            }
-        };
-
         let mut state = HashState::default();
         let report = state.update_hash_from_records(&[
             record_with(&[0x01; 32], &[0x11; 32]),
-            unkeyed(0x22),
-            unkeyed(0x33),
+            unkeyed_record(&[0x22; 32]),
+            unkeyed_record(&[0x33; 32]),
         ]);
 
         assert_eq!(
-            report.folded, 3,
-            "every record carried a foldable value MAC"
+            report.folded, 2,
+            "the keyed record, and one entry for both unkeyed ones"
         );
         assert_eq!(report.unkeyed, 2, "two of them carried no index MAC");
+    }
 
-        // The number a caller would reach for cannot tell the two apart, which
-        // is the whole reason the fold answers instead.
+    // ---- Anchored on WhatsApp Web's own fold ----
+    //
+    // Every `ORACLE` below is the ltHash read back out of
+    // `WAWebSyncdAntiTampering.computeLtHashAndValidateSnapshot`, evaluated
+    // against the bundle over the record list beside it (unit 3 of the appstate
+    // conformance harness). They are the bundle's bytes, not ours: an
+    // expectation computed by this file would only prove it agrees with itself,
+    // which is exactly how the two bugs below survived a review.
+
+    fn hex_to_bytes(hexed: &str) -> Vec<u8> {
+        (0..hexed.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hexed[i..i + 2], 16).expect("hex"))
+            .collect()
+    }
+
+    fn to_hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// A record spelled the way a vector spells one: `None` is an index message
+    /// carrying no blob, `Some("")` is a blob that is present and empty, and
+    /// the value is the whole blob rather than its MAC tail.
+    fn vector_record(index: Option<&str>, value: &str) -> wa::SyncdRecord {
+        wa::SyncdRecord {
+            index: buffa::MessageField::some(wa::SyncdIndex {
+                blob: index.map(hex_to_bytes),
+            }),
+            value: buffa::MessageField::some(wa::SyncdValue {
+                blob: Some(hex_to_bytes(value)),
+            }),
+            key_id: buffa::MessageField::some(wa::KeyId {
+                id: Some(b"unit-3".to_vec()),
+            }),
+        }
+    }
+
+    fn fold_vector(records: &[(Option<&str>, &str)]) -> String {
+        let records: Vec<wa::SyncdRecord> = records
+            .iter()
+            .map(|(index, value)| vector_record(*index, value))
+            .collect();
+        let mut state = HashState::default();
+        state.update_hash_from_records(&records);
+        to_hex(&state.hash)
+    }
+
+    const VALUE_AA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const VALUE_BB: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const VALUE_CC: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    const VALUE_DD: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    const VALUE_11: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1111111111111111111111111111111111111111111111111111111111111111";
+    const VALUE_22: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2222222222222222222222222222222222222222222222222222222222222222";
+    const VALUE_SHORT_16: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const INDEX_01: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+    /// The bug this fold was fixed for. Two records with no index, and only the
+    /// *last* counts -- `hex(undefined)` is the empty string, so both take the
+    /// same slot in `new Map(...)` and the second overwrites the first. The
+    /// control is that the pair's ltHash is byte-identical to folding `bb`
+    /// alone, which is what "only the last one counts" looks like in bytes.
+    #[test]
+    fn unkeyed_records_collapse_onto_the_last_of_them() {
+        const ORACLE: &str = "322369af239d58af2d96e079f16b2e2f34e99857b2fcb79e03f14989dff0c8a1c90f9318729190703d0b13278d8535244a0392039477f452d8aadd722eb9a494e4c5df3b181804fb4a1416c2a50c0d9557520341764dcc422bed529c8dd1f01512d1943e8ea87c70bcfb423eed082a170d7c73b75f26128799bf4d95add79a2c";
+
+        assert_eq!(fold_vector(&[(None, VALUE_AA), (None, VALUE_BB)]), ORACLE);
         assert_eq!(
-            report.folded, 3,
-            "and the folded count still equals the record count"
+            fold_vector(&[(None, VALUE_BB)]),
+            ORACLE,
+            "the pair must fold to exactly the last of them"
         );
+    }
+
+    /// Three of them, in case a fix had merely deduped adjacent pairs.
+    #[test]
+    fn three_unkeyed_records_still_collapse_onto_the_last() {
+        const ORACLE: &str = "6d40554f4612a572442973232ae0b7fbaf4fa2dd142ee8c911daebb4b2b58d2379e35e00fc6ddc65de04e585b1f4319f9408c213ed5789a24d909e645f895abda713d137bac36ab1098be79f1f43890ff1dfc71f92e4501b17117781f70daaea0f7bb1901d2395f572a206466c32db0c5f9cc4f247d8609bdb183b50fa61e850";
+
+        assert_eq!(
+            fold_vector(&[(None, VALUE_AA), (None, VALUE_BB), (None, VALUE_CC)]),
+            ORACLE
+        );
+    }
+
+    /// The empty key is a key like any other, so a real index standing between
+    /// two unkeyed records neither joins them nor separates them: two entries
+    /// out of three records, and the unkeyed winner is still the later one.
+    #[test]
+    fn unkeyed_records_collapse_beside_a_keyed_one() {
+        const ORACLE: &str = "23fcaabc814078febe708da2e0da0e5157848f57b7cadaeaafc8e396aa78bee2378e0829de8b9c4ce15ec1e2f926dfc492e5c0bc8bad1236e06365415485140ffe050199e3bd2414947983ac8cb261d8c8c9679bf628a8035c1689ef0451fb2075f3399e0595dafb0638a55b2643861d0577a664681144e9291e65c2e2103e8e";
+
+        assert_eq!(
+            fold_vector(&[
+                (None, VALUE_AA),
+                (Some(INDEX_01), VALUE_DD),
+                (None, VALUE_BB),
+            ]),
+            ORACLE
+        );
+    }
+
+    /// An index blob that is present and empty hexes to the same empty string
+    /// as an absent one, so the two collide. Which is why the fold keys on the
+    /// blob's bytes and lets `unwrap_or_default` put the absent case on that
+    /// same empty slice, rather than on a branch of its own.
+    #[test]
+    fn an_empty_index_blob_collides_with_an_absent_one() {
+        const ORACLE: &str = "68f4dc5922d09f0977128992998640f811874354483239f723e73f2bc2d77cdae8b01fa438247f7502daaa05eb688ba7bb488eb24496a57784c85195af193a1cd809459c847f1d0e1a4b3caf9985dcd4029a75f17491c2ceecaa912ce73e79465c788d8453b6224435deee6f12398d7e193a7e86dd39135246cc2a5ca8fee0c7";
+
+        assert_eq!(
+            fold_vector(&[(Some(""), VALUE_11), (None, VALUE_22)]),
+            ORACLE
+        );
+        assert_eq!(
+            fold_vector(&[(None, VALUE_22)]),
+            ORACLE,
+            "the second record must have overwritten the first, not joined it"
+        );
+    }
+
+    /// A 16-byte value blob is folded rather than dropped. `slice(16 - 32)` is
+    /// `slice(-16)`, which on a 16-byte buffer is the whole of it -- so this is
+    /// the length at which "short blobs fold whole" happens to be true, and the
+    /// one below is where it stops being.
+    #[test]
+    fn a_value_blob_shorter_than_a_mac_folds_whole() {
+        const ORACLE: &str = "f20d9b6ec1df9853c9ebf7210db4067cd489e8072f730a1eb61627e7ee0d506ee55c7aa9b631337e583f7d6aa17c535c65d7a0d2bbd73bdf9e0b0c3411757177ef470bb0f0530263b160f535bacdd7ca074631a10f139a6f3fbc03197351091bac2268212e94c000b0078d53363f2a496293646d422b329aa7e861d52b49ac84";
+
+        assert_eq!(fold_vector(&[(Some(INDEX_01), VALUE_SHORT_16)]), ORACLE);
+    }
+
+    /// 31 bytes, and the answer is one byte. `slice(t - MAC_LENGTH)` subtracts
+    /// the length once by arithmetic and once again by JS's negative-start
+    /// rule, so the start is `max(0, 2*31 - 32) = 30`. The control is that this
+    /// folds to exactly what a one-byte blob folds to -- which is what makes it
+    /// a statement about the arithmetic and not about our own `saturating_sub`,
+    /// whose answer for 31 bytes is the whole 31 and is a different hash.
+    #[test]
+    fn a_thirty_one_byte_value_blob_folds_its_last_byte() {
+        const ORACLE: &str = "db072222f470dc859876c6234d729f626f0a5f75592f90a562407419b617a7f812e5c5e003271fff4456b1071603d7848a7d8c64984f6652032eac523bd04d4a8e626524fbafad694ba285faba6afe60fcc62871c6933f8e74859e29deb0dccf7f5fa160d5449581616214f061315b5e486e5d136979ccbe9e2d7a55a59eea6e";
+
+        assert_eq!(fold_vector(&[(Some(INDEX_01), &"cc".repeat(31))]), ORACLE);
+        assert_eq!(
+            fold_vector(&[(Some(INDEX_01), "cc")]),
+            ORACLE,
+            "31 bytes must fold as its last byte alone"
+        );
+    }
+
+    /// The whole of the length table the two rules above are two points on.
+    #[test]
+    fn the_value_mac_start_is_wa_webs_double_subtraction() {
+        assert_eq!(value_mac_start(0), 0);
+        assert_eq!(value_mac_start(15), 0, "2*15 - 32 is negative, so from 0");
+        assert_eq!(value_mac_start(16), 0, "the whole buffer, exactly once");
+        assert_eq!(value_mac_start(17), 2);
+        assert_eq!(value_mac_start(31), 30);
+        assert_eq!(
+            value_mac_start(32),
+            0,
+            "at a MAC's length the tail is all of it"
+        );
+        assert_eq!(value_mac_start(48), 16, "and above it, the ordinary tail");
+    }
+
+    /// And an empty one folds an empty operand, which the ltHash's HKDF derives
+    /// from perfectly well -- the answer is not the zero hash.
+    #[test]
+    fn an_empty_value_blob_folds_an_empty_operand() {
+        const ORACLE: &str = "26671b06d4639067479b3e756bae60656d52dce6b2c73700951d88ee11d7fc11a22bd04b32a2de041368056c60c49af58990ff2f1a55e25d4ea05a3c4b867ea633d8b3af026d84324ca1073f6f53f5b48dc4840457119d872d4d4c23d87de2c8ddb51a1e2738ca3748e80ae8c6d71b076c9c66ad0a85308891bda3c7d86f2e0e";
+
+        assert_eq!(fold_vector(&[(Some(INDEX_01), "")]), ORACLE);
+    }
+
+    /// Where the two rules meet: a short value blob is still the last record
+    /// for its index, so it wins the dedup. Skipping it made the *previous*
+    /// record the winner, which is a different value MAC and so a different
+    /// ltHash -- a wrong answer where dropping a lone short record was merely
+    /// an incomplete one.
+    #[test]
+    fn a_short_value_still_wins_its_index() {
+        const ORACLE: &str = "f20d9b6ec1df9853c9ebf7210db4067cd489e8072f730a1eb61627e7ee0d506ee55c7aa9b631337e583f7d6aa17c535c65d7a0d2bbd73bdf9e0b0c3411757177ef470bb0f0530263b160f535bacdd7ca074631a10f139a6f3fbc03197351091bac2268212e94c000b0078d53363f2a496293646d422b329aa7e861d52b49ac84";
+
+        assert_eq!(
+            fold_vector(&[(Some(INDEX_01), VALUE_11), (Some(INDEX_01), VALUE_SHORT_16),]),
+            ORACLE
+        );
+    }
+
+    /// Every byte string below came out of executing WA Web's own
+    /// `to64BitNetworkOrder` over the bundle corpus
+    /// (`06-snapshot-mac/vectors.json`, `to64BitNetworkOrder_observed`). It is
+    /// the four-low-bytes shape, not a u64: everything at or above 2^32 wraps.
+    #[test]
+    fn version_encoding_matches_the_bundles_to_64_bit_network_order() {
+        for (version, expected) in [
+            (0u64, "0000000000000000"),
+            (1, "0000000000000001"),
+            (253, "00000000000000fd"),
+            // The last version a u32 can hold, and the last one that survives
+            // the round trip.
+            (u32::MAX as u64, "00000000ffffffff"),
+            // 2^32 wraps to zero — the whole of this bug.
+            (1u64 << 32, "0000000000000000"),
+            ((1u64 << 32) + 1, "0000000000000001"),
+            (1u64 << 40, "0000000000000000"),
+            ((1u64 << 48) - 1, "00000000ffffffff"),
+        ] {
+            assert_eq!(
+                hex::encode(version_to_64_bit_network_order(version)),
+                expected,
+                "version {version}"
+            );
+        }
+    }
+
+    /// The top four bytes are the `ArrayBuffer`'s untouched zeros: `setUint32`
+    /// only ever writes at offset 4.
+    #[test]
+    fn the_high_four_bytes_of_a_version_are_always_zero() {
+        for version in [0u64, 1, 253, u32::MAX as u64, 1u64 << 32, u64::MAX] {
+            assert_eq!(
+                &version_to_64_bit_network_order(version)[..4],
+                &[0u8; 4],
+                "version {version}"
+            );
+        }
+    }
+
+    /// The ltHash and key both oracle vectors are generated over
+    /// (`06-snapshot-mac/vectors.json`, collection `regular_low`).
+    const ORACLE_HASH: &str = "0b30557a9fc4e90e33587da2c7ec11365b80a5caef14395e83a8cdf2173c6186abd0f51a3f6489aed3f81d42678cb1d6fb20456a8fb4d9fe23486d92b7dc01264b7095badf04294e7398bde2072c51769bc0e50a2f54799ec3e80d32577ca1c6eb10355a7fa4c9ee13385d82a7ccf1163b6085aacff4193e6388add2f71c4166";
+    const ORACLE_KEY: &str = "28582f9112b4da4049e786b9ab6edfb38eda814736ff638e025e0ca7b608b712";
+
+    /// Snapshot MACs produced by WhatsApp Web's own
+    /// `WAWebSyncdEncryptionManager.generateSnapshotMac`, copied from
+    /// `06-snapshot-mac/vectors.json`. The four cases at or above 2^32 are the
+    /// ones this file used to get wrong; the small ones are the controls that
+    /// prove the fix did not move anything a real account can reach.
+    #[test]
+    fn snapshot_mac_matches_whatsapp_webs_own_output() {
+        let mut hash = [0u8; 128];
+        hash.copy_from_slice(&hex_to_bytes(ORACLE_HASH));
+        let key = hex_to_bytes(ORACLE_KEY);
+
+        for (version, expected) in [
+            (
+                0u64,
+                "afd291ad5599afa5e3c0d5b2daf02a4bb101b370a7ab130139578e979c419a2e",
+            ),
+            (
+                1,
+                "e4e75567d69a6a38b0adff30f176d8285b269de0f77b67a3d4e0202770ed5fe8",
+            ),
+            (
+                253,
+                "9fbec1d8d747d515ba57ac0dae3138185dfdc4aff22e6279336772b62963979e",
+            ),
+            (
+                65536,
+                "5673fd3288ecfd7760226795adfc7495b55caf98f67dc8755463f975ef2f0d64",
+            ),
+            // 2^32-1: the boundary that still round-trips.
+            (
+                4294967295,
+                "b10707136944665bfb0a85f68abd2f13d9a8e240a368cfdc367efd4a60405494",
+            ),
+            // 2^32 and 2^32+1 answer with version 0's and version 1's MACs.
+            (
+                4294967296,
+                "afd291ad5599afa5e3c0d5b2daf02a4bb101b370a7ab130139578e979c419a2e",
+            ),
+            (
+                4294967297,
+                "e4e75567d69a6a38b0adff30f176d8285b269de0f77b67a3d4e0202770ed5fe8",
+            ),
+            (
+                1099511627776,
+                "afd291ad5599afa5e3c0d5b2daf02a4bb101b370a7ab130139578e979c419a2e",
+            ),
+            (
+                281474976710655,
+                "b10707136944665bfb0a85f68abd2f13d9a8e240a368cfdc367efd4a60405494",
+            ),
+        ] {
+            let state = HashState {
+                version,
+                hash,
+                ..Default::default()
+            };
+            assert_eq!(
+                hex::encode(state.generate_snapshot_mac("regular_low", &key)),
+                expected,
+                "snapshot MAC for version {version}"
+            );
+        }
+    }
+
+    /// The wrap is not a property of the encoder alone: the oracle answers
+    /// version 2^32 with version 0's MAC byte for byte, so a collection that
+    /// ever reached 2^32 would be indistinguishable from a fresh one. Stated as
+    /// its own test because it is the fact that makes the truncation a
+    /// conformance decision rather than an implementation detail.
+    #[test]
+    fn a_version_and_that_version_plus_2_32_share_a_snapshot_mac() {
+        let mut hash = [0u8; 128];
+        hash.copy_from_slice(&hex_to_bytes(ORACLE_HASH));
+        let key = hex_to_bytes(ORACLE_KEY);
+
+        for version in [0u64, 1, 253] {
+            let low = HashState {
+                version,
+                hash,
+                ..Default::default()
+            };
+            let wrapped = HashState {
+                version: version + (1u64 << 32),
+                hash,
+                ..Default::default()
+            };
+            assert_eq!(
+                low.generate_snapshot_mac("regular_low", &key),
+                wrapped.generate_snapshot_mac("regular_low", &key),
+                "version {version} and {} must collide, as they do in WA Web",
+                version + (1u64 << 32)
+            );
+        }
+    }
+
+    /// Patch MACs from WhatsApp Web's own
+    /// `WAWebSyncdEncryptionManager.generatePatchMac`, copied from
+    /// `07-patch-mac/vectors.json`. `version-above-2^32` (2^32+5) and
+    /// `version-five-control` (5) carry the same expected answer in the oracle's
+    /// own output, which is the second function reading the same truncation.
+    #[test]
+    fn patch_mac_matches_whatsapp_webs_own_output() {
+        const PATCH_MAC_KEY: &str =
+            "c18e344692effe59af62f7e5f603feecf669620eada0ce0f40780dbaa044035c";
+        const SNAPSHOT_MAC: &str =
+            "04294e7398bde2072c51769bc0e50a2f54799ec3e80d32577ca1c6eb10355a7f";
+        const BLOB: &str = "03284d7297bce1062b50759abfe4092e092e53789dc2e70c31567ba0c5ea0f34597ea3c8ed12375c81a6cbf0153a5f84";
+
+        let key = hex_to_bytes(PATCH_MAC_KEY);
+        let patch = wa::SyncdPatch {
+            snapshot_mac: Some(hex_to_bytes(SNAPSHOT_MAC)),
+            mutations: vec![wa::SyncdMutation {
+                operation: Some(wa::syncd_mutation::SyncdOperation::SET.into()),
+                record: buffa::MessageField::some(wa::SyncdRecord {
+                    index: buffa::MessageField::some(wa::SyncdIndex {
+                        blob: Some(vec![0u8; 32]),
+                    }),
+                    value: buffa::MessageField::some(wa::SyncdValue {
+                        blob: Some(hex_to_bytes(BLOB)),
+                    }),
+                    key_id: buffa::MessageField::some(wa::KeyId {
+                        id: Some(b"conformance".to_vec()),
+                    }),
+                }),
+            }],
+            ..Default::default()
+        };
+
+        for (version, expected) in [
+            (
+                0u64,
+                "5197d9bd696573fd0de52f2761a907ea6914f5030d319ee5dd118901f556e801",
+            ),
+            (
+                5,
+                "cc830a016ecab383f84b03e117007deaa014e7ad5a648b87a44d477f584ce261",
+            ),
+            // 2^32-1 round-trips; 2^32+5 comes back as 5's answer above.
+            (
+                4294967295,
+                "3cdbde9510e60994236746d734c05a2805500b2b1f74cff86fa5e273705610b9",
+            ),
+            (
+                4294967301,
+                "cc830a016ecab383f84b03e117007deaa014e7ad5a648b87a44d477f584ce261",
+            ),
+        ] {
+            assert_eq!(
+                hex::encode(generate_patch_mac(&patch, "regular", &key, version)),
+                expected,
+                "patch MAC for version {version}"
+            );
+        }
     }
 }

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -597,6 +597,14 @@ fn last_record_per_index(records: &[wa::SyncdRecord]) -> Vec<&wa::SyncdRecord> {
     let mut seen: Vec<&[u8]> = Vec::new();
     // Backwards, so the first hit for an index is its last record.
     for rec in records.iter().rev() {
+        // Skipped for the same reason the fold skips it: a record with no value
+        // blob contributes no value MAC, so it is not part of what the accepted
+        // MAC describes. Letting it win an index anyway is worse than letting it
+        // through -- it displaces the record that *was* folded, so the two
+        // passes disagree about a snapshot that is otherwise perfectly ordinary.
+        if rec.value.blob.is_none() {
+            continue;
+        }
         let index_mac = rec
             .index
             .as_option()
@@ -707,15 +715,9 @@ mod tests {
         }
     }
 
-    /// The two passes over a snapshot must describe the same set of records.
-    ///
-    /// `update_hash_from_records` decides which MAC we accept and
-    /// `last_record_per_index` decides what we then decrypt and store, so a
-    /// disagreement means accepting a snapshot on one set of records and
-    /// persisting another. Records carrying no index are where the two came
-    /// apart: each pass independently read "no index" as "cannot collide" and
-    /// let every one of them through, where WA Web keys on `hex(index.blob)`
-    /// and collides them all on the empty string.
+    /// A run of one index and three records with no index describe two things,
+    /// and both passes have to say two -- the last of the run and the last of
+    /// the unkeyed.
     #[test]
     fn the_decode_set_is_the_set_the_fold_folded() {
         fn record(index: Option<&[u8]>, value_mac: u8) -> wa::SyncdRecord {
@@ -764,6 +766,46 @@ mod tests {
         };
         assert!(last_of(0x33), "the run's last record, not its first");
         assert!(last_of(0x55), "the last unkeyed record, not the first");
+    }
+
+    /// The regression the invariant above did not catch on its own: a record
+    /// with no value blob is skipped by the fold, so it must not be allowed to
+    /// win an index from the record that *was* folded. Every record here is
+    /// perfectly ordinary except the last, and the snapshot is one the server
+    /// could send.
+    #[test]
+    fn a_record_with_no_value_cannot_displace_the_one_that_folded() {
+        let mut blob = vec![0u8; 16];
+        blob.extend_from_slice(&[0x11; 32]);
+        let records = vec![
+            wa::SyncdRecord {
+                index: buffa::MessageField::some(wa::SyncdIndex {
+                    blob: Some(vec![0x01; 32]),
+                }),
+                value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
+                ..Default::default()
+            },
+            // Same index, no value: later in the run, and so the winner under a
+            // dedup that only looks at indices.
+            wa::SyncdRecord {
+                index: buffa::MessageField::some(wa::SyncdIndex {
+                    blob: Some(vec![0x01; 32]),
+                }),
+                value: buffa::MessageField::some(wa::SyncdValue { blob: None }),
+                ..Default::default()
+            },
+        ];
+
+        let mut state = HashState::default();
+        let fold = state.update_hash_from_records(&records);
+        let winners = last_record_per_index(&records);
+
+        assert_eq!(fold.folded, 1, "only the record carrying a value folded");
+        assert_eq!(winners.len(), 1, "and only that record is decoded");
+        assert!(
+            winners[0].value.blob.is_some(),
+            "the winner is the folded record, not the valueless one that followed it"
+        );
     }
 
     #[test]

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -6,7 +6,7 @@
 
 use crate::AppStateError;
 use crate::decode::{Mutation, decode_record};
-use crate::hash::{HashState, generate_patch_mac};
+use crate::hash::{HashState, generate_patch_mac, value_mac_tail};
 use crate::keys::ExpandedAppStateKeys;
 use log::{Level, debug, log_enabled, trace, warn};
 use serde::{Deserialize, Serialize};
@@ -344,12 +344,16 @@ where
         } else {
             get_prev_value_mac(index_mac).map_err(|e| anyhow::anyhow!(e))?
         };
+        // The operand `update_hash` just added for this SET, by the same rule it
+        // used -- so the next SET on this index subtracts what the first one
+        // contributed rather than the store's pre-patch value. A short blob is
+        // folded there, so recording it only when it is 32 bytes long leaves the
+        // first SET's operand added and never cancelled.
         if let Some(rec) = patch.mutations[idx].record.as_option()
             && let Some(index) = rec.index.as_option().and_then(|i| i.blob.as_deref())
             && let Some(value) = rec.value.as_option().and_then(|v| v.blob.as_deref())
-            && value.len() >= 32
         {
-            in_patch.insert(index, &value[value.len() - 32..]);
+            in_patch.insert(index, value_mac_tail(value));
         }
         Ok(prev)
     });
@@ -1638,6 +1642,84 @@ mod tests {
             result.state.hash.as_slice(),
             both_kept.as_slice(),
             "both SET values must not remain: in-patch overwrite regressed"
+        );
+    }
+
+    /// The overwrite map has to record the operand the fold actually added, not
+    /// the one a 32-byte rule would have. A first SET whose value blob is short
+    /// still contributes -- `slice(len - 32)` counts from the end -- so a map
+    /// that only remembers full-length values leaves that operand added and
+    /// uncancelled, and the second SET subtracts the store's pre-patch value
+    /// instead.
+    ///
+    /// Observed on the state rather than the return value on purpose: the hash
+    /// is updated before any record is decoded, and a 16-byte blob is not
+    /// decryptable, so this patch fails afterwards. The ltHash it left behind is
+    /// still the thing under test.
+    #[test]
+    fn a_short_first_set_is_cancelled_by_the_second() {
+        let index_mac = vec![9u8; 32];
+        let short = vec![0xABu8; 16];
+        let second: Vec<u8> = (0..48u8).collect();
+
+        let mutation = |blob: &[u8]| wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::SET.into()),
+            record: buffa::MessageField::some(wa::SyncdRecord {
+                index: buffa::MessageField::some(wa::SyncdIndex {
+                    blob: Some(index_mac.clone()),
+                }),
+                value: buffa::MessageField::some(wa::SyncdValue {
+                    blob: Some(blob.to_vec()),
+                }),
+                key_id: buffa::MessageField::some(wa::KeyId {
+                    id: Some(b"test_key_id".to_vec()),
+                }),
+            }),
+        };
+
+        let patch = wa::SyncdPatch {
+            version: buffa::MessageField::some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![mutation(&short), mutation(&second)],
+            key_id: buffa::MessageField::some(wa::KeyId {
+                id: Some(b"test_key_id".to_vec()),
+            }),
+            ..Default::default()
+        };
+
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let mut state = HashState::default();
+        let _ = process_patch(
+            &patch,
+            &mut state,
+            |_: &[u8]| Ok(Arc::new(keys.clone())),
+            |_: &[u8]| Ok(None),
+            false,
+            "regular",
+        );
+
+        const EMPTY: &[Vec<u8>] = &[];
+        let only_second = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            EMPTY,
+            &[second[second.len() - 32..].to_vec()],
+        );
+        assert_eq!(
+            state.hash.as_slice(),
+            only_second.as_slice(),
+            "the short first SET must be cancelled by the second, not left in the ltHash"
+        );
+
+        // The exact regression: the short operand added and never subtracted.
+        let both_kept = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            EMPTY,
+            &[short.clone(), second[second.len() - 32..].to_vec()],
+        );
+        assert_ne!(
+            state.hash.as_slice(),
+            both_kept.as_slice(),
+            "the overwrite map forgot the short operand the fold added"
         );
     }
 

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -577,25 +577,34 @@ pub fn validate_patch_macs(
 }
 
 /// The records a keyed snapshot actually describes: one per index, the last of
-/// any run, plus every record that carries no index and so cannot collide.
+/// any run.
 ///
 /// Mirrors the `Map` WA Web builds in `WAWebSyncdAntiTampering`, and must stay in
 /// step with [`HashState::update_hash_from_records`] -- the ltHash is folded over
 /// this same set, and a snapshot whose MAC we accepted has to be the snapshot we
 /// then decode.
+///
+/// Which is why a record carrying no index is keyed here too, on the empty
+/// slice, exactly as the fold keys it. Letting every such record through as its
+/// own winner read as "they cannot collide" and was the same mistake the fold
+/// made: WA Web keys on `hex(index.blob)`, `hex` of an absent buffer is the
+/// empty string, and they all collide there. Keeping the two in step matters
+/// more than either answer on its own -- the fold decides which MAC we accept
+/// and this decides what we then decrypt, so a disagreement means accepting a
+/// snapshot on one set of records and storing another.
 fn last_record_per_index(records: &[wa::SyncdRecord]) -> Vec<&wa::SyncdRecord> {
     let mut winners: Vec<&wa::SyncdRecord> = Vec::with_capacity(records.len());
     let mut seen: Vec<&[u8]> = Vec::new();
     // Backwards, so the first hit for an index is its last record.
     for rec in records.iter().rev() {
-        match rec.index.as_option().and_then(|idx| idx.blob.as_deref()) {
-            Some(index_mac) => {
-                if !seen.contains(&index_mac) {
-                    seen.push(index_mac);
-                    winners.push(rec);
-                }
-            }
-            None => winners.push(rec),
+        let index_mac = rec
+            .index
+            .as_option()
+            .and_then(|idx| idx.blob.as_deref())
+            .unwrap_or_default();
+        if !seen.contains(&index_mac) {
+            seen.push(index_mac);
+            winners.push(rec);
         }
     }
     winners.reverse();
@@ -696,6 +705,65 @@ mod tests {
                 id: Some(key_id.to_vec()),
             }),
         }
+    }
+
+    /// The two passes over a snapshot must describe the same set of records.
+    ///
+    /// `update_hash_from_records` decides which MAC we accept and
+    /// `last_record_per_index` decides what we then decrypt and store, so a
+    /// disagreement means accepting a snapshot on one set of records and
+    /// persisting another. Records carrying no index are where the two came
+    /// apart: each pass independently read "no index" as "cannot collide" and
+    /// let every one of them through, where WA Web keys on `hex(index.blob)`
+    /// and collides them all on the empty string.
+    #[test]
+    fn the_decode_set_is_the_set_the_fold_folded() {
+        fn record(index: Option<&[u8]>, value_mac: u8) -> wa::SyncdRecord {
+            let mut blob = vec![0u8; 16];
+            blob.extend_from_slice(&[value_mac; 32]);
+            wa::SyncdRecord {
+                index: buffa::MessageField::some(wa::SyncdIndex {
+                    blob: index.map(<[u8]>::to_vec),
+                }),
+                value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
+                ..Default::default()
+            }
+        }
+
+        // One ordinary index carrying a run of two, and three records with no
+        // index at all: five records describing two things.
+        let records = vec![
+            record(Some(&[0x01; 32]), 0x11),
+            record(None, 0x22),
+            record(Some(&[0x01; 32]), 0x33),
+            record(None, 0x44),
+            record(None, 0x55),
+        ];
+
+        let mut state = HashState::default();
+        let fold = state.update_hash_from_records(&records);
+        let winners = last_record_per_index(&records);
+
+        assert_eq!(fold.folded, 2, "one index and one empty key");
+        assert_eq!(
+            winners.len(),
+            fold.folded,
+            "the decode walks the records the fold folded, or the MAC we accepted \
+             was computed over a different snapshot than the one we store"
+        );
+        assert_eq!(
+            fold.unkeyed, 3,
+            "and it still says how many arrived unkeyed"
+        );
+
+        // Last wins in both, and on the same records.
+        let last_of = |mac: u8| {
+            winners
+                .iter()
+                .any(|rec| rec.value.blob.as_ref().is_some_and(|b| b[16] == mac))
+        };
+        assert!(last_of(0x33), "the run's last record, not its first");
+        assert!(last_of(0x55), "the last unkeyed record, not the first");
     }
 
     #[test]

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -88,6 +88,24 @@ where
     // Update hash state directly from records (no cloning needed)
     let fold = initial_state.update_hash_from_records(&snapshot.records);
 
+    // A record with no value blob is one nobody can agree about: WA Web reads
+    // `.byteLength` off the absent buffer and the whole fold throws. Refused
+    // here rather than folded around, because the fold and the decode both have
+    // to leave it out to stay in step -- and two passes quietly agreeing to
+    // ignore a record is how a malformed snapshot would validate and be stored
+    // as though it were whole. Rejecting keeps the old answer
+    // (`decode_record`'s `MissingValueBlob`) for input that never changed.
+    if fold.valueless > 0 {
+        warn!(
+            target: "AppState",
+            "Snapshot {} v{} carries {} record(s) with no value blob; refusing it",
+            collection_name,
+            version,
+            fold.valueless,
+        );
+        return Err(AppStateError::MissingValueBlob);
+    }
+
     debug!(
         target: "AppState",
         "Snapshot {} v{}: {} records, ltHash ends with ...{}",
@@ -806,6 +824,49 @@ mod tests {
             winners[0].value.blob.is_some(),
             "the winner is the folded record, not the valueless one that followed it"
         );
+    }
+
+    /// A snapshot carrying a record with no value blob is refused, not quietly
+    /// folded around. Both passes leave such a record out to stay in step, so
+    /// without this the two would agree to ignore it and a malformed snapshot
+    /// would validate and be stored as though it were whole -- where before it
+    /// was rejected at the decode.
+    #[test]
+    fn a_snapshot_with_a_valueless_record_is_refused() {
+        let mut blob = vec![0u8; 16];
+        blob.extend_from_slice(&[0x11; 32]);
+        let snapshot = wa::SyncdSnapshot {
+            version: buffa::MessageField::some(wa::SyncdVersion { version: Some(7) }),
+            records: vec![
+                wa::SyncdRecord {
+                    index: buffa::MessageField::some(wa::SyncdIndex {
+                        blob: Some(vec![0x01; 32]),
+                    }),
+                    value: buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) }),
+                    ..Default::default()
+                },
+                wa::SyncdRecord {
+                    index: buffa::MessageField::some(wa::SyncdIndex {
+                        blob: Some(vec![0x02; 32]),
+                    }),
+                    value: buffa::MessageField::some(wa::SyncdValue { blob: None }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let mut state = HashState::default();
+        // Refused before the MAC is even reached, so it needs no key and no mac.
+        let err = process_snapshot(
+            &snapshot,
+            &mut state,
+            |_| panic!("a valueless record is refused before any key is looked up"),
+            true,
+            "regular_low",
+        )
+        .expect_err("a snapshot with a valueless record must be refused");
+        assert!(matches!(err, AppStateError::MissingValueBlob), "{err:?}");
     }
 
     #[test]

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -349,7 +349,15 @@ where
         // contributed rather than the store's pre-patch value. A short blob is
         // folded there, so recording it only when it is 32 bytes long leaves the
         // first SET's operand added and never cancelled.
-        if let Some(rec) = patch.mutations[idx].record.as_option()
+        //
+        // Only a SET, because only a SET adds one. A REMOVE subtracts, and after
+        // it the index holds nothing -- so recording its tail here would have a
+        // later SET on that index subtract a value the patch had already taken
+        // out. `update_hash` suppresses that lookup entirely, but only when
+        // every mutation carries an index; one that does not drops the whole
+        // patch to the legacy path, where this map is what answers.
+        if !is_remove
+            && let Some(rec) = patch.mutations[idx].record.as_option()
             && let Some(index) = rec.index.as_option().and_then(|i| i.blob.as_deref())
             && let Some(value) = rec.value.as_option().and_then(|v| v.blob.as_deref())
         {
@@ -1645,17 +1653,96 @@ mod tests {
         );
     }
 
-    /// The overwrite map has to record the operand the fold actually added, not
-    /// the one a 32-byte rule would have. A first SET whose value blob is short
-    /// still contributes -- `slice(len - 32)` counts from the end -- so a map
-    /// that only remembers full-length values leaves that operand added and
-    /// uncancelled, and the second SET subtracts the store's pre-patch value
-    /// instead.
+    /// A REMOVE leaves nothing behind for a later SET to subtract.
     ///
-    /// Observed on the state rather than the return value on purpose: the hash
-    /// is updated before any record is decoded, and a 16-byte blob is not
-    /// decryptable, so this patch fails afterwards. The ltHash it left behind is
-    /// still the thing under test.
+    /// `update_hash` suppresses that subtraction outright, but only when every
+    /// mutation carries an index MAC; the unindexed third mutation here is what
+    /// drops the patch to the legacy path, where the overwrite map is the only
+    /// thing answering. A REMOVE recorded there would have the SET subtract a
+    /// value the REMOVE had already taken out.
+    #[test]
+    fn a_remove_leaves_nothing_for_a_later_set_to_subtract() {
+        let index_mac = vec![9u8; 32];
+        let removed: Vec<u8> = (0..48u8).collect();
+        let set: Vec<u8> = (100..148u8).collect();
+        let unindexed: Vec<u8> = (200..248u8).collect();
+        let tail = |b: &[u8]| b[b.len() - 32..].to_vec();
+
+        let mutation = |op: wa::syncd_mutation::SyncdOperation,
+                        index: Option<&[u8]>,
+                        blob: &[u8]| wa::SyncdMutation {
+            operation: Some(op.into()),
+            record: buffa::MessageField::some(wa::SyncdRecord {
+                index: buffa::MessageField::some(wa::SyncdIndex {
+                    blob: index.map(<[u8]>::to_vec),
+                }),
+                value: buffa::MessageField::some(wa::SyncdValue {
+                    blob: Some(blob.to_vec()),
+                }),
+                key_id: buffa::MessageField::some(wa::KeyId {
+                    id: Some(b"test_key_id".to_vec()),
+                }),
+            }),
+        };
+
+        use wa::syncd_mutation::SyncdOperation::{REMOVE, SET};
+        let patch = wa::SyncdPatch {
+            version: buffa::MessageField::some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![
+                mutation(REMOVE, Some(&index_mac), &removed),
+                mutation(SET, Some(&index_mac), &set),
+                // No index: this is what makes it the legacy path.
+                mutation(SET, None, &unindexed),
+            ],
+            key_id: buffa::MessageField::some(wa::KeyId {
+                id: Some(b"test_key_id".to_vec()),
+            }),
+            ..Default::default()
+        };
+
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let mut state = HashState::default();
+        let _ = process_patch(
+            &patch,
+            &mut state,
+            |_: &[u8]| Ok(Arc::new(keys.clone())),
+            |_: &[u8]| Ok(None),
+            false,
+            "regular",
+        );
+
+        const EMPTY: &[Vec<u8>] = &[];
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            EMPTY,
+            &[tail(&set), tail(&unindexed)],
+        );
+        assert_eq!(
+            state.hash.as_slice(),
+            expected.as_slice(),
+            "the store held nothing, so the two SETs are all there is to fold"
+        );
+
+        // The exact regression: the SET subtracting the REMOVE's own tail.
+        let subtracted_the_remove = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            &[tail(&removed)],
+            &[tail(&set), tail(&unindexed)],
+        );
+        assert_ne!(
+            state.hash.as_slice(),
+            subtracted_the_remove.as_slice(),
+            "a REMOVE must not leave an operand for the SET after it to cancel"
+        );
+    }
+
+    /// A first SET whose value blob is short must still be cancelled by the
+    /// second SET on the same index.
+    ///
+    /// Read off the state rather than the return value: a 16-byte blob is not
+    /// decryptable, so this patch fails after the hash has already been updated,
+    /// and the ltHash it left behind is the thing under test.
     #[test]
     fn a_short_first_set_is_cancelled_by_the_second() {
         let index_mac = vec![9u8; 32];


### PR DESCRIPTION
Three divergences from the official client, each found by **executing** WhatsApp
Web's own code and comparing its answer to ours over the same inputs.

## How these were found

Reading the bundle is what this repository has always done, and
`agent_docs/wa_web_reference.md` already says what it is worth: "a static
reading of minified code, not the contract itself... Treat it as high-quality
evidence, not as a specification." These three are what turned up when the
reading was replaced by running the thing.

A conformance suite loads the vendor's real modules out of the minified bundle
— `WACryptoLtHash`, `WACryptoHkdf`, `WAWebSyncdCrypto`,
`WAWebSyncdCryptoConst`, `WAWebSyncdEncryptionManager`, `WAWebSyncdAntiTampering`
— runs them on controlled inputs, and compares against `wacore`. Seven units:

| unit | verdict |
|---|---|
| LTHash operand (HKDF derivation) | agrees, 17/17 |
| LTHash arithmetic (u16 LE lanes, wrapping) | agrees, 27/27 |
| Mutation key expansion (160 bytes, 5 slices) | agrees, 54/54 |
| Content MAC and index MAC | agrees, 26/26 |
| **Snapshot record fold** | **diverged, 10/20** |
| **Snapshot MAC** | **diverged, 21/25** |
| **Patch MAC** | **diverged, 16/21** |

Five agreeing byte for byte is what makes the two that did not worth acting on.
Every unit carries a self-test that corrupts each candidate answer and requires
100% mismatches — a gate that cannot fail proves nothing when it passes.

## 1. A record with no index MAC is not a record that cannot collide

The fold read an absent index as "unkeyed, therefore unique" and folded each
such record on its own. WA Web keys every record through `hex(index.blob)` and
sums the map's values; `hex` of an absent buffer is the empty string, so they
all collide there and exactly one survives — the last in list order.

Proven rather than inferred. With two unkeyed records `[aa, bb]` the oracle's
ltHash equals the fold of `bb` alone; reversing the pair moves the answer to
`aa`. An *empty* index blob collides with an absent one for the same reason.

## 2. A value blob shorter than a MAC still contributes

`valueMacFromIndexAndValueCipherText` is `slice(len - 32)`, and a negative start
in JS subtracts the length a second time, so the slice begins at
`max(2*len - 32, 0)`:

| blob length | 0 | 1 | 16 | 17 | 20 | 31 | 32 |
|---|---|---|---|---|---|---|---|
| bytes WA Web feeds | 0 | 1 | 16 | 15 | 12 | **1** | 32 |
| bytes we fed | 0 | 0 | 0 | 0 | 0 | 0 | 32 |

A 31-byte blob folds its *last byte*. Everything at 16 and under folds whole,
which is why the intuitive reading — "a negative start means the whole buffer" —
survived being written down: the lengths that agree with it are the ones anybody
would try.

Requiring `len >= 32` was wrong twice over. In the patch MAC it fed the hash as
though the mutation were absent — for a single-mutation patch, byte for byte the
empty patch's MAC. In the snapshot fold it also removed the record from the
index dedup, handing a repeated index to the wrong record and folding a
different value MAC entirely. That second one is a wrong answer, not an omission.

The arithmetic now lives in one function that both paths call.

## 3. `to64BitNetworkOrder` does not encode 64 bits

```js
function m(e){ var t = new ArrayBuffer(8); return new DataView(t).setUint32(4, e, !1), t }
```

Four bytes at offset 4 of an eight-byte buffer: the version rides in the low
four and the top four are always zero. The oracle answers the identical MAC for
version `0` and version `2^32`, and for `2^32-1` and `2^48-1`.

Unreachable in practice — real collection versions are two and three digits —
but the truncation destroys an identity, so it is logged rather than swallowed.
Not rejected: the server's own client accepts the value and the MAC we produce
is the correct one. Conformance means matching the oracle including where the
oracle is lossy. Not `debug_assert!` either: the version is server-supplied, and
turning remote input into a panic in the crate that parses the wire is a worse
failure than the one it detects.

## The mirror in `last_record_per_index`

It carried the same "cannot collide" reading, and its own doc comment already
required it to stay in step with the fold. Fixing one and not the other would
leave the MAC accepted over one set of records and the decode storing another —
worse than either mistake alone. `the_decode_set_is_the_set_the_fold_folded`
pins it.

## Tests

Every expected value is a literal from the oracle's output. None is computed by
this crate: a known-answer test whose answer came from the code under test
proves only that it agrees with itself, which is exactly how the first two of
these survived review. `test_generate_patch_mac_known_answer` was one such test
— its value was right, but it only ever used blobs of 32 bytes and more, so it
could never have seen the divergence. It is re-anchored here on the vendor's own
byte string.

The version fix carries a negative control: reverting only the encoder body
fails the five new tests and nothing else.

## Performance

No measurable change to the fold, which is on a hot path and benchmarked.
Divan medians, before → after: 5.048 → 5.073 µs at 10 records, 102.3 → 102.4 µs
at 200, 3.159 → 3.173 ms at 5000, 1.682 → 1.697 ms at 5000 with duplicates. No
per-record allocation was added.

## What this does not do

It does not explain any particular account. These close three real gaps against
the official client; none of them is known to be the cause of a snapshot that
fails to validate in the field.

Worth stating because it is the likelier answer to that: WhatsApp Web treats a
snapshot MAC failure as an **expected** condition. It throws, then asks the
primary device for the collection over
`COMPANION_SYNCD_SNAPSHOT_FATAL_RECOVERY` and rewrites it from the plaintext
mutations and the primary's own ltHash. The request and response messages are
already in `waproto`; the only mention of the type in this repository is a test
enumerating push priorities. That path does not exist here, and a collection
whose snapshot will not validate is therefore stuck at version 0 for ever,
retrying the same download and failing the same way.