### PR TITLE
fix(mex): stop sending a persisted query fewer variables than it declares

### DIFF
--- a/src/features/business.rs
+++ b/src/features/business.rs
@@ -980,6 +980,9 @@ mod tests {
         assert_eq!(request["collection_limit"], json!("51"));
         assert_eq!(request["item_limit"], json!("51"));
         assert_eq!(request["width"], json!("100"));
+        // Same rule as the catalog: no cursor on the first page, because an
+        // explicit null is a cursor value.
+        assert!(request.get("after").is_none());
     }
 
     /// The order query is the one that sends real JSON numbers, and it wraps

--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -21,6 +21,10 @@ use wacore::iq::groups::{
 use wacore::iq::mex_operations::{fetch_all_subgroups, query_subgroup_participant_count};
 use wacore_binary::Jid;
 
+/// How the subgroup queries say the request came from a user acting now, which
+/// is the only context WA Web sends from the web client.
+const SUBGROUP_QUERY_CONTEXT: &str = "INTERACTIVE";
+
 /// Error returned by community operations.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -303,7 +307,11 @@ impl<'a> Community<'a> {
             .mex()
             .query(mex_request!(fetch_all_subgroups {
                 group_id: Some(community_jid.to_string()),
-                ..Default::default()
+                query_context: Some(SUBGROUP_QUERY_CONTEXT.to_string()),
+                // WA Web names a subgroup the user has already joined here, to
+                // steer which subgroups come back first. There is no such hint
+                // to give from this API, and WA Web omits it in that case too.
+                sub_group_hint_id: None,
             }))
             .await?;
 
@@ -370,7 +378,8 @@ impl<'a> Community<'a> {
             .query(mex_request!(query_subgroup_participant_count {
                 input: Some(query_subgroup_participant_count::Input {
                     group_jid: Some(community_jid.to_string()),
-                    ..Default::default()
+                    query_context: Some(SUBGROUP_QUERY_CONTEXT.to_string()),
+                    sub_group_jid_hint: None,
                 }),
             }))
             .await?;
@@ -539,6 +548,63 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn community_jid() -> Jid {
+        "120363000000000001@g.us"
+            .parse()
+            .expect("fictitious community")
+    }
+
+    /// Regression for the same 400 as the newsletter queries: WhatsApp Web
+    /// always sends `query_context`, and only leaves `sub_group_hint_id` out
+    /// when it has no joined subgroup to name, which is this client's case.
+    #[test]
+    fn subgroup_listing_sends_the_query_context_and_omits_only_the_hint() {
+        let request = mex_request!(fetch_all_subgroups {
+            group_id: Some(community_jid().to_string()),
+            query_context: Some(SUBGROUP_QUERY_CONTEXT.to_string()),
+            sub_group_hint_id: None,
+        });
+
+        assert_eq!(
+            request.missing_variables().expect("serialize"),
+            vec!["sub_group_hint_id"]
+        );
+        assert_eq!(
+            serde_json::to_value(&request.variables).expect("serialize"),
+            serde_json::json!({
+                "group_id": "120363000000000001@g.us",
+                "query_context": "INTERACTIVE",
+            })
+        );
+    }
+
+    /// The participant count carries the same context, one level down inside
+    /// `input`, where the compiler cannot force the decision.
+    #[test]
+    fn participant_count_input_carries_the_query_context() {
+        let request = mex_request!(query_subgroup_participant_count {
+            input: Some(query_subgroup_participant_count::Input {
+                group_jid: Some(community_jid().to_string()),
+                query_context: Some(SUBGROUP_QUERY_CONTEXT.to_string()),
+                sub_group_jid_hint: None,
+            }),
+        });
+
+        assert_eq!(
+            request.missing_variables().expect("serialize"),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            serde_json::to_value(&request.variables).expect("serialize"),
+            serde_json::json!({
+                "input": {
+                    "group_jid": "120363000000000001@g.us",
+                    "query_context": "INTERACTIVE",
+                }
+            })
+        );
+    }
 
     #[test]
     fn subgroup_parser_preserves_typed_metadata() {

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -47,19 +47,51 @@ pub enum MexError {
 pub struct MexRequest<V> {
     /// GraphQL persisted-query descriptor (name + id).
     pub doc: MexDoc,
+    /// The variable names the persisted document declares, from the op module's
+    /// `VARIABLE_KEYS`. Carried so a payload can be checked against them even
+    /// when the variables are a loosely-typed `json!`.
+    pub declared_variables: &'static [&'static str],
     /// Typed query variables: a generated `Variables`, or any `Serialize` value
     /// (e.g. a `json!` object) for inputs the generated mirror types too loosely.
     pub variables: V,
 }
 
 impl<V> MexRequest<V> {
-    /// Pair a `(name, id)` from a generated op module with its variables.
-    /// Prefer the `mex_request!` macro, which names the op once.
-    pub fn new(name: &'static str, id: &'static str, variables: V) -> Self {
+    /// Pair a `(name, id, declared variables)` from a generated op module with
+    /// its variables. Prefer the `mex_request!` macro, which names the op once.
+    pub fn new(
+        name: &'static str,
+        id: &'static str,
+        declared_variables: &'static [&'static str],
+        variables: V,
+    ) -> Self {
         Self {
             doc: MexDoc { name, id },
+            declared_variables,
             variables,
         }
+    }
+}
+
+impl<V: Serialize> MexRequest<V> {
+    /// Declared variables this request's payload does not carry.
+    ///
+    /// A persisted query the server cannot bind every variable of comes back as
+    /// a bare `400 Bad Request`, so serializing and looking is the only way to
+    /// see the omission before it reaches the wire. A non-empty result is not
+    /// automatically wrong: WhatsApp Web omits an optional variable it has no
+    /// value for, and this reports that the same way.
+    pub fn missing_variables(&self) -> Result<Vec<&'static str>, serde_json::Error> {
+        let value = serde_json::to_value(&self.variables)?;
+        let Some(object) = value.as_object() else {
+            return Ok(self.declared_variables.to_vec());
+        };
+        Ok(self
+            .declared_variables
+            .iter()
+            .copied()
+            .filter(|key| !object.contains_key(*key))
+            .collect())
     }
 }
 
@@ -78,12 +110,18 @@ macro_rules! mex_request {
         $crate::features::mex::MexRequest::new(
             __mex_op::NAME,
             __mex_op::DOC_ID,
+            __mex_op::VARIABLE_KEYS,
             __mex_op::Variables { $($body)* },
         )
     }};
     ($op:path, $vars:expr $(,)?) => {{
         use $op as __mex_op;
-        $crate::features::mex::MexRequest::new(__mex_op::NAME, __mex_op::DOC_ID, $vars)
+        $crate::features::mex::MexRequest::new(
+            __mex_op::NAME,
+            __mex_op::DOC_ID,
+            __mex_op::VARIABLE_KEYS,
+            $vars,
+        )
     }};
 }
 pub(crate) use mex_request;
@@ -331,11 +369,49 @@ mod tests {
         };
         let request = MexRequest {
             doc: DOC,
+            declared_variables: &[],
             variables: json!({}),
         };
 
         assert_eq!(request.doc.id, "29829202653362039");
         assert_eq!(request.doc.name, "WAWebMexTestQuery");
+    }
+
+    /// The guard for the loosely-typed form of `mex_request!`, where the
+    /// compiler cannot see the variables at all: a `json!` payload is still
+    /// checked against the op's own `VARIABLE_KEYS`.
+    #[test]
+    fn missing_variables_names_what_a_payload_leaves_out() {
+        use wacore::iq::mex_operations::fetch_all_newsletters_metadata as op;
+
+        let complete = MexRequest::new(
+            op::NAME,
+            op::DOC_ID,
+            op::VARIABLE_KEYS,
+            json!({ "fetch_status_metadata": false, "fetch_wamo_sub": false }),
+        );
+        assert_eq!(
+            complete.missing_variables().expect("serialize"),
+            Vec::<&str>::new()
+        );
+
+        let partial = MexRequest::new(
+            op::NAME,
+            op::DOC_ID,
+            op::VARIABLE_KEYS,
+            json!({ "fetch_wamo_sub": true }),
+        );
+        assert_eq!(
+            partial.missing_variables().expect("serialize"),
+            vec!["fetch_status_metadata"]
+        );
+
+        // A payload that is not an object binds nothing at all.
+        let bogus = MexRequest::new(op::NAME, op::DOC_ID, op::VARIABLE_KEYS, json!("nope"));
+        assert_eq!(
+            bogus.missing_variables().expect("serialize"),
+            vec!["fetch_status_metadata", "fetch_wamo_sub"]
+        );
     }
 
     #[test]

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -80,7 +80,9 @@ impl<V: Serialize> MexRequest<V> {
     /// a bare `400 Bad Request`, so serializing and looking is the only way to
     /// see the omission before it reaches the wire. A non-empty result is not
     /// automatically wrong: WhatsApp Web omits an optional variable it has no
-    /// value for, and this reports that the same way.
+    /// value for, and this reports that the same way. That is also why the send
+    /// path does not check it: an assert here would fire on `fetch_all_subgroups`,
+    /// which is correct precisely because it omits one. Tests know the wanted set.
     pub fn missing_variables(&self) -> Result<Vec<&'static str>, serde_json::Error> {
         let value = serde_json::to_value(&self.variables)?;
         let Some(object) = value.as_object() else {

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -214,7 +214,11 @@ impl<'a> Newsletter<'a> {
             .client
             .mex()
             .query(mex_request!(fetch_all_newsletters_metadata {
-                ..Default::default()
+                // Both gate response blocks this client does not parse. WA Web
+                // reads the same two feature flags and sends whatever they say,
+                // so `false` is a value the server sees from it every day.
+                fetch_status_metadata: Some(false),
+                fetch_wamo_sub: Some(false),
             }))
             .await?;
 
@@ -235,17 +239,10 @@ impl<'a> Newsletter<'a> {
         let response = self
             .client
             .mex()
-            .query(mex_request!(fetch_newsletter {
-                input: Some(fetch_newsletter::Input {
-                    key: Some(jid.to_string()),
-                    r#type: Some("JID".into()),
-                    view_role: Some("GUEST".into()),
-                }),
-                fetch_viewer_metadata: Some(true),
-                fetch_full_image: Some(true),
-                fetch_creation_time: Some(true),
-                ..Default::default()
-            }))
+            .query(mex_request!(
+                fetch_newsletter,
+                newsletter_variables(&jid.to_string(), "JID")
+            ))
             .await?;
 
         let data = response
@@ -549,17 +546,10 @@ impl<'a> Newsletter<'a> {
         let response = self
             .client
             .mex()
-            .query(mex_request!(fetch_newsletter {
-                input: Some(fetch_newsletter::Input {
-                    key: Some(invite_code.to_string()),
-                    r#type: Some("INVITE".into()),
-                    view_role: Some("GUEST".into()),
-                }),
-                fetch_viewer_metadata: Some(true),
-                fetch_full_image: Some(true),
-                fetch_creation_time: Some(true),
-                ..Default::default()
-            }))
+            .query(mex_request!(
+                fetch_newsletter,
+                newsletter_variables(invite_code, "INVITE")
+            ))
             .await?;
 
         let data = response
@@ -1026,6 +1016,28 @@ fn picture_update_variables(jid: &Jid, jpeg: Option<&[u8]>) -> update_newsletter
     }
 }
 
+/// Variables for `WAWebMexFetchNewsletterJobQuery`, addressing a channel by
+/// `key`/`key_type` (`"JID"` or `"INVITE"`).
+///
+/// The three `false` flags ask for response blocks this client does not parse;
+/// WA Web puts each behind a feature flag and sends the flag's value either
+/// way. `view_role` is `GUEST` because WA Web maps an absent role to it.
+fn newsletter_variables(key: &str, key_type: &str) -> fetch_newsletter::Variables {
+    fetch_newsletter::Variables {
+        input: Some(fetch_newsletter::Input {
+            key: Some(key.to_string()),
+            r#type: Some(key_type.to_string()),
+            view_role: Some("GUEST".into()),
+        }),
+        fetch_viewer_metadata: Some(true),
+        fetch_full_image: Some(true),
+        fetch_creation_time: Some(true),
+        fetch_pinned_messages: Some(false),
+        fetch_status_metadata: Some(false),
+        fetch_wamo_sub: Some(false),
+    }
+}
+
 fn delete_variables(jid: &Jid) -> delete_newsletter::Variables {
     delete_newsletter::Variables {
         newsletter_id: Some(jid.to_string()),
@@ -1076,6 +1088,79 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wacore_binary::builder::NodeBuilder;
+
+    /// Regression for the 400 the server answers a persisted query that omits a
+    /// declared variable with. WhatsApp Web sends both flags unconditionally,
+    /// as whatever their feature gates say.
+    #[test]
+    fn subscribed_list_request_declares_every_variable() {
+        let request = mex_request!(fetch_all_newsletters_metadata {
+            fetch_status_metadata: Some(false),
+            fetch_wamo_sub: Some(false),
+        });
+
+        assert_eq!(
+            request.missing_variables().expect("serialize"),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            serde_json::to_value(&request.variables).expect("serialize"),
+            json!({ "fetch_status_metadata": false, "fetch_wamo_sub": false })
+        );
+    }
+
+    /// Same regression for the newsletter fetch, whose seven variables WA Web
+    /// also writes out in full at every call site.
+    #[test]
+    fn newsletter_fetch_request_declares_every_variable() {
+        for (key, key_type) in [
+            ("120363000000000001@newsletter", "JID"),
+            ("0029Vabcdefghij0123456789", "INVITE"),
+        ] {
+            let request = mex_request!(fetch_newsletter, newsletter_variables(key, key_type));
+
+            assert_eq!(
+                request.missing_variables().expect("serialize"),
+                Vec::<&str>::new(),
+                "{key_type}"
+            );
+            assert_eq!(
+                serde_json::to_value(&request.variables).expect("serialize"),
+                json!({
+                    "input": { "key": key, "type": key_type, "view_role": "GUEST" },
+                    "fetch_viewer_metadata": true,
+                    "fetch_full_image": true,
+                    "fetch_creation_time": true,
+                    "fetch_pinned_messages": false,
+                    "fetch_status_metadata": false,
+                    "fetch_wamo_sub": false,
+                })
+            );
+        }
+    }
+
+    /// `updates` is a tri-state: an absent key means "leave alone" and a null
+    /// would clear the field. Serializing `None` as null here would wipe a
+    /// channel's name and description on every picture change, so this pins the
+    /// omission that the `skip_serializing_if` on the nested types provides.
+    #[test]
+    fn a_picture_update_does_not_touch_the_name_or_description() {
+        for jpeg in [Some(&b"\xff\xd8\xff"[..]), None] {
+            let updates = serde_json::to_value(picture_update_variables(&newsletter_jid(), jpeg))
+                .expect("serialize");
+            let updates = &updates["updates"];
+
+            assert!(updates.get("name").is_none(), "{updates}");
+            assert!(updates.get("description").is_none(), "{updates}");
+            assert!(updates.get("settings").is_none(), "{updates}");
+            assert!(updates["picture"].is_string(), "{updates}");
+        }
+        // Clearing is an empty string, not a null: the server collapses null to
+        // "no change" and the picture would survive.
+        let cleared = serde_json::to_value(picture_update_variables(&newsletter_jid(), None))
+            .expect("serialize");
+        assert_eq!(cleared["updates"]["picture"], json!(""));
+    }
 
     #[test]
     fn mute_variables_match_wa_web_shape() {

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -1139,10 +1139,9 @@ mod tests {
         }
     }
 
-    /// `updates` is a tri-state: an absent key means "leave alone" and a null
-    /// would clear the field. Serializing `None` as null here would wipe a
-    /// channel's name and description on every picture change, so this pins the
-    /// omission that the `skip_serializing_if` on the nested types provides.
+    /// Pins the omission that makes `updates` a tri-state. Dropping
+    /// `skip_serializing_if` from the nested types would send `name` and
+    /// `description` as nulls, which clear them: see `picture_update_variables`.
     #[test]
     fn a_picture_update_does_not_touch_the_name_or_description() {
         for jpeg in [Some(&b"\xff\xd8\xff"[..]), None] {
@@ -1155,8 +1154,8 @@ mod tests {
             assert!(updates.get("settings").is_none(), "{updates}");
             assert!(updates["picture"].is_string(), "{updates}");
         }
-        // Clearing is an empty string, not a null: the server collapses null to
-        // "no change" and the picture would survive.
+        // Clearing needs an explicit empty string, because an omitted key means
+        // "leave alone" and the old picture would survive.
         let cleared = serde_json::to_value(picture_update_variables(&newsletter_jid(), None))
             .expect("serialize");
         assert_eq!(cleared["updates"]["picture"], json!(""));

--- a/tools/whatspec-codegen/src/emit/mex.rs
+++ b/tools/whatspec-codegen/src/emit/mex.rs
@@ -18,6 +18,19 @@ const HEADER: &str = "\
 use serde::{Deserialize, Serialize};
 ";
 
+/// Doc comment on every generated `Variables`.
+///
+/// It is the one place the no-`Default` decision is explained, because the
+/// generated file is where a reader meets it.
+const VARIABLES_DOC: &str = "\
+Variables for this operation, one field per variable the persisted document
+declares.
+
+Deliberately not `Default`: the server rejects a persisted query whose
+variables it cannot bind, so every variable is a decision a call site has to
+write out, and `..Default::default()` would make skipping one invisible.
+Passing `None` is still how a variable WhatsApp Web itself omits is omitted.";
+
 pub fn generate(ir: &MexIr) -> String {
     let mut out = super::header("typed mex operations", &ir.wa_version);
     out.push_str(HEADER);
@@ -31,8 +44,8 @@ pub fn generate(ir: &MexIr) -> String {
         // just as easily want the name `Response`.
         b.reserve("Variables");
         b.reserve("Response");
-        b.register("Variables", &op.variables_shape);
-        b.register("Response", &op.response);
+        b.register("Variables", &op.variables_shape, true);
+        b.register("Response", &op.response, false);
 
         let kind = op.operation_kind.as_str();
         out.push_str(&format!("\n/// `{}` ({kind}).\n", op.original_name));
@@ -47,8 +60,15 @@ pub fn generate(ir: &MexIr) -> String {
             rust_lit(&op.doc_id)
         ));
         out.push_str(&format!(
-            "    pub const OPERATION_KIND: &str = {};\n\n",
+            "    pub const OPERATION_KIND: &str = {};\n",
             rust_lit(kind)
+        ));
+        // The declared variable names, so a test can check a payload against
+        // them instead of a literal transcribed from the bundle by hand.
+        let keys: Vec<String> = op.variables_shape.keys().map(|k| rust_lit(k)).collect();
+        out.push_str(&format!(
+            "    pub const VARIABLE_KEYS: &[&str] = &[{}];\n\n",
+            keys.join(", ")
         ));
         for s in &b.structs {
             out.push_str(&s.render("    "));
@@ -63,6 +83,10 @@ pub fn generate(ir: &MexIr) -> String {
 struct StructDef {
     name: String,
     fields: Vec<(String, String, String)>,
+    /// `true` for an operation's own `Variables`, which is rendered without
+    /// `Default` so a call site cannot inherit `None` for a variable it never
+    /// considered; see [`VARIABLES_DOC`].
+    variables: bool,
 }
 
 impl StructDef {
@@ -79,9 +103,17 @@ impl StructDef {
 
     fn render(&self, indent: &str) -> String {
         let mut s = String::new();
-        s.push_str(&format!(
-            "{indent}#[derive(Debug, Clone, Default, Serialize, Deserialize)]\n"
-        ));
+        if self.variables {
+            for line in VARIABLES_DOC.lines() {
+                s.push_str(&format!("{indent}/// {line}\n"));
+            }
+        }
+        let derives = if self.variables {
+            "Debug, Clone, Serialize, Deserialize"
+        } else {
+            "Debug, Clone, Default, Serialize, Deserialize"
+        };
+        s.push_str(&format!("{indent}#[derive({derives})]\n"));
         s.push_str(&format!("{indent}pub struct {} {{\n", self.name));
         for (rust_field, json_key, ty) in &self.fields {
             if rust_field.trim_start_matches("r#") != json_key {
@@ -120,8 +152,14 @@ impl Builder {
         self.reserved.insert(name.to_string());
     }
 
-    fn register(&mut self, name: &str, fields: &BTreeMap<String, TypeNode>) -> String {
-        let def = self.struct_def(name, fields);
+    fn register(
+        &mut self,
+        name: &str,
+        fields: &BTreeMap<String, TypeNode>,
+        variables: bool,
+    ) -> String {
+        let mut def = self.struct_def(name, fields);
+        def.variables = variables;
         self.intern(def, true)
     }
 
@@ -130,6 +168,7 @@ impl Builder {
         let mut def = StructDef {
             name: name.to_string(),
             fields: Vec::new(),
+            variables: false,
         };
         // `rust_ident` is not injective: `fooBar` and `foo_bar` are one Rust
         // field. Two of them in the same object would emit the field twice.
@@ -260,6 +299,7 @@ mod tests {
         assert!(code.contains("pub const NAME: &str = \"WAWebFetchThingQuery\";"));
         assert!(code.contains("pub const DOC_ID: &str = \"123\";"));
         assert!(code.contains("pub const OPERATION_KIND: &str = \"query\";"));
+        assert!(code.contains("pub const VARIABLE_KEYS: &[&str] = &[\"thing_id\"];"));
         assert!(code.contains("pub thing_id: Option<String>,"));
         assert!(code.contains("pub count: Option<i64>,"));
         assert!(code.contains("pub ok: Option<bool>,"));
@@ -269,6 +309,72 @@ mod tests {
         let nested = code.find("pub struct Xwa2Thing").expect("nested struct");
         let response = code.find("pub struct Response").expect("response struct");
         assert!(nested < response);
+    }
+
+    /// The bug this shape exists to prevent: a call site that names some
+    /// variables and inherits the rest, sending a persisted query fewer
+    /// variables than it declares.
+    #[test]
+    fn variables_is_not_default_but_every_other_struct_is() {
+        let code = generate(&ir(
+            "FetchThing",
+            op(
+                &[("a", leaf("boolean")), ("b", leaf("boolean"))],
+                &[("node", obj(&[("id", leaf("string"))]))],
+            ),
+        ));
+        assert!(
+            code.contains(
+                "#[derive(Debug, Clone, Serialize, Deserialize)]\n    pub struct Variables {"
+            ),
+            "{code}"
+        );
+        assert!(
+            code.contains(
+                "#[derive(Debug, Clone, Default, Serialize, Deserialize)]\n    pub struct Node {"
+            ),
+            "{code}"
+        );
+        assert!(
+            code.contains("pub const VARIABLE_KEYS: &[&str] = &[\"a\", \"b\"];"),
+            "{code}"
+        );
+    }
+
+    /// An operation with no variables still gets the pair, so a caller and a
+    /// test can name them without knowing which kind of operation it is.
+    #[test]
+    fn an_operation_without_variables_still_declares_an_empty_key_list() {
+        let code = generate(&ir("FetchThing", op(&[], &[("ok", leaf("boolean"))])));
+        assert!(
+            code.contains("pub const VARIABLE_KEYS: &[&str] = &[];"),
+            "{code}"
+        );
+        assert!(
+            code.contains(
+                "#[derive(Debug, Clone, Serialize, Deserialize)]\n    pub struct Variables {"
+            ),
+            "{code}"
+        );
+    }
+
+    /// A nested object named `variables` must not inherit the required-field
+    /// rendering: only the operation's own variables are the wire's variables.
+    #[test]
+    fn only_the_operations_own_variables_lose_default() {
+        let code = generate(&ir(
+            "FetchThing",
+            op(
+                &[("a", leaf("boolean"))],
+                &[("variables", obj(&[("b", leaf("string"))]))],
+            ),
+        ));
+        assert!(
+            code.contains(
+                "#[derive(Debug, Clone, Default, Serialize, Deserialize)]\n    pub struct Variables2 {"
+            ),
+            "{code}"
+        );
     }
 
     #[test]

--- a/tools/whatspec-codegen/whatspec.lock.json
+++ b/tools/whatspec-codegen/whatspec.lock.json
@@ -1,19 +1,19 @@
 {
   "repo": "https://github.com/oxidezap/whatspec",
-  "rev": "12dbeeb89be46d823902aa73859373440e0eb014",
+  "rev": "1d086ce49279afeeee0a37cffedcf8f83ca50347",
   "waVersion": "2.3000.1045368834",
   "files": {
-    "abprops/index.json": "sha256:5fb1f19c2547f8617f719268276016336aa04949fea91690773015a250a526f3",
-    "appstate/index.json": "sha256:5c3b3881a6eb307436496236f981a466c195bd8f0a19a719eb6ed47eff0af2ed",
-    "enums/index.json": "sha256:7eda6cfd16fd0e5b927e797b01d891ab2296cedd23e89635cb47877dffe84a21",
-    "iq/index.json": "sha256:b814494668a0bf36839679dff0cb9f263238391378b57b90ad8bfae7f70fcffa",
-    "manifest.json": "sha256:222c5a1047b0e21e20f4f02371f3328d179cd0dbb374f98e555107c3f1966bb2",
-    "mex/index.json": "sha256:2f94dad2691eb9036fea7a2685acf3340364ba2a333df88299145933847ddb4a",
-    "notif/index.json": "sha256:0002dd3f9e74a9ffcc37f0bca4772abcb9f6efdcdfcbceea80d245ca691729fa",
+    "abprops/index.json": "sha256:8a82b844bbf713422c17d086eb03ec38016acd836908c6b1ceed6d0d4537939e",
+    "appstate/index.json": "sha256:c8c0166ba7a2a3e9ca8cd0b232cc4b7c6f38411a18114c69755f7fac02cdfb25",
+    "enums/index.json": "sha256:53ca154bd9c638ccdbeec58182b98a31dc2e24e15c8e6712d7be4330705d1628",
+    "iq/index.json": "sha256:c166fdcc55403e4faf9b284b68e74407a2423ea53eccb353af45308c8ea7bab0",
+    "manifest.json": "sha256:f3f1e45fe8f4d03727ff1a2b9eb91b3fea56a867a0d64e2e54b26802ac5b895d",
+    "mex/index.json": "sha256:e21de62c589ae594d4f7465e50e71260bb34b5e4d6ed7f2e01ad16cdcdfb0a82",
+    "notif/index.json": "sha256:ab1d53a025ba89b0abbe86dbeed5be5a3889f622fa0798580a2a22ac85f863f1",
     "proto/WAProto.proto": "sha256:f3da4ba028402ea225747dc40247a5d55473012da9c4ef0c4b9de5c443117e2f",
-    "srvreq/index.json": "sha256:d8eff4e11cdbb4d1f98daccde3bc90756ff0606853d2d547cde4d90742c0d544",
-    "stanza/index.json": "sha256:71bf4cf68551b9a70a9eca21e78ac33f02c13925a039769780f8da3bc6c016ab",
-    "tokens/index.json": "sha256:2c21ee752449f0d12d6ea3b10897597416013eb14e36e12bad815f266985c3c7",
-    "wam/index.json": "sha256:39e3ffcac131264d99b368a951a94c1fc3ff44091f837250d70fa445c2948736"
+    "srvreq/index.json": "sha256:6900750eb85603564213e06c79dae359a8ef21388dc8a17f14c82de45c0d128a",
+    "stanza/index.json": "sha256:c49afaa82604a52aa0a33f22aa204030886b30935667e5f838c058a0cdab3d41",
+    "tokens/index.json": "sha256:9b74e5fdef0fc980f907ecff1ccdbf5c5acd356f6ba5686acae31fa3f2172488",
+    "wam/index.json": "sha256:0358960b52ec49c94306588e81a0d012756d32c73acc3e1af632fc4e0f880913"
   }
 }

--- a/wacore/src/iq/mex.rs
+++ b/wacore/src/iq/mex.rs
@@ -15,6 +15,40 @@
 //!   <result>{"data":{...},"errors":[...]}</result>
 //! </iq>
 //! ```
+//!
+//! # Variables are all-or-nothing
+//!
+//! The server binds a persisted query's variables by name and answers a bare
+//! `400 Bad Request` when it cannot bind one, so a call site has to decide every
+//! variable the document declares. That is why a generated `Variables` is not
+//! `Default`, and it is the compiler that enforces it:
+//!
+//! ```compile_fail
+//! use wacore::iq::mex_operations::fetch_newsletter;
+//!
+//! // Names one variable and inherits six. `Variables` has no `Default`, so
+//! // this does not compile.
+//! let _ = fetch_newsletter::Variables {
+//!     fetch_full_image: Some(true),
+//!     ..Default::default()
+//! };
+//! ```
+//!
+//! Writing every field out compiles, and `VARIABLE_KEYS` is the same list for
+//! anything that has to check a payload it did not build from the type:
+//!
+//! ```
+//! use wacore::iq::mex_operations::fetch_all_newsletters_metadata as op;
+//!
+//! let variables = op::Variables {
+//!     fetch_status_metadata: Some(false),
+//!     fetch_wamo_sub: Some(false),
+//! };
+//! let payload = serde_json::to_value(&variables).expect("variables serialize");
+//! for key in op::VARIABLE_KEYS {
+//!     assert!(payload.get(key).is_some(), "{key} is missing");
+//! }
+//! ```
 
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;

--- a/wacore/src/iq/mex_operations.rs
+++ b/wacore/src/iq/mex_operations.rs
@@ -14,8 +14,16 @@ pub mod acs_server_provider_config {
     pub const NAME: &str = "WAWebACSServerProviderConfigQuery";
     pub const DOC_ID: &str = "25133761326299603";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["project_name"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub project_name: Option<String>,
@@ -53,6 +61,7 @@ pub mod acs_server_provider_issuance {
     pub const NAME: &str = "WAWebACSServerProviderIssuanceMutation";
     pub const DOC_ID: &str = "26039599689054760";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -66,7 +75,14 @@ pub mod acs_server_provider_issuance {
         pub request_proof: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -118,8 +134,16 @@ pub mod accept_newsletter_admin_invite {
     pub const NAME: &str = "WAWebMexAcceptNewsletterAdminInviteJobMutation";
     pub const DOC_ID: &str = "9580828702035549";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -148,8 +172,16 @@ pub mod ai_agent_auto_reply_control {
     pub const NAME: &str = "WAWebAiAgentAutoReplyControlMutation";
     pub const DOC_ID: &str = "27338647792432014";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["consumer_lid", "phone_number", "thread_status"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub consumer_lid: Option<String>,
@@ -181,8 +213,16 @@ pub mod auth_agent_feature_policy {
     pub const NAME: &str = "WAWebAuthAgentFeaturePolicyQuery";
     pub const DOC_ID: &str = "26467789126176720";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -205,8 +245,16 @@ pub mod bp_access_token_and_session_cookies {
     pub const NAME: &str = "WAWebBPAccessTokenAndSessionCookiesMutation";
     pub const DOC_ID: &str = "26756198580685447";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["application_id", "code"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub application_id: Option<String>,
@@ -244,6 +292,7 @@ pub mod biz_create_order {
     pub const NAME: &str = "WAWebBizCreateOrderJobMutation";
     pub const DOC_ID: &str = "26486627094287046";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Order {
@@ -259,7 +308,14 @@ pub mod biz_create_order {
         pub order: Option<Order>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -307,6 +363,7 @@ pub mod biz_custom_url_get_user_graphql {
     pub const NAME: &str = "WAWebBizCustomUrlGetUserGraphqlQuery";
     pub const DOC_ID: &str = "26867176859566677";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["data"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct CustomUrl {
@@ -320,7 +377,14 @@ pub mod biz_custom_url_get_user_graphql {
         pub custom_url: Option<CustomUrl>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub data: Option<Data>,
@@ -352,6 +416,7 @@ pub mod biz_get_categories {
     pub const NAME: &str = "WAWebBizGetCategoriesQuery";
     pub const DOC_ID: &str = "26266473919627648";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["query_params"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct QueryParams {
@@ -365,7 +430,14 @@ pub mod biz_get_categories {
         pub version: Option<i64>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub query_params: Option<QueryParams>,
@@ -409,6 +481,7 @@ pub mod biz_get_categories_v2 {
     pub const NAME: &str = "WAWebBizGetCategoriesV2Query";
     pub const DOC_ID: &str = "26869203922665622";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["query_params"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct QueryParams {
@@ -422,7 +495,14 @@ pub mod biz_get_categories_v2 {
         pub version: Option<i64>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub query_params: Option<QueryParams>,
@@ -486,6 +566,7 @@ pub mod biz_get_custom_url_user_graphql {
     pub const NAME: &str = "WAWebBizGetCustomUrlUserGraphqlQuery";
     pub const DOC_ID: &str = "WAWebBizGetCustomUrlUserGraphqlQuery";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["data"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct CustomUrl {
@@ -499,7 +580,14 @@ pub mod biz_get_custom_url_user_graphql {
         pub custom_url: Option<CustomUrl>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub data: Option<Data>,
@@ -537,8 +625,16 @@ pub mod biz_get_merchant_compliance {
     pub const NAME: &str = "WAWebBizGetMerchantComplianceQuery";
     pub const DOC_ID: &str = "25960403573553316";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<String>,
@@ -602,6 +698,7 @@ pub mod biz_get_price_tiers {
     pub const NAME: &str = "WAWebBizGetPriceTiersQuery";
     pub const DOC_ID: &str = "25362864436721857";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Request {
@@ -609,7 +706,14 @@ pub mod biz_get_price_tiers {
         pub locale: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -645,8 +749,16 @@ pub mod biz_get_profile_shimlinks {
     pub const NAME: &str = "WAWebBizGetProfileShimlinksQuery";
     pub const DOC_ID: &str = "24491258413796282";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["bizJid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "bizJid")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -675,8 +787,16 @@ pub mod biz_graph_ql_refresh_cart {
     pub const NAME: &str = "WAWebBizGraphQLRefreshCartJobQuery";
     pub const DOC_ID: &str = "WAWebBizGraphQLRefreshCartJobQuery";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<String>,
@@ -932,6 +1052,7 @@ pub mod biz_profile_address_autocomplete {
     pub const NAME: &str = "WAWebBizProfileAddressAutocompleteQuery";
     pub const DOC_ID: &str = "34963438739971331";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -943,7 +1064,14 @@ pub mod biz_profile_address_autocomplete {
         pub use_case_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -1003,6 +1131,7 @@ pub mod biz_query_order {
     pub const NAME: &str = "WAWebBizQueryOrderJobQuery";
     pub const DOC_ID: &str = "26593811266898374";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct ImageDimensions {
@@ -1038,7 +1167,14 @@ pub mod biz_query_order {
         pub order: Option<Order>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -1130,8 +1266,16 @@ pub mod biz_set_merchant_compliance {
     pub const NAME: &str = "WAWebBizSetMerchantComplianceMutation";
     pub const DOC_ID: &str = "25188352884120072";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -1199,6 +1343,7 @@ pub mod cached_token {
     pub const NAME: &str = "WAWebMexCachedTokenJobMutation";
     pub const DOC_ID: &str = "27013462064904056";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -1208,7 +1353,14 @@ pub mod cached_token {
         pub request_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -1249,8 +1401,16 @@ pub mod canonical_user_valid {
     pub const NAME: &str = "WAWebCanonicalUserValidQuery";
     pub const DOC_ID: &str = "25995999653397511";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1273,8 +1433,16 @@ pub mod change_newsletter_owner {
     pub const NAME: &str = "WAWebMexChangeNewsletterOwnerJobMutation";
     pub const DOC_ID: &str = "9546742745432473";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id", "user_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -1305,6 +1473,7 @@ pub mod consumer_fetch_quick_promotions {
     pub const NAME: &str = "WAWebConsumerFetchQuickPromotionsQuery";
     pub const DOC_ID: &str = "35462584533386409";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["nux_ids", "trigger_context"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct WaSmbTriggerContext {
@@ -1324,7 +1493,14 @@ pub mod consumer_fetch_quick_promotions {
         pub wa_smb_trigger_context: Option<WaSmbTriggerContext>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub nux_ids: Option<Vec<String>>,
@@ -1598,8 +1774,16 @@ pub mod consumer_quick_promotion_action_graph_ql {
     pub const NAME: &str = "WAWebConsumerQuickPromotionActionGraphQLMutation";
     pub const DOC_ID: &str = "25690382143972563";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -1625,8 +1809,16 @@ pub mod contact_manager_customer_profile {
     pub const NAME: &str = "WAWebContactManagerCustomerProfileQuery";
     pub const DOC_ID: &str = "37925750573706165";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["lid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub lid: Option<String>,
@@ -1674,8 +1866,16 @@ pub mod contact_manager_customer_profile_upsert {
     pub const NAME: &str = "WAWebContactManagerCustomerProfileUpsertMutation";
     pub const DOC_ID: &str = "27789071790751197";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Vec<String>>,
@@ -1707,6 +1907,7 @@ pub mod contact_manager_customer_profiles {
     pub const NAME: &str = "WAWebContactManagerCustomerProfilesQuery";
     pub const DOC_ID: &str = "27747880408206174";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -1722,7 +1923,14 @@ pub mod contact_manager_customer_profiles {
         pub sort_descending: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -1772,6 +1980,7 @@ pub mod create_invite_code {
     pub const NAME: &str = "WAWebMexCreateInviteCodeJobMutation";
     pub const DOC_ID: &str = "26155584267463745";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -1783,7 +1992,14 @@ pub mod create_invite_code {
         pub server_send_sms: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -1809,8 +2025,16 @@ pub mod create_labyrinth_backup {
     pub const NAME: &str = "WAWebCreateLabyrinthBackupJobMutation";
     pub const DOC_ID: &str = "27515507191403198";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -1851,8 +2075,16 @@ pub mod create_marketing_campaign_action {
     pub const NAME: &str = "WAWebCreateMarketingCampaignActionMutation";
     pub const DOC_ID: &str = "26304826652483067";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -1894,6 +2126,7 @@ pub mod create_newsletter {
     pub const NAME: &str = "WAWebMexCreateNewsletterJobMutation";
     pub const DOC_ID: &str = "25149874324715067";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -1905,7 +2138,14 @@ pub mod create_newsletter {
         pub picture: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -2021,8 +2261,16 @@ pub mod create_newsletter_admin_invite {
     pub const NAME: &str = "WAWebMexCreateNewsletterAdminInviteJobMutation";
     pub const DOC_ID: &str = "9387141988078609";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id", "user_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -2052,8 +2300,16 @@ pub mod create_report_appeal {
     pub const NAME: &str = "WAWebMexCreateReportAppealJobMutation";
     pub const DOC_ID: &str = "27103316329328467";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["reason", "report_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
@@ -2145,6 +2401,7 @@ pub mod create_whats_app_ads_identity {
     pub const NAME: &str = "WAWebCreateWhatsAppAdsIdentityMutation";
     pub const DOC_ID: &str = "24393949203623093";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["code", "phone_number"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Code {
@@ -2158,7 +2415,14 @@ pub mod create_whats_app_ads_identity {
         pub sensitive_string_value: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub code: Option<Code>,
@@ -2186,8 +2450,16 @@ pub mod custom_label3pd_event {
     pub const NAME: &str = "WAWebCustomLabel3pdEventQuery";
     pub const DOC_ID: &str = "24247439618185103";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["custom_labels", "expt_group"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub custom_labels: Option<String>,
@@ -2221,6 +2493,7 @@ pub mod debug_labyrinth_inbox_snapshot {
     pub const NAME: &str = "WAWebDebugLabyrinthInboxSnapshotQuery";
     pub const DOC_ID: &str = "26544537655223129";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["params"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Params {
@@ -2234,7 +2507,14 @@ pub mod debug_labyrinth_inbox_snapshot {
         pub upper_timestamp: Option<i64>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub params: Option<Params>,
@@ -2301,8 +2581,16 @@ pub mod debug_labyrinth_range {
     pub const NAME: &str = "WAWebDebugLabyrinthRangeQuery";
     pub const DOC_ID: &str = "27219778391054922";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["device_id", "message_count", "partial_thread_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub device_id: Option<String>,
@@ -2381,8 +2669,16 @@ pub mod delete_newsletter {
     pub const NAME: &str = "WAWebMexDeleteNewsletterJobMutation";
     pub const DOC_ID: &str = "30062808666639665";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -2416,8 +2712,16 @@ pub mod demote_newsletter_admin {
     pub const NAME: &str = "WAWebMexDemoteNewsletterAdminJobMutation";
     pub const DOC_ID: &str = "9880997548630971";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id", "user_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -2448,8 +2752,16 @@ pub mod eb_message_metadata_query {
     pub const NAME: &str = "EBMessageMetadataQueryQuery";
     pub const DOC_ID: &str = "28525853583670706";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["data"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub data: Option<String>,
@@ -2503,8 +2815,16 @@ pub mod edit_biz_profile {
     pub const NAME: &str = "WAWebEditBizProfileMutation";
     pub const DOC_ID: &str = "26652989367627867";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input", "lid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -2526,8 +2846,16 @@ pub mod external_ctx_authorise_wa_chat {
     pub const NAME: &str = "WAWebExternalCtxAuthoriseWAChatMutation";
     pub const DOC_ID: &str = "9790465291023292";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -2555,6 +2883,7 @@ pub mod fetch_about_status {
     pub const NAME: &str = "WAWebMexFetchAboutStatusJobQuery";
     pub const DOC_ID: &str = "24535500086059408";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["user"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct User {
@@ -2562,7 +2891,14 @@ pub mod fetch_about_status {
         pub user_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub user: Option<User>,
@@ -2597,8 +2933,16 @@ pub mod fetch_all_newsletters_metadata {
     pub const NAME: &str = "WAWebMexFetchAllNewslettersMetadataJobQuery";
     pub const DOC_ID: &str = "25399611239711790";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "fetch_wamo_sub"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -2748,8 +3092,16 @@ pub mod fetch_all_subgroups {
     pub const NAME: &str = "WAWebMexFetchAllSubgroupsJobQuery";
     pub const DOC_ID: &str = "9935467776504344";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["group_id", "query_context", "sub_group_hint_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub group_id: Option<String>,
@@ -2842,8 +3194,16 @@ pub mod fetch_bot_certificate_revocation_list {
     pub const NAME: &str = "WAWebMexFetchBotCertificateRevocationListQuery";
     pub const DOC_ID: &str = "35807917542188393";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["crl_name"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub crl_name: Option<String>,
@@ -2871,8 +3231,16 @@ pub mod fetch_bot_profiles_gql {
     pub const NAME: &str = "WAWebFetchBotProfilesGQLQuery";
     pub const DOC_ID: &str = "26368585139502858";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["ids"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ids: Option<String>,
@@ -2934,8 +3302,16 @@ pub mod fetch_dynamic_ai_modes {
     pub const NAME: &str = "WAWebFetchDynamicAIModesQuery";
     pub const DOC_ID: &str = "25335662402775799";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -2966,8 +3342,21 @@ pub mod fetch_group_info {
     pub const NAME: &str = "WAWebMexFetchGroupInfoJobQuery";
     pub const DOC_ID: &str = "27508847222068472";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[
+        "id",
+        "include_username",
+        "participants_phash",
+        "query_context",
+    ];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub id: Option<String>,
@@ -3169,8 +3558,21 @@ pub mod fetch_group_info_includ_bots {
     pub const NAME: &str = "WAWebMexFetchGroupInfoIncludBotsJobQuery";
     pub const DOC_ID: &str = "27795062750123057";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[
+        "id",
+        "include_username",
+        "participants_phash",
+        "query_context",
+    ];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub id: Option<String>,
@@ -3377,8 +3779,16 @@ pub mod fetch_group_invite_code {
     pub const NAME: &str = "WAWebMexFetchGroupInviteCodeJobQuery";
     pub const DOC_ID: &str = "29247029834912157";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["id", "query_context"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub id: Option<String>,
@@ -3411,8 +3821,16 @@ pub mod fetch_group_is_internal {
     pub const NAME: &str = "WAWebMexFetchGroupIsInternalJobQuery";
     pub const DOC_ID: &str = "34119218944390847";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub id: Option<String>,
@@ -3449,6 +3867,7 @@ pub mod fetch_integrity_signals {
     pub const NAME: &str = "WAWebMexFetchIntegritySignalsQuery";
     pub const DOC_ID: &str = "26438847999065394";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct IntegritySignals {
@@ -3478,7 +3897,14 @@ pub mod fetch_integrity_signals {
         pub telemetry: Option<Telemetry>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -3520,6 +3946,7 @@ pub mod fetch_new_chat_message_capping_info {
     pub const NAME: &str = "WAWebMexFetchNewChatMessageCappingInfoJobQuery";
     pub const DOC_ID: &str = "27910975521856601";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -3527,7 +3954,14 @@ pub mod fetch_new_chat_message_capping_info {
         pub r#type: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -3577,6 +4011,15 @@ pub mod fetch_newsletter {
     pub const NAME: &str = "WAWebMexFetchNewsletterJobQuery";
     pub const DOC_ID: &str = "27456920720571478";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[
+        "fetch_creation_time",
+        "fetch_full_image",
+        "fetch_pinned_messages",
+        "fetch_status_metadata",
+        "fetch_viewer_metadata",
+        "fetch_wamo_sub",
+        "input",
+    ];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -3588,7 +4031,14 @@ pub mod fetch_newsletter {
         pub view_role: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_creation_time: Option<bool>,
@@ -3760,8 +4210,16 @@ pub mod fetch_newsletter_admin_capabilities {
     pub const NAME: &str = "WAWebMexFetchNewsletterAdminCapabilitiesJobQuery";
     pub const DOC_ID: &str = "9801384413216421";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -3789,8 +4247,16 @@ pub mod fetch_newsletter_admin_info {
     pub const NAME: &str = "WAWebMexFetchNewsletterAdminInfoJobQuery";
     pub const DOC_ID: &str = "26278439461859188";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -3846,6 +4312,7 @@ pub mod fetch_newsletter_dehydrated {
     pub const NAME: &str = "WAWebMexFetchNewsletterDehydratedJobQuery";
     pub const DOC_ID: &str = "26944199458535748";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_pinned_messages", "fetch_wamo_sub", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -3857,7 +4324,14 @@ pub mod fetch_newsletter_dehydrated {
         pub view_role: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_pinned_messages: Option<bool>,
@@ -3937,6 +4411,7 @@ pub mod fetch_newsletter_directory_categories_preview {
     pub const NAME: &str = "WAWebMexFetchNewsletterDirectoryCategoriesPreviewJobQuery";
     pub const DOC_ID: &str = "35266481849605779";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -3948,7 +4423,14 @@ pub mod fetch_newsletter_directory_categories_preview {
         pub per_category_limit: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -4055,6 +4537,7 @@ pub mod fetch_newsletter_directory_list {
     pub const NAME: &str = "WAWebMexFetchNewsletterDirectoryListJobQuery";
     pub const DOC_ID: &str = "26125047313831973";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Filters {
@@ -4076,7 +4559,14 @@ pub mod fetch_newsletter_directory_list {
         pub view: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -4190,6 +4680,7 @@ pub mod fetch_newsletter_directory_search_results {
     pub const NAME: &str = "WAWebMexFetchNewsletterDirectorySearchResultsJobQuery";
     pub const DOC_ID: &str = "26301059626252132";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -4203,7 +4694,14 @@ pub mod fetch_newsletter_directory_search_results {
         pub start_cursor: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -4317,8 +4815,16 @@ pub mod fetch_newsletter_enforcements {
     pub const NAME: &str = "WAWebMexFetchNewsletterEnforcementsJobQuery";
     pub const DOC_ID: &str = "27835373536068060";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["locale", "newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub locale: Option<String>,
@@ -4611,6 +5117,7 @@ pub mod fetch_newsletter_followers {
     pub const NAME: &str = "WAWebMexFetchNewsletterFollowersJobQuery";
     pub const DOC_ID: &str = "27472091235714801";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -4620,7 +5127,14 @@ pub mod fetch_newsletter_followers {
         pub newsletter_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -4703,6 +5217,7 @@ pub mod fetch_newsletter_insights {
     pub const NAME: &str = "WAWebMexFetchNewsletterInsightsJobQuery";
     pub const DOC_ID: &str = "9853618868050977";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -4712,7 +5227,14 @@ pub mod fetch_newsletter_insights {
         pub newsletter_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -4772,8 +5294,16 @@ pub mod fetch_newsletter_is_domain_previewable {
     pub const NAME: &str = "WAWebMexFetchNewsletterIsDomainPreviewableJobQuery";
     pub const DOC_ID: &str = "9849510985088294";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["url_domains"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub url_domains: Option<String>,
@@ -4807,6 +5337,7 @@ pub mod fetch_newsletter_message_reaction_sender_list {
     pub const NAME: &str = "WAWebMexFetchNewsletterMessageReactionSenderListJobQuery";
     pub const DOC_ID: &str = "29575462448733991";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -4816,7 +5347,14 @@ pub mod fetch_newsletter_message_reaction_sender_list {
         pub server_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -4870,8 +5408,16 @@ pub mod fetch_newsletter_pending_invites {
     pub const NAME: &str = "WAWebMexFetchNewsletterPendingInvitesJobQuery";
     pub const DOC_ID: &str = "9783111038412085";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -4913,6 +5459,7 @@ pub mod fetch_newsletter_poll_voters {
     pub const NAME: &str = "WAWebMexFetchNewsletterPollVotersJobQuery";
     pub const DOC_ID: &str = "9407762219322536";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -4926,7 +5473,14 @@ pub mod fetch_newsletter_poll_voters {
         pub vote_hash: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -4980,8 +5534,16 @@ pub mod fetch_newsletter_reports {
     pub const NAME: &str = "WAWebMexFetchNewsletterReportsJobQuery";
     pub const DOC_ID: &str = "35936238352686172";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["locale"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub locale: Option<String>,
@@ -5077,8 +5639,16 @@ pub mod fetch_ohai_key_config {
     pub const NAME: &str = "WAWebFetchOHAIKeyConfigJobQuery";
     pub const DOC_ID: &str = "29366514836329275";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -5119,8 +5689,16 @@ pub mod fetch_oidc_state {
     pub const NAME: &str = "WAWebFetchOIDCStateQuery";
     pub const DOC_ID: &str = "24622479247368194";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -5137,6 +5715,7 @@ pub mod fetch_plaintext_link_preview {
     pub const NAME: &str = "WAWebMexFetchPlaintextLinkPreviewJobQuery";
     pub const DOC_ID: &str = "9101130456653613";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -5144,7 +5723,14 @@ pub mod fetch_plaintext_link_preview {
         pub url: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -5184,6 +5770,7 @@ pub mod fetch_quick_promotions {
     pub const NAME: &str = "WAWebFetchQuickPromotionsQuery";
     pub const DOC_ID: &str = "27262639366727460";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["nux_ids", "trigger_context"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct WaSmbTriggerContext {
@@ -5203,7 +5790,14 @@ pub mod fetch_quick_promotions {
         pub wa_smb_trigger_context: Option<WaSmbTriggerContext>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub nux_ids: Option<Vec<String>>,
@@ -5469,8 +6063,16 @@ pub mod fetch_reachout_timelock {
     pub const NAME: &str = "WAWebMexFetchReachoutTimelockJobQuery";
     pub const DOC_ID: &str = "23983697327930364";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -5497,6 +6099,7 @@ pub mod fetch_recommended_newsletters {
     pub const NAME: &str = "WAWebMexFetchRecommendedNewslettersJobQuery";
     pub const DOC_ID: &str = "25806748772361516";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -5506,7 +6109,14 @@ pub mod fetch_recommended_newsletters {
         pub limit: Option<i64>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -5628,6 +6238,7 @@ pub mod fetch_similar_newsletters {
     pub const NAME: &str = "WAWebMexFetchSimilarNewslettersJobQuery";
     pub const DOC_ID: &str = "26217043484590756";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["fetch_status_metadata", "input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -5639,7 +6250,14 @@ pub mod fetch_similar_newsletters {
         pub newsletter_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fetch_status_metadata: Option<bool>,
@@ -5721,8 +6339,16 @@ pub mod fetch_subgroup_suggestions {
     pub const NAME: &str = "WAWebMexFetchSubgroupSuggestionsJobQuery";
     pub const DOC_ID: &str = "23972005349071865";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["group_id", "query_context", "sub_group_hint_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub group_id: Option<String>,
@@ -5809,8 +6435,16 @@ pub mod fetch_subscription_entry_points {
     pub const NAME: &str = "WAWebFetchSubscriptionEntryPointsQuery";
     pub const DOC_ID: &str = "9569660009784796";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -5848,6 +6482,7 @@ pub mod fetch_subscriptions {
     pub const NAME: &str = "WAWebFetchSubscriptionsQuery";
     pub const DOC_ID: &str = "35324254123840149";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["data"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Data {
@@ -5855,7 +6490,14 @@ pub mod fetch_subscriptions {
         pub platform: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub data: Option<Data>,
@@ -5915,8 +6557,16 @@ pub mod fetch_text_status_list {
     pub const NAME: &str = "WAWebMexFetchTextStatusListJobQuery";
     pub const DOC_ID: &str = "24072923595647473";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -5956,8 +6606,16 @@ pub mod fetch_wass_bot_list_profiles_gql {
     pub const NAME: &str = "WAWebFetchWassBotListProfilesGQLQuery";
     pub const DOC_ID: &str = "28479090065021614";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -5990,8 +6648,16 @@ pub mod fetch_wass_bot_profile_gql {
     pub const NAME: &str = "WAWebFetchWassBotProfileGQLQuery";
     pub const DOC_ID: &str = "27911751148486446";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["botFbid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "botFbid")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6026,8 +6692,16 @@ pub mod get_access_token_from_oidc_code {
     pub const NAME: &str = "WAWebGetAccessTokenFromOIDCCodeMutation";
     pub const DOC_ID: &str = "25278212845117908";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["code", "state"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub code: Option<String>,
@@ -6057,6 +6731,7 @@ pub mod get_account_nonce {
     pub const NAME: &str = "WAWebGetAccountNonceMutation";
     pub const DOC_ID: &str = "25091178200467555";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Identifier {
@@ -6070,7 +6745,14 @@ pub mod get_account_nonce {
         pub identifier: Option<Identifier>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6110,8 +6792,16 @@ pub mod get_fb_account_pages {
     pub const NAME: &str = "WAWebGetFBAccountPagesQuery";
     pub const DOC_ID: &str = "24564518546541529";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["userId"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "userId")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6164,6 +6854,7 @@ pub mod get_numbers_for_brand_ids {
     pub const NAME: &str = "WAWebGetNumbersForBrandIdsJobQuery";
     pub const DOC_ID: &str = "33391034967211217";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -6173,7 +6864,14 @@ pub mod get_numbers_for_brand_ids {
         pub lid_based_response: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6211,6 +6909,7 @@ pub mod get_privacy_lists {
     pub const NAME: &str = "WAWebMexGetPrivacyListsQuery";
     pub const DOC_ID: &str = "26806428515612550";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct PrivacyContactListType {
@@ -6236,7 +6935,14 @@ pub mod get_privacy_lists {
         pub query_input: Option<Vec<QueryInput>>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6294,6 +7000,7 @@ pub mod get_privacy_settings {
     pub const NAME: &str = "WAWebMexGetPrivacySettingsQuery";
     pub const DOC_ID: &str = "25637004609323493";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct QueryInput {
@@ -6309,7 +7016,14 @@ pub mod get_privacy_settings {
         pub query_input: Option<Vec<QueryInput>>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6354,8 +7068,16 @@ pub mod get_username {
     pub const NAME: &str = "WAWebMexGetUsernameJobQuery";
     pub const DOC_ID: &str = "25347099718279209";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -6388,6 +7110,7 @@ pub mod get_waa_eligibility {
     pub const NAME: &str = "WAWebGetWAAEligibilityQuery";
     pub const DOC_ID: &str = "24346676171620002";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -6397,7 +7120,14 @@ pub mod get_waa_eligibility {
         pub request_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6423,6 +7153,7 @@ pub mod graph_ql_product_catalog_get_public_key {
     pub const NAME: &str = "WAWebGraphQLProductCatalogGetPublicKeyJobQuery";
     pub const DOC_ID: &str = "WAWebGraphQLProductCatalogGetPublicKeyJobQuery";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct PublicKey {
@@ -6436,7 +7167,14 @@ pub mod graph_ql_product_catalog_get_public_key {
         pub public_key: Option<PublicKey>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -6472,6 +7210,7 @@ pub mod graph_ql_verify_postcode {
     pub const NAME: &str = "WAWebGraphQLVerifyPostcodeJobQuery";
     pub const DOC_ID: &str = "WAWebGraphQLVerifyPostcodeJobQuery";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct VerifyPostcode {
@@ -6487,7 +7226,14 @@ pub mod graph_ql_verify_postcode {
         pub verify_postcode: Option<VerifyPostcode>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -6521,6 +7267,7 @@ pub mod group_store_invite_sms {
     pub const NAME: &str = "WAWebMexGroupStoreInviteSmsJobMutation";
     pub const DOC_ID: &str = "26810859745268181";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -6530,7 +7277,14 @@ pub mod group_store_invite_sms {
         pub partcipants: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6564,6 +7318,7 @@ pub mod group_suspension_appeal {
     pub const NAME: &str = "WAWebGroupSuspensionAppealMutation";
     pub const DOC_ID: &str = "25946115325088226";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -6575,7 +7330,14 @@ pub mod group_suspension_appeal {
         pub group_jid: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6605,6 +7367,7 @@ pub mod integrity_challenge_response {
     pub const NAME: &str = "WAWebMexIntegrityChallengeResponseMutation";
     pub const DOC_ID: &str = "26230331493320650";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct PasskeyResponse {
@@ -6622,7 +7385,14 @@ pub mod integrity_challenge_response {
         pub passkey_response: Option<PasskeyResponse>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6650,8 +7420,16 @@ pub mod join_newsletter {
     pub const NAME: &str = "WAWebMexJoinNewsletterJobMutation";
     pub const DOC_ID: &str = "24404358912487870";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -6685,8 +7463,16 @@ pub mod leave_newsletter {
     pub const NAME: &str = "WAWebMexLeaveNewsletterJobMutation";
     pub const DOC_ID: &str = "9767147403369991";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -6720,8 +7506,16 @@ pub mod lid_change_notification {
     pub const NAME: &str = "WAWebMexLidChangeNotificationQuery";
     pub const DOC_ID: &str = "9892367127524985";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -6746,6 +7540,7 @@ pub mod log_newsletter_exposures {
     pub const NAME: &str = "WAWebMexLogNewsletterExposuresJobMutation";
     pub const DOC_ID: &str = "25260800823586918";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Exposures {
@@ -6761,7 +7556,14 @@ pub mod log_newsletter_exposures {
         pub exposures: Option<Vec<Exposures>>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6788,8 +7590,16 @@ pub mod native_ml_model {
     pub const NAME: &str = "WAWebNativeMLModelQuery";
     pub const DOC_ID: &str = "32743078615336512";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["client_capability_metadata", "model_request_metadatas"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub client_capability_metadata: Option<String>,
@@ -6873,8 +7683,16 @@ pub mod newsletter_add_paid_partnership_label {
     pub const NAME: &str = "WAWebMexNewsletterAddPaidPartnershipLabelJobMutation";
     pub const DOC_ID: &str = "26102375079404865";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["message_type", "newsletter_id", "server_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub message_type: Option<String>,
@@ -6904,8 +7722,16 @@ pub mod newsletter_label_ai_content {
     pub const NAME: &str = "WAWebMexNewsletterLabelAiContentJobMutation";
     pub const DOC_ID: &str = "27909718265289596";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["message_type", "newsletter_id", "server_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub message_type: Option<String>,
@@ -6935,6 +7761,7 @@ pub mod newsletter_pin_messages {
     pub const NAME: &str = "WAWebMexNewsletterPinMessagesJobMutation";
     pub const DOC_ID: &str = "27165709459706559";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input", "newsletter_id"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -6942,7 +7769,14 @@ pub mod newsletter_pin_messages {
         pub message_ids: Option<Vec<String>>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -6986,8 +7820,17 @@ pub mod newsletter_question_response_state_update {
     pub const NAME: &str = "WAWebMexNewsletterQuestionResponseStateUpdateJobMutation";
     pub const DOC_ID: &str = "24636260219323456";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] =
+        &["newsletter_id", "response_server_id", "server_id", "state"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -7020,6 +7863,7 @@ pub mod newsletter_unpin_messages {
     pub const NAME: &str = "WAWebMexNewsletterUnpinMessagesJobMutation";
     pub const DOC_ID: &str = "28007176042216937";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input", "newsletter_id"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -7027,7 +7871,14 @@ pub mod newsletter_unpin_messages {
         pub message_ids: Option<Vec<String>>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -7071,8 +7922,16 @@ pub mod payments_passkey_has_credential {
     pub const NAME: &str = "WAWebMexPaymentsPasskeyHasCredentialJobQuery";
     pub const DOC_ID: &str = "36878915648418618";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -7095,6 +7954,7 @@ pub mod query_catalog {
     pub const NAME: &str = "WAWebQueryCatalogQuery";
     pub const DOC_ID: &str = "30445081048424116";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct ProductCatalog {
@@ -7128,7 +7988,14 @@ pub mod query_catalog {
         pub product_catalog: Option<ProductCatalog>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -7377,6 +8244,7 @@ pub mod query_catalog_has_categories {
     pub const NAME: &str = "WAWebQueryCatalogHasCategoriesQuery";
     pub const DOC_ID: &str = "9746549555457302";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Categories {
@@ -7396,7 +8264,14 @@ pub mod query_catalog_has_categories {
         pub categories: Option<Categories>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -7429,6 +8304,7 @@ pub mod query_catalog_product {
     pub const NAME: &str = "WAWebQueryCatalogProductQuery";
     pub const DOC_ID: &str = "9660926520672123";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Product {
@@ -7458,7 +8334,14 @@ pub mod query_catalog_product {
         pub product: Option<Product>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -7694,6 +8577,7 @@ pub mod query_product_collections {
     pub const NAME: &str = "WAWebQueryProductCollectionsQuery";
     pub const DOC_ID: &str = "9430970660362540";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Collections {
@@ -7725,7 +8609,14 @@ pub mod query_product_collections {
         pub collections: Option<Collections>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -7990,6 +8881,7 @@ pub mod query_product_list_catalog {
     pub const NAME: &str = "WAWebQueryProductListCatalogJobQuery";
     pub const DOC_ID: &str = "30125049463760630";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Products {
@@ -8017,7 +8909,14 @@ pub mod query_product_list_catalog {
         pub product_list: Option<ProductList>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -8256,6 +9155,7 @@ pub mod query_product_single_collection {
     pub const NAME: &str = "WAWebQueryProductSingleCollectionQuery";
     pub const DOC_ID: &str = "9546992575408789";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["request"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Collection {
@@ -8287,7 +9187,14 @@ pub mod query_product_single_collection {
         pub collection: Option<Collection>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub request: Option<Request>,
@@ -8549,6 +9456,7 @@ pub mod query_subgroup_participant_count {
     pub const NAME: &str = "WAWebMexQuerySubgroupParticipantCountJobQuery";
     pub const DOC_ID: &str = "24079399904996141";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -8560,7 +9468,14 @@ pub mod query_subgroup_participant_count {
         pub sub_group_jid_hint: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -8611,8 +9526,16 @@ pub mod quick_promotion_action {
     pub const NAME: &str = "WAWebQuickPromotionActionMutation";
     pub const DOC_ID: &str = "9741612265875562";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -8638,6 +9561,7 @@ pub mod report_product {
     pub const NAME: &str = "WAWebReportProductJobMutation";
     pub const DOC_ID: &str = "27419506181072609";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -8647,7 +9571,14 @@ pub mod report_product {
         pub product_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -8676,6 +9607,7 @@ pub mod request_client_logs_for_bug {
     pub const NAME: &str = "WAWebMexRequestClientLogsForBugJobMutation";
     pub const DOC_ID: &str = "27135500612803533";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -8689,7 +9621,14 @@ pub mod request_client_logs_for_bug {
         pub up_to_timestamp_secs: Option<i64>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -8709,13 +9648,17 @@ pub mod resolve_account_type_and_ad_page {
     pub const NAME: &str = "WAWebResolveAccountTypeAndAdPageMutation";
     pub const DOC_ID: &str = "24732033759799062";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-    pub struct Variables {
-        #[serde(rename = "pageId")]
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub page_id: Option<String>,
-    }
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Response {
@@ -8731,8 +9674,16 @@ pub mod resolve_account_type_and_ad_page_query {
     pub const NAME: &str = "WAWebResolveAccountTypeAndAdPageQuery";
     pub const DOC_ID: &str = "24856134350695832";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["pageId"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "pageId")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8761,8 +9712,16 @@ pub mod revoke_newsletter_admin_invite {
     pub const NAME: &str = "WAWebMexRevokeNewsletterAdminInviteJobMutation";
     pub const DOC_ID: &str = "9656078347839416";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id", "user_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -8793,8 +9752,16 @@ pub mod rotate_labyrinth_epoch {
     pub const NAME: &str = "WAWebRotateLabyrinthEpochJobMutation";
     pub const DOC_ID: &str = "27545094465170765";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -8827,8 +9794,16 @@ pub mod set_username {
     pub const NAME: &str = "WAWebMexSetUsernameJobMutation";
     pub const DOC_ID: &str = "25757341163897635";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input", "reserved", "session_id", "source"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -8860,8 +9835,16 @@ pub mod set_username_key {
     pub const NAME: &str = "WAWebMexSetUsernameKeyJobMutation";
     pub const DOC_ID: &str = "9749436995157074";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["pin"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub pin: Option<String>,
@@ -8887,8 +9870,16 @@ pub mod signup_metadata {
     pub const NAME: &str = "WAWebSignupMetadataQuery";
     pub const DOC_ID: &str = "26378108788468347";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["phone_number", "signup_id"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub phone_number: Option<i64>,
@@ -8920,8 +9911,16 @@ pub mod support_bug_report_submit {
     pub const NAME: &str = "WAWebSupportBugReportSubmitMutation";
     pub const DOC_ID: &str = "25952242091096312";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -8955,8 +9954,16 @@ pub mod support_contact_form_submit {
     pub const NAME: &str = "WAWebSupportContactFormSubmitMutation";
     pub const DOC_ID: &str = "26494666453460666";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -8990,8 +9997,16 @@ pub mod support_message_feedback_submit {
     pub const NAME: &str = "WAWebSupportMessageFeedbackSubmitMutation";
     pub const DOC_ID: &str = "25772720305756789";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9021,8 +10036,16 @@ pub mod team_link_create_invitation {
     pub const NAME: &str = "WAWebTeamLinkCreateInvitationMutation";
     pub const DOC_ID: &str = "27693700016951648";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["employeeName", "lid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "employeeName")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9060,8 +10083,16 @@ pub mod team_link_list_invitations {
     pub const NAME: &str = "WAWebTeamLinkListInvitationsQuery";
     pub const DOC_ID: &str = "27966540672965115";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -9093,8 +10124,16 @@ pub mod team_link_remove_invitation {
     pub const NAME: &str = "WAWebTeamLinkRemoveInvitationMutation";
     pub const DOC_ID: &str = "27015637738109068";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["lid"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub lid: Option<String>,
@@ -9123,8 +10162,16 @@ pub mod transfer_community_ownership {
     pub const NAME: &str = "WAWebMexTransferCommunityOwnershipJobMutation";
     pub const DOC_ID: &str = "29643783178598899";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9158,8 +10205,16 @@ pub mod update_group_property {
     pub const NAME: &str = "WAWebMexUpdateGroupPropertyJobMutation";
     pub const DOC_ID: &str = "9418211574894172";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["group_id", "update"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub group_id: Option<String>,
@@ -9189,6 +10244,7 @@ pub mod update_newsletter {
     pub const NAME: &str = "WAWebMexUpdateNewsletterJobMutation";
     pub const DOC_ID: &str = "24250201037901610";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["newsletter_id", "updates"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Updates {
@@ -9202,7 +10258,14 @@ pub mod update_newsletter {
         pub settings: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub newsletter_id: Option<String>,
@@ -9314,8 +10377,16 @@ pub mod update_newsletter_user_setting {
     pub const NAME: &str = "WAWebMexUpdateNewsletterUserSettingJobMutation";
     pub const DOC_ID: &str = "31938993655691868";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9349,8 +10420,16 @@ pub mod update_text_status {
     pub const NAME: &str = "WAWebMexUpdateTextStatusJobMutation";
     pub const DOC_ID: &str = "9152604461510864";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9376,8 +10455,16 @@ pub mod upload_labyrinth_messages {
     pub const NAME: &str = "WAWebUploadLabyrinthMessagesJobMutation";
     pub const DOC_ID: &str = "28023438937253549";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9420,8 +10507,16 @@ pub mod username_availability {
     pub const NAME: &str = "WAWebMexUsernameAvailabilityQuery";
     pub const DOC_ID: &str = "26122779627399568";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &["input", "session_id", "source"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9453,6 +10548,12 @@ pub mod usync {
     pub const NAME: &str = "WAWebMexUsyncQuery";
     pub const DOC_ID: &str = "29829202653362039";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[
+        "include_about_status",
+        "include_country_code",
+        "include_username",
+        "input",
+    ];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -9462,7 +10563,14 @@ pub mod usync {
         pub telemetry: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub include_about_status: Option<bool>,
@@ -9535,6 +10643,7 @@ pub mod waa_onboarding {
     pub const NAME: &str = "WAWebWAAOnboardingMutation";
     pub const DOC_ID: &str = "25173295938976172";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
     pub struct Input {
@@ -9544,7 +10653,14 @@ pub mod waa_onboarding {
         pub request_id: Option<String>,
     }
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<Input>,
@@ -9572,8 +10688,16 @@ pub mod waffle_fx_service_data_query_v2 {
     pub const NAME: &str = "WAWebWaffleFXServiceDataQueryV2Mutation";
     pub const DOC_ID: &str = "9475021792620702";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -9646,8 +10770,16 @@ pub mod waffle_fxwamo_update_uoom {
     pub const NAME: &str = "WAWebWaffleFXWAMOUpdateUOOMMutation";
     pub const DOC_ID: &str = "10031635203620145";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &[];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {}
 
     #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -9664,8 +10796,16 @@ pub mod waffle_xe {
     pub const NAME: &str = "WAWebWaffleXEQuery";
     pub const DOC_ID: &str = "32172601809054525";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,
@@ -9737,8 +10877,16 @@ pub mod use_passkey_upsell_eligibility_check {
     pub const NAME: &str = "usePasskeyUpsellEligibilityCheckMutation";
     pub const DOC_ID: &str = "24998666569801021";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["encryptedContext"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "encryptedContext")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9759,8 +10907,26 @@ pub mod use_wa_web_estimated_daily_reach {
     pub const NAME: &str = "useWAWebEstimatedDailyReachQuery";
     pub const DOC_ID: &str = "26555147174103537";
     pub const OPERATION_KIND: &str = "query";
+    pub const VARIABLE_KEYS: &[&str] = &[
+        "audienceOptionAudience",
+        "configuredPlacementSpec",
+        "currency",
+        "flow",
+        "flowID",
+        "legacyAdAccountID",
+        "optimizationGoalInput",
+        "postID",
+        "targetingSpecAudience",
+    ];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(rename = "audienceOptionAudience")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9837,8 +11003,16 @@ pub mod use_wa_web_smart_composer_report_used {
     pub const NAME: &str = "useWAWebSmartComposerReportUsedMutation";
     pub const DOC_ID: &str = "27016039438072594";
     pub const OPERATION_KIND: &str = "mutation";
+    pub const VARIABLE_KEYS: &[&str] = &["input"];
 
-    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    /// Variables for this operation, one field per variable the persisted document
+    /// declares.
+    ///
+    /// Deliberately not `Default`: the server rejects a persisted query whose
+    /// variables it cannot bind, so every variable is a decision a call site has to
+    /// write out, and `..Default::default()` would make skipping one invisible.
+    /// Passing `None` is still how a variable WhatsApp Web itself omits is omitted.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Variables {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub input: Option<String>,


### PR DESCRIPTION
## Summary

The MEX server binds a persisted query's variables by name and answers a bare `400 Bad Request` when it cannot bind one. It checks presence, not value: `false` works exactly as well as `true`, and a subset of the declared set fails. Our generator made violating that easy, because every generated `Variables` derived `Default` and every field was `Option<T>` with `skip_serializing_if`, so `..Default::default()` dropped whatever a call site had not named and the omission was invisible until the server rejected it. The fix renders `Variables` without `Default`, which turns the compiler into the thing that notices, and fills in the missing variables with the values WA Web sends. Nested input objects are untouched, so nothing about serialization changes and no explicit `null` is ever sent.

## Audit

Confirmed on current `main` (not just on `v0.7.0`):

- `tools/whatspec-codegen/src/emit/mex.rs`, `StructDef::render`: every field of every generated struct, at every nesting level, got `Option<T>` plus `#[serde(default, skip_serializing_if = "Option::is_none")]`. No branch consulted presence; the constructor looked only at the type.
- `src/features/mex.rs`, `execute_request` -> `MexQuerySpec::new`: the body is `serde_json::to_vec` of a `{ variables }` wrapper. No intermediate tree, so the serde attributes are literally what goes on the wire.
- `wacore/src/iq/mex_operations.rs` is generated and reproduces at the pinned commit, so the `Variables` shapes are identical between the tag and `main`. "Bump the version" was never the answer.

I walked every `mex_request!` in the workspace (20 call sites, 20 operations) and compared what each fills against what the operation declares. **Three operations sent an incomplete payload, at four call sites** -- one more operation than the issue names:

| operation | call site | left out |
| --- | --- | --- |
| `fetch_all_newsletters_metadata` | `newsletter.rs` `list_subscribed` | `fetch_status_metadata`, `fetch_wamo_sub` |
| `fetch_newsletter` | `newsletter.rs` `get_metadata`, `get_metadata_by_invite` | `fetch_pinned_messages`, `fetch_status_metadata`, `fetch_wamo_sub` |
| `fetch_all_subgroups` | `community.rs` `get_subgroups` | `query_context` |

Refuted, and worth saying:

- **`fetch_all_subgroups` was missing one variable, not two.** WA Web writes `sub_group_hint_id: t == null ? void 0 : t.toString()`, and `JSON.stringify` drops an `undefined` value, so the official client itself omits that key whenever the user has no joined subgroup to name. So "every declared variable is always sent" is false as a general rule, and a design that assumed it would have been wrong.
- **`fetch_reachout_timelock` is not a fourth case.** Its generated `Variables` is empty; the three fields that look like variables belong to `Xwa2FetchAccountReachoutTimelock`, the response type.
- **`docs/captured-js/` does not exist in this repository.** The whatspec bundle cache is the only raw source.
- The correlation the scan suggested holds: every operation with a full shape test was already correct, and every incomplete one had no shape test at all.
- One divergence I found and deliberately did not change: WA Web sends `fetch_full_image: type !== "INVITE"`, so `false` for an invite lookup. We send `true` at both call sites today. Since the server enforces presence and not value, that is not part of this bug, and matching WA Web there would silently drop the full picture from `get_metadata_by_invite`. Left as is on purpose.

## WA Web

Restored the pinned bundle set (516 files, every SHA-256 checked against `generated/bundles.lock.json`) and read the call sites verbatim.

`WAWebMexFetchAllNewslettersMetadataJob`:

```js
fetchQuery(r, {
  fetch_wamo_sub: (t == null ? void 0 : t.fetchWamoSub) === !0,
  fetch_status_metadata: (t == null ? void 0 : t.fetchStatusMetadata) === !0
})
```

Its caller passes `{fetchWamoSub: isWamoSubExperienceEnabled(), fetchStatusMetadata: isNewsletterStatusReceiverEnabled()}`.

`WAWebMexFetchNewsletterJob`:

```js
u = isNewsletter(t) ? "JID" : "INVITE", c = u !== "INVITE",
d = {
  input: {key: t, type: u, view_role: a},
  fetch_viewer_metadata: i.fetchViewerMetadata,
  fetch_full_image: c,
  fetch_creation_time: i.fetchCreationTime === !0,
  fetch_wamo_sub: i.fetchWamoSub === !0,
  fetch_status_metadata: i.fetchStatusMetadata === !0,
  fetch_pinned_messages: isChannelMessagePinReadEnabled()
}
```

`WAWebMexFetchAllSubgroupsJob`, and its one caller:

```js
i = {group_id: e.toString(), query_context: n, sub_group_hint_id: t == null ? void 0 : t.toString()}
mexFetchAllSubgroups(e, t != null && t.length ? t[0] : void 0, "INTERACTIVE")
```

`WAWebMexQuerySubgroupParticipantCountJob`, same shape one level down, also called with `"INTERACTIVE"`:

```js
a = {input: {group_jid: e.toString(), query_context: n, sub_group_jid_hint: t == null ? void 0 : t.toString()}}
```

Where each new value comes from:

- `fetch_wamo_sub` -> `isWamoSubExperienceEnabled()`, `fetch_status_metadata` -> `isNewsletterStatusReceiverEnabled()` (`isNewsletterFeatureEnabled("channel_status_consumption")`), `fetch_pinned_messages` -> `isChannelMessagePinReadEnabled()` (`channels_message_pin_follower_enabled || channels_message_pin_admin_enabled`). All three are A/B-prop gates whose off value is `false`, and each gates a response block this client does not parse, so `false` is both what a gated-off official client sends and the honest answer for us.
- `query_context` -> the literal `"INTERACTIVE"`, the only value either subgroup job is ever called with.
- `sub_group_hint_id` / `sub_group_jid_hint` -> omitted, exactly as WA Web omits them when it has no joined subgroup to name, which is always our case.
- `view_role: "GUEST"` -> unchanged, and confirmed: WA Web maps an absent role to `"GUEST"` before building the input.

For every operation this PR declares complete, the set we send is the set WA Web sends, no more and no less.

## Design

I took the **require-a-real-decision** family, not the `null` family.

`Variables` is now emitted without `#[derive(Default)]`. Its fields stay `Option<T>` with `skip_serializing_if`, so `None` still means "leave it out" -- which is needed, because WA Web really does omit `sub_group_hint_id`. What goes away is the ability to *inherit* `None`: a struct literal must name every field, so every declared variable becomes a decision written at the call site, and a variable WhatsApp adds upstream breaks every call site at compile time rather than at runtime on the server.

Keeping `Option` rather than going to a bare `T` matters. A bare `T` that kept `Default` would have made things worse -- `bool` and `String` implement `Default`, so `..Default::default()` would still compile and start sending `false` in silence -- and a bare `T` without `Default` could not express the one variable the official client legitimately omits.

**What I could not validate:** whether the server accepts an explicit `null` where it rejects an omission. The compiled Relay artifacts discard nullability, so neither the bundle nor the IR says whether these variables are nullable, and the official client never sends `null` because it never has a declared variable it left unfilled. Only a request against a real account answers it, and I have no paired account. That is precisely why I did not take the `null` family: it would have rested on an assumption I cannot check, and a wrong guess there trades a loud 400 for a differently-shaped failure. The design I took depends on nothing about the server beyond what the issue already measured.

I also evaluated and rejected steering by the IR's new `variablesPresence`. Taking it literally reproduces the bug: the fields that would stay omissible are `fetch_viewer_metadata` (conditional), `fetch_pinned_messages` (undetermined), `input.key` and `input.view_role` (conditional) -- the exact fields of the two operations in the issue. The reason is that `conditional` is a claim about static provability, not about the wire, and the bundle confirms it: `fetch_viewer_metadata` comes from a chain of `=== !0` joined by `||` that always yields a strict boolean, `view_role` comes from a function that maps null to `"GUEST"`, and `key` is only reached after the caller has checked it non-null. It is also unusable in the other direction: `group_id` (which is always sent) and `sub_group_hint_id` (which is not) are both `undetermined`.

## Constraints

Neither of the two serialization-shaped invariants is reachable by this change, because serialization did not change at all -- only the `Default` derive on the top-level `Variables` did.

- **`update_newsletter`'s tri-state.** `picture_update_variables` builds `Updates` with `name: None` / `description: None` meaning "do not touch" and `picture: Some("")` meaning "clear". `Updates` is a nested struct: it keeps `Default`, keeps `skip_serializing_if`, and is byte-identical on the wire. Dropping `skip_serializing_if` globally would have made every picture change wipe the channel's name and description, so there is now a test pinning that, written even though this design cannot reach it.
- **The catalog's paging cursor.** `catalog_variables` / `collection_variables` are hand-built `json!` values that omit `after` on the first page, because an explicit null is a cursor value. Untouched; the catalog test already pinned it and the collections test now pins it too.

## Codegen

The pin was one commit behind the whatspec release that added `variablesPresence`, and `MexOperation` had no field for it, so serde was dropping it silently -- bumping alone would have delivered nothing. Bumped to `1d086ce` and regenerated in the same PR, since CI's `--check` compares the emitter's output byte for byte against the tree.

The bump is nearly inert, as expected. Of the eleven generated artifacts only `mex_operations.rs` changed. No change to the `.proto`, tokens, wire enums, IQ targets, stanza tags, appstate schemas, WAM catalog or `waVersion`. The only shape change from upstream is that `resolve_account_type_and_ad_page::Variables` loses its `pageId` field: that is an upstream extraction fix, and nothing in this repository references that operation. Everything else in the generated diff is the emitter's own doing -- 143 `Variables` structs losing `Default`, plus the new `VARIABLE_KEYS` const per module.

We still do not consume `variablesPresence`, for the reasons in **Design**, so `MexOperation` deliberately gains no field for it.

## Guard

The guard is the compiler, and it is verified in both directions by doctests on `wacore::iq::mex`: a `compile_fail` block that names one variable of `fetch_newsletter` and inherits the rest, and a passing block that writes a full literal and checks it against `VARIABLE_KEYS`. CI runs `cargo test --doc` as its own step, since nextest cannot run doctests. It does not age: the check is "does this struct literal name every field", which the compiler re-derives from the regenerated type on every build.

The compiler cannot see the loosely-typed `mex_request!(op, json!(...))` form, which four call sites use, so the emitter now also keeps the list of declared keys it used to discard: `pub const VARIABLE_KEYS: &[&str]` per operation, carried on `MexRequest` and readable through `MexRequest::missing_variables()`. That is one mechanical check over any payload instead of a literal transcribed from the bundle by hand, and it reports omission without judging it, since some omission is correct.

I kept the per-operation shape tests too, in the existing house style, rather than replacing them: they pin values (`INTERACTIVE`, `GUEST`, which flags are `false`) that a key-set check cannot see.

## Compatibility

Breaking for anyone constructing a generated `Variables` directly:

- `..Default::default()` on a `Variables` no longer compiles. Name every field; the compiler lists what is missing. `Variables::default()` is likewise gone. Nested types are unaffected.
- `MexRequest` gains a `declared_variables` field, and `MexRequest::new` takes it as its third argument. The `mex_request!` macro fills it in, so call sites that use the macro need no change.
- `resolve_account_type_and_ad_page::Variables` loses its `page_id` field, from the upstream extraction fix.

On the wire, the three fixed operations now send their full variable set. No other request changes.

## Validation

```
cargo fmt --all
cargo run -p whatspec-codegen -- --check      # all artifacts match the pinned IR
cargo test -p wacore --lib                    # 1541 passed
cargo test -p wacore --doc                    # includes both guard doctests
cargo test -p whatsapp-rust --lib             # 1839 passed
cargo clippy -p wacore -p whatsapp-rust -p whatspec-codegen --all-targets -- -D warnings
```

The three regression tests were checked to fail before the fix, naming exactly the omitted variables (`["fetch_status_metadata", "fetch_wamo_sub"]`, `["fetch_pinned_messages", "fetch_status_metadata", "fetch_wamo_sub"]`, `["query_context", "sub_group_hint_id"]`). No existing test needed adapting. `cargo clippy --workspace` could not run here because `alsa-sys` has no system library in this environment, which is unrelated to the change; full matrix left to CI.

Fixes #1372


---
_Generated by [Claude Code](https://claude.ai/code/session_016zueq3Znb6dLuzYUHkhuC7)_