### PR TITLE
fix(offline): end an interrupted resume with a signal instead of silence

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1536,18 +1536,18 @@ pub struct Client {
     /// idempotent). Separate from `offline_sync_completed` because the finish
     /// runs off the read loop and the flag must flip only after its commit.
     pub(crate) offline_sync_finish_started: Arc<AtomicBool>,
-    /// Once-guard for the *event* that ends one resume, either
-    /// `OfflineSyncCompleted` or `OfflineSyncInterrupted`. The finisher runs
-    /// detached and can pass its generation check just before a teardown bumps
-    /// it, so both terminal publications can be in flight for the same drain;
-    /// this makes them mutually exclusive, and the loser stays silent rather
-    /// than telling the consumer the opposite of what it was just told.
+    /// Highest connection generation whose resume already published a terminal
+    /// event, either `OfflineSyncCompleted` or `OfflineSyncInterrupted`, held
+    /// as `generation + 1` so zero reads as "none yet".
     ///
-    /// Cleared where a drain begins (the `<ib><offline_preview>` branch in
-    /// `process_node`), never in the connection-state resets: a reset runs
-    /// alongside the finisher it is racing, so reopening the guard there would
-    /// hand the loser its slot back.
-    pub(crate) offline_terminal_reported: Arc<AtomicBool>,
+    /// Monotonic rather than a boolean that something clears, because the
+    /// publications race in two directions. The finisher runs detached and
+    /// checks the generation before publishing, so it can pass that check and
+    /// then be descheduled past a teardown, past a reconnect, and past the
+    /// next drain's preview. A claim therefore fails both for a drain already
+    /// reported and for one a *newer* drain has overtaken, and nothing has to
+    /// reopen the guard for the next drain: its own higher stamp does that.
+    pub(crate) offline_terminal_reported: Arc<AtomicU64>,
     /// Delivery receipts buffered during offline sync, flushed as aggregate
     /// `<receipt>` stanzas at completion (WA Web `sendAggregateOfflineReceipts`).
     /// Empty (zero capacity) outside the offline window.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1536,6 +1536,13 @@ pub struct Client {
     /// idempotent). Separate from `offline_sync_completed` because the finish
     /// runs off the read loop and the flag must flip only after its commit.
     pub(crate) offline_sync_finish_started: Arc<AtomicBool>,
+    /// Once-guard for the *event* that ends one resume, either
+    /// `OfflineSyncCompleted` or `OfflineSyncInterrupted`. The finisher runs
+    /// detached and can pass its generation check just before a teardown bumps
+    /// it, so both terminal publications can be in flight for the same drain;
+    /// this makes them mutually exclusive, and the loser stays silent rather
+    /// than telling the consumer the opposite of what it was just told.
+    pub(crate) offline_terminal_reported: Arc<AtomicBool>,
     /// Delivery receipts buffered during offline sync, flushed as aggregate
     /// `<receipt>` stanzas at completion (WA Web `sendAggregateOfflineReceipts`).
     /// Empty (zero capacity) outside the offline window.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1542,6 +1542,11 @@ pub struct Client {
     /// it, so both terminal publications can be in flight for the same drain;
     /// this makes them mutually exclusive, and the loser stays silent rather
     /// than telling the consumer the opposite of what it was just told.
+    ///
+    /// Cleared where a drain begins (the `<ib><offline_preview>` branch in
+    /// `process_node`), never in the connection-state resets: a reset runs
+    /// alongside the finisher it is racing, so reopening the guard there would
+    /// hand the loser its slot back.
     pub(crate) offline_terminal_reported: Arc<AtomicBool>,
     /// Delivery receipts buffered during offline sync, flushed as aggregate
     /// `<receipt>` stanzas at completion (WA Web `sendAggregateOfflineReceipts`).

--- a/src/client.rs
+++ b/src/client.rs
@@ -1532,10 +1532,17 @@ pub struct Client {
     /// Flips only AFTER the drain-tail commit, so the tail's acks still join
     /// the aggregate offline-receipt drain.
     pub(crate) offline_sync_completed: Arc<AtomicBool>,
-    /// Once-guard for the drain finisher (the semaphore swap is not
-    /// idempotent). Separate from `offline_sync_completed` because the finish
-    /// runs off the read loop and the flag must flip only after its commit.
-    pub(crate) offline_sync_finish_started: Arc<AtomicBool>,
+    /// Highest connection generation whose drain finisher has started, held as
+    /// `generation + 1` so zero reads as "none yet". Separate from
+    /// `offline_sync_completed` because the finish runs off the read loop and
+    /// that flag must flip only after its commit.
+    ///
+    /// A once-guard because the semaphore swap is not idempotent, and stamped
+    /// with the generation for the same reason the terminal report is: a
+    /// completion descheduled past its own connection would otherwise claim
+    /// the boolean after a teardown cleared it, and the next connection's
+    /// completion would find the guard taken and never start a finisher.
+    pub(crate) offline_sync_finish_started: Arc<AtomicU64>,
     /// Highest connection generation whose resume already published a terminal
     /// event, either `OfflineSyncCompleted` or `OfflineSyncInterrupted`, held
     /// as `generation + 1` so zero reads as "none yet".

--- a/src/client.rs
+++ b/src/client.rs
@@ -1791,6 +1791,16 @@ pub struct Client {
     /// holds it around the settle. Lock order is always this-gate → processing
     /// permit / sessions lock, so no inversion.
     pub(crate) signal_flush_lifecycle: Mutex<()>,
+    /// Serializes a drain's end against the teardown that retires it.
+    ///
+    /// The generation stamp decides *who* reports, but the finisher runs
+    /// detached, so without this its check and its publication interleave with
+    /// the teardown's own resets: the winner's writes could land on either
+    /// side of them, and a semaphore widened after the reset would follow the
+    /// next connection into its drain. Held across the claim and everything it
+    /// publishes on one side, and across the teardown's offline resets on the
+    /// other.
+    pub(crate) offline_terminal_lock: Mutex<()>,
     /// Injected failures for the coalesced flush (consumed one per attempt),
     /// so tests can exercise the retry/backoff path deterministically.
     #[cfg(test)]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -537,6 +537,7 @@ impl Client {
             subsystems: subsystem::Subsystems::default(),
             signal_flush_state: AtomicU64::new(0),
             signal_flush_lifecycle: Mutex::new(()),
+            offline_terminal_lock: Mutex::new(()),
             #[cfg(test)]
             signal_flush_test_failures: AtomicU32::new(0),
             #[cfg(test)]
@@ -1847,10 +1848,14 @@ impl Client {
         // connection don't trigger an immediate reconnect on the next one.
         self.stats.reset_connection_activity();
         self.pending_device_sync.clear();
-        // Reset offline sync state for next connection. The report is stamped
-        // with the generation being retired, not the one just installed, so it
-        // silences that drain's own stale finisher without claiming the slot
-        // the next drain will need.
+        // Reset offline sync state for next connection, under the lock the
+        // finisher publishes beneath: whichever of the two wins the stamp, its
+        // writes land wholly before or wholly after the other's, so a widened
+        // semaphore can never survive into the next connection's drain.
+        // The report is stamped with the generation being retired, not the one
+        // just installed, so it silences that drain's own stale finisher
+        // without claiming the slot the next drain will need.
+        let terminal_gate = self.offline_terminal_lock.lock().await;
         self.abandon_offline_sync_if_interrupted(closed_generation);
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
@@ -1880,6 +1885,7 @@ impl Client {
             Ok(mut guard) => *guard = None,
             Err(poison) => *poison.into_inner() = None,
         }
+        drop(terminal_gate);
         self.history_sync_activity.reset();
         // Drain all pending IQ waiters so they fail fast with InternalChannelClosed
         // instead of hanging until the 75s timeout.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -516,7 +516,7 @@ impl Client {
             signed_pre_key_rotation_lock: Arc::new(Mutex::new(())),
             offline_sync_notifier: Arc::new(event_listener::Event::new()),
             offline_sync_completed: Arc::new(AtomicBool::new(false)),
-            offline_sync_finish_started: Arc::new(AtomicBool::new(false)),
+            offline_sync_finish_started: Arc::new(AtomicU64::new(0)),
             offline_terminal_reported: Arc::new(AtomicU64::new(0)),
             offline_receipt_buffer: std::sync::Mutex::new(Vec::new()),
             inbound_commit_batch: Default::default(),
@@ -1061,8 +1061,6 @@ impl Client {
             self.connection_generation.load(Ordering::Acquire),
         );
         self.offline_sync_completed.store(false, Ordering::Relaxed);
-        self.offline_sync_finish_started
-            .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Uncommitted batch entries were never acked; the server redelivers
         // them on this fresh connection. The cache decision is coupled to the
@@ -1855,8 +1853,6 @@ impl Client {
         // the next drain will need.
         self.abandon_offline_sync_if_interrupted(closed_generation);
         self.offline_sync_completed.store(false, Ordering::Relaxed);
-        self.offline_sync_finish_started
-            .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Same rule as receipts: uncommitted entries drop here and the server
         // redelivers them on the next connect. The cache falls with dropped

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1051,6 +1051,10 @@ impl Client {
         // refuse the login. `run` already clears it before each attempt; a
         // caller driving connections itself has nowhere else to learn of it.
         self.expected_disconnect.store(false, Ordering::Relaxed);
+        // Runs before the flags it reads are cleared below. Teardown normally
+        // reported the interruption already and this is a no-op; it covers the
+        // paths that reach a new attempt without one.
+        self.abandon_offline_sync_if_interrupted();
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
             .store(false, Ordering::Relaxed);
@@ -1844,6 +1848,7 @@ impl Client {
         self.stats.reset_connection_activity();
         self.pending_device_sync.clear();
         // Reset offline sync state for next connection
+        self.abandon_offline_sync_if_interrupted();
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
             .store(false, Ordering::Relaxed);

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1059,8 +1059,6 @@ impl Client {
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
             .store(false, Ordering::Relaxed);
-        self.offline_terminal_reported
-            .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Uncommitted batch entries were never acked; the server redelivers
         // them on this fresh connection. The cache decision is coupled to the
@@ -1854,8 +1852,6 @@ impl Client {
         self.abandon_offline_sync_if_interrupted();
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
-            .store(false, Ordering::Relaxed);
-        self.offline_terminal_reported
             .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Same rule as receipts: uncommitted entries drop here and the server

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -517,6 +517,7 @@ impl Client {
             offline_sync_notifier: Arc::new(event_listener::Event::new()),
             offline_sync_completed: Arc::new(AtomicBool::new(false)),
             offline_sync_finish_started: Arc::new(AtomicBool::new(false)),
+            offline_terminal_reported: Arc::new(AtomicBool::new(false)),
             offline_receipt_buffer: std::sync::Mutex::new(Vec::new()),
             inbound_commit_batch: Default::default(),
             history_sync_activity: Arc::new(crate::sync_task::HistorySyncActivity::new()),
@@ -1057,6 +1058,8 @@ impl Client {
         self.abandon_offline_sync_if_interrupted();
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
+            .store(false, Ordering::Relaxed);
+        self.offline_terminal_reported
             .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Uncommitted batch entries were never acked; the server redelivers
@@ -1851,6 +1854,8 @@ impl Client {
         self.abandon_offline_sync_if_interrupted();
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
+            .store(false, Ordering::Relaxed);
+        self.offline_terminal_reported
             .store(false, Ordering::Relaxed);
         self.clear_offline_receipt_buffer();
         // Same rule as receipts: uncommitted entries drop here and the server

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -517,7 +517,7 @@ impl Client {
             offline_sync_notifier: Arc::new(event_listener::Event::new()),
             offline_sync_completed: Arc::new(AtomicBool::new(false)),
             offline_sync_finish_started: Arc::new(AtomicBool::new(false)),
-            offline_terminal_reported: Arc::new(AtomicBool::new(false)),
+            offline_terminal_reported: Arc::new(AtomicU64::new(0)),
             offline_receipt_buffer: std::sync::Mutex::new(Vec::new()),
             inbound_commit_batch: Default::default(),
             history_sync_activity: Arc::new(crate::sync_task::HistorySyncActivity::new()),
@@ -1054,8 +1054,12 @@ impl Client {
         self.expected_disconnect.store(false, Ordering::Relaxed);
         // Runs before the flags it reads are cleared below. Teardown normally
         // reported the interruption already and this is a no-op; it covers the
-        // paths that reach a new attempt without one.
-        self.abandon_offline_sync_if_interrupted();
+        // paths that reach a new attempt without one. The current generation
+        // is the right stamp here: this connection has not logged in yet, so
+        // its own drain arms at a higher one.
+        self.abandon_offline_sync_if_interrupted(
+            self.connection_generation.load(Ordering::Acquire),
+        );
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
             .store(false, Ordering::Relaxed);
@@ -1729,10 +1733,7 @@ impl Client {
         // process_classified_message — no decrypt can START after the
         // permit-held cache settle below, so no rowless ratchet advances can
         // dirty the cache behind teardown's back.
-        #[cfg(feature = "client-lifecycle")]
         let closed_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst);
-        #[cfg(not(feature = "client-lifecycle"))]
-        self.connection_generation.fetch_add(1, Ordering::SeqCst);
         #[cfg(feature = "client-lifecycle")]
         let scope_close = self.lifecycle.as_ref().map(|lifecycle| {
             let lifecycle = Arc::clone(lifecycle);
@@ -1848,8 +1849,11 @@ impl Client {
         // connection don't trigger an immediate reconnect on the next one.
         self.stats.reset_connection_activity();
         self.pending_device_sync.clear();
-        // Reset offline sync state for next connection
-        self.abandon_offline_sync_if_interrupted();
+        // Reset offline sync state for next connection. The report is stamped
+        // with the generation being retired, not the one just installed, so it
+        // silences that drain's own stale finisher without claiming the slot
+        // the next drain will need.
+        self.abandon_offline_sync_if_interrupted(closed_generation);
         self.offline_sync_completed.store(false, Ordering::Relaxed);
         self.offline_sync_finish_started
             .store(false, Ordering::Relaxed);

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -404,13 +404,6 @@ impl Client {
                     self.offline_sync_metrics
                         .active
                         .store(true, Ordering::Release);
-                    // The terminal-event guard belongs to the drain, not the
-                    // connection: reopening it in a teardown reset would let a
-                    // finisher still between its generation check and its
-                    // publish claim it again, right after that same teardown
-                    // reported the interruption.
-                    self.offline_terminal_reported
-                        .store(false, Ordering::Release);
                     match self.offline_sync_metrics.start_time.lock() {
                         Ok(mut guard) => *guard = Some(wacore::time::Instant::now()),
                         Err(poison) => *poison.into_inner() = Some(wacore::time::Instant::now()),

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -404,6 +404,13 @@ impl Client {
                     self.offline_sync_metrics
                         .active
                         .store(true, Ordering::Release);
+                    // The terminal-event guard belongs to the drain, not the
+                    // connection: reopening it in a teardown reset would let a
+                    // finisher still between its generation check and its
+                    // publish claim it again, right after that same teardown
+                    // reported the interruption.
+                    self.offline_terminal_reported
+                        .store(false, Ordering::Release);
                     match self.offline_sync_metrics.start_time.lock() {
                         Ok(mut guard) => *guard = Some(wacore::time::Instant::now()),
                         Err(poison) => *poison.into_inner() = Some(wacore::time::Instant::now()),

--- a/src/client/offline_resume.rs
+++ b/src/client/offline_resume.rs
@@ -170,7 +170,10 @@ pub(crate) fn spawn_inactivity_watchdog(client: Arc<Client>, generation: u64, ti
                     processed,
                 );
                 client
-                    .complete_offline_sync(i32::try_from(processed).unwrap_or(i32::MAX))
+                    .complete_offline_sync_for_generation(
+                        i32::try_from(processed).unwrap_or(i32::MAX),
+                        generation,
+                    )
                     .await;
                 return;
             }

--- a/src/client/offline_resume.rs
+++ b/src/client/offline_resume.rs
@@ -36,6 +36,10 @@ const REQUEST_DEBOUNCE: Duration = Duration::from_millis(100);
 /// on every offline stanza, and on expiry completes the session itself.
 const STANZA_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Parked in `stanza_activity` by the watchdog that completes a stalled drain,
+/// so a stanza racing that decision loses the CAS instead of being ignored.
+const INACTIVE_CLAIMED: u64 = u64::MAX;
+
 #[derive(Default)]
 pub(crate) struct OfflineBatchCoordinator {
     armed: AtomicBool,
@@ -71,12 +75,28 @@ impl OfflineBatchCoordinator {
         self.armed.swap(false, Ordering::AcqRel)
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_armed(&self) -> bool {
+        self.armed.load(Ordering::Acquire)
+    }
+
     pub(crate) fn stanza_activity(&self) -> u64 {
         self.stanza_activity.load(Ordering::Acquire)
     }
 
     pub(crate) fn note_stanza_activity(&self) {
         self.stanza_activity.fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Claim a drain as inactive, but only if no stanza has arrived since
+    /// `seen`. A bump landing between the watchdog's read and its decision
+    /// fails the CAS, so a drain that is still being fed is never completed
+    /// behind the server's back. The sentinel it parks on is never a value
+    /// `note_stanza_activity` can reach from a fresh `arm()`.
+    fn try_claim_inactive(&self, seen: u64) -> bool {
+        self.stanza_activity
+            .compare_exchange(seen, INACTIVE_CLAIMED, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
     fn arm(&self, generation: u64) {
@@ -157,6 +177,12 @@ pub(crate) fn spawn_inactivity_watchdog(client: Arc<Client>, generation: u64, ti
                 let current = client.offline_batch.stanza_activity();
                 if current != seen {
                     seen = current;
+                    continue;
+                }
+                if !client.offline_batch.try_claim_inactive(seen) {
+                    // A stanza arrived while this was deciding; the drain is
+                    // alive after all, so give it another window.
+                    seen = client.offline_batch.stanza_activity();
                     continue;
                 }
                 let processed = client

--- a/src/client/offline_resume.rs
+++ b/src/client/offline_resume.rs
@@ -31,6 +31,11 @@ const BATCH_SIZE: u32 = 200;
 /// Mirrors `WAWebOfflineHandler.S = 100`.
 const REQUEST_DEBOUNCE: Duration = Duration::from_millis(100);
 
+/// Mirrors `WAWebOfflineResumeConst.OFFLINE_STANZA_TIMEOUT_MS = 60000`: the
+/// blocking resume manager arms a `ShiftTimer` on the first preview, shifts it
+/// on every offline stanza, and on expiry completes the session itself.
+const STANZA_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Default)]
 pub(crate) struct OfflineBatchCoordinator {
     armed: AtomicBool,
@@ -39,6 +44,12 @@ pub(crate) struct OfflineBatchCoordinator {
     /// stanza of that batch's response. CAS-gated so concurrent arrivals
     /// deterministically elect a single "first arrival" winner per cycle.
     prev_batch_inflight: AtomicBool,
+    /// Bumped by every offline stanza. Stands in for WA Web's `ShiftTimer`
+    /// re-arm (`$13`): the watchdog compares the counter across a sleep
+    /// instead of reading a clock per stanza, which costs one relaxed
+    /// increment on the receive path and in exchange lets the timeout fire
+    /// anywhere in [timeout, 2 * timeout) after the last stanza.
+    stanza_activity: AtomicU64,
 }
 
 impl OfflineBatchCoordinator {
@@ -52,10 +63,27 @@ impl OfflineBatchCoordinator {
         self.prev_batch_inflight.store(false, Ordering::Release);
     }
 
+    /// Disarm and report whether this call is the one that did it. The
+    /// teardown paths use it as a once-guard for the interrupted-resume
+    /// event, so a second teardown (or a `connect()` that follows one) stays
+    /// silent.
+    pub(crate) fn take_armed(&self) -> bool {
+        self.armed.swap(false, Ordering::AcqRel)
+    }
+
+    pub(crate) fn stanza_activity(&self) -> u64 {
+        self.stanza_activity.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn note_stanza_activity(&self) {
+        self.stanza_activity.fetch_add(1, Ordering::AcqRel);
+    }
+
     fn arm(&self, generation: u64) {
         // Set inner state first; `armed` is published last so readers that
         // observe armed=true also see the matching generation and inflight.
         self.generation.store(generation, Ordering::Release);
+        self.stanza_activity.store(0, Ordering::Release);
         self.prev_batch_inflight.store(true, Ordering::Release);
         self.armed.store(true, Ordering::Release);
     }
@@ -100,11 +128,54 @@ pub(crate) async fn send_first_batch(client: Arc<Client>, total: usize) {
         total,
         BATCH_SIZE,
     );
+    spawn_inactivity_watchdog(Arc::clone(&client), generation, STANZA_INACTIVITY_TIMEOUT);
     // arm() already published prev_batch_inflight=true. Do NOT republish after
     // the await: an arrival (primer) processed concurrently with this send may
     // have legitimately won the CAS already, and republishing would let a
     // second arrival win again and schedule a duplicate continuation.
     let _ = send_batch(&client, BATCH_SIZE).await;
+}
+
+/// WA Web's `ShiftTimer` (`WAWebBlockingOfflineResumeManager.$12`/`$13`): a
+/// drain the server stops feeding is completed by the client rather than left
+/// open, so consumers of the completion signal are never stranded on a stall.
+/// Bounded by the connection generation, since a drain that ends with the
+/// connection is reported as interrupted instead.
+pub(crate) fn spawn_inactivity_watchdog(client: Arc<Client>, generation: u64, timeout: Duration) {
+    let runtime = client.runtime.clone();
+    runtime
+        .spawn(Box::pin(async move {
+            let mut seen = client.offline_batch.stanza_activity();
+            loop {
+                client.runtime.sleep(timeout).await;
+                if !client.offline_batch.is_armed_for(generation)
+                    || client.connection_generation.load(Ordering::Acquire) != generation
+                    || client.offline_sync_completed.load(Ordering::Acquire)
+                {
+                    return;
+                }
+                let current = client.offline_batch.stanza_activity();
+                if current != seen {
+                    seen = current;
+                    continue;
+                }
+                let processed = client
+                    .offline_sync_metrics
+                    .processed_messages
+                    .load(Ordering::Acquire);
+                log::warn!(
+                    target: "Client/OfflineResume",
+                    "No offline stanza for {:?}; completing the resume by timeout at {} item(s)",
+                    timeout,
+                    processed,
+                );
+                client
+                    .complete_offline_sync(i32::try_from(processed).unwrap_or(i32::MAX))
+                    .await;
+                return;
+            }
+        }))
+        .detach();
 }
 
 /// Called from `process_node` after the per-stanza `processed_messages` bump.
@@ -116,6 +187,7 @@ pub(crate) fn on_offline_stanza_arrived(client: &Arc<Client>, pending: usize) {
     if !coord.is_armed_for(generation) {
         return;
     }
+    coord.note_stanza_activity();
     if pending == 0 {
         // Server has nothing more for us; let the end marker drive completion.
         return;

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -292,6 +292,28 @@ impl Client {
     pub(crate) const DEFAULT_OFFLINE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
 
     pub(crate) async fn complete_offline_sync(&self, count: i32) {
+        let generation = self.connection_generation.load(Ordering::Acquire);
+        self.complete_offline_sync_for_generation(count, generation)
+            .await
+    }
+
+    /// [`complete_offline_sync`](Self::complete_offline_sync) for a caller that
+    /// checked the generation earlier and may have been descheduled since.
+    ///
+    /// The check is the first thing done, before any drain state is touched,
+    /// and the same `generation` is handed to the finisher instead of being
+    /// re-read: a completion belongs to the connection whose drain it is, and
+    /// applying it to the replacement would mark that connection's backlog
+    /// finished and widen its semaphore mid-drain.
+    pub(crate) async fn complete_offline_sync_for_generation(&self, count: i32, generation: u64) {
+        if self.connection_generation.load(Ordering::Acquire) != generation {
+            log::debug!(
+                target: "Client/OfflineSync",
+                "Ignoring a completion for generation {} on a newer connection",
+                generation,
+            );
+            return;
+        }
         self.offline_sync_metrics
             .active
             .store(false, Ordering::Release);
@@ -333,7 +355,6 @@ impl Client {
         // trip the keepalive at the end of every drain. Ordering does not need
         // the inline await: the single permit already serializes the finisher
         // against stanza processing, so run it off-loop.
-        let generation = self.connection_generation.load(Ordering::Acquire);
         self.runtime
             .spawn(Box::pin(async move {
                 client.finish_offline_sync(count, generation).await;
@@ -358,10 +379,12 @@ impl Client {
             log::debug!(
                 "finish_offline_sync: connection generation changed during the tail commit; leaving the new connection's state alone"
             );
-            // The teardown that bumped the generation normally reported the
-            // interruption already; this covers losing the race to it, and the
-            // claim keeps it from being a second terminal event.
-            self.abandon_offline_sync_if_interrupted();
+            // No report from here: the only production bump of the generation
+            // with a drain in flight is `cleanup_connection_state`, which
+            // reports the interruption itself a few lines later. Reporting
+            // here as well would read (and disarm) whatever drain is current
+            // by the time this stale task runs, which may already be the next
+            // connection's.
             return;
         }
 
@@ -521,8 +544,11 @@ impl Client {
                 processed,
                 expected,
             );
-            self.complete_offline_sync(i32::try_from(processed).unwrap_or(i32::MAX))
-                .await;
+            self.complete_offline_sync_for_generation(
+                i32::try_from(processed).unwrap_or(i32::MAX),
+                wait_generation,
+            )
+            .await;
             // The finisher runs as a spawned task; keep this helper's contract
             // that live state is in place when it returns (callers start
             // session/send work right after). Ticked so a reconnect or

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -14,7 +14,7 @@ use wacore::types::jid::JidExt;
 use wacore_binary::Jid;
 
 use super::Client;
-use crate::types::events::{Event, OfflineSyncCompleted};
+use crate::types::events::{Event, OfflineSyncCompleted, OfflineSyncInterrupted};
 use wacore::send::PrimaryDeviceRejected;
 
 /// Waiter side of an in-flight ensure: it never receives a value, only the
@@ -410,6 +410,51 @@ impl Client {
         ));
     }
 
+    /// Report a drain that ended before its `<ib><offline>` end marker.
+    ///
+    /// Called from the connection-state resets, which are the only places a
+    /// resume can end without the finisher running. Both flags are consumed,
+    /// so the pair of resets around one teardown emits at most one event, and
+    /// a drain that already completed emits none. Nothing is retained past
+    /// this point: the numbers are read out of the same per-connection state
+    /// the reset is about to clear, which is what keeps this from becoming
+    /// another flag that outlives its connection.
+    pub(crate) fn abandon_offline_sync_if_interrupted(&self) {
+        // `active` covers the window before the first batch request is armed;
+        // `armed` covers the one after the last stanza cleared `active` but
+        // before the end marker arrived. Neither is set once the finisher has
+        // published completion.
+        let was_active = self
+            .offline_sync_metrics
+            .active
+            .swap(false, Ordering::AcqRel);
+        let was_armed = self.offline_batch.take_armed();
+        if (!was_active && !was_armed) || self.offline_sync_completed.load(Ordering::Acquire) {
+            return;
+        }
+
+        let total = self
+            .offline_sync_metrics
+            .total_messages
+            .load(Ordering::Acquire);
+        let delivered = self
+            .offline_sync_metrics
+            .processed_messages
+            .load(Ordering::Acquire);
+        log::warn!(
+            target: "Client/OfflineSync",
+            "Offline resume interrupted at {} of {} item(s); the undelivered backlog was never acked and the server redelivers it",
+            delivered,
+            total,
+        );
+        self.core.event_bus.dispatch(Event::OfflineSyncInterrupted(
+            OfflineSyncInterrupted::builder()
+                .total(i32::try_from(total).unwrap_or(i32::MAX))
+                .delivered(i32::try_from(delivered).unwrap_or(i32::MAX))
+                .build(),
+        ));
+    }
+
     /// Wait for offline message delivery to complete (with timeout).
     pub(crate) async fn wait_for_offline_delivery_end(&self) {
         self.wait_for_offline_delivery_end_with_timeout(Self::DEFAULT_OFFLINE_SYNC_TIMEOUT)
@@ -496,11 +541,25 @@ impl Client {
         self.history_sync_activity.begin(payload_bytes)
     }
 
+    /// Wait until this connection's offline drain and its history-sync work
+    /// have both settled.
+    ///
+    /// Scoped to the connection it is called on: if that connection ends first
+    /// this returns an error, because neither half of the wait can be answered
+    /// truthfully afterwards. `HistorySyncActivity::reset()` runs on every
+    /// teardown and zeroes the task count while notifying every listener, so a
+    /// waiter that only looked at the count would read the teardown's zero as
+    /// "all tasks finished" and report a sync that never happened.
     pub async fn wait_for_startup_sync(&self, timeout: Duration) -> Result<()> {
         use anyhow::anyhow;
         use wacore::time::Instant;
 
         let deadline = Instant::now() + timeout;
+        let wait_generation = self.connection_generation.load(Ordering::Acquire);
+        let connection_ended = || {
+            self.connection_generation.load(Ordering::Acquire) != wait_generation
+                || self.expected_disconnect.load(Ordering::Relaxed)
+        };
 
         // Register the notified future *before* checking state to avoid missing
         // a notify_waiters() that fires between the check and the await.
@@ -510,11 +569,23 @@ impl Client {
             wacore::runtime::timeout(&*self.runtime, remaining, offline_fut)
                 .await
                 .map_err(|_| anyhow!("Timeout waiting for offline sync completion"))?;
+            if connection_ended() {
+                return Err(anyhow!("Connection ended before offline sync completed"));
+            }
         }
 
         loop {
             let history_fut = self.history_sync_activity.listen();
-            if self.history_sync_activity.tasks() == 0 {
+            let idle = self.history_sync_activity.tasks() == 0;
+            // Read the generation *after* the count: teardown bumps it before
+            // `reset()` zeroes the count, so this ordering is what tells a
+            // genuine idle from the one teardown manufactures.
+            if connection_ended() {
+                return Err(anyhow!(
+                    "Connection ended before history sync tasks became idle"
+                ));
+            }
+            if idle {
                 return Ok(());
             }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -343,7 +343,7 @@ impl Client {
                 "complete_offline_sync: self_weak upgrade failed; dropping the drain tail and switching to live mode"
             );
             self.inbound_commit_batch.force_live_dropping_entries();
-            self.publish_offline_sync_live_state(count, None);
+            self.publish_offline_sync_live_state(count, None, generation);
             return;
         };
 
@@ -388,7 +388,7 @@ impl Client {
             return;
         }
 
-        self.publish_offline_sync_live_state(count, Some(durable));
+        self.publish_offline_sync_live_state(count, Some(durable), generation);
     }
 
     /// The drain→live state publication, shared by the finisher and its
@@ -416,7 +416,7 @@ impl Client {
     /// the deferred transition (see `complete_deferred_live_transition`) and
     /// widens the semaphore then. `None` (upgrade-failure fallback) leaves
     /// the buffer alone for the connection-state reset to clear.
-    fn publish_offline_sync_live_state(&self, count: i32, durable: Option<bool>) {
+    fn publish_offline_sync_live_state(&self, count: i32, durable: Option<bool>, generation: u64) {
         self.offline_sync_completed.store(true, Ordering::Release);
         if durable != Some(false) {
             self.swap_message_semaphore(64);
@@ -431,24 +431,47 @@ impl Client {
             }
             None => {}
         }
-        self.offline_sync_notifier.notify(usize::MAX);
         // Only the event is claimed, never the live-state publication above:
         // the semaphore, the flag and the receipt flush must land whether or
         // not a concurrent teardown already spoke for this drain.
-        if self.claim_offline_terminal_report() {
+        if self.claim_offline_terminal_report(generation) {
             self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
                 OfflineSyncCompleted::builder().count(count).build(),
             ));
         }
+        // Notified last, so a waiter that wakes on it can already see the
+        // event: the notifier is the coarser signal and firing it first left a
+        // window where the drain looked finished and its event had not been
+        // dispatched yet.
+        self.offline_sync_notifier.notify(usize::MAX);
     }
 
-    /// Claim the right to publish the event that ends this resume. Exactly
-    /// one of `OfflineSyncCompleted` / `OfflineSyncInterrupted` reaches the
-    /// consumer per drain, whichever publication gets here first.
-    fn claim_offline_terminal_report(&self) -> bool {
-        self.offline_terminal_reported
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+    /// Claim the right to publish the event that ends the resume of
+    /// `generation`. Exactly one of `OfflineSyncCompleted` /
+    /// `OfflineSyncInterrupted` reaches the consumer per drain.
+    ///
+    /// Fails for a drain already reported and for one a newer drain has
+    /// overtaken, so a finisher descheduled past its own connection cannot
+    /// take the slot a later drain needs, nor contradict the interruption its
+    /// own teardown reported. Generations only count up, which is what makes
+    /// the comparison a decision rather than a guess.
+    pub(crate) fn claim_offline_terminal_report(&self, generation: u64) -> bool {
+        let stamp = generation.saturating_add(1);
+        let mut reported = self.offline_terminal_reported.load(Ordering::Acquire);
+        loop {
+            if reported >= stamp {
+                return false;
+            }
+            match self.offline_terminal_reported.compare_exchange_weak(
+                reported,
+                stamp,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => reported = actual,
+            }
+        }
     }
 
     /// Report a drain that ended before its `<ib><offline>` end marker.
@@ -460,7 +483,7 @@ impl Client {
     /// this point: the numbers are read out of the same per-connection state
     /// the reset is about to clear, which is what keeps this from becoming
     /// another flag that outlives its connection.
-    pub(crate) fn abandon_offline_sync_if_interrupted(&self) {
+    pub(crate) fn abandon_offline_sync_if_interrupted(&self, generation: u64) {
         // `active` covers the window before the first batch request is armed;
         // `armed` covers the one after the last stanza cleared `active` but
         // before the end marker arrived. Neither is set once the finisher has
@@ -473,7 +496,7 @@ impl Client {
         if (!was_active && !was_armed) || self.offline_sync_completed.load(Ordering::Acquire) {
             return;
         }
-        if !self.claim_offline_terminal_report() {
+        if !self.claim_offline_terminal_report(generation) {
             return;
         }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -339,6 +339,7 @@ impl Client {
                 "complete_offline_sync: self_weak upgrade failed; dropping the drain tail and switching to live mode"
             );
             self.inbound_commit_batch.force_live_dropping_entries();
+            let _terminal_gate = self.offline_terminal_lock.lock().await;
             self.publish_offline_sync_live_state(count, None, generation);
             return;
         };
@@ -371,6 +372,9 @@ impl Client {
         // first (WA Web's createSnapshot ordering).
         let durable = self.finish_inbound_commit_drain(generation).await;
 
+        // Taken before the check so the check and everything it publishes are
+        // one section against the teardown that would retire this generation.
+        let _terminal_gate = self.offline_terminal_lock.lock().await;
         if self.connection_generation.load(Ordering::Acquire) != generation {
             log::debug!(
                 "finish_offline_sync: connection generation changed during the tail commit; leaving the new connection's state alone"

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -327,11 +327,7 @@ impl Client {
         // flips after the tail commit so the tail's acks still observe it as
         // false and join the aggregate offline-receipt drain (WA Web
         // `sendAggregateOfflineReceipts`) instead of going out 1:1.
-        if self
-            .offline_sync_finish_started
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
+        if !Self::claim_generation_stamp(&self.offline_sync_finish_started, generation) {
             return;
         }
 
@@ -417,6 +413,20 @@ impl Client {
     /// widens the semaphore then. `None` (upgrade-failure fallback) leaves
     /// the buffer alone for the connection-state reset to clear.
     fn publish_offline_sync_live_state(&self, count: i32, durable: Option<bool>, generation: u64) {
+        // The claim is the serialization point for the whole transition, not
+        // just its event. Losing it means a teardown already reported this
+        // drain's end, or a newer drain overtook it: either way that teardown
+        // has reset the flag, the semaphore and the receipt buffer this would
+        // publish, and applying them now would be publishing one connection's
+        // drain onto another's state.
+        if !self.claim_offline_terminal_report(generation) {
+            log::debug!(
+                target: "Client/OfflineSync",
+                "Drain of generation {} was already ended by its teardown; leaving live state alone",
+                generation,
+            );
+            return;
+        }
         self.offline_sync_completed.store(true, Ordering::Release);
         if durable != Some(false) {
             self.swap_message_semaphore(64);
@@ -431,19 +441,36 @@ impl Client {
             }
             None => {}
         }
-        // Only the event is claimed, never the live-state publication above:
-        // the semaphore, the flag and the receipt flush must land whether or
-        // not a concurrent teardown already spoke for this drain.
-        if self.claim_offline_terminal_report(generation) {
-            self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
-                OfflineSyncCompleted::builder().count(count).build(),
-            ));
-        }
+        self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
+            OfflineSyncCompleted::builder().count(count).build(),
+        ));
         // Notified last, so a waiter that wakes on it can already see the
         // event: the notifier is the coarser signal and firing it first left a
         // window where the drain looked finished and its event had not been
         // dispatched yet.
         self.offline_sync_notifier.notify(usize::MAX);
+    }
+
+    /// Claim `stamp_cell` for `generation`, once, and never for a drain a
+    /// newer one has already overtaken.
+    ///
+    /// Generations only count up, so "a stamp at or above mine is already
+    /// there" decides both cases at once: my drain has been reported (or
+    /// finished) already, or I am a task descheduled past my own connection
+    /// and the answer is no longer mine to give. Cells hold `generation + 1`
+    /// so the initial zero reads as "none yet".
+    fn claim_generation_stamp(cell: &portable_atomic::AtomicU64, generation: u64) -> bool {
+        let stamp = generation.saturating_add(1);
+        let mut seen = cell.load(Ordering::Acquire);
+        loop {
+            if seen >= stamp {
+                return false;
+            }
+            match cell.compare_exchange_weak(seen, stamp, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => return true,
+                Err(actual) => seen = actual,
+            }
+        }
     }
 
     /// Claim the right to publish the event that ends the resume of
@@ -456,22 +483,7 @@ impl Client {
     /// own teardown reported. Generations only count up, which is what makes
     /// the comparison a decision rather than a guess.
     pub(crate) fn claim_offline_terminal_report(&self, generation: u64) -> bool {
-        let stamp = generation.saturating_add(1);
-        let mut reported = self.offline_terminal_reported.load(Ordering::Acquire);
-        loop {
-            if reported >= stamp {
-                return false;
-            }
-            match self.offline_terminal_reported.compare_exchange_weak(
-                reported,
-                stamp,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return true,
-                Err(actual) => reported = actual,
-            }
-        }
+        Self::claim_generation_stamp(&self.offline_terminal_reported, generation)
     }
 
     /// Report a drain that ended before its `<ib><offline>` end marker.
@@ -631,17 +643,30 @@ impl Client {
                 || self.expected_disconnect.load(Ordering::Relaxed)
         };
 
-        // Register the notified future *before* checking state to avoid missing
-        // a notify_waiters() that fires between the check and the await.
-        let offline_fut = self.offline_sync_notifier.listen();
-        if !self.offline_sync_completed.load(Ordering::Relaxed) {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            wacore::runtime::timeout(&*self.runtime, remaining, offline_fut)
-                .await
-                .map_err(|_| anyhow!("Timeout waiting for offline sync completion"))?;
+        // Ticked rather than one long wait: a teardown ends this wait's answer
+        // but does not notify `offline_sync_notifier`, so a single await on it
+        // would sit out the caller's whole timeout before reporting a
+        // connection that has been gone the entire time.
+        loop {
+            // Register the listener *before* checking state to avoid missing a
+            // notify that fires between the check and the await.
+            let offline_fut = self.offline_sync_notifier.listen();
+            if self.offline_sync_completed.load(Ordering::Relaxed) {
+                break;
+            }
             if connection_ended() {
                 return Err(anyhow!("Connection ended before offline sync completed"));
             }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow!("Timeout waiting for offline sync completion"));
+            }
+            let _ = wacore::runtime::timeout(
+                &*self.runtime,
+                remaining.min(Duration::from_millis(250)),
+                offline_fut,
+            )
+            .await;
         }
 
         loop {

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -358,6 +358,10 @@ impl Client {
             log::debug!(
                 "finish_offline_sync: connection generation changed during the tail commit; leaving the new connection's state alone"
             );
+            // The teardown that bumped the generation normally reported the
+            // interruption already; this covers losing the race to it, and the
+            // claim keeps it from being a second terminal event.
+            self.abandon_offline_sync_if_interrupted();
             return;
         }
 
@@ -405,9 +409,23 @@ impl Client {
             None => {}
         }
         self.offline_sync_notifier.notify(usize::MAX);
-        self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
-            OfflineSyncCompleted::builder().count(count).build(),
-        ));
+        // Only the event is claimed, never the live-state publication above:
+        // the semaphore, the flag and the receipt flush must land whether or
+        // not a concurrent teardown already spoke for this drain.
+        if self.claim_offline_terminal_report() {
+            self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
+                OfflineSyncCompleted::builder().count(count).build(),
+            ));
+        }
+    }
+
+    /// Claim the right to publish the event that ends this resume. Exactly
+    /// one of `OfflineSyncCompleted` / `OfflineSyncInterrupted` reaches the
+    /// consumer per drain, whichever publication gets here first.
+    fn claim_offline_terminal_report(&self) -> bool {
+        self.offline_terminal_reported
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
     }
 
     /// Report a drain that ended before its `<ib><offline>` end marker.
@@ -430,6 +448,9 @@ impl Client {
             .swap(false, Ordering::AcqRel);
         let was_armed = self.offline_batch.take_armed();
         if (!was_active && !was_armed) || self.offline_sync_completed.load(Ordering::Acquire) {
+            return;
+        }
+        if !self.claim_offline_terminal_report() {
             return;
         }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7310,6 +7310,38 @@ async fn completed_offline_resume_is_not_reported_as_interrupted() {
     );
 }
 
+/// One resume produces one terminal event, never both.
+///
+/// The finisher runs detached and can pass its generation check just before a
+/// teardown bumps it, so the two publications can be in flight for the same
+/// drain. This drives that interleaving directly: the teardown reports the
+/// interruption while `offline_sync_completed` is still false, and the
+/// finisher then arrives with its completion.
+#[tokio::test]
+async fn one_resume_never_reports_both_terminal_events() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 700).await;
+    client.abandon_offline_sync_if_interrupted();
+    client.complete_offline_sync(711).await;
+    client.wait_for_offline_delivery_end().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(
+        interrupted.len() + completed.len(),
+        1,
+        "exactly one terminal event per resume, got interrupted={interrupted:?} completed={completed:?}"
+    );
+    assert!(
+        client.offline_sync_completed.load(Ordering::Acquire),
+        "suppressing the duplicate event must not suppress the live-state publication"
+    );
+}
+
 /// WA Web's `ShiftTimer`: a drain the server stops feeding on a live
 /// connection is completed by the client rather than left open.
 #[tokio::test]

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7398,6 +7398,12 @@ async fn a_later_drain_still_reports_its_own_outcome() {
     client
         .process_node(crate::test_utils::node_to_owned_ref(&preview))
         .await;
+    // The preview handler arms the coordinator from a spawned task; wait for
+    // that rather than racing it, so this really does cover the preview path.
+    crate::test_utils::poll_until("the new preview arms a drain", || {
+        client.offline_batch.is_armed()
+    })
+    .await;
     client.complete_offline_sync(25).await;
     client.wait_for_offline_delivery_end().await;
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7402,6 +7402,43 @@ async fn a_new_preview_re_arms_the_terminal_report_slot() {
     assert_eq!(completed, vec![25], "the second drain's own completion");
 }
 
+/// A completion belongs to the connection whose drain it is.
+///
+/// The inactivity watchdog and the offline-delivery waiter both check the
+/// generation and then call into completion, so a reconnect landing in between
+/// would otherwise mark the replacement connection's backlog finished and
+/// widen its semaphore mid-drain.
+#[tokio::test]
+async fn a_completion_for_a_retired_generation_is_ignored() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    let stale_generation = client.connection_generation.load(Ordering::Acquire);
+    client.connection_generation.fetch_add(1, Ordering::SeqCst);
+
+    client
+        .complete_offline_sync_for_generation(711, stale_generation)
+        .await;
+
+    let (_, completed) = drain_offline_sync_events(&rx);
+    assert!(
+        completed.is_empty(),
+        "a retired generation's completion must not be published, got {completed:?}"
+    );
+    assert!(
+        !client.offline_sync_completed.load(Ordering::Acquire),
+        "nor may it flip the live-state flag for the connection that replaced it"
+    );
+    assert!(
+        client.offline_sync_metrics.active.load(Ordering::Acquire),
+        "nor touch the drain state it no longer owns"
+    );
+}
+
 /// WA Web's `ShiftTimer`: a drain the server stops feeding on a live
 /// connection is completed by the client rather than left open.
 #[tokio::test]

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7274,8 +7274,10 @@ async fn interrupted_offline_resume_reports_once() {
 
     arm_offline_drain(&client, 711, 5).await;
     client.cleanup_connection_state().await;
-    client.abandon_offline_sync_if_interrupted();
-    client.abandon_offline_sync_if_interrupted();
+    client
+        .abandon_offline_sync_if_interrupted(client.connection_generation.load(Ordering::Acquire));
+    client
+        .abandon_offline_sync_if_interrupted(client.connection_generation.load(Ordering::Acquire));
 
     let (interrupted, _) = drain_offline_sync_events(&rx);
     assert_eq!(interrupted.len(), 1, "got {interrupted:?}");
@@ -7326,7 +7328,8 @@ async fn one_resume_never_reports_both_terminal_events() {
     client.core.event_bus.subscribe_handler(handler).detach();
 
     arm_offline_drain(&client, 711, 700).await;
-    client.abandon_offline_sync_if_interrupted();
+    client
+        .abandon_offline_sync_if_interrupted(client.connection_generation.load(Ordering::Acquire));
     client.complete_offline_sync(711).await;
     client.wait_for_offline_delivery_end().await;
 
@@ -7342,14 +7345,14 @@ async fn one_resume_never_reports_both_terminal_events() {
     );
 }
 
-/// The teardown that reports the interruption must not hand the slot back.
+/// The teardown reports the interruption under the generation it is retiring,
+/// which is what silences that drain's own finisher afterwards.
 ///
-/// Reopening the guard inside the connection-state reset would do exactly
-/// that: the reset runs alongside the finisher it is racing, so a finisher
-/// still between its generation check and its publish would find the guard
-/// free again and contradict the interruption the same teardown just reported.
+/// Stamping the generation it just installed instead would leave the stale
+/// finisher free to contradict the interruption, and would claim the slot the
+/// next drain needs.
 #[tokio::test]
-async fn a_teardown_reset_does_not_reopen_the_terminal_report_slot() {
+async fn a_teardown_reports_under_the_generation_it_retires() {
     use wacore::types::events::ChannelEventHandler;
 
     let client = offline_resume_test_client().await;
@@ -7357,10 +7360,13 @@ async fn a_teardown_reset_does_not_reopen_the_terminal_report_slot() {
     client.core.event_bus.subscribe_handler(handler).detach();
 
     arm_offline_drain(&client, 711, 700).await;
-    client.abandon_offline_sync_if_interrupted();
+    let retired = client.connection_generation.load(Ordering::Acquire);
     client.cleanup_connection_state().await;
-    client.complete_offline_sync(711).await;
-    client.wait_for_offline_delivery_end().await;
+
+    assert!(
+        !client.claim_offline_terminal_report(retired),
+        "the retired drain's finisher finds its slot taken by its own teardown"
+    );
 
     let (interrupted, completed) = drain_offline_sync_events(&rx);
     assert_eq!(
@@ -7370,10 +7376,10 @@ async fn a_teardown_reset_does_not_reopen_the_terminal_report_slot() {
     );
 }
 
-/// And the next drain gets a fresh slot: the guard is cleared where a resume
-/// begins, so a second connection still reports its own outcome.
+/// And the next drain still reports its own outcome: nothing has to reopen the
+/// guard, the newer generation's higher stamp does it.
 #[tokio::test]
-async fn a_new_preview_re_arms_the_terminal_report_slot() {
+async fn a_later_drain_still_reports_its_own_outcome() {
     use wacore::types::events::ChannelEventHandler;
 
     let client = offline_resume_test_client().await;
@@ -7381,11 +7387,10 @@ async fn a_new_preview_re_arms_the_terminal_report_slot() {
     client.core.event_bus.subscribe_handler(handler).detach();
 
     arm_offline_drain(&client, 711, 700).await;
-    client.abandon_offline_sync_if_interrupted();
     client.cleanup_connection_state().await;
 
-    // The real re-arm path: an `<ib><offline_preview count>` on the next
-    // connection, processed inline like any other stanza.
+    // The real path: an `<ib><offline_preview count>` on the next connection,
+    // processed inline like any other stanza.
     let preview = NodeBuilder::new("ib")
         .children([NodeBuilder::new("offline_preview")
             .attr("count", "25")
@@ -7396,6 +7401,43 @@ async fn a_new_preview_re_arms_the_terminal_report_slot() {
         .await;
     client.complete_offline_sync(25).await;
     client.wait_for_offline_delivery_end().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(interrupted.len(), 1, "the first drain's interruption");
+    assert_eq!(completed, vec![25], "the second drain's own completion");
+}
+
+/// A finisher descheduled past its own connection can neither contradict the
+/// interruption its teardown reported nor steal the slot a later drain needs.
+///
+/// This is the interleaving that ruled out a boolean guard something has to
+/// clear: whoever cleared it handed the stale finisher its slot back.
+#[tokio::test]
+async fn a_finisher_left_behind_by_two_connections_reports_nothing() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    // The drain that will be interrupted, and the teardown that reports it.
+    arm_offline_drain(&client, 711, 5).await;
+    let stale_generation = client.connection_generation.load(Ordering::Acquire);
+    client.cleanup_connection_state().await;
+
+    // A whole new connection and a new drain, which reports its own outcome.
+    let live_generation = client.connection_generation.load(Ordering::Acquire);
+    arm_offline_drain(&client, 25, 25).await;
+    client
+        .complete_offline_sync_for_generation(25, live_generation)
+        .await;
+    client.wait_for_offline_delivery_end().await;
+
+    // Only now does the finisher from the first drain get to run.
+    assert!(
+        !client.claim_offline_terminal_report(stale_generation),
+        "a finisher two connections behind must not publish"
+    );
 
     let (interrupted, completed) = drain_offline_sync_events(&rx);
     assert_eq!(interrupted.len(), 1, "the first drain's interruption");

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7178,3 +7178,245 @@ async fn reading_reachability_costs_nothing_on_the_reachable_path() {
     });
     assert_eq!(allocations, 0);
 }
+
+// ── Interrupted offline resume (issue #1377) ────────────────────────────────
+
+async fn offline_resume_test_client() -> Arc<Client> {
+    let backend = crate::test_utils::create_test_backend().await;
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager should initialize"),
+    );
+    let (client, _rx) = Client::new(
+        Arc::new(crate::runtime_impl::TokioRuntime),
+        pm,
+        Arc::new(crate::transport::mock::MockTransportFactory::new()),
+        Arc::new(MockHttpClient),
+        None,
+    )
+    .await;
+    client
+}
+
+/// Put the client in the state the log in issue #1377 shows: a preview
+/// announced `total`, the resume armed, and `delivered` stanzas arrived.
+async fn arm_offline_drain(client: &Arc<Client>, total: usize, delivered: usize) {
+    client
+        .offline_sync_metrics
+        .total_messages
+        .store(total, Ordering::Release);
+    client
+        .offline_sync_metrics
+        .processed_messages
+        .store(delivered, Ordering::Release);
+    client
+        .offline_sync_metrics
+        .active
+        .store(true, Ordering::Release);
+    // The send fails (no socket) and is logged; the arming that precedes it is
+    // what this helper is after.
+    offline_resume::send_first_batch(Arc::clone(client), total).await;
+}
+
+fn drain_offline_sync_events(
+    rx: &async_channel::Receiver<Arc<Event>>,
+) -> (Vec<(i32, i32)>, Vec<i32>) {
+    let mut interrupted = Vec::new();
+    let mut completed = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        match &*event {
+            Event::OfflineSyncInterrupted(e) => {
+                interrupted.push((e.total, e.delivered));
+            }
+            Event::OfflineSyncCompleted(e) => completed.push(e.count),
+            _ => {}
+        }
+    }
+    (interrupted, completed)
+}
+
+/// Regression for issue #1377: a connection that dies mid-drain used to end the
+/// resume in total silence — no completion, no anything — and the consumer had
+/// only the absence of an event to go on.
+#[tokio::test]
+async fn interrupted_offline_resume_reports_a_terminal_event() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    client.cleanup_connection_state().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(
+        interrupted,
+        vec![(711, 5)],
+        "a teardown mid-drain must report exactly one OfflineSyncInterrupted carrying both counts"
+    );
+    assert!(
+        completed.is_empty(),
+        "an interrupted drain must not claim completion, got {completed:?}"
+    );
+}
+
+/// The event is the *end* of one resume, not a per-teardown tick: the reset in
+/// `connect()` runs over the same state and must stay silent.
+#[tokio::test]
+async fn interrupted_offline_resume_reports_once() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    client.cleanup_connection_state().await;
+    client.abandon_offline_sync_if_interrupted();
+    client.abandon_offline_sync_if_interrupted();
+
+    let (interrupted, _) = drain_offline_sync_events(&rx);
+    assert_eq!(interrupted.len(), 1, "got {interrupted:?}");
+}
+
+/// The happy path is untouched: a drain that reaches its end marker completes
+/// once with its count, and the teardown that follows adds nothing.
+#[tokio::test]
+async fn completed_offline_resume_is_not_reported_as_interrupted() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 711).await;
+    client.complete_offline_sync(711).await;
+    client.wait_for_offline_delivery_end().await;
+    assert!(client.offline_sync_completed.load(Ordering::Acquire));
+
+    client.cleanup_connection_state().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(
+        completed,
+        vec![711],
+        "completion fires once, with its count"
+    );
+    assert!(
+        interrupted.is_empty(),
+        "a completed drain is never interrupted, got {interrupted:?}"
+    );
+}
+
+/// WA Web's `ShiftTimer`: a drain the server stops feeding on a live
+/// connection is completed by the client rather than left open.
+#[tokio::test]
+async fn offline_resume_inactivity_timeout_completes_the_drain() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    let generation = client.connection_generation.load(Ordering::Acquire);
+    offline_resume::spawn_inactivity_watchdog(
+        Arc::clone(&client),
+        generation,
+        Duration::from_millis(30),
+    );
+
+    let event = wait_for_offline_completion(&rx).await;
+    assert_eq!(
+        event, 5,
+        "the timeout completes at the count actually processed"
+    );
+}
+
+/// The other direction: progress shifts the deadline, so a drain that keeps
+/// arriving is never completed behind the server's back.
+#[tokio::test]
+async fn offline_resume_inactivity_timer_is_rearmed_by_progress() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    let generation = client.connection_generation.load(Ordering::Acquire);
+    let timeout = Duration::from_millis(30);
+    offline_resume::spawn_inactivity_watchdog(Arc::clone(&client), generation, timeout);
+
+    // Ten ticks of traffic spanning several timeout windows. The watchdog may
+    // observe up to two windows of silence before firing, so this covers it.
+    for _ in 0..10 {
+        client.offline_batch.note_stanza_activity();
+        tokio::time::sleep(timeout / 2).await;
+        assert!(
+            !client.offline_sync_completed.load(Ordering::Acquire),
+            "a drain that keeps making progress must not be completed by the timer"
+        );
+    }
+
+    // Traffic stops: the same timer that stayed quiet now ends the drain.
+    let count = wait_for_offline_completion(&rx).await;
+    assert_eq!(count, 5);
+}
+
+/// Poll the event stream for the completion event. Bounded by the test
+/// harness's own timeout rather than a sleep long enough to "probably" cover it.
+async fn wait_for_offline_completion(rx: &async_channel::Receiver<Arc<Event>>) -> i32 {
+    loop {
+        let event = rx.recv().await.expect("event bus stays open");
+        if let Event::OfflineSyncCompleted(e) = &*event {
+            return e.count;
+        }
+    }
+}
+
+/// Regression sibling of #1377: `HistorySyncActivity::reset()` runs on every
+/// teardown, zeroing the task count and notifying every listener, so a waiter
+/// that only read the count reported a history sync that never finished.
+#[tokio::test]
+async fn wait_for_startup_sync_fails_when_the_connection_ends_mid_history_sync() {
+    let client = offline_resume_test_client().await;
+
+    client.offline_sync_completed.store(true, Ordering::Release);
+    let _tracker = client.begin_history_sync_task(4096);
+    assert_eq!(client.history_sync_activity.tasks(), 1);
+
+    let waiter = tokio::spawn({
+        let client = Arc::clone(&client);
+        async move { client.wait_for_startup_sync(Duration::from_secs(5)).await }
+    });
+    crate::test_utils::wait_for_notifier_listeners(client.history_sync_activity.idle_notifier(), 1)
+        .await;
+
+    // Exactly what `cleanup_connection_state` does, in that order.
+    client.connection_generation.fetch_add(1, Ordering::SeqCst);
+    client.history_sync_activity.reset();
+
+    let result = waiter.await.expect("waiter task must not panic");
+    assert!(
+        result.is_err(),
+        "a teardown's zeroed task count is not a finished history sync"
+    );
+}
+
+/// The same waiter still succeeds when the tasks genuinely drain.
+#[tokio::test]
+async fn wait_for_startup_sync_succeeds_when_history_tasks_finish() {
+    let client = offline_resume_test_client().await;
+
+    client.offline_sync_completed.store(true, Ordering::Release);
+    let tracker = client.begin_history_sync_task(4096);
+    drop(tracker);
+
+    client
+        .wait_for_startup_sync(Duration::from_secs(5))
+        .await
+        .expect("an idle activity tracker is a completed startup sync");
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7342,6 +7342,66 @@ async fn one_resume_never_reports_both_terminal_events() {
     );
 }
 
+/// The teardown that reports the interruption must not hand the slot back.
+///
+/// Reopening the guard inside the connection-state reset would do exactly
+/// that: the reset runs alongside the finisher it is racing, so a finisher
+/// still between its generation check and its publish would find the guard
+/// free again and contradict the interruption the same teardown just reported.
+#[tokio::test]
+async fn a_teardown_reset_does_not_reopen_the_terminal_report_slot() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 700).await;
+    client.abandon_offline_sync_if_interrupted();
+    client.cleanup_connection_state().await;
+    client.complete_offline_sync(711).await;
+    client.wait_for_offline_delivery_end().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(
+        (interrupted.len(), completed.len()),
+        (1, 0),
+        "the interruption stands; got interrupted={interrupted:?} completed={completed:?}"
+    );
+}
+
+/// And the next drain gets a fresh slot: the guard is cleared where a resume
+/// begins, so a second connection still reports its own outcome.
+#[tokio::test]
+async fn a_new_preview_re_arms_the_terminal_report_slot() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 700).await;
+    client.abandon_offline_sync_if_interrupted();
+    client.cleanup_connection_state().await;
+
+    // The real re-arm path: an `<ib><offline_preview count>` on the next
+    // connection, processed inline like any other stanza.
+    let preview = NodeBuilder::new("ib")
+        .children([NodeBuilder::new("offline_preview")
+            .attr("count", "25")
+            .build()])
+        .build();
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&preview))
+        .await;
+    client.complete_offline_sync(25).await;
+    client.wait_for_offline_delivery_end().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(interrupted.len(), 1, "the first drain's interruption");
+    assert_eq!(completed, vec![25], "the second drain's own completion");
+}
+
 /// WA Web's `ShiftTimer`: a drain the server stops feeding on a live
 /// connection is completed by the client rather than left open.
 #[tokio::test]

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7331,7 +7331,6 @@ async fn one_resume_never_reports_both_terminal_events() {
     client
         .abandon_offline_sync_if_interrupted(client.connection_generation.load(Ordering::Acquire));
     client.complete_offline_sync(711).await;
-    client.wait_for_offline_delivery_end().await;
 
     let (interrupted, completed) = drain_offline_sync_events(&rx);
     assert_eq!(
@@ -7340,8 +7339,8 @@ async fn one_resume_never_reports_both_terminal_events() {
         "exactly one terminal event per resume, got interrupted={interrupted:?} completed={completed:?}"
     );
     assert!(
-        client.offline_sync_completed.load(Ordering::Acquire),
-        "suppressing the duplicate event must not suppress the live-state publication"
+        !client.offline_sync_completed.load(Ordering::Acquire),
+        "the loser publishes nothing at all: the winner's teardown owns this state"
     );
 }
 
@@ -7442,6 +7441,72 @@ async fn a_finisher_left_behind_by_two_connections_reports_nothing() {
     let (interrupted, completed) = drain_offline_sync_events(&rx);
     assert_eq!(interrupted.len(), 1, "the first drain's interruption");
     assert_eq!(completed, vec![25], "the second drain's own completion");
+}
+
+/// A completion descheduled past its own connection must not consume the
+/// finisher guard the next connection needs.
+///
+/// With a plain boolean the stale call claimed it after the teardown cleared
+/// it, and the next drain's completion then found the guard taken and never
+/// started a finisher, so that drain reported nothing at all.
+#[tokio::test]
+async fn a_stale_completion_does_not_consume_the_next_connection_finisher() {
+    use wacore::types::events::ChannelEventHandler;
+
+    let client = offline_resume_test_client().await;
+    let (handler, rx) = ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    arm_offline_drain(&client, 711, 5).await;
+    let stale_generation = client.connection_generation.load(Ordering::Acquire);
+    client.cleanup_connection_state().await;
+
+    // The stale completion runs late, against a connection that is gone.
+    client
+        .complete_offline_sync_for_generation(711, stale_generation)
+        .await;
+
+    // The next connection's drain still gets its own finisher and its own event.
+    let live_generation = client.connection_generation.load(Ordering::Acquire);
+    arm_offline_drain(&client, 25, 25).await;
+    client
+        .complete_offline_sync_for_generation(25, live_generation)
+        .await;
+    client.wait_for_offline_delivery_end().await;
+
+    let (interrupted, completed) = drain_offline_sync_events(&rx);
+    assert_eq!(interrupted.len(), 1, "the first drain's interruption");
+    assert_eq!(completed, vec![25], "the second drain still completes");
+}
+
+/// The startup waiter reports a teardown as soon as it happens.
+///
+/// A teardown ends this wait's answer but never notifies
+/// `offline_sync_notifier`, so a single await on that notifier sat out the
+/// caller's whole timeout before reporting a connection that had been gone the
+/// entire time.
+#[tokio::test]
+async fn wait_for_startup_sync_reports_a_teardown_without_waiting_out_its_timeout() {
+    let client = offline_resume_test_client().await;
+
+    let started = wacore::time::Instant::now();
+    let waiter = tokio::spawn({
+        let client = Arc::clone(&client);
+        async move { client.wait_for_startup_sync(Duration::from_secs(30)).await }
+    });
+    crate::test_utils::wait_for_notifier_listeners(&client.offline_sync_notifier, 1).await;
+
+    // The teardown lands under the parked waiter, and never notifies it.
+    client.connection_generation.fetch_add(1, Ordering::SeqCst);
+
+    let result = waiter.await.expect("waiter task must not panic");
+    let waited = started.elapsed();
+
+    assert!(result.is_err(), "a dead connection cannot have synced");
+    assert!(
+        waited < Duration::from_secs(5),
+        "reported after {waited:?}, which means it sat out the timeout"
+    );
 }
 
 /// A completion belongs to the connection whose drain it is.

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -230,8 +230,13 @@ impl Client {
     /// test does — a send measured in drain mode is not the steady state.
     pub(crate) fn enter_live_mode_for_tests(&self) {
         self.offline_sync_completed.store(true, Ordering::Release);
-        self.offline_sync_finish_started
-            .store(true, Ordering::Release);
+        // The guard is a generation stamp now; mark the current one finished.
+        self.offline_sync_finish_started.store(
+            self.connection_generation
+                .load(Ordering::Acquire)
+                .saturating_add(1),
+            Ordering::Release,
+        );
         self.swap_message_semaphore(64);
         self.inbound_commit_batch.deactivate();
     }

--- a/src/sync_task.rs
+++ b/src/sync_task.rs
@@ -67,6 +67,11 @@ impl HistorySyncActivity {
         self.idle_notifier.listen()
     }
 
+    #[cfg(test)]
+    pub(crate) fn idle_notifier(&self) -> &event_listener::Event {
+        &self.idle_notifier
+    }
+
     pub(crate) fn tasks(&self) -> usize {
         self.state_guard().tasks
     }

--- a/tests/e2e/tests/offline_messages.rs
+++ b/tests/e2e/tests/offline_messages.rs
@@ -139,3 +139,53 @@ async fn test_server_accepts_messages_for_offline_recipient() -> anyhow::Result<
 
     Ok(())
 }
+
+/// An offline drain always ends with a terminal event, even when the
+/// connection goes away in the middle of it (issue #1377).
+///
+/// The first e2e test to drop a connection with an operation still in flight.
+/// It does not try to win the race — a drain this small often finishes first,
+/// and then the terminal event is the completion. What it locks is that the
+/// resume never ends in silence, which is exactly what it used to do whenever
+/// the reconnect landed first.
+#[tokio::test]
+async fn test_offline_drain_interrupted_by_reconnect_still_signals() -> anyhow::Result<()> {
+    use wacore::types::events::Event;
+
+    let client_a = TestClient::connect("e2e_offline_interrupt_a").await?;
+    let mut client_b = TestClient::connect("e2e_offline_interrupt_b").await?;
+
+    let jid_b = client_b.jid().await;
+    client_b.go_offline().await?;
+
+    for i in 1..=5 {
+        client_a
+            .client
+            .send_message(jid_b.clone(), text_msg(&format!("backlog {i}")))
+            .await?;
+    }
+
+    client_b.come_back_online();
+    client_b
+        .wait_for_event(30, |e| matches!(e, Event::OfflineSyncPreview(_)))
+        .await?;
+    info!("Resume armed; tearing the connection down under it");
+
+    client_b.client.reconnect().await;
+    client_b.wait_for_disconnected(5).await?;
+
+    let terminal = client_b
+        .wait_for_event(30, |e| {
+            matches!(
+                e,
+                Event::OfflineSyncCompleted(_) | Event::OfflineSyncInterrupted(_)
+            )
+        })
+        .await?;
+    info!("Resume ended with {terminal:?}");
+
+    client_a.disconnect().await;
+    client_b.disconnect().await;
+
+    Ok(())
+}

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -974,7 +974,6 @@ pub enum Event {
     HistorySync(Box<LazyHistorySync>),
     OfflineSyncPreview(OfflineSyncPreview),
     OfflineSyncCompleted(OfflineSyncCompleted),
-    OfflineSyncInterrupted(OfflineSyncInterrupted),
     /// The server marked one of its cached protocol domains dirty.
     DirtyState(DirtyState),
 
@@ -1085,6 +1084,12 @@ pub enum Event {
 
     /// The server pushed (or withdrew) a retirement deadline for this build.
     ClientExpirationChanged(ClientExpirationChanged),
+
+    /// An offline backlog drain ended without its `<ib><offline>` end marker.
+    ///
+    /// Last, next to its sibling rather than next to
+    /// [`Event::OfflineSyncCompleted`], for the index reason above.
+    OfflineSyncInterrupted(OfflineSyncInterrupted),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].
@@ -1180,10 +1185,10 @@ impl Event {
             Event::EncDecryptFailed(_) => EventKind::EncDecryptFailed,
             Event::CallLogSync(_) => EventKind::CallLogSync,
             Event::ClientExpirationChanged(_) => EventKind::ClientExpirationChanged,
+            Event::OfflineSyncInterrupted(_) => EventKind::OfflineSyncInterrupted,
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
-            Event::OfflineSyncInterrupted(_) => EventKind::OfflineSyncInterrupted,
             Event::DirtyState(_) => EventKind::DirtyState,
             Event::DeviceListUpdate(_) => EventKind::DeviceListUpdate,
             Event::IdentityChange(_) => EventKind::IdentityChange,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -289,6 +289,7 @@ pub enum EventKind {
     EncDecryptFailed,
     CallLogSync,
     ClientExpirationChanged,
+    OfflineSyncInterrupted,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -302,7 +303,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::ClientExpirationChanged as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::OfflineSyncInterrupted as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids
@@ -973,6 +974,7 @@ pub enum Event {
     HistorySync(Box<LazyHistorySync>),
     OfflineSyncPreview(OfflineSyncPreview),
     OfflineSyncCompleted(OfflineSyncCompleted),
+    OfflineSyncInterrupted(OfflineSyncInterrupted),
     /// The server marked one of its cached protocol domains dirty.
     DirtyState(DirtyState),
 
@@ -1181,6 +1183,7 @@ impl Event {
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
+            Event::OfflineSyncInterrupted(_) => EventKind::OfflineSyncInterrupted,
             Event::DirtyState(_) => EventKind::DirtyState,
             Event::DeviceListUpdate(_) => EventKind::DeviceListUpdate,
             Event::IdentityChange(_) => EventKind::IdentityChange,
@@ -1732,6 +1735,31 @@ pub struct OfflineSyncPreview {
 #[non_exhaustive]
 pub struct OfflineSyncCompleted {
     pub count: i32,
+}
+
+/// An offline backlog drain ended without its `<ib><offline>` end marker,
+/// because the connection went away first.
+///
+/// This is the counterpart of [`OfflineSyncCompleted`], not a variant of it:
+/// the drain did not finish, the client is not caught up, and the remainder of
+/// the backlog is still queued server-side. Nothing was lost — an offline
+/// message is only acked through the aggregate receipt flush that a *completed*
+/// drain performs, so everything undelivered (and the last open batch) is
+/// redelivered on the next connection, where a fresh
+/// [`OfflineSyncPreview`] announces it.
+///
+/// A consumer that gates "caught up" UI or startup work on
+/// [`OfflineSyncCompleted`] should treat this as "not caught up, wait for the
+/// next preview" rather than as completion.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct OfflineSyncInterrupted {
+    /// What the preview announced for this drain.
+    pub total: i32,
+    /// Offline stanzas processed before the connection ended. Never larger
+    /// than `total` in practice, but the server owns both numbers, so treat
+    /// the pair as a progress report rather than an invariant.
+    pub delivered: i32,
 }
 
 /// A valid `<ib><dirty>` marker received from the server.


### PR DESCRIPTION
## Summary

An offline drain that lost its connection mid-flight ended in total silence. `Event::OfflineSyncCompleted` has exactly one producer, the drain finisher, and every teardown path resets the whole per-connection resume state without going through it, so a consumer subscribed to the public event had only the absence of an event to tell it anything had happened. This adds `Event::OfflineSyncInterrupted { total, delivered }`, emitted once per armed resume from the connection-state resets, plus the drain-level inactivity timeout WA Web has and we did not: 60s without an offline stanza on a live connection now completes the drain instead of leaving it open forever. It also fixes the same class of bug in `wait_for_startup_sync`, which read a teardown's zeroed history-sync task count as "all tasks finished" and returned success for a sync that never happened.

## Audit

Confirmed:

- `Event::OfflineSyncCompleted` is dispatched from exactly one place, `publish_offline_sync_live_state` (`src/client/sessions.rs:408`), reached only from the finisher and its upgrade-failure fallback. Four paths end a resume without it and none emits anything: the `connect()` reset (`src/client/lifecycle.rs:1055-1077`), the `cleanup_connection_state` reset (`src/client/lifecycle.rs:1852-1868`), the finisher's generation bail (`src/client/sessions.rs:357-362`) and the internal waiter's generation bail (`src/client/sessions.rs:434-441`).
- The internal waiters are all bounded and self-recovering (`DEFAULT_OFFLINE_SYNC_TIMEOUT`, 60s, `src/client/sessions.rs:292`). The external consumer subscribed to the public event is the one with no deadline at all.
- No receipt is sent in an interrupted drain. `try_buffer_offline_receipt` (`src/receipt.rs:821`) buffers every offline delivery receipt, `flush_offline_receipts` only runs from `publish_offline_sync_live_state`, and `clear_offline_receipt_buffer` drops the buffer on both resets. So from the server's side nothing in an interrupted drain was ever confirmed.
- `wait_for_startup_sync` had the same-family false positive: `HistorySyncActivity::reset()` (`src/sync_task.rs:56`) zeroes the task count and notifies every listener, runs on every teardown, and the waiter checked neither the generation nor `expected_disconnect`. Its sibling `wait_for_offline_delivery_end_with_timeout` already did.

Refuted, and this is the important part, because it is the natural reading of the log and it is wrong:

- **There is no stale flag surviving the reconnect.** `OfflineBatchCoordinator::reset()` runs in *both* connection-state resets (`src/client/lifecycle.rs:1077` and `:1868`), and `is_armed_for` requires the flag *and* the current `connection_generation` (`src/client/offline_resume.rs:91`), so even a missed reset could not make a new `offline_preview` a no-op: it would arm at the new generation and the old cycle's timers would stand down on their own generation checks. The second `Resume armed: total=25` in the log is a real, clean arm.
- **`gen=63` and `gen=7` are not a race.** `connection_generation` is a per-`Client` counter (`src/client.rs:1400`) bumped monotonically on teardown (`src/client/lifecycle.rs:1728`). One client cannot go 63 down to 7. The issue author's "gen=7 is the other account" is literal: two `Client` instances on the same relay.

So the fix the issue proposes, re-arming on the new preview, is not what was missing. The state was already reset correctly and the new resume really did arm. What was missing is that the *old* one never told anyone it had ended.

## WA Web

Read out of the restored bundle (`WAWebBlockingOfflineResumeManager`, `WAWebOfflineHandler`, `WAWebOfflineResumeConst`):

- **No cursor, anywhere.** The only thing the client ever tells the server about the backlog is how many more it will take, via `<ib><offline_batch count="N"/></ib>` (`WASmaxOutOfflineBatchRequest.makeBatchRequest`). That is flow control, not position. There is no offset, no last-message id, nothing persisted about "where I was".
- **The drain has a client-side inactivity timeout that completes it.** `WAWebOfflineResumeConst.OFFLINE_STANZA_TIMEOUT_MS = 6e4`. The blocking manager arms a `ShiftTimer` with it on the first preview and shifts it from `processDecryptResult` and `newOfflineStanza`; on expiry it logs `offline session completed by timeout` / `offline resume finished by timeout` and calls `processOfflineSessionComplete(message + receipt)` itself. So a drain that stops progressing is completed by the client, not left open.
- **Recovery is the server re-announcing, but narrowly.** `processOfflinePreview` has the three branches: first preview of the session; a preview during an in-progress drain, which is accepted and *added* to `offlineMessagePreviewCounter` without reconciling against what was already delivered, but **only within `OFFLINE_PREVIEW_PERIOD_MS = 1000`** of the first, and rejected with an error log after that; and a drain already complete, which goes down `RESUME_WITH_OPEN_TAB`. Worth noting for our case: the blocking manager's state is per page load, not per socket, so a reconnect mid-drain lands in that third branch's "reject, then shift the timer", and the 60s timer is what actually ends the session. We have a better signal than WA Web here, because the teardown is an observable event for us and is not for the page.
- **Batch size 200 and the terminal marker match ours.** `WAWebOfflineHandler` `C = 200`, `DEFAULT_MAX_BATCH_SIZE = 200`, `S = 100` debounce, and `processOfflineIb` on `<ib><offline count="N"/>` is what calls `processOfflineSessionComplete`. Our pull mechanics are already parity; what was missing is only what happens when it is interrupted.
- Two smaller ones, with corrections to what an earlier scan reported: the 10s warning is real and log-only (`no offline preview IB within 10s`, `sendLogs("offline-delivery-end-fallback-timer")`, armed after `WAComms.startHandlingRequests()`), and the post-completion guard is **20s**, not 10, and is not log-only: `OFFLINE_STANZA_COUNT_CHECK_TIMEOUT_MS = 2e4`, and if more than `OFFLINE_STANZA_COUNT_LIMIT = 100` offline stanzas arrive after the completion marker it calls `refreshWindow()`.
- I could not find any relaxation of a transport timeout while draining. `DGWPinger` has no offline-resume awareness at all; it resets on traffic, and offline stanzas are traffic. Nothing to port.

## Design

Two signals, because there are two different things to say.

**A stalled drain on a live connection completes**, exactly like WA Web's `ShiftTimer`. `spawn_inactivity_watchdog` is armed with the first batch request and stands down on generation change or completion; progress re-arms it via a counter the receive path bumps. On expiry it calls the ordinary `complete_offline_sync(processed)`, so the whole existing tail runs: the batch commits, receipts flush, `OfflineSyncCompleted` fires with the count actually processed. The counter is compared across a sleep instead of reading a clock per stanza, so the timeout fires somewhere in `[60s, 120s)` after the last one; that is documented at the field.

**A drain that ends with its connection reports `OfflineSyncInterrupted { total, delivered }`.** Completing it instead would be a lie: the connection is gone, live mode is not happening, and the backlog is coming back. A consumer that gates "caught up" UI or startup work on `OfflineSyncCompleted` should treat `OfflineSyncInterrupted` as "not caught up, wait for the next preview". The difference matters, so the two are distinct events rather than a flag on one.

I did not add a cursor and did not invent resumption by offset, per what WA Web does.

On state: nothing new is retained. `abandon_offline_sync_if_interrupted` reads `total`/`delivered` out of `offline_sync_metrics`, which the reset it sits in is about to clear anyway, and uses `OfflineBatchCoordinator::take_armed()` plus the `active` swap as its once-guard, so the pair of resets around one teardown emits at most one event and a completed drain emits none. The whole point is that there is no flag that outlives its connection, which is the failure mode this batch exists to avoid re-introducing.

## Sibling

`wait_for_startup_sync` had the same shape of bug from the other end: **the shutdown produces the completion signal**. `HistorySyncActivity::reset()` zeroes the task count and notifies every listener, and it runs on every teardown, so a waiter parked mid-history-sync woke up, read zero and returned `Ok(())`. The caller believed it had synced. It now captures the generation on entry and fails with `Connection ended before history sync tasks became idle`, reading the generation *after* the task count so a teardown landing between the two reads cannot be mistaken for a genuine idle. Aligning it with `wait_for_offline_delivery_end_with_timeout`, which already checked both the generation and `expected_disconnect`, is sufficient.

I swept the other notifiers for the same pattern: a waiter parked on a notifier that a teardown reset fires while zeroing the condition it waits on. `HistorySyncActivity` is the only one. `offline_sync_notifier` is never notified from teardown; `session_state_notifier`, `connected_notifier`, `socket_ready_notifier` and `pause_state_notifier` are hint notifiers whose waiters re-read real state; `FlushScope::idle` is only notified when tracked work genuinely drains, and `reopen()` does not notify.

## Safety

Re-delivering is safe, and that is what makes re-arming on the next preview the right recovery rather than a duplicate-message risk:

- **No receipt is ever sent for an interrupted drain.** Offline delivery receipts are buffered for the aggregate flush a *completed* drain performs, and both resets drop the buffer. So the server never got a confirmation for anything in that drain and redelivers all of it. This PR deliberately does not flush them.
- **Reprocessing is idempotent** for anything the drain already committed in batch, so redelivery of those is a no-op locally.
- **What is actually lost** is the batch still open at the instant the connection died: its entries were uncommitted, they drop with the batcher, they were never acked, and they come back on the next connection. The Signal state that goes with them drops in the same step, which is what keeps a redelivery from turning into an unackable duplicate.

## Compatibility

`Event` is `#[non_exhaustive]`, so a new variant does not break a consumer that matches with a wildcard arm. `EventKind::OfflineSyncInterrupted` is appended at the end, so no existing discriminant moves.

Two behaviour changes worth naming:

- `wait_for_startup_sync` now returns `Err` when the connection ends mid-sync, where it used to return `Ok(())`. Callers that treated success as "history is synced" were being told something untrue; callers that only used it as a "settle for a while" barrier will now see an error on a reconnect. This is the intended break and we are pre-1.0.
- A drain that stalls on a live connection now completes after ~60s instead of hanging, so `OfflineSyncCompleted` can arrive with a `count` lower than the announced preview total. That was already possible through the existing timeout path in `wait_for_offline_delivery_end`; it is now reachable without an internal waiter happening to be parked.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib            # 1541 passed
cargo test -p whatsapp-rust --lib     # 1840 passed
cargo clippy -p wacore -p whatsapp-rust -p e2e-tests --all-targets -- -D warnings
```

The workspace-wide clippy does not build in this environment (a plugin pulls `alsa-sys` and the system `alsa` dev package is absent), so full matrix left to CI.

The two regressions were verified to fail before the change: with the two `abandon_offline_sync_if_interrupted` calls and the history-loop generation check removed, `interrupted_offline_resume_reports_a_terminal_event`, `interrupted_offline_resume_reports_once` and `wait_for_startup_sync_fails_when_the_connection_ends_mid_history_sync` all fail; everything else still passes.

One e2e test is added (`test_offline_drain_interrupted_by_reconnect_still_signals`) and is validated by CI against the pinned mock server, not locally. A note on what it does and does not claim: it is the first e2e test to drop a connection with an operation still in flight, but it does not try to win the race, because a five-message drain often finishes before the reconnect lands and the mock server gives no way to hold one open deterministically. What it locks is the contract this PR establishes, that a resume never ends in silence, whichever of the two terminal events it ends with. The deterministic regression coverage is in the unit tests, which drive the teardown directly.

Fixes #1377

The reconnect that interrupted the drain in the reported log is itself the bug in #1376 and is not touched here; this batch assumes reconnects happen and exists so that they stop costing a backlog.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149M3g27TtKt452V6zq2dPx)_