### PR TITLE
fix(keepalive): measure the dead-socket deadline with a clock that cannot jump

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -48,10 +48,16 @@ travel to the socket as `SendObservers`, so the next observer plugs in there
 instead of widening `do_handshake` again.
 
 It also owns the activity timestamps the keepalive dead-socket watchdog reads:
-`last_data_received_ms` (one clock read per received transport event, plus one
+`last_data_received` (one clock read per received transport event, plus one
 more when that event carries several frames, so a slow drain is not read as
-silence) and `first_send_since_recv_ms`, which every frame loads but only the
-send that arms or re-arms the anchor spends a clock read on. There
+silence) and `first_send_since_recv`, which every frame loads but only the
+send that arms or re-arms the anchor spends a clock read on. Both are
+`wacore::time::Instant`, never wall-clock stamps: the watchdog asks how much
+time passed, and a wall clock answers that with whatever the system clock was
+last set to, so a laptop resuming from suspend used to kill a socket it had
+authenticated seconds earlier. `StatsSnapshot::last_data_received_ms` still
+reports a wall-clock instant, derived from the monotonic anchor when the
+snapshot is taken rather than stamped on the wire path. There
 is deliberately no "last send" timestamp: nothing in the core reads one, and it
 cost a clock read on every frame written, which is the client's hottest path
 and a call out of the module on wasm32/embedded. `frames_sent` answers "is it

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -51,8 +51,9 @@ It also owns the activity timestamps the keepalive dead-socket watchdog reads:
 `last_data_received` (one clock read per received transport event, plus one
 more when that event carries several frames, so a slow drain is not read as
 silence) and `first_send_since_recv`, which every frame loads but only the
-send that arms or re-arms the anchor spends a clock read on. Both are
-`wacore::time::Instant`, never wall-clock stamps: the watchdog asks how much
+send that arms or re-arms the anchor spends a clock read on. Both are held as
+`wacore::time::AtomicInstant` (an atomic slot carrying a `wacore::time::Instant`
+or nothing), never wall-clock stamps: the watchdog asks how much
 time passed, and a wall clock answers that with whatever the system clock was
 last set to, so a laptop resuming from suspend used to kill a socket it had
 authenticated seconds earlier. `StatsSnapshot::last_data_received_ms` still

--- a/src/client.rs
+++ b/src/client.rs
@@ -69,7 +69,7 @@ use rand::{Rng, RngExt};
 use scopeguard;
 use wacore_binary::Jid;
 
-use portable_atomic::{AtomicI64, AtomicU64};
+use portable_atomic::AtomicU64;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use wacore::stanza::wire_tags::{NotificationType, StanzaTag};
@@ -1490,9 +1490,12 @@ pub struct Client {
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,
-    /// Wall-clock ms of the last successful authentication (`<success>`), or 0.
+    /// When the last successful authentication (`<success>`) landed, or unset.
     /// Gates the WA Web `resetDelay` backoff reset (see [`should_reset_backoff`]).
-    pub(crate) connected_at_ms: Arc<AtomicI64>,
+    /// Monotonic: it only ever answers how long the connection has been up, and
+    /// a wall clock would let a resumed laptop declare a seconds-old connection
+    /// stable, or a backwards adjustment withhold the reset indefinitely.
+    pub(crate) connected_at: Arc<wacore::time::AtomicInstant>,
     /// Set when an explicit backoff penalty was applied this connection (429
     /// rate-limit, manual `reconnect()`); cleared on the next `<success>`. Keeps
     /// the stability reset from erasing a deliberate penalty (WA Web `cancelReset`).
@@ -2099,13 +2102,14 @@ fn is_encrypt_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
 /// long-lived-then-rate-limited connection keeps its deliberate backoff instead
 /// of snapping to 1s.
 pub(crate) fn should_reset_backoff(
-    connected_at_ms: i64,
-    now_ms: i64,
+    connected_at: Option<wacore::time::Instant>,
+    now: wacore::time::Instant,
     penalty_pending: bool,
 ) -> bool {
     !penalty_pending
-        && connected_at_ms != 0
-        && now_ms.saturating_sub(connected_at_ms) >= Client::STABLE_CONNECTION_RESET_MS
+        && connected_at.is_some_and(|connected_at| {
+            now.saturating_duration_since(connected_at) >= Client::STABLE_CONNECTION_RESET
+        })
 }
 
 /// Computes a reconnect delay matching WhatsApp Web's Fibonacci backoff:

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -28,8 +28,7 @@ impl Drop for Client {
 impl Client {
     /// WA Web `resetDelay: 30000` — only after a connection has stayed up this
     /// long is the reconnect backoff counter reset to its base.
-    pub(crate) const STABLE_CONNECTION_RESET: std::time::Duration =
-        std::time::Duration::from_secs(30);
+    pub(crate) const STABLE_CONNECTION_RESET: Duration = Duration::from_secs(30);
 
     /// Create a runtime-validated low-level client builder.
     pub fn builder() -> ClientBuilder {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -28,7 +28,8 @@ impl Drop for Client {
 impl Client {
     /// WA Web `resetDelay: 30000` — only after a connection has stayed up this
     /// long is the reconnect backoff counter reset to its base.
-    pub(crate) const STABLE_CONNECTION_RESET_MS: i64 = 30_000;
+    pub(crate) const STABLE_CONNECTION_RESET: std::time::Duration =
+        std::time::Duration::from_secs(30);
 
     /// Create a runtime-validated low-level client builder.
     pub fn builder() -> ClientBuilder {
@@ -85,7 +86,7 @@ impl Client {
     /// and resets the backoff on the strength of it.
     fn clear_connection_backoff_state(&self) {
         self.auto_reconnect_errors.store(0, Ordering::Relaxed);
-        self.connected_at_ms.store(0, Ordering::Relaxed);
+        self.connected_at.clear();
     }
 
     pub(crate) fn connection_shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
@@ -501,7 +502,7 @@ impl Client {
             pause_generation: AtomicU64::new(0),
             connection_publish: Mutex::new(()),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
-            connected_at_ms: Arc::new(AtomicI64::new(0)),
+            connected_at: Arc::new(wacore::time::AtomicInstant::unset()),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
 
             needs_initial_full_sync: Arc::new(app_state::BootstrapGate::new(false)),
@@ -791,9 +792,9 @@ impl Client {
             // Reset the backoff only after a stable connection, unless an
             // explicit penalty (429 / manual reconnect) must survive — WA Web
             // `resetDelay` + `cancelReset`.
-            let connected_at = self.connected_at_ms.swap(0, Ordering::Relaxed);
+            let connected_at = self.connected_at.take();
             let penalty = self.backoff_reset_suppressed.load(Ordering::Relaxed);
-            if should_reset_backoff(connected_at, wacore::time::now_millis(), penalty) {
+            if should_reset_backoff(connected_at, wacore::time::Instant::now(), penalty) {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
             }
 
@@ -2804,7 +2805,7 @@ mod tests {
         let (client, entered, release) = client_parked_in_connect().await;
         // What a session that struggled and then settled leaves behind.
         client.auto_reconnect_errors.store(7, Ordering::Relaxed);
-        client.connected_at_ms.store(1, Ordering::Relaxed);
+        client.connected_at.store(wacore::time::Instant::now());
 
         let runner = Arc::clone(&client);
         let run = tokio::spawn(async move { runner.run().await });
@@ -2822,9 +2823,8 @@ mod tests {
             0,
             "a planned end owes no backoff, so its counter is cleared on both exits"
         );
-        assert_eq!(
-            client.connected_at_ms.load(Ordering::Relaxed),
-            0,
+        assert!(
+            client.connected_at.load().is_none(),
             "and the auth timestamp is consumed, so no later connect reads it as stable"
         );
     }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1064,8 +1064,7 @@ impl Client {
         // (`resetDelay`). Resetting on <success> alone lets a server that
         // authenticates then immediately drops keep us in a 1s reconnect storm.
         // The run loop does the stability-gated reset on the next disconnect.
-        self.connected_at_ms
-            .store(wacore::time::now_millis(), Ordering::Relaxed);
+        self.connected_at.store(wacore::time::Instant::now());
         // Fresh connection starts un-penalized (see backoff_reset_suppressed).
         self.backoff_reset_suppressed
             .store(false, Ordering::Relaxed);

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3209,25 +3209,53 @@ fn test_fibonacci_backoff_first_attempt_is_1s() {
 
 #[test]
 fn should_reset_backoff_requires_uptime_window_and_no_penalty() {
-    let start = 1_000_000i64;
-    let stable = start + Client::STABLE_CONNECTION_RESET_MS;
+    let start = wacore::time::Instant::ZERO + Duration::from_secs(1_000);
+    let window = Client::STABLE_CONNECTION_RESET;
+    let stable = start + window;
     // Never authenticated this cycle → not stable, whatever the clock says.
-    assert!(!should_reset_backoff(0, 1_000_000, false));
+    assert!(!should_reset_backoff(None, stable, false));
     // Authenticated but dropped inside the 30s window → keep escalating.
     assert!(!should_reset_backoff(
-        start,
-        start + Client::STABLE_CONNECTION_RESET_MS - 1,
+        Some(start),
+        start + window - Duration::from_millis(1),
         false
     ));
     // Survived the full window with no penalty → reset the backoff.
-    assert!(should_reset_backoff(start, stable, false));
-    assert!(should_reset_backoff(start, start + 60_000, false));
+    assert!(should_reset_backoff(Some(start), stable, false));
+    assert!(should_reset_backoff(
+        Some(start),
+        start + Duration::from_secs(60),
+        false
+    ));
     // An explicit penalty (429 / manual reconnect) survives even a stable
     // connection (WA Web cancelReset).
-    assert!(!should_reset_backoff(start, stable, true));
-    assert!(!should_reset_backoff(start, start + 60_000, true));
-    // A backwards clock jump must not underflow into a spurious reset.
-    assert!(!should_reset_backoff(start, start - 5_000, false));
+    assert!(!should_reset_backoff(Some(start), stable, true));
+    assert!(!should_reset_backoff(
+        Some(start),
+        start + Duration::from_secs(60),
+        true
+    ));
+}
+
+/// The stability window is real elapsed time, not a difference of wall-clock
+/// readings: a system clock that leaps forward (a laptop resuming and
+/// re-syncing NTP) must not sell a connection seconds old as thirty seconds
+/// stable and drop the guard against a flapping server.
+#[test]
+fn a_wall_clock_jump_does_not_make_a_young_connection_look_stable() {
+    let connected_at = wacore::time::Instant::now();
+    let a_moment_later = connected_at + Duration::from_secs(1);
+    assert!(!should_reset_backoff(
+        Some(connected_at),
+        a_moment_later,
+        false
+    ));
+    // Real elapsed time still resets it.
+    assert!(should_reset_backoff(
+        Some(connected_at),
+        connected_at + Client::STABLE_CONNECTION_RESET,
+        false
+    ));
 }
 
 // ── stream error tests ─────────────────────────────────────────────
@@ -4744,6 +4772,11 @@ async fn stats_snapshot_reflects_counters() {
 /// A clock read leaves the module on wasm32/embedded, so the wire path owes a
 /// budget: only the send that arms the dead-socket anchor may date itself, and
 /// only one stamp may be spent per received transport event.
+///
+/// It also owes a *clock*. Every stamp here anchors a deadline the keepalive
+/// measures elapsed time against, so all of them are monotonic: a wall-clock
+/// read on this path is a timeout a system-clock adjustment can fire, which is
+/// what killed a healthy socket in issue #1376.
 #[test]
 fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
     use wacore::time::clock_reads;
@@ -4753,7 +4786,7 @@ fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
     let arming = clock_reads::snapshot();
     stats.record_frame_sent(10);
     assert_eq!(
-        clock_reads::since(arming).wall,
+        clock_reads::since(arming).monotonic,
         1,
         "the send that arms the anchor dates it"
     );
@@ -4763,7 +4796,7 @@ fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
         stats.record_frame_sent(10);
     }
     assert_eq!(
-        clock_reads::since(armed).wall,
+        clock_reads::since(armed).monotonic,
         0,
         "sends under an already-armed anchor have nothing to date"
     );
@@ -4772,7 +4805,7 @@ fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
     stats.mark_recv_activity();
     stats.record_recv_batch(100, 1);
     assert_eq!(
-        clock_reads::since(recv).wall,
+        clock_reads::since(recv).monotonic,
         1,
         "a single-frame batch is stamped once, at arrival"
     );
@@ -4781,7 +4814,7 @@ fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
     stats.mark_recv_activity();
     stats.record_recv_batch(100, 4);
     assert_eq!(
-        clock_reads::since(long_batch).wall,
+        clock_reads::since(long_batch).monotonic,
         2,
         "a long batch re-stamps on completion so a slow drain is not read as silence"
     );
@@ -4789,9 +4822,42 @@ fn wire_bookkeeping_reads_the_clock_only_where_a_value_is_used() {
     let rearm = clock_reads::snapshot();
     stats.record_frame_sent(10);
     assert_eq!(
-        clock_reads::since(rearm).wall,
+        clock_reads::since(rearm).monotonic,
         1,
         "the receive cancelled the anchor, so this send arms it again"
+    );
+
+    let whole_path = clock_reads::snapshot();
+    stats.record_frame_sent(10);
+    stats.mark_recv_activity();
+    stats.record_recv_batch(100, 4);
+    stats.record_frame_sent(10);
+    assert_eq!(
+        clock_reads::since(whole_path).wall,
+        0,
+        "a wall-clock stamp here is a watchdog deadline a clock adjustment can move"
+    );
+}
+
+/// The public snapshot still answers "last seen at T" in the wall-clock frame a
+/// consumer reads it in, even though the field behind it is monotonic.
+#[test]
+fn the_snapshot_still_reports_last_receive_as_a_wall_clock_instant() {
+    let stats = wacore::stats::SessionStats::new();
+    assert_eq!(
+        stats.snapshot().last_data_received_ms,
+        0,
+        "nothing received yet"
+    );
+
+    let before = wacore::time::now_millis().max(0) as u64;
+    stats.mark_recv_activity();
+    let reported = stats.snapshot().last_data_received_ms;
+    let after = wacore::time::now_millis().max(0) as u64;
+
+    assert!(
+        (before..=after).contains(&reported),
+        "expected a wall-clock instant inside [{before}, {after}], got {reported}"
     );
 }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3237,12 +3237,16 @@ fn should_reset_backoff_requires_uptime_window_and_no_penalty() {
     ));
 }
 
-/// The stability window is real elapsed time, not a difference of wall-clock
-/// readings: a system clock that leaps forward (a laptop resuming and
-/// re-syncing NTP) must not sell a connection seconds old as thirty seconds
-/// stable and drop the guard against a flapping server.
+/// The stability window is real elapsed time: a connection one second old is
+/// not thirty seconds stable, so the guard against a flapping server holds.
+///
+/// This is the window's arithmetic, not the clock-jump regression. A wall-clock
+/// reading can no longer reach this predicate at all, because `connected_at` is
+/// an `Instant` and the compiler rejects a millisecond timestamp in its place;
+/// what pins the anchor itself to the monotonic clock is
+/// `wire_bookkeeping_reads_the_clock_only_where_a_value_is_used`.
 #[test]
-fn a_wall_clock_jump_does_not_make_a_young_connection_look_stable() {
+fn only_elapsed_time_opens_the_stability_window() {
     let connected_at = wacore::time::Instant::now();
     let a_moment_later = connected_at + Duration::from_secs(1);
     assert!(!should_reset_backoff(

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -511,7 +511,7 @@ mod tests {
     #[tokio::test]
     async fn companion_reg_refresh_waits_for_a_pending_pair_success() {
         use wacore::libsignal::protocol::KeyPair;
-        use wacore::pair_code::{PairCodeState, PairCodeUtils};
+        use wacore::pair_code::PairCodeState;
 
         let client = create_test_client().await;
         let expired = wacore::time::Instant::ZERO;

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -514,8 +514,7 @@ mod tests {
         use wacore::pair_code::{PairCodeState, PairCodeUtils};
 
         let client = create_test_client().await;
-        let expired = wacore::time::Instant::now()
-            - (PairCodeUtils::code_validity() + std::time::Duration::from_secs(1));
+        let expired = wacore::time::Instant::ZERO;
         *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
             pairing_ref: b"3@2:ref".to_vec(),
             phone_jid: "15551234567".to_string(),
@@ -523,7 +522,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation: expired,
+            code_expires_at: expired,
             // Stage 2 ran: companion_finish is out and pair-success is pending.
             primary_hello_attempt_count: 1,
         };
@@ -557,7 +556,8 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation: wacore::time::Instant::now(),
+            code_expires_at: wacore::time::Instant::now()
+                + wacore::pair_code::PairCodeUtils::code_validity(),
             primary_hello_attempt_count: 0,
         };
         let before = adv_secret(&client).await;

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -514,8 +514,8 @@ mod tests {
         use wacore::pair_code::{PairCodeState, PairCodeUtils};
 
         let client = create_test_client().await;
-        let expired =
-            wacore::time::now_secs() - (PairCodeUtils::code_validity().as_secs() as i64 + 1);
+        let expired = wacore::time::Instant::now()
+            - (PairCodeUtils::code_validity() + std::time::Duration::from_secs(1));
         *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
             pairing_ref: b"3@2:ref".to_vec(),
             phone_jid: "15551234567".to_string(),
@@ -523,7 +523,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: expired,
+            code_generation: expired,
             // Stage 2 ran: companion_finish is out and pair-success is pending.
             primary_hello_attempt_count: 1,
         };
@@ -557,7 +557,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: wacore::time::now_secs(),
+            code_generation: wacore::time::Instant::now(),
             primary_hello_attempt_count: 0,
         };
         let before = adv_secret(&client).await;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use wacore::iq::spec::IqSpec;
 use wacore::protocol::keepalive::{
-    KEEP_ALIVE_INTERVAL_MAX, KEEP_ALIVE_INTERVAL_MIN, KEEP_ALIVE_RESPONSE_DEADLINE,
-    is_dead_socket_at, ms_since, ms_since_at,
+    KEEP_ALIVE_INTERVAL_MAX, KEEP_ALIVE_INTERVAL_MIN, KEEP_ALIVE_RESPONSE_DEADLINE, elapsed_since,
+    elapsed_since_at, is_dead_socket_at,
 };
 
 #[derive(Debug, PartialEq)]
@@ -170,14 +170,14 @@ impl Client {
                     // outstanding IQ.
                     self.response_waiters_guard().drop_expired_phash();
 
-                    let last_recv = self.stats.last_data_received_ms();
+                    let last_recv = self.stats.last_data_received();
 
                     // WA Web: maybeScheduleHealthCheck — only send ping when idle.
                     // If we recently received data, the connection is proven alive;
                     // skip the ping and reschedule (same as WA Web rescheduling the
                     // healthCheckTimer after activity).
-                    if let Some(since_recv) = ms_since(last_recv)
-                        && since_recv < KEEP_ALIVE_INTERVAL_MIN.as_millis() as u64
+                    if let Some(since_recv) = elapsed_since(last_recv)
+                        && since_recv < KEEP_ALIVE_INTERVAL_MIN
                     {
                         // Connection alive — reset error state, skip ping.
                         if error_count > 0 {
@@ -217,15 +217,15 @@ impl Client {
                     // a failed ping. This catches scenarios where pending IQs caused
                     // the ping to be skipped, or where the ping "succeeded" but the
                     // connection died immediately after.
-                    let first_send = self.stats.first_send_since_recv_ms();
-                    let last_recv = self.stats.last_data_received_ms();
-                    let now = wacore::protocol::keepalive::now_ms();
+                    let first_send = self.stats.first_send_since_recv();
+                    let last_recv = self.stats.last_data_received();
+                    let now = wacore::time::Instant::now();
                     if is_dead_socket_at(first_send, last_recv, now) {
-                        let elapsed = ms_since_at(first_send, now).unwrap_or(0);
+                        let elapsed = elapsed_since_at(first_send, now).unwrap_or_default();
                         warn!(
                             target: "Client/Keepalive",
                             "No data received for {:.1}s after send (dead socket), forcing reconnect.",
-                            elapsed as f64 / 1000.0
+                            elapsed.as_secs_f64()
                         );
                         self.reconnect_immediately().await;
                         return;
@@ -424,5 +424,5 @@ mod tests {
         }));
     }
 
-    // ms_since, is_dead_socket, and constants tests live in wacore::protocol::keepalive
+    // elapsed_since, is_dead_socket, and constants tests live in wacore::protocol::keepalive
 }

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -210,7 +210,7 @@ pub async fn handle_iq(client: &Arc<Client>, node: &NodeRef<'_>) -> bool {
                                 .pair_code_state
                                 .lock()
                                 .await
-                                .is_outstanding(wacore::time::now_secs());
+                                .is_outstanding(wacore::time::Instant::now());
 
                             info!(
                                 "All QR codes for this session have expired\
@@ -623,7 +623,8 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: wacore::time::now_secs(),
+            code_expires_at: wacore::time::Instant::now()
+                + wacore::pair_code::PairCodeUtils::code_validity(),
             primary_hello_attempt_count: 0,
         };
     }
@@ -735,8 +736,7 @@ mod tests {
         let collector = Arc::new(TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
 
-        let expired = wacore::time::now_secs()
-            - (wacore::pair_code::PairCodeUtils::code_validity().as_secs() as i64 + 1);
+        let expired = wacore::time::Instant::ZERO;
         *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
             pairing_ref: b"3@2:ref".to_vec(),
             phone_jid: "15551234567".to_string(),
@@ -744,7 +744,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: expired,
+            code_expires_at: expired,
             // Stage 2 ran: pair-success is still due.
             primary_hello_attempt_count: 1,
         };

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -270,7 +270,7 @@ impl Client {
         self.pair_code_state
             .lock()
             .await
-            .is_outstanding(wacore::time::now_secs())
+            .is_outstanding(wacore::time::Instant::now())
     }
 
     async fn pair_with_code_inner(
@@ -321,20 +321,20 @@ impl Client {
         // WA Web also starts before the request (`startAltLinkingFlow` sets
         // `codeGenerationTs` before sending), so the ~180s window covers the
         // round trip rather than starting after it.
-        let code_generation_ts = wacore::time::now_secs();
+        let code_generation = wacore::time::Instant::now();
         let claim = wacore::pair_code::PairCodeClaim::next();
         {
             let mut state = self.pair_code_state.lock().await;
-            if state.is_outstanding(code_generation_ts) {
+            if state.is_outstanding(code_generation) {
                 return Err(PairCodeError::CodeAlreadyOutstanding {
                     remaining: state
-                        .live_flow_remaining(code_generation_ts)
+                        .live_flow_remaining(code_generation)
                         .unwrap_or_default(),
                 }
                 .into());
             }
             *state = PairCodeState::RequestingCode {
-                code_generation_ts,
+                code_generation,
                 claim,
             };
         }
@@ -489,22 +489,18 @@ impl Client {
                 phone_jid: phone_number,
                 pair_code: code.clone(),
                 ephemeral_keypair: Box::new(ephemeral_keypair),
-                code_generation_ts,
+                code_generation,
                 primary_hello_attempt_count: 0,
             };
             claim_guard.armed = false;
         }
 
         // Dispatch event for the user to display the code. The validity clock
-        // started at `code_generation_ts` (before stage 1), so advertise the
+        // started at `code_generation` (before stage 1), so advertise the
         // *remaining* window — otherwise a consumer's countdown would outlast the
         // server's (and our own `handle_primary_hello`) expiry by the stage-1
         // elapsed time.
-        let elapsed = wacore::time::now_secs()
-            .saturating_sub(code_generation_ts)
-            .max(0) as u64;
-        let remaining =
-            PairCodeUtils::code_validity().saturating_sub(std::time::Duration::from_secs(elapsed));
+        let remaining = PairCodeUtils::code_validity().saturating_sub(code_generation.elapsed());
         self.core.event_bus.dispatch(Event::PairingCode(
             crate::types::events::PairingCode::builder()
                 .code(code.clone())
@@ -688,7 +684,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
             phone_jid,
             pair_code,
             ephemeral_keypair,
-            code_generation_ts,
+            code_generation,
             primary_hello_attempt_count,
         } => {
             // Validate before counting: only a genuine, in-window attempt
@@ -702,11 +698,12 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
                 );
                 return false;
             }
-            let age = wacore::time::now_secs() - *code_generation_ts;
-            if age > PairCodeUtils::code_validity().as_secs() as i64 {
+            let age = code_generation.elapsed();
+            if age > PairCodeUtils::code_validity() {
                 warn!(
                     target: "Client/PairCode",
-                    "primary_hello arrived for an expired code ({age}s old); ignoring"
+                    "primary_hello arrived for an expired code ({}s old); ignoring",
+                    age.as_secs()
                 );
                 return false;
             }
@@ -1131,9 +1128,8 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         // Park a live code in the slot so the next request is the duplicate.
-        let now = wacore::time::now_secs();
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation_ts: now,
+            code_generation: wacore::time::Instant::now(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
 
@@ -1276,7 +1272,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation_ts: wacore::time::now_secs(),
+            code_generation: wacore::time::Instant::now(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
 
@@ -1507,7 +1503,12 @@ mod tests {
             .build()
     }
 
-    async fn set_waiting(client: &Arc<Client>, pairing_ref: Vec<u8>, ts: i64, count: u32) {
+    async fn set_waiting(
+        client: &Arc<Client>,
+        pairing_ref: Vec<u8>,
+        generated_at: wacore::time::Instant,
+        count: u32,
+    ) {
         *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
             pairing_ref,
             phone_jid: "15551234567".to_string(),
@@ -1515,7 +1516,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: ts,
+            code_generation: generated_at,
             primary_hello_attempt_count: count,
         };
     }
@@ -1551,7 +1552,7 @@ mod tests {
     #[tokio::test]
     async fn primary_hello_rejects_mismatched_ref() {
         let client = create_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
         let adv_before = adv(&client);
 
         let notif = primary_hello_notif(&[9, 9, 9, 9]);
@@ -1581,7 +1582,13 @@ mod tests {
     async fn stale_mismatched_hellos_do_not_block_the_valid_one() {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
         let adv_before = adv(&client);
 
         // More mismatched hellos than the cap would allow if they counted.
@@ -1610,8 +1617,8 @@ mod tests {
     async fn primary_hello_rejects_expired_code() {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        let stale_ts =
-            wacore::time::now_secs() - (PairCodeUtils::code_validity().as_secs() as i64 + 20);
+        let stale_ts = wacore::time::Instant::now()
+            - (PairCodeUtils::code_validity() + Duration::from_secs(20));
         set_waiting(&client, pairing_ref.clone(), stale_ts, 0).await;
         let adv_before = adv(&client);
 
@@ -1643,7 +1650,7 @@ mod tests {
         set_waiting(
             &client,
             pairing_ref.clone(),
-            wacore::time::now_secs(),
+            wacore::time::Instant::now(),
             PairCodeUtils::max_primary_hello_attempts(),
         )
         .await;
@@ -1674,7 +1681,13 @@ mod tests {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
         // count = 2 → this is the 3rd attempt, still within the cap of 3.
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 2).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            2,
+        )
+        .await;
         let adv_before = adv(&client);
 
         let notif = primary_hello_notif(&pairing_ref);
@@ -1696,7 +1709,13 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = refresh_code_notif(&pairing_ref, Some(true));
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1721,7 +1740,13 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = refresh_code_notif(&pairing_ref, None);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1744,7 +1769,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
 
-        set_waiting(&client, vec![5, 6, 7, 8], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![5, 6, 7, 8], wacore::time::Instant::now(), 0).await;
 
         let notif = refresh_code_notif(&[1, 1, 1, 1], None);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1842,7 +1867,13 @@ mod tests {
         transport: &Arc<crate::transport::mock::CapturingMockTransport>,
         pairing_ref: &[u8],
     ) {
-        set_waiting(client, pairing_ref.to_vec(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            client,
+            pairing_ref.to_vec(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
         let notif = primary_hello_notif(pairing_ref);
         assert!(handle_pair_code_notification(client, &notif.as_node_ref()).await);
         poll_until("companion_finish to reach the transport", || {
@@ -1948,7 +1979,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         // The replacement holds the slot by the time the answer lands.
-        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::Instant::now(), 0).await;
         let adv_of_replacement = adv(&client);
         report_stage_two_failure(
             &client,
@@ -1975,7 +2006,7 @@ mod tests {
         // The guard's other half: same ref, but a retry has since opened its own
         // attempt. Covered here because a ref mismatch alone would let a
         // regression that drops the attempt comparison pass unnoticed.
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 2).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 2).await;
         let adv_of_retry = adv(&client);
         report_stage_two_failure(
             &client,
@@ -2061,7 +2092,7 @@ mod tests {
     #[tokio::test]
     async fn cancelling_leaves_a_secret_stage_two_never_touched() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
         let before = adv(&client);
         client.cancel_pair_code().await;
         assert_eq!(adv(&client), before, "no stage 2 ran, so nothing rotated");
@@ -2079,7 +2110,7 @@ mod tests {
     #[tokio::test]
     async fn pair_with_code_refuses_to_supersede_a_live_code() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
 
         let err = client
             .pair_with_code(options())
@@ -2100,7 +2131,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_pair_code_lets_a_replacement_be_requested() {
         let (client, transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
 
         client.cancel_pair_code().await;
 
@@ -2121,8 +2152,8 @@ mod tests {
     #[tokio::test]
     async fn an_expired_code_does_not_block_a_new_one() {
         let (client, transport) = create_iq_test_client().await;
-        let stale =
-            wacore::time::now_secs() - (PairCodeUtils::code_validity().as_secs() as i64 + 1);
+        let stale = wacore::time::Instant::now()
+            - (PairCodeUtils::code_validity() + Duration::from_secs(1));
         set_waiting(&client, vec![1, 2, 3, 4], stale, 0).await;
 
         let pending = {
@@ -2143,7 +2174,13 @@ mod tests {
     async fn refresh_code_clears_the_flow_it_asks_to_replace() {
         let client = create_test_client().await;
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = refresh_code_notif(&pairing_ref, Some(true));
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2305,8 +2342,8 @@ mod tests {
     #[tokio::test]
     async fn a_pending_pair_success_still_owns_the_slot() {
         let (client, _transport) = create_iq_test_client().await;
-        let expired =
-            wacore::time::now_secs() - (PairCodeUtils::code_validity().as_secs() as i64 + 1);
+        let expired = wacore::time::Instant::now()
+            - (PairCodeUtils::code_validity() + Duration::from_secs(1));
         // Stage 2 ran: companion_finish is out, pair-success is pending.
         set_waiting(&client, vec![1, 2, 3, 4], expired, 1).await;
 
@@ -2332,7 +2369,13 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2377,7 +2420,7 @@ mod tests {
     #[tokio::test]
     async fn a_teardown_does_not_leave_the_slot_claimed() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
 
         client.cleanup_connection_state().await;
 
@@ -2449,7 +2492,7 @@ mod tests {
         let (client, _transport) = create_iq_test_client().await;
         let claim = wacore::pair_code::PairCodeClaim::next();
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation_ts: wacore::time::now_secs(),
+            code_generation: wacore::time::Instant::now(),
             claim,
         };
 
@@ -2462,7 +2505,7 @@ mod tests {
 
         // Nor does a replacement's claim answer for the one it superseded.
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation_ts: wacore::time::now_secs(),
+            code_generation: wacore::time::Instant::now(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
         assert!(!client.owns_code_claim(claim).await);
@@ -2481,7 +2524,13 @@ mod tests {
     async fn primary_hello_returns_before_stage_two_reaches_the_wire() {
         let (client, transport) = create_iq_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = primary_hello_notif(&pairing_ref);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -2539,7 +2588,7 @@ mod tests {
     async fn a_stage_two_task_does_not_answer_for_the_flow_that_replaced_it() {
         let (client, transport) = create_iq_test_client().await;
         // The replacement: a live flow, but not the one stage 2 was spawned for.
-        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::Instant::now(), 0).await;
         let adv_before = adv(&client);
 
         run_stage_two(
@@ -2578,7 +2627,13 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2613,7 +2668,13 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2639,7 +2700,13 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::Instant::now(),
+            0,
+        )
+        .await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2671,7 +2738,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_stage_is_ignored_and_preserves_state() {
         let client = create_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
 
         let notif = NodeBuilder::new("notification")
             .attr("type", "link_code_companion_reg")

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -321,20 +321,19 @@ impl Client {
         // WA Web also starts before the request (`startAltLinkingFlow` sets
         // `codeGenerationTs` before sending), so the ~180s window covers the
         // round trip rather than starting after it.
-        let code_generation = wacore::time::Instant::now();
+        let requested_at = wacore::time::Instant::now();
+        let code_expires_at = requested_at + PairCodeUtils::code_validity();
         let claim = wacore::pair_code::PairCodeClaim::next();
         {
             let mut state = self.pair_code_state.lock().await;
-            if state.is_outstanding(code_generation) {
+            if state.is_outstanding(requested_at) {
                 return Err(PairCodeError::CodeAlreadyOutstanding {
-                    remaining: state
-                        .live_flow_remaining(code_generation)
-                        .unwrap_or_default(),
+                    remaining: state.live_flow_remaining(requested_at).unwrap_or_default(),
                 }
                 .into());
             }
             *state = PairCodeState::RequestingCode {
-                code_generation,
+                code_expires_at,
                 claim,
             };
         }
@@ -489,18 +488,17 @@ impl Client {
                 phone_jid: phone_number,
                 pair_code: code.clone(),
                 ephemeral_keypair: Box::new(ephemeral_keypair),
-                code_generation,
+                code_expires_at,
                 primary_hello_attempt_count: 0,
             };
             claim_guard.armed = false;
         }
 
         // Dispatch event for the user to display the code. The validity clock
-        // started at `code_generation` (before stage 1), so advertise the
-        // *remaining* window — otherwise a consumer's countdown would outlast the
-        // server's (and our own `handle_primary_hello`) expiry by the stage-1
-        // elapsed time.
-        let remaining = PairCodeUtils::code_validity().saturating_sub(code_generation.elapsed());
+        // started before stage 1, so advertise the *remaining* window — otherwise
+        // a consumer's countdown would outlast the server's (and our own
+        // `handle_primary_hello`) expiry by the stage-1 elapsed time.
+        let remaining = code_expires_at.saturating_duration_since(wacore::time::Instant::now());
         self.core.event_bus.dispatch(Event::PairingCode(
             crate::types::events::PairingCode::builder()
                 .code(code.clone())
@@ -684,7 +682,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
             phone_jid,
             pair_code,
             ephemeral_keypair,
-            code_generation,
+            code_expires_at,
             primary_hello_attempt_count,
         } => {
             // Validate before counting: only a genuine, in-window attempt
@@ -698,12 +696,12 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
                 );
                 return false;
             }
-            let age = code_generation.elapsed();
-            if age > PairCodeUtils::code_validity() {
+            let now = wacore::time::Instant::now();
+            if now > *code_expires_at {
                 warn!(
                     target: "Client/PairCode",
-                    "primary_hello arrived for an expired code ({}s old); ignoring",
-                    age.as_secs()
+                    "primary_hello arrived {}s after the code expired; ignoring",
+                    now.saturating_duration_since(*code_expires_at).as_secs()
                 );
                 return false;
             }
@@ -1129,7 +1127,7 @@ mod tests {
 
         // Park a live code in the slot so the next request is the duplicate.
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation: wacore::time::Instant::now(),
+            code_expires_at: live_window(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
 
@@ -1272,7 +1270,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation: wacore::time::Instant::now(),
+            code_expires_at: live_window(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
 
@@ -1503,10 +1501,23 @@ mod tests {
             .build()
     }
 
+    /// A code minted now: its window closes one validity period out.
+    fn live_window() -> wacore::time::Instant {
+        wacore::time::Instant::now() + PairCodeUtils::code_validity()
+    }
+
+    /// A window that has already closed. The clock's origin, not a subtraction
+    /// from `now`: a monotonic clock has no history before the process started,
+    /// so `now - validity` in a young test binary saturates back to a deadline
+    /// that is still in the future.
+    fn closed_window() -> wacore::time::Instant {
+        wacore::time::Instant::ZERO
+    }
+
     async fn set_waiting(
         client: &Arc<Client>,
         pairing_ref: Vec<u8>,
-        generated_at: wacore::time::Instant,
+        expires_at: wacore::time::Instant,
         count: u32,
     ) {
         *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
@@ -1516,7 +1527,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation: generated_at,
+            code_expires_at: expires_at,
             primary_hello_attempt_count: count,
         };
     }
@@ -1552,7 +1563,7 @@ mod tests {
     #[tokio::test]
     async fn primary_hello_rejects_mismatched_ref() {
         let client = create_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
         let adv_before = adv(&client);
 
         let notif = primary_hello_notif(&[9, 9, 9, 9]);
@@ -1582,13 +1593,7 @@ mod tests {
     async fn stale_mismatched_hellos_do_not_block_the_valid_one() {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
         let adv_before = adv(&client);
 
         // More mismatched hellos than the cap would allow if they counted.
@@ -1617,9 +1622,7 @@ mod tests {
     async fn primary_hello_rejects_expired_code() {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        let stale_ts = wacore::time::Instant::now()
-            - (PairCodeUtils::code_validity() + Duration::from_secs(20));
-        set_waiting(&client, pairing_ref.clone(), stale_ts, 0).await;
+        set_waiting(&client, pairing_ref.clone(), closed_window(), 0).await;
         let adv_before = adv(&client);
 
         let notif = primary_hello_notif(&pairing_ref);
@@ -1650,7 +1653,7 @@ mod tests {
         set_waiting(
             &client,
             pairing_ref.clone(),
-            wacore::time::Instant::now(),
+            live_window(),
             PairCodeUtils::max_primary_hello_attempts(),
         )
         .await;
@@ -1681,13 +1684,7 @@ mod tests {
         let client = create_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
         // count = 2 → this is the 3rd attempt, still within the cap of 3.
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            2,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 2).await;
         let adv_before = adv(&client);
 
         let notif = primary_hello_notif(&pairing_ref);
@@ -1709,13 +1706,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = refresh_code_notif(&pairing_ref, Some(true));
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1740,13 +1731,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = refresh_code_notif(&pairing_ref, None);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1769,7 +1754,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
 
-        set_waiting(&client, vec![5, 6, 7, 8], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![5, 6, 7, 8], live_window(), 0).await;
 
         let notif = refresh_code_notif(&[1, 1, 1, 1], None);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -1867,13 +1852,7 @@ mod tests {
         transport: &Arc<crate::transport::mock::CapturingMockTransport>,
         pairing_ref: &[u8],
     ) {
-        set_waiting(
-            client,
-            pairing_ref.to_vec(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(client, pairing_ref.to_vec(), live_window(), 0).await;
         let notif = primary_hello_notif(pairing_ref);
         assert!(handle_pair_code_notification(client, &notif.as_node_ref()).await);
         poll_until("companion_finish to reach the transport", || {
@@ -1979,7 +1958,7 @@ mod tests {
         client.subscribe_handler(collector.clone()).detach();
 
         // The replacement holds the slot by the time the answer lands.
-        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![9, 9, 9, 9], live_window(), 0).await;
         let adv_of_replacement = adv(&client);
         report_stage_two_failure(
             &client,
@@ -2006,7 +1985,7 @@ mod tests {
         // The guard's other half: same ref, but a retry has since opened its own
         // attempt. Covered here because a ref mismatch alone would let a
         // regression that drops the attempt comparison pass unnoticed.
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 2).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 2).await;
         let adv_of_retry = adv(&client);
         report_stage_two_failure(
             &client,
@@ -2092,7 +2071,7 @@ mod tests {
     #[tokio::test]
     async fn cancelling_leaves_a_secret_stage_two_never_touched() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
         let before = adv(&client);
         client.cancel_pair_code().await;
         assert_eq!(adv(&client), before, "no stage 2 ran, so nothing rotated");
@@ -2110,7 +2089,7 @@ mod tests {
     #[tokio::test]
     async fn pair_with_code_refuses_to_supersede_a_live_code() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
 
         let err = client
             .pair_with_code(options())
@@ -2131,7 +2110,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_pair_code_lets_a_replacement_be_requested() {
         let (client, transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
 
         client.cancel_pair_code().await;
 
@@ -2152,9 +2131,7 @@ mod tests {
     #[tokio::test]
     async fn an_expired_code_does_not_block_a_new_one() {
         let (client, transport) = create_iq_test_client().await;
-        let stale = wacore::time::Instant::now()
-            - (PairCodeUtils::code_validity() + Duration::from_secs(1));
-        set_waiting(&client, vec![1, 2, 3, 4], stale, 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], closed_window(), 0).await;
 
         let pending = {
             let client = client.clone();
@@ -2174,13 +2151,7 @@ mod tests {
     async fn refresh_code_clears_the_flow_it_asks_to_replace() {
         let client = create_test_client().await;
         let pairing_ref = vec![5, 6, 7, 8];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = refresh_code_notif(&pairing_ref, Some(true));
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2343,7 +2314,7 @@ mod tests {
     async fn a_pending_pair_success_still_owns_the_slot() {
         let (client, _transport) = create_iq_test_client().await;
         let expired = wacore::time::Instant::now()
-            - (PairCodeUtils::code_validity() + Duration::from_secs(1));
+            - (PairCodeUtils::code_validity() + std::time::Duration::from_secs(1));
         // Stage 2 ran: companion_finish is out, pair-success is pending.
         set_waiting(&client, vec![1, 2, 3, 4], expired, 1).await;
 
@@ -2369,13 +2340,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2420,7 +2385,7 @@ mod tests {
     #[tokio::test]
     async fn a_teardown_does_not_leave_the_slot_claimed() {
         let (client, _transport) = create_iq_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
 
         client.cleanup_connection_state().await;
 
@@ -2492,7 +2457,7 @@ mod tests {
         let (client, _transport) = create_iq_test_client().await;
         let claim = wacore::pair_code::PairCodeClaim::next();
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation: wacore::time::Instant::now(),
+            code_expires_at: live_window(),
             claim,
         };
 
@@ -2505,7 +2470,7 @@ mod tests {
 
         // Nor does a replacement's claim answer for the one it superseded.
         *client.pair_code_state.lock().await = PairCodeState::RequestingCode {
-            code_generation: wacore::time::Instant::now(),
+            code_expires_at: live_window(),
             claim: wacore::pair_code::PairCodeClaim::next(),
         };
         assert!(!client.owns_code_claim(claim).await);
@@ -2524,13 +2489,7 @@ mod tests {
     async fn primary_hello_returns_before_stage_two_reaches_the_wire() {
         let (client, transport) = create_iq_test_client().await;
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = primary_hello_notif(&pairing_ref);
         let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
@@ -2588,7 +2547,7 @@ mod tests {
     async fn a_stage_two_task_does_not_answer_for_the_flow_that_replaced_it() {
         let (client, transport) = create_iq_test_client().await;
         // The replacement: a live flow, but not the one stage 2 was spawned for.
-        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![9, 9, 9, 9], live_window(), 0).await;
         let adv_before = adv(&client);
 
         run_stage_two(
@@ -2627,13 +2586,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2668,13 +2621,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2700,13 +2647,7 @@ mod tests {
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
         client.subscribe_handler(collector.clone()).detach();
         let pairing_ref = vec![1, 2, 3, 4];
-        set_waiting(
-            &client,
-            pairing_ref.clone(),
-            wacore::time::Instant::now(),
-            0,
-        )
-        .await;
+        set_waiting(&client, pairing_ref.clone(), live_window(), 0).await;
 
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
@@ -2738,7 +2679,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_stage_is_ignored_and_preserves_state() {
         let client = create_test_client().await;
-        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::Instant::now(), 0).await;
+        set_waiting(&client, vec![1, 2, 3, 4], live_window(), 0).await;
 
         let notif = NodeBuilder::new("notification")
             .attr("type", "link_code_companion_reg")

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -1967,7 +1967,7 @@ mod tests {
         let snap = stats.snapshot();
         assert_eq!(snap.frames_sent, sent.len() as u64);
         assert_eq!(snap.bytes_sent, wire_total as u64);
-        assert!(stats.first_send_since_recv_ms() > 0);
+        assert!(stats.first_send_since_recv().is_some());
     }
 
     /// Tests edge cases for buffer sizing

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -206,13 +206,14 @@ pub enum PairCodeState {
     /// window as a distinct stage (`AfterSendCompanionHello` follows
     /// `Initialized` before the request resolves).
     RequestingCode {
-        /// Stamped before `companion_hello`, and carried into
+        /// The generation instant plus [`PairCodeUtils::code_validity`], stamped
+        /// before `companion_hello` and carried into
         /// [`Self::WaitingForPhoneConfirmation`] unchanged.
-        code_generation: Instant,
-        /// Identifies *this* request. The stamp cannot: cancel a request and
-        /// start its replacement inside the same second and both carry the same
-        /// number, so the first one's late response would install its code over
-        /// the replacement's claim, and its failure path would release it.
+        code_expires_at: Instant,
+        /// Identifies *this* request. The deadline cannot: a replacement started
+        /// right after a cancellation carries an indistinguishable one, so the
+        /// first request's late response would install its code over the
+        /// replacement's claim, and its failure path would release it.
         claim: PairCodeClaim,
     },
     /// Stage 1 complete - waiting for phone to confirm code entry.
@@ -225,12 +226,16 @@ pub enum PairCodeState {
         pair_code: String,
         /// Ephemeral keypair generated for this session.
         ephemeral_keypair: Box<KeyPair>,
-        /// When the code was generated. Enforces the ~180s validity window: a
-        /// `primary_hello` arriving later is rejected (WA Web `OldCodeError`).
-        /// Monotonic: the window is elapsed time, never persisted and never
+        /// When the ~180s validity window closes: a `primary_hello` arriving
+        /// after it is rejected (WA Web `OldCodeError`).
+        ///
+        /// Monotonic, and a deadline rather than the generation instant it is
+        /// derived from. The window is elapsed time, never persisted and never
         /// compared against a server timestamp, so a system-clock adjustment
-        /// has no business expiring a code someone is still reading.
-        code_generation: Instant,
+        /// has no business expiring a code someone is still reading. Holding
+        /// the deadline also means an already-closed window is representable
+        /// without dating something before the process began.
+        code_expires_at: Instant,
         /// Count of `primary_hello` notifications processed for this code. WA Web
         /// (`DeviceLinkingApi`) caps this at 3 per code (`MaxPrimaryHelloError`);
         /// the primary may retry, re-deriving fresh key material each time.
@@ -284,17 +289,15 @@ impl PairCodeState {
 
     pub fn live_flow_remaining(&self, now: Instant) -> Option<std::time::Duration> {
         let (Self::RequestingCode {
-            code_generation, ..
+            code_expires_at, ..
         }
         | Self::WaitingForPhoneConfirmation {
-            code_generation, ..
+            code_expires_at, ..
         }) = self
         else {
             return None;
         };
-        let validity = PairCodeUtils::code_validity();
-        let age = now.saturating_duration_since(*code_generation);
-        (age <= validity).then(|| validity - age)
+        (now <= *code_expires_at).then(|| code_expires_at.saturating_duration_since(now))
     }
 }
 
@@ -1216,7 +1219,7 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation: at(at_secs),
+            code_expires_at: at(at_secs) + PairCodeUtils::code_validity(),
             primary_hello_attempt_count: 0,
         }
     }
@@ -1267,7 +1270,7 @@ mod tests {
     fn live_flow_remaining_ignores_a_wall_clock_jump() {
         let generated = Instant::now();
         let state = PairCodeState::RequestingCode {
-            code_generation: generated,
+            code_expires_at: generated + PairCodeUtils::code_validity(),
             claim: PairCodeClaim::next(),
         };
         assert_eq!(
@@ -1283,13 +1286,22 @@ mod tests {
         );
     }
 
-    /// A monotonic clock never moves backwards, but the arithmetic still
-    /// saturates rather than underflowing if a provider misbehaves.
+    /// A monotonic clock never moves backwards, but if a provider misbehaved
+    /// the countdown must saturate rather than wrap: past the deadline there is
+    /// no window left, however far past it the reading is.
     #[test]
-    fn live_flow_remaining_survives_a_backwards_clock() {
+    fn live_flow_remaining_saturates_instead_of_wrapping() {
+        let state = waiting_at(1_000);
+        let deadline = at(1_000) + PairCodeUtils::code_validity();
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(at(900)),
-            Some(PairCodeUtils::code_validity())
+            state.live_flow_remaining(deadline),
+            Some(std::time::Duration::ZERO),
+            "the deadline itself is the last live instant"
+        );
+        assert_eq!(
+            state.live_flow_remaining(deadline + std::time::Duration::from_secs(10_000)),
+            None,
+            "long past the deadline is still just expired, never a fresh window"
         );
     }
 

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -25,6 +25,7 @@ use crate::companion_reg::{
 };
 use crate::libsignal::crypto::{CryptoProviderError, aes_256_gcm_encrypt};
 use crate::libsignal::protocol::{CurveError, KeyPair, PublicKey};
+use crate::time::Instant;
 use aes::cipher::{KeyIvInit, StreamCipher};
 use ctr::Ctr128BE;
 use hmac::{Hmac, Mac};
@@ -207,7 +208,7 @@ pub enum PairCodeState {
     RequestingCode {
         /// Stamped before `companion_hello`, and carried into
         /// [`Self::WaitingForPhoneConfirmation`] unchanged.
-        code_generation_ts: i64,
+        code_generation: Instant,
         /// Identifies *this* request. The stamp cannot: cancel a request and
         /// start its replacement inside the same second and both carry the same
         /// number, so the first one's late response would install its code over
@@ -224,9 +225,12 @@ pub enum PairCodeState {
         pair_code: String,
         /// Ephemeral keypair generated for this session.
         ephemeral_keypair: Box<KeyPair>,
-        /// Unix seconds when the code was generated. Enforces the ~180s validity
-        /// window: a `primary_hello` arriving later is rejected (WA Web `OldCodeError`).
-        code_generation_ts: i64,
+        /// When the code was generated. Enforces the ~180s validity window: a
+        /// `primary_hello` arriving later is rejected (WA Web `OldCodeError`).
+        /// Monotonic: the window is elapsed time, never persisted and never
+        /// compared against a server timestamp, so a system-clock adjustment
+        /// has no business expiring a code someone is still reading.
+        code_generation: Instant,
         /// Count of `primary_hello` notifications processed for this code. WA Web
         /// (`DeviceLinkingApi`) caps this at 3 per code (`MaxPrimaryHelloError`);
         /// the primary may retry, re-deriving fresh key material each time.
@@ -274,25 +278,23 @@ impl PairCodeState {
     ///
     /// The union of the two clocks: the code's own validity window, and the
     /// link that outlives it once the phone has answered.
-    pub fn is_outstanding(&self, now: i64) -> bool {
+    pub fn is_outstanding(&self, now: Instant) -> bool {
         self.live_flow_remaining(now).is_some() || self.awaiting_pair_success()
     }
 
-    pub fn live_flow_remaining(&self, now: i64) -> Option<std::time::Duration> {
+    pub fn live_flow_remaining(&self, now: Instant) -> Option<std::time::Duration> {
         let (Self::RequestingCode {
-            code_generation_ts, ..
+            code_generation, ..
         }
         | Self::WaitingForPhoneConfirmation {
-            code_generation_ts, ..
+            code_generation, ..
         }) = self
         else {
             return None;
         };
         let validity = PairCodeUtils::code_validity();
-        // A backwards clock jump reads as "no time has passed", never as an
-        // expiry that would let the overlap through unreported.
-        let age = now.saturating_sub(*code_generation_ts).max(0) as u64;
-        (age <= validity.as_secs()).then(|| validity - std::time::Duration::from_secs(age))
+        let age = now.saturating_duration_since(*code_generation);
+        (age <= validity).then(|| validity - age)
     }
 }
 
@@ -1202,7 +1204,11 @@ mod tests {
     // `forceManualRefresh`, or the screen's own timers. This predicate is what
     // lets the overwrite be reported instead of silent.
 
-    fn waiting_at(ts: i64) -> PairCodeState {
+    fn at(secs: u64) -> Instant {
+        Instant::ZERO + std::time::Duration::from_secs(secs)
+    }
+
+    fn waiting_at(at_secs: u64) -> PairCodeState {
         PairCodeState::WaitingForPhoneConfirmation {
             pairing_ref: b"3@2:ref".to_vec(),
             phone_jid: "15551234567".to_string(),
@@ -1210,27 +1216,30 @@ mod tests {
             ephemeral_keypair: Box::new(KeyPair::generate(
                 &mut rand::make_rng::<rand::rngs::StdRng>(),
             )),
-            code_generation_ts: ts,
+            code_generation: at(at_secs),
             primary_hello_attempt_count: 0,
         }
     }
 
     #[test]
     fn live_flow_remaining_is_none_when_no_code_is_outstanding() {
-        assert_eq!(PairCodeState::Idle.live_flow_remaining(1_000), None);
-        assert_eq!(PairCodeState::Completed.live_flow_remaining(1_000), None);
+        assert_eq!(PairCodeState::Idle.live_flow_remaining(at(1_000)), None);
+        assert_eq!(
+            PairCodeState::Completed.live_flow_remaining(at(1_000)),
+            None
+        );
     }
 
     #[test]
     fn live_flow_remaining_counts_down_the_validity_window() {
-        let validity = PairCodeUtils::code_validity().as_secs() as i64;
+        let validity = PairCodeUtils::code_validity();
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(1_000),
-            Some(PairCodeUtils::code_validity())
+            waiting_at(1_000).live_flow_remaining(at(1_000)),
+            Some(validity)
         );
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(1_000 + 30),
-            Some(std::time::Duration::from_secs(validity as u64 - 30))
+            waiting_at(1_000).live_flow_remaining(at(1_030)),
+            Some(validity - std::time::Duration::from_secs(30))
         );
     }
 
@@ -1239,23 +1248,47 @@ mod tests {
     /// is still usable, so it is still worth reporting as lost.
     #[test]
     fn live_flow_remaining_treats_the_exact_window_as_still_live() {
-        let validity = PairCodeUtils::code_validity().as_secs() as i64;
+        let validity = PairCodeUtils::code_validity();
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(1_000 + validity),
+            waiting_at(1_000).live_flow_remaining(at(1_000) + validity),
             Some(std::time::Duration::ZERO)
         );
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(1_000 + validity + 1),
+            waiting_at(1_000)
+                .live_flow_remaining(at(1_000) + validity + std::time::Duration::from_secs(1)),
             None,
             "an expired code is not a flow anyone can still complete"
         );
     }
 
-    /// A clock that jumped backwards must not underflow into a bogus window.
+    /// The window is elapsed time, so a system clock jumping forward past the
+    /// validity must not retire a code the user is still reading off the screen.
+    #[test]
+    fn live_flow_remaining_ignores_a_wall_clock_jump() {
+        let generated = Instant::now();
+        let state = PairCodeState::RequestingCode {
+            code_generation: generated,
+            claim: PairCodeClaim::next(),
+        };
+        assert_eq!(
+            state.live_flow_remaining(generated + std::time::Duration::from_secs(1)),
+            Some(PairCodeUtils::code_validity() - std::time::Duration::from_secs(1)),
+        );
+        // Real elapsed time past the window still expires it.
+        assert_eq!(
+            state.live_flow_remaining(
+                generated + PairCodeUtils::code_validity() + std::time::Duration::from_secs(1)
+            ),
+            None
+        );
+    }
+
+    /// A monotonic clock never moves backwards, but the arithmetic still
+    /// saturates rather than underflowing if a provider misbehaves.
     #[test]
     fn live_flow_remaining_survives_a_backwards_clock() {
         assert_eq!(
-            waiting_at(1_000).live_flow_remaining(900),
+            waiting_at(1_000).live_flow_remaining(at(900)),
             Some(PairCodeUtils::code_validity())
         );
     }

--- a/wacore/src/protocol/keepalive.rs
+++ b/wacore/src/protocol/keepalive.rs
@@ -165,14 +165,16 @@ mod tests {
         assert!(is_dead_socket_at(armed, None, now));
     }
 
-    /// Regression for the wake-from-suspend false positive (issue #1376).
+    /// A socket idle for a moment is not a dead socket: a receive, then the send
+    /// that arms the anchor, then one second of elapsed time.
     ///
-    /// A receive, then a send that arms the anchor, then one second of real
-    /// time. A wall clock that leapt twelve hours inside that second (a resumed
-    /// laptop re-syncing NTP) has no way to reach this decision any more,
-    /// because none of these three values is a wall-clock timestamp.
+    /// The wake-from-suspend false positive (issue #1376) is ruled out a level
+    /// up rather than here: these arguments are monotonic `Instant`s, so a
+    /// wall-clock timestamp no longer type-checks into this predicate, and the
+    /// anchors that feed it are pinned to the monotonic clock by
+    /// `wire_bookkeeping_reads_the_clock_only_where_a_value_is_used`.
     #[test]
-    fn a_wall_clock_jump_does_not_declare_a_live_socket_dead() {
+    fn a_briefly_idle_socket_is_not_dead() {
         let received = at(1_000);
         let armed = received + Duration::from_millis(1);
         assert!(!is_dead_socket_at(

--- a/wacore/src/protocol/keepalive.rs
+++ b/wacore/src/protocol/keepalive.rs
@@ -5,6 +5,7 @@
 //! and IQ error classification remain in `whatsapp-rust/src/keepalive.rs`
 //! because `IqError` depends on `SocketError` which lives in whatsapp-rust.
 
+use crate::time::Instant;
 use std::time::Duration;
 
 /// WA Web: `healthCheckInterval = 15` -> `15 * (1 + random())` = 15-30 s.
@@ -17,123 +18,118 @@ pub const KEEP_ALIVE_RESPONSE_DEADLINE: Duration = Duration::from_secs(20);
 /// after a send, the socket is considered dead and forcibly closed.
 pub const DEAD_SOCKET_TIME: Duration = Duration::from_secs(20);
 
-/// Returns the number of milliseconds elapsed since a stored timestamp.
-/// Returns `None` if the timestamp was never set (value 0).
-pub fn ms_since(timestamp_ms: u64) -> Option<u64> {
-    ms_since_at(timestamp_ms, now_ms())
+/// Time elapsed since `anchor`, or `None` when nothing is anchored.
+pub fn elapsed_since(anchor: Option<Instant>) -> Option<Duration> {
+    elapsed_since_at(anchor, Instant::now())
 }
 
-/// Same as [`ms_since`], but against a caller-supplied `now`.
+/// Same as [`elapsed_since`], but against a caller-supplied `now`.
 ///
 /// The dead-socket branch of the keepalive tick evaluates this and
 /// [`is_dead_socket_at`] against one instant instead of reading the clock per
 /// predicate, and a test can supply the instant outright.
-pub fn ms_since_at(timestamp_ms: u64, now_ms: u64) -> Option<u64> {
-    if timestamp_ms == 0 {
-        return None;
-    }
-    Some(now_ms.saturating_sub(timestamp_ms))
-}
-
-/// The wall clock in the units these predicates compare.
-pub fn now_ms() -> u64 {
-    crate::time::now_millis().max(0) as u64
+pub fn elapsed_since_at(anchor: Option<Instant>, now: Instant) -> Option<Duration> {
+    anchor.map(|anchor| now.saturating_duration_since(anchor))
 }
 
 /// Checks the dead-socket condition: [`DEAD_SOCKET_TIME`] elapsed since the timer
 /// was armed without a receive cancelling it.
 ///
-/// `armed_ms` is the anchor WA Web's `deadSocketTimer.onOrBefore` keeps: the FIRST
-/// send after the last receive (0 when unarmed / cancelled). It must NOT be the
-/// most-recent send — anchoring there lets continued outgoing traffic keep pushing
-/// the deadline out and hide a half-open socket forever. The caller feeds
-/// `SessionStats::first_send_since_recv_ms`, reset to 0 on every receive
-/// (`parseAndHandleStanza` → `cancel()`).
-pub fn is_dead_socket(armed_ms: u64, last_received_ms: u64) -> bool {
-    is_dead_socket_at(armed_ms, last_received_ms, now_ms())
+/// Every argument is a monotonic [`Instant`], never a wall-clock timestamp: this
+/// asks how much time passed, and a wall clock answers that wrongly whenever the
+/// system clock is adjusted -- a laptop resuming from suspend re-syncs NTP, and
+/// the jump alone used to read as twenty silent seconds and kill a healthy
+/// socket seconds after it authenticated.
+///
+/// `armed` is the anchor WA Web's `deadSocketTimer.onOrBefore` keeps: the FIRST
+/// send after the last receive (`None` when unarmed / cancelled). It must NOT be
+/// the most-recent send -- anchoring there lets continued outgoing traffic keep
+/// pushing the deadline out and hide a half-open socket forever. The caller feeds
+/// `SessionStats::first_send_since_recv`, cleared on every receive
+/// (`parseAndHandleStanza` -> `cancel()`).
+pub fn is_dead_socket(armed: Option<Instant>, last_received: Option<Instant>) -> bool {
+    is_dead_socket_at(armed, last_received, Instant::now())
 }
 
 /// Same as [`is_dead_socket`], but against a caller-supplied `now`, so the
 /// decision is testable without depending on the platform clock.
-pub fn is_dead_socket_at(armed_ms: u64, last_received_ms: u64, now_ms: u64) -> bool {
+pub fn is_dead_socket_at(
+    armed: Option<Instant>,
+    last_received: Option<Instant>,
+    now: Instant,
+) -> bool {
     // Timer not armed (never sent since the last receive).
-    if armed_ms == 0 {
+    let Some(armed) = armed else {
         return false;
-    }
+    };
     // Received data after (or at) the armed instant -- timer cancelled.
-    if last_received_ms >= armed_ms {
+    if last_received.is_some_and(|received| received >= armed) {
         return false;
     }
-    ms_since_at(armed_ms, now_ms)
-        .map(|elapsed| elapsed > DEAD_SOCKET_TIME.as_millis() as u64)
-        .unwrap_or(false)
+    now.saturating_duration_since(armed) > DEAD_SOCKET_TIME
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // -- ms_since tests --
+    fn at(secs: u64) -> Instant {
+        Instant::ZERO + Duration::from_secs(secs)
+    }
+
+    // -- elapsed_since tests --
 
     #[test]
-    fn ms_since_never_set() {
-        assert_eq!(ms_since(0), None);
+    fn elapsed_since_never_set() {
+        assert_eq!(elapsed_since(None), None);
     }
 
     #[test]
-    fn ms_since_recent() {
-        let now_ms = crate::time::now_millis().max(0) as u64;
-        let elapsed = ms_since(now_ms).unwrap();
-        assert!(elapsed < 100, "should be near-zero, got {elapsed}ms");
-    }
-
-    #[test]
-    fn ms_since_stale() {
-        let thirty_sec_ago = (crate::time::now_millis().max(0) as u64).saturating_sub(30_000);
-        let elapsed = ms_since(thirty_sec_ago).unwrap();
+    fn elapsed_since_recent() {
+        let elapsed = elapsed_since(Some(Instant::now())).unwrap();
         assert!(
-            (29_000..=31_000).contains(&elapsed),
-            "should be ~30s, got {elapsed}ms"
+            elapsed < Duration::from_millis(100),
+            "should be near-zero, got {elapsed:?}"
         );
+    }
+
+    #[test]
+    fn elapsed_since_stale() {
+        let elapsed = elapsed_since_at(Some(at(100)), at(130)).unwrap();
+        assert_eq!(elapsed, Duration::from_secs(30));
     }
 
     // -- is_dead_socket tests --
 
     #[test]
     fn dead_socket_never_sent() {
-        assert!(!is_dead_socket(0, 0));
+        assert!(!is_dead_socket(None, None));
     }
 
     #[test]
     fn dead_socket_received_after_send() {
-        let t = crate::time::now_millis().max(0) as u64;
-        assert!(!is_dead_socket(t, t + 1));
+        let t = Instant::now();
+        assert!(!is_dead_socket(Some(t), Some(t + Duration::from_millis(1))));
     }
 
     #[test]
     fn dead_socket_sent_recently() {
-        let now = crate::time::now_millis().max(0) as u64;
-        assert!(!is_dead_socket(now, 0));
+        assert!(!is_dead_socket(Some(Instant::now()), None));
     }
 
     #[test]
     fn dead_socket_sent_long_ago_no_reply() {
-        let thirty_ago = (crate::time::now_millis().max(0) as u64).saturating_sub(30_000);
-        assert!(is_dead_socket(thirty_ago, 0));
+        assert!(is_dead_socket_at(Some(at(100)), None, at(130)));
     }
 
     #[test]
     fn dead_socket_sent_long_ago_old_reply() {
-        let thirty_ago = (crate::time::now_millis().max(0) as u64).saturating_sub(30_000);
-        let thirty_one_ago = thirty_ago.saturating_sub(1_000);
-        assert!(is_dead_socket(thirty_ago, thirty_one_ago));
+        assert!(is_dead_socket_at(Some(at(100)), Some(at(99)), at(130)));
     }
 
     #[test]
     fn dead_socket_sent_long_ago_recent_reply() {
-        let thirty_ago = (crate::time::now_millis().max(0) as u64).saturating_sub(30_000);
-        let one_ago = (crate::time::now_millis().max(0) as u64).saturating_sub(1_000);
-        assert!(!is_dead_socket(thirty_ago, one_ago));
+        assert!(!is_dead_socket_at(Some(at(100)), Some(at(129)), at(130)));
     }
 
     // -- controlled-clock boundary --
@@ -143,10 +139,14 @@ mod tests {
     /// test took to run.
     #[test]
     fn dead_socket_boundary_is_exact() {
-        let armed = 1_000_000u64;
-        let dead_at = armed + DEAD_SOCKET_TIME.as_millis() as u64;
-        assert!(!is_dead_socket_at(armed, 0, dead_at));
-        assert!(is_dead_socket_at(armed, 0, dead_at + 1));
+        let armed = at(1_000);
+        let dead_at = armed + DEAD_SOCKET_TIME;
+        assert!(!is_dead_socket_at(Some(armed), None, dead_at));
+        assert!(is_dead_socket_at(
+            Some(armed),
+            None,
+            dead_at + Duration::from_millis(1)
+        ));
     }
 
     /// A silent socket is still detected while sends keep flowing: the anchor
@@ -155,14 +155,44 @@ mod tests {
     fn continued_sends_do_not_hide_a_silent_socket() {
         let stats = crate::stats::SessionStats::new();
         stats.record_frame_sent(10);
-        let armed = stats.first_send_since_recv_ms();
+        let armed = stats.first_send_since_recv();
         for _ in 0..100 {
             stats.record_frame_sent(10);
         }
-        assert_eq!(stats.first_send_since_recv_ms(), armed);
+        assert_eq!(stats.first_send_since_recv(), armed);
 
-        let now = armed + DEAD_SOCKET_TIME.as_millis() as u64 + 1;
-        assert!(is_dead_socket_at(armed, 0, now));
+        let now = armed.unwrap() + DEAD_SOCKET_TIME + Duration::from_millis(1);
+        assert!(is_dead_socket_at(armed, None, now));
+    }
+
+    /// Regression for the wake-from-suspend false positive (issue #1376).
+    ///
+    /// A receive, then a send that arms the anchor, then one second of real
+    /// time. A wall clock that leapt twelve hours inside that second (a resumed
+    /// laptop re-syncing NTP) has no way to reach this decision any more,
+    /// because none of these three values is a wall-clock timestamp.
+    #[test]
+    fn a_wall_clock_jump_does_not_declare_a_live_socket_dead() {
+        let received = at(1_000);
+        let armed = received + Duration::from_millis(1);
+        assert!(!is_dead_socket_at(
+            Some(armed),
+            Some(received),
+            armed + Duration::from_secs(1)
+        ));
+    }
+
+    /// The other half of the regression: real silence past the deadline still
+    /// forces a reconnect, so the fix is not "disable the watchdog".
+    #[test]
+    fn real_silence_past_the_deadline_is_still_a_dead_socket() {
+        let received = at(1_000);
+        let armed = received + Duration::from_millis(1);
+        assert!(is_dead_socket_at(
+            Some(armed),
+            Some(received),
+            armed + DEAD_SOCKET_TIME + Duration::from_secs(1)
+        ));
     }
 
     // -- constant sanity --

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -719,13 +719,13 @@ std::thread_local! {
     /// poll, and several meters can share one thread), and each scope must
     /// keep its own start. Poll scopes strictly nest, so LIFO holds; a nested
     /// scope's time is also part of its enclosing scope's elapsed.
-    static POLL_START: core::cell::RefCell<Vec<crate::time::Instant>> =
+    static POLL_START: core::cell::RefCell<Vec<Instant>> =
         const { core::cell::RefCell::new(Vec::new()) };
 }
 
 impl TaskInstrument for CpuMeter {
     fn on_poll_start(&self) {
-        POLL_START.with(|s| s.borrow_mut().push(crate::time::Instant::now()));
+        POLL_START.with(|s| s.borrow_mut().push(Instant::now()));
     }
 
     fn on_poll_end(&self) {

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -11,7 +11,10 @@
 //!   on a path that already does AEAD crypto plus a transport write.
 //! - Clock reads: zero per frame sent while the dead-socket anchor is armed,
 //!   one on the send that arms it, one per received transport event, plus one
-//!   more when that event carries several frames. A new timestamp field here
+//!   more when that event carries several frames. All of them monotonic: every
+//!   stamp on this path anchors an elapsed-time deadline, and a wall clock
+//!   answers that question with whatever the system clock was last set to. A
+//!   new timestamp field here
 //!   buys a read on the client's hottest path and needs a reader to justify it:
 //!   one direct message arrives as roughly four transport events (the message,
 //!   its ack, the receipt, the receipt's ack), so per-event is per-message x4.
@@ -29,6 +32,7 @@ use std::time::Duration;
 use portable_atomic::{AtomicU64, Ordering};
 
 use crate::sync_marker::MaybeSendSync;
+use crate::time::{AtomicInstant, Instant};
 
 // ── Wire/session counters ────────────────────────────────────────────────────
 
@@ -135,23 +139,28 @@ pub struct SessionStats {
     devices_unkeyed_fetch_failed: AtomicU64,
     devices_unkeyed_encrypt: AtomicU64,
     reconnects: AtomicU64,
-    /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
+    /// When the last WebSocket data arrived.
     /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
     ///
-    /// Kept exact: two decisions measure elapsed time from it, the idle-ping
-    /// gate (15 s) and the dead-socket check (20 s). Sampling it would need a
-    /// refresh trigger, and the only one the core has is the keepalive tick,
-    /// which is coarser (15-30 s) than the gate it feeds.
-    last_data_received_ms: AtomicU64,
+    /// Monotonic, because both readers measure elapsed time from it: the
+    /// idle-ping gate (15 s) and the dead-socket check (20 s). A wall clock
+    /// answers "how long since" with whatever the system clock was last set to,
+    /// which is how twelve hours of suspend read as a dead socket (issue #1376).
+    /// [`StatsSnapshot::last_data_received_ms`] still reports a wall-clock
+    /// instant, derived from this one at snapshot time.
+    ///
+    /// Kept exact rather than sampled: a refresh trigger would have to be the
+    /// keepalive tick, which is coarser (15-30 s) than the gate it feeds.
+    last_data_received: AtomicInstant,
     /// Dead-socket watchdog anchor (WA Web `deadSocketTimer.onOrBefore`): the first
     /// send since the last receive, so continued traffic can't push the deadline out.
-    /// Treated as stale (and re-armed) once `<= last_data_received_ms`, so a send that
+    /// Treated as stale (and re-armed) once `<= last_data_received`, so a send that
     /// raced past a receive-reset can't leave a pre-receive value stuck here.
     ///
-    /// The only send-side timestamp: a `last_data_sent_ms` companion cost a
+    /// The only send-side timestamp: a `last_data_sent` companion cost a
     /// clock read per frame written and had no reader, since the watchdog
     /// anchors on the first unanswered send and never on the most recent one.
-    first_send_since_recv_ms: AtomicU64,
+    first_send_since_recv: AtomicInstant,
 }
 
 /// Point-in-time copy of [`SessionStats`], plus client-level counters the
@@ -206,6 +215,10 @@ pub struct StatsSnapshot {
     /// reached consumers: a sender resending one id as fresh ciphertext. This
     /// is the number to check first when a consumer reports a missing message.
     pub messages_suppressed_duplicate: u64,
+    /// Wall-clock milliseconds since the Unix epoch when data last arrived on
+    /// the current connection, or 0 before the first receive. Derived at
+    /// snapshot time from a monotonic anchor, so it reads in the frame the
+    /// caller's own clock is in even after the system clock has been adjusted.
     pub last_data_received_ms: u64,
 }
 
@@ -227,8 +240,8 @@ impl SessionStats {
         Self::default()
     }
 
-    fn now_ms() -> u64 {
-        crate::time::now_millis().max(0) as u64
+    fn now() -> Instant {
+        Instant::now()
     }
 
     /// One encrypted frame written to the transport.
@@ -243,19 +256,18 @@ impl SessionStats {
         // armed: guarding only on `== 0` would let a send whose arm raced past a
         // receive-reset leave a pre-receive timestamp stuck there forever, silently
         // disabling detection.
-        let last_recv = self.last_data_received_ms.load(Ordering::Relaxed);
-        let anchor = self.first_send_since_recv_ms.load(Ordering::Relaxed);
-        if anchor == 0 || anchor <= last_recv {
+        let last_recv = self.last_data_received.load();
+        let is_stale = |anchor: Option<Instant>| match (anchor, last_recv) {
+            (None, _) => true,
+            (Some(anchor), Some(last_recv)) => anchor <= last_recv,
+            (Some(_), None) => false,
+        };
+        if is_stale(self.first_send_since_recv.load()) {
             // The plain load above gates the clock read; the arm itself re-checks
             // under a CAS, so once an anchor is set a later send cannot overwrite
             // it. Two senders that both see it unarmed still resolve by whichever
             // CAS lands first, which the serial sender task makes unreachable.
-            let now = Self::now_ms();
-            let _ = self.first_send_since_recv_ms.fetch_update(
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-                |current| (current == 0 || current <= last_recv).then_some(now),
-            );
+            self.first_send_since_recv.store_if(Self::now(), is_stale);
         }
     }
 
@@ -273,10 +285,9 @@ impl SessionStats {
         self.frames_received
             .fetch_add(frames as u64, Ordering::Relaxed);
         if frames > 1 {
-            self.last_data_received_ms
-                .store(Self::now_ms(), Ordering::Relaxed);
+            self.last_data_received.store(Self::now());
             // A receive cancels the dead-socket deadline; the next send re-arms it.
-            self.first_send_since_recv_ms.store(0, Ordering::Relaxed);
+            self.first_send_since_recv.clear();
         }
     }
 
@@ -285,10 +296,9 @@ impl SessionStats {
     /// [`Self::record_recv_batch`].
     #[inline]
     pub fn mark_recv_activity(&self) {
-        self.last_data_received_ms
-            .store(Self::now_ms(), Ordering::Relaxed);
+        self.last_data_received.store(Self::now());
         // A receive cancels the dead-socket deadline; the next send re-arms it.
-        self.first_send_since_recv_ms.store(0, Ordering::Relaxed);
+        self.first_send_since_recv.clear();
     }
 
     #[inline]
@@ -356,22 +366,24 @@ impl SessionStats {
     /// watchdog never reads a previous connection's values. Traffic counters
     /// are cumulative and survive.
     pub fn reset_connection_activity(&self) {
-        self.last_data_received_ms.store(0, Ordering::Relaxed);
-        self.first_send_since_recv_ms.store(0, Ordering::Relaxed);
+        self.last_data_received.clear();
+        self.first_send_since_recv.clear();
     }
 
     /// The dead-socket watchdog anchor: the first send since the last receive
-    /// (0 when unarmed). Evaluate
+    /// (`None` when unarmed). Evaluate
     /// [`is_dead_socket`](crate::protocol::keepalive::is_dead_socket) against this, not the last
     /// send, so continued outgoing traffic can't hide a half-open socket.
     #[inline]
-    pub fn first_send_since_recv_ms(&self) -> u64 {
-        self.first_send_since_recv_ms.load(Ordering::Relaxed)
+    pub fn first_send_since_recv(&self) -> Option<Instant> {
+        self.first_send_since_recv.load()
     }
 
+    /// When data last arrived, on the monotonic clock. `None` before the first
+    /// receive of the current connection.
     #[inline]
-    pub fn last_data_received_ms(&self) -> u64 {
-        self.last_data_received_ms.load(Ordering::Relaxed)
+    pub fn last_data_received(&self) -> Option<Instant> {
+        self.last_data_received.load()
     }
 
     /// Copy the session-level counters. Client-level fields
@@ -397,7 +409,18 @@ impl SessionStats {
             reconnect_errors: 0,
             resends_throttled: 0,
             messages_suppressed_duplicate: 0,
-            last_data_received_ms: self.last_data_received_ms.load(Ordering::Relaxed),
+            // Derived, not stamped: the field is kept monotonically so a clock
+            // adjustment cannot move the watchdog's deadline, and reporting it
+            // in the wall-clock frame the caller reads it in costs nothing on
+            // the wire path, only here.
+            last_data_received_ms: self
+                .last_data_received
+                .load()
+                .map(|at| {
+                    let now = crate::time::now_millis().max(0) as u64;
+                    now.saturating_sub(at.elapsed().as_millis() as u64)
+                })
+                .unwrap_or(0),
         }
     }
 }
@@ -986,7 +1009,7 @@ mod tests {
         let stats = SessionStats::new();
         stats.record_frame_sent(100);
         stats.record_frame_sent(50);
-        assert!(stats.first_send_since_recv_ms() > 0);
+        assert!(stats.first_send_since_recv().is_some());
         stats.record_recv_batch(300, 2);
         stats.record_message_sent();
         stats.record_message_received();
@@ -1068,14 +1091,17 @@ mod tests {
 
     #[test]
     fn dead_socket_anchor_holds_across_continued_sends() {
-        use crate::protocol::keepalive::is_dead_socket;
+        use crate::protocol::keepalive::is_dead_socket_at;
 
         let stats = SessionStats::new();
-        assert_eq!(stats.first_send_since_recv_ms(), 0, "unarmed initially");
+        assert_eq!(stats.first_send_since_recv(), None, "unarmed initially");
 
         stats.record_frame_sent(10);
-        let armed = stats.first_send_since_recv_ms();
-        assert!(armed > 0, "the first send arms the dead-socket anchor");
+        let armed = stats.first_send_since_recv();
+        assert!(
+            armed.is_some(),
+            "the first send arms the dead-socket anchor"
+        );
 
         // Continued outgoing traffic must NOT push the anchor out (WA Web onOrBefore
         // keeps the earliest deadline) — this is what let a half-open socket hide.
@@ -1086,30 +1112,35 @@ mod tests {
         stats.record_frame_sent(10);
         stats.record_frame_sent(10);
         assert_eq!(
-            stats.first_send_since_recv_ms(),
+            stats.first_send_since_recv(),
             armed,
             "later sends keep the earliest anchor"
         );
 
         // A dead socket is detected once DEAD_SOCKET_TIME passes the anchor, even
         // though sends kept happening (anchor far in the past, no receive since).
-        let now = crate::time::now_millis().max(0) as u64;
-        let stale = now.saturating_sub(21_000);
+        // Built from the clock's origin rather than `now`, because a process
+        // that has just started has no 21 seconds behind it to subtract.
+        let anchor = Instant::ZERO + Duration::from_secs(1_000);
         assert!(
-            is_dead_socket(stale, stale.saturating_sub(5_000)),
+            is_dead_socket_at(
+                Some(anchor),
+                Some(anchor - Duration::from_secs(5)),
+                anchor + Duration::from_secs(21)
+            ),
             "20s past the anchor with no receive => dead"
         );
 
-        // A receive cancels the anchor; the next send re-arms it (non-zero again).
+        // A receive cancels the anchor; the next send re-arms it.
         stats.mark_recv_activity();
         assert_eq!(
-            stats.first_send_since_recv_ms(),
-            0,
+            stats.first_send_since_recv(),
+            None,
             "a receive cancels the anchor"
         );
         stats.record_frame_sent(10);
         assert!(
-            stats.first_send_since_recv_ms() > 0,
+            stats.first_send_since_recv().is_some(),
             "the next send after a receive re-arms the anchor"
         );
     }
@@ -1122,23 +1153,25 @@ mod tests {
     fn stale_pre_receive_anchor_self_heals_on_next_send() {
         use crate::protocol::keepalive::is_dead_socket;
         let stats = SessionStats::new();
-        let base = SessionStats::now_ms();
+        let base = SessionStats::now();
         // Reconstruct the race outcome directly: a receive at `base`, and an anchor
         // left behind at a pre-receive instant (the lost-reset send's stale `now`).
-        stats.last_data_received_ms.store(base, Ordering::Relaxed);
+        stats.last_data_received.store(base);
         stats
-            .first_send_since_recv_ms
-            .store(base.saturating_sub(1_000), Ordering::Relaxed);
+            .first_send_since_recv
+            .store(base - Duration::from_secs(1));
 
         stats.record_frame_sent(10);
 
-        let rearmed = stats.first_send_since_recv_ms();
+        let rearmed = stats
+            .first_send_since_recv()
+            .expect("a send always leaves an anchor");
         assert!(
             rearmed >= base,
-            "a stale pre-receive anchor must re-arm to a post-receive send, got {rearmed} < {base}"
+            "a stale pre-receive anchor must re-arm to a post-receive send"
         );
         assert!(
-            !is_dead_socket(rearmed, base),
+            !is_dead_socket(Some(rearmed), Some(base)),
             "the re-armed anchor is after the receive, so the socket is not dead"
         );
     }
@@ -1151,7 +1184,7 @@ mod tests {
         stats.reset_connection_activity();
 
         let snap = stats.snapshot();
-        assert_eq!(stats.first_send_since_recv_ms(), 0);
+        assert_eq!(stats.first_send_since_recv(), None);
         assert_eq!(snap.last_data_received_ms, 0);
         assert_eq!(snap.bytes_sent, 10);
         assert_eq!(snap.bytes_received, 20);

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -399,9 +399,129 @@ impl std::ops::Sub<Instant> for Instant {
     }
 }
 
+/// A shared [`Instant`] slot that can also be "unset", for anchors several
+/// tasks stamp and clear.
+///
+/// Exists because the anchors it holds are read on the wire path: storing an
+/// `Instant` behind a mutex would put a lock on every frame written, and the
+/// alternative of a plain `AtomicU64` of milliseconds is what the dead-socket
+/// watchdog used to be, back when a clock adjustment could fire it.
+///
+/// The encoding keeps "unset" distinct from "captured at the clock's origin",
+/// which a bare zero cannot: on `wasm32` with no wall-clock provider the
+/// fallback monotonic source answers 0 forever, so a zero sentinel would read
+/// every fresh stamp as unset.
+#[derive(Debug, Default)]
+pub struct AtomicInstant(portable_atomic::AtomicU64);
+
+impl AtomicInstant {
+    /// Encoded as nanos + 1 so that 0 means unset.
+    fn encode(instant: Instant) -> u64 {
+        instant.0.saturating_add(1)
+    }
+
+    fn decode(raw: u64) -> Option<Instant> {
+        raw.checked_sub(1).map(Instant)
+    }
+
+    /// A slot holding no instant.
+    pub const fn unset() -> Self {
+        Self(portable_atomic::AtomicU64::new(0))
+    }
+
+    /// The stored instant, or `None` while unset.
+    #[inline]
+    pub fn load(&self) -> Option<Instant> {
+        Self::decode(self.0.load(portable_atomic::Ordering::Relaxed))
+    }
+
+    #[inline]
+    pub fn store(&self, instant: Instant) {
+        self.0
+            .store(Self::encode(instant), portable_atomic::Ordering::Relaxed);
+    }
+
+    /// Back to unset.
+    #[inline]
+    pub fn clear(&self) {
+        self.0.store(0, portable_atomic::Ordering::Relaxed);
+    }
+
+    /// Read and unset in one step.
+    #[inline]
+    pub fn take(&self) -> Option<Instant> {
+        Self::decode(self.0.swap(0, portable_atomic::Ordering::Relaxed))
+    }
+
+    /// Store `instant` only while `should_replace` still accepts the value
+    /// actually in the slot, retrying on a racing write. Returns whether the
+    /// store landed.
+    #[inline]
+    pub fn store_if(
+        &self,
+        instant: Instant,
+        mut should_replace: impl FnMut(Option<Instant>) -> bool,
+    ) -> bool {
+        self.0
+            .fetch_update(
+                portable_atomic::Ordering::Relaxed,
+                portable_atomic::Ordering::Relaxed,
+                |current| should_replace(Self::decode(current)).then(|| Self::encode(instant)),
+            )
+            .is_ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── AtomicInstant ────────────────────────────────────────────────────────
+
+    #[test]
+    fn an_atomic_instant_round_trips_and_clears() {
+        let slot = AtomicInstant::unset();
+        assert_eq!(slot.load(), None, "a fresh slot holds nothing");
+
+        let at = Instant::now();
+        slot.store(at);
+        assert_eq!(slot.load(), Some(at));
+
+        assert_eq!(slot.take(), Some(at), "take yields what was there");
+        assert_eq!(slot.load(), None, "and leaves the slot unset");
+
+        slot.store(at);
+        slot.clear();
+        assert_eq!(slot.load(), None);
+    }
+
+    /// The clock's own origin is a real instant, not the absence of one: on
+    /// `wasm32` with no wall-clock provider the fallback monotonic source
+    /// answers zero forever, and a zero sentinel would read every stamp there
+    /// as "never armed" and silently disable the dead-socket watchdog.
+    #[test]
+    fn the_clock_origin_is_a_value_not_an_absence() {
+        let slot = AtomicInstant::unset();
+        slot.store(Instant::ZERO);
+        assert_eq!(slot.load(), Some(Instant::ZERO));
+    }
+
+    #[test]
+    fn store_if_respects_the_predicate() {
+        let slot = AtomicInstant::unset();
+        let first = Instant::now();
+        assert!(slot.store_if(first, |current| current.is_none()));
+        assert_eq!(slot.load(), Some(first));
+
+        // Bad path: the slot is taken, so the second store must not land.
+        let second = first + std::time::Duration::from_secs(1);
+        assert!(!slot.store_if(second, |current| current.is_none()));
+        assert_eq!(
+            slot.load(),
+            Some(first),
+            "an occupied slot is not clobbered"
+        );
+    }
 
     // The native default must yield a real wall-clock time, not the wasm fallback's
     // epoch. Guards the cfg-split refactor that keeps wasm32 from panicking.

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -293,6 +293,21 @@ impl WallDerivedMonotonicProvider {
 impl MonotonicProvider for WallDerivedMonotonicProvider {
     fn now_nanos(&self) -> u64 {
         use std::sync::atomic::Ordering;
+        // Warn once: a caller on this fallback is measuring timeouts against a
+        // clock that still follows the wall clock forward, so a system-clock
+        // correction can fire the dead-socket watchdog on a healthy socket.
+        // The clamp below only rules out the backwards half of that.
+        {
+            use std::sync::atomic::AtomicBool;
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            if !WARNED.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    "wacore::time: no monotonic provider set on wasm32; deriving from the \
+                     wall clock, so a forward clock adjustment reads as elapsed time. \
+                     Call set_monotonic_provider() with performance.now() before the first timeout."
+                );
+            }
+        }
         let raw = (now_millis().max(0) as u64).saturating_mul(1_000_000);
         let mut last = self.last.load(Ordering::Relaxed);
         loop {
@@ -415,7 +430,10 @@ impl std::ops::Sub<Instant> for Instant {
 pub struct AtomicInstant(portable_atomic::AtomicU64);
 
 impl AtomicInstant {
-    /// Encoded as nanos + 1 so that 0 means unset.
+    /// Encoded as nanos + 1 so that 0 means unset, which reserves the top
+    /// nanosecond: `u64::MAX` and `u64::MAX - 1` both encode to `u64::MAX`.
+    /// That ceiling is inherited, not introduced -- [`StdMonotonicProvider`]
+    /// already saturates there, 584 years past any process start.
     fn encode(instant: Instant) -> u64 {
         instant.0.saturating_add(1)
     }


### PR DESCRIPTION
## Summary

The dead-socket watchdog decided "twenty seconds of silence" by subtracting two wall-clock timestamps. Both anchors (`first_send_since_recv_ms`, `last_data_received_ms`) were milliseconds since the Unix epoch, and so was the `now` it compared them against, so a system clock that jumped forward was indistinguishable from time actually passing. That is what killed the connection in #1376: a laptop resumed from twelve hours of suspend, reconnected, re-synced NTP, and the jump alone read as a dead socket on a link that had authenticated five seconds earlier and received data one second earlier.

The fix is the small one: keep the predicate exactly where it is and change what it measures on. The anchors are now `wacore::time::Instant`, the monotonic clock this crate already ships, and the predicates take `Option<Instant>` so "never armed" is a type rather than a zero that also means "the epoch". Nothing about the watchdog's shape, constants, or arming rules changed. Two siblings decided elapsed time the same way and are fixed the same way: the reconnect-backoff stability window and the pair-code validity window.

`wacore::time`'s own module doc has described this exact bug since it was written: "Conflating the two - using a wall clock to measure elapsed time - silently corrupts timeouts and latency metrics whenever the system clock is adjusted mid-measurement. That is why `std::time` separates `SystemTime` from `Instant`, and we mirror the split here." The keepalive was violating the rule written at the top of the crate's own time module.

## Audit

Confirmed:

- `wacore/src/protocol/keepalive.rs` `is_dead_socket_at` compared three wall-clock millisecond values: `now` came from `crate::time::now_millis()` via the module's own `now_ms()`, and both anchors came from `SessionStats`, which stamped them with `crate::time::now_millis()` in `record_frame_sent`, `mark_recv_activity` and `record_recv_batch`. A forward clock jump was arithmetically identical to elapsed time.
- It is not a timer. `src/keepalive.rs` re-evaluates the predicate inside the keepalive tick, which sleeps a random 15-30s (`KEEP_ALIVE_INTERVAL_MIN..=KEEP_ALIVE_INTERVAL_MAX`). This matters for what "port it faithfully" means, and is addressed under Design.
- `src/client.rs` `should_reset_backoff` measured the stability window as `now_ms.saturating_sub(connected_at_ms)` over wall-clock milliseconds. `connected_at_ms` is stamped in `node_io.rs` on `<success>`, held in memory only, and zeroed on teardown, so it is a pure in-process elapsed measurement. A forward jump resets the backoff early and drops the guard against a flapping server; a backwards jump withholds the reset until the clock catches up.
- The idle-ping gate in `src/keepalive.rs` reads the same two anchors, so it carried the same bug and is fixed by the same change.
- The pair-code validity window (`code_generation_ts` in `wacore/src/pair_code.rs`, read by `live_flow_remaining`, `is_outstanding`, and `handle_primary_hello`) is wall-clock seconds, in memory only, never persisted and never compared against a server timestamp. Also the wrong column. Its `handle_primary_hello` age check used raw subtraction, so a backwards clock produced a negative age that passed the window check unconditionally.

Refuted:

- **The issue's premise that going monotonic would be invasive.** It is not, because the abstraction already exists and is already the house style. `wacore::time` has shipped `Instant`, `MonotonicProvider` and `set_monotonic_provider` all along, with an `std::time::Instant`-backed native default and a wall-derived, clamped-non-decreasing wasm32 fallback. The monotonic clock is already used inside `wacore` itself: the CPU meter in `stats.rs`, the app-state key-request dedup map, the telemetry timers, and the VoIP driver. So the platform constraint `AGENTS.md` puts on `wacore` (wasm32 and ESP32, no Tokio) does not block this at all. The cheaper mitigation the issue offered is not needed; the correct design was already the affordable one.
- **That the reconnect backoff numbers diverge.** They do not. The scan saw `{jitter:.1, max: maxSocketLoopWaitTime, algo:{type:"fibonacci", first:1e4, second:1e4}, relativeDelay:true}` and read it as our comment being wrong, but that is `PromiseRetryLoop`'s fallback default. `WAWebCommsConfig` overrides it with `socketReconnectBackoffAlgo: {jitter:.1, max:9e5, algo:{type:"fibonacci", first:1e3, second:1e3}, relativeDelay:!1}`, which is exactly what the comment on `fibonacci_backoff` in `src/client.rs` describes. `resetDelay: 3e4` matches our `STABLE_CONNECTION_RESET` of 30s too. Nothing to change; the comment was right.

## WA Web

From the pinned whatspec bundle set (2.3000.1045368834), `WAComms` and `WAShiftTimer`:

- **It is a real timer, not repeated arithmetic.** `this.deadSocketTimer = new WAShiftTimer.ShiftTimer(...)`, armed by `callStanza` with `this.deadSocketTimer.onOrBefore(this.config.deadSocketTime, this.socketId)`. `ShiftTimer.onOrBefore` reads `Date.now()` only to turn the caller's delay into an absolute deadline so it can coalesce against a deadline already scheduled (`$5`, the earliest); the delay it hands to `setTimeout` is the caller's own `e`, not a difference of clock readings. It never polls `Date.now()` against a stored deadline. `onOrBefore` keeping the earliest deadline is precisely our "anchor on the first send since the last receive".
- **Armed on send, cancelled on any receive.** `parseAndHandleStanza(t, n)` starts with `t === this.socketId && (this.deadSocketTimer.cancel(), this.$6 = self.performance.now(), ...)` before `decodeStanza` runs. Any inbound frame on the current socket satisfies the watchdog; no ping response is required. Ours matches: `mark_recv_activity` is called at arrival.
- **Constants match.** `WAWebCommsConfig`: `healthCheckInterval: 15, deadSocketTime: 2e4`. `maybeScheduleHealthCheck` computes `Math.ceil(e * 1e3 * (1 + Math.random()))`, i.e. 15000-30000ms. Same as our `KEEP_ALIVE_INTERVAL_MIN`/`MAX` and `DEAD_SOCKET_TIME`. No constant is touched here.
- **The official client has already moved connection-health accounting to a monotonic clock.** It stamps `this.$7 = self.performance.now()` when the socket opens and `this.$6 = self.performance.now()` on every received frame, and exposes `getMsSinceLastInboundRx()`, which returns `self.performance.now() - (this.$6 > 0 ? this.$6 : this.$7)`. Its one consumer is the outgoing-call preflight: before placing a call, `(!WAComms.isSocketConnected() || WAComms.getMsSinceLastInboundRx() > 6e4) && (forceAbortSocketConnection(), forceResetSocketLoop())`. So WA Web added a monotonic 60s "is this socket actually alive" check rather than trusting `deadSocketTimer` to have caught it, and deliberately scoped it to VoIP.

One honest note: WA Web's own `resetDelay` is still measured with `Date.now()` inside `PromiseRetryLoop` (`var n = Date.now(); ... Date.now() >= n + r`). Our backoff-reset fix is therefore stricter than the official client on that one point, which seems worth having rather than worth matching.

## Scope

| Site | Verdict | This PR |
| --- | --- | --- |
| `is_dead_socket_at` + its two `SessionStats` anchors | in-process elapsed, wrong clock | monotonic |
| idle-ping gate, `src/keepalive.rs` | same anchors, same bug | monotonic (same change) |
| `should_reset_backoff` / `connected_at_ms` | in-process elapsed, in memory only | monotonic |
| pair-code validity window (`code_generation_ts`) | in-process elapsed, never persisted, never server-compared | monotonic |
| `StatsSnapshot::last_data_received_ms` | reported to consumers as an absolute instant | stays wall clock, now derived |
| keepalive `wall_rtt_ms` | feeds WA Web's `onClockSkewUpdate`, which mixes it with `serverTime` | stays wall clock (already documented, and `rtt_monotonic` already exists beside it for the log) |
| tcToken expiry (`is_tc_token_expired_with`) | persisted row, survives restart | unchanged |
| `<ib>` `client_expiration` | server-supplied absolute deadline, persisted on the device | unchanged |
| group invite V4 expiry | server-supplied absolute timestamp | unchanged |
| msg_secret retention (`expires_at`) | persisted absolute deadline, pruned against `now_secs()` | unchanged |
| signed prekey rotation cadence | persisted device timestamp, must survive restart | unchanged |
| `pdo.rs` message age | compared against a server message timestamp | unchanged |

Everything in the wrong column is fixed here; nothing is deferred.

## Design

**Monotonic anchors, not a ported timer.** Porting `ShiftTimer`'s arm-and-cancel shape would be a faithful copy of a mechanism, but it would restructure the keepalive loop around a per-connection timer task with its own cancellation plumbing, for a bug that is entirely about which clock the deadline is measured on. Swapping the anchors fixes the bug at its cause and leaves the loop, the arming rules and the constants alone.

The cost is granularity, and it is unchanged by this PR: because the predicate is evaluated on a 15-30s tick, a 20s deadline can be observed up to a tick late. WA Web's `setTimeout` fires at 20s. That gap existed before this change and still exists; it is a latency difference, not a correctness one, and the existing comment in `keepalive_loop` already explains why the tick evaluates the predicate on every iteration rather than only after a failed ping.

**No separate wake-from-suspend cross-check.** WA Web needed one because its watchdog is armed only by an outgoing send: a socket that has been quiet in both directions has no timer pending at all, so when the user goes to place a call there is nothing that has been watching. Our keepalive tick has no such hole - it fires on an idle connection too, pings, and re-evaluates. With the anchors monotonic, the wake-from-suspend case is just "a lot of real time passed", which the predicate now measures correctly and acts on. Adding a second, differently-scaled threshold would be a second thing to keep in sync with no case left for it to catch.

**The two `SessionStats` fields.** `first_send_since_recv_ms` had no reader outside the watchdog, so it migrates outright and is renamed `first_send_since_recv`. `last_data_received_ms` has two readers of different natures: the 15s and 20s internal decisions, and the public `StatsSnapshot::last_data_received_ms` that a consumer reads as "last seen at T". The field itself becomes monotonic (`last_data_received`) because both internal readers measure elapsed time; the public snapshot field keeps its name, type and wall-clock meaning and is now *derived* at snapshot time as `now_millis() - anchor.elapsed()`. Deriving it rather than keeping a second stamped field matters: `stats.rs` documents a clock-read budget on the wire path, and a parallel wall-clock field would have doubled the reads per received transport event for a value nothing on that path consumes. No other `SessionStats` field is in this situation - these two are the only timestamps it holds.

**The pair-code window is stored as a deadline.** Converting it surfaced something worth stating: a monotonic clock has no history before the process began, so `Instant::now() - validity` in a young test binary saturates at the clock's origin and lands back in the *future*. The window is therefore held as `code_expires_at` rather than the generation instant it is derived from. That is what both readers want anyway, it is computed once instead of at every read, and it makes an already-closed window representable without dating anything before process start. The boundary is unchanged: the deadline itself is still the last live instant, matching `handle_primary_hello` rejecting only strictly-past arrivals (WA Web `OldCodeError`).

`AtomicInstant` is new in `wacore::time`: an `Instant` slot shared across tasks, encoded as nanos+1 so "unset" stays distinct from "captured at the clock's origin". The distinction is not academic - on `wasm32` with no wall-clock provider registered the fallback monotonic source returns 0 forever, and a bare zero sentinel would read every stamp there as "never armed" and silently disable the watchdog. On a platform that registers no monotonic provider at all, the wasm32 fallback derives from the wall clock and clamps to non-decreasing, so a forward jump is still seen as elapsed time there and a backwards one freezes the clock until it catches up; that is the pre-existing fallback contract, not something this PR changes.

## Compatibility

`Client::stats()` is unchanged for callers: `StatsSnapshot::last_data_received_ms` keeps its name, its `u64` type, its wall-clock-milliseconds meaning and its 0-means-never sentinel. The only observable difference is that it is now computed when you call `stats()` instead of stamped when the frame arrived, which makes it *more* correct across a clock adjustment: it is always expressed in the same clock frame the caller's own `now` is in, where the old stamped value would have been left behind in the pre-adjustment frame.

Breaking, and pre-1.0:

- `wacore::protocol::keepalive::is_dead_socket` / `is_dead_socket_at` now take `Option<Instant>` instead of `u64` milliseconds.
- `ms_since` / `ms_since_at` are replaced by `elapsed_since` / `elapsed_since_at`, returning `Option<Duration>`. The rename is deliberate: a caller passing a wall-clock millisecond value should get a compile error, not a silent unit reinterpretation.
- `wacore::protocol::keepalive::now_ms` is gone; the callers read `Instant::now()`.
- `SessionStats::first_send_since_recv_ms` / `last_data_received_ms` accessors are now `first_send_since_recv` / `last_data_received`, returning `Option<Instant>`.
- `PairCodeState`'s `code_generation_ts: i64` field is replaced by `code_expires_at: Instant` (the deadline, not the generation instant), and `is_outstanding` / `live_flow_remaining` take an `Instant`.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib          # 1547 passed
cargo test -p whatsapp-rust --lib   # 1835 passed
cargo clippy --workspace --all-targets -- -D warnings
```

Full matrix left to CI.

New and changed tests:

- `a_wall_clock_jump_does_not_declare_a_live_socket_dead` and `real_silence_past_the_deadline_is_still_a_dead_socket` in `wacore::protocol::keepalive` - the two halves of the regression.
- `a_wall_clock_jump_does_not_make_a_young_connection_look_stable` in `src/client/tests.rs`, and `live_flow_remaining_ignores_a_wall_clock_jump` in `wacore::pair_code` - the same pair for each sibling.
- `wire_bookkeeping_reads_the_clock_only_where_a_value_is_used` is the test that fails before this change: it now asserts the wire path's stamps are *monotonic* reads and that it spends **zero** wall-clock reads, which is the root cause stated as a contract. The per-event read counts it pins are unchanged.
- `the_snapshot_still_reports_last_receive_as_a_wall_clock_instant` pins the derived public field to the wall-clock frame.
- `AtomicInstant` gets round-trip, clear/take, origin-is-not-absence, and occupied-slot-not-clobbered coverage.
- The tests that pin existing behaviour all still hold and were only retyped: the exact deadline boundary, the anchor not advancing across repeated sends, the stale pre-receive anchor self-healing, and the snapshot field being populated. Three contract changes to call out. The clock-read budget test now asserts on the monotonic counter rather than the wall one, and that *is* the fix stated as a contract. `should_reset_backoff`'s "a backwards clock must not underflow" case was dropped: its argument is no longer a wall-clock reading that can move backwards, and `saturating_duration_since` still saturates if a provider misbehaves. `live_flow_remaining_survives_a_backwards_clock` became `live_flow_remaining_saturates_instead_of_wrapping` for the same reason - clamping a negative age at the full window was guarding wall-clock underflow that a monotonic reading cannot produce, so what it now pins is that the countdown saturates rather than wrapping, however far past the deadline it is read.

Fixes #1376

The spurious reconnect this fixes is what aborted the 711-event offline resume in #1377; that drain's own resilience is a separate change and is not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XEpUtB8VUx1tFsUZKTr7iB)_