### PR TITLE
chore(ci): batch dependabot updates into grouped pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,65 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependency updates arrive as a few batched pull requests, not one per crate.
+# Configuration reference:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # One directory covers the whole workspace: the cargo updater reads the root
+  # Cargo.toml's `members` and resolves against the single shared Cargo.lock, so
+  # every crate under wacore/, storages/, transports/, plugins/, http_clients/,
+  # examples/ and tools/ is already in scope from here.
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+    # Group PRs, not individual bumps — 5 is headroom for the two groups below
+    # plus anything Dependabot has to split out (a security advisory opens its
+    # own PR regardless of grouping).
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      # The routine weekly batch: one PR, one CI matrix run, one merge.
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      # Majors ride in their own PR so a breaking bump that needs code changes
+      # never holds the routine batch hostage. They stay grouped rather than
+      # one-per-crate because most of this tree is 0.x, where Dependabot counts
+      # 0.24 -> 0.25 as a *minor* update even though Cargo treats it as
+      # breaking; splitting on the semver position alone would not buy the
+      # isolation it looks like it buys, so the split is only about keeping the
+      # rare loud PR separate from the quiet one.
+      cargo-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
+  # Not previously configured, and the workflows show it: actions/cache is
+  # pinned at both v4 and v5, upload-artifact at v4, v7 and a bare SHA. One
+  # weekly PR keeps the matrix consistent. SHA pins are updated in place, with
+  # the version carried in a trailing comment.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # No docker entry: the Dockerfile builds `FROM rust:alpine` and `FROM
+  # scratch`, neither of which carries a version for the updater to bump. Add
+  # one here the day a base image gets pinned to a digest or a tagged release.


### PR DESCRIPTION
Dependabot opened one pull request per crate, so a quiet week still cost several CI matrix runs and several merges.

## Cargo

One `directory: /` already covers the whole workspace — the cargo updater reads the root `Cargo.toml`'s `members` and resolves against the single shared `Cargo.lock`, so `wacore/*`, `storages/`, `transports/`, `plugins/`, `http_clients/`, `examples/` and `tools/` are all in scope from that one entry.

Two groups:

- **`cargo`** — every `minor` and `patch` bump in one PR. The routine weekly batch: one PR, one CI matrix run, one merge.
- **`cargo-major`** — majors in their own PR, so a breaking bump that needs code changes cannot hold the routine batch hostage.

The split is deliberately not finer. Most of this tree is `0.x`, where Dependabot counts `0.24 -> 0.25` as a *minor* update even though Cargo treats it as breaking — splitting on the semver position alone would not buy the isolation it looks like it buys. The split is only about keeping the rare loud PR separate from the quiet one.

`open-pull-requests-limit: 5` leaves headroom for the two groups plus anything Dependabot has to split out; a security advisory opens its own PR regardless of grouping.

## GitHub Actions

Never configured, and the workflows show it: `actions/cache` is pinned at both v4 and v5, `upload-artifact` at v4, v7 and a bare SHA. One weekly grouped PR keeps the matrix consistent. SHA pins are updated in place with the version carried in a trailing comment.

## No docker entry

The Dockerfile builds `FROM rust:alpine` and `FROM scratch`, neither of which carries a version for the updater to bump. A comment in the config says to add one the day a base image gets pinned to a digest or a tagged release.

## Verification

The config is validated by GitHub on merge (Insights → Dependency graph → Dependabot shows parse errors); locally it round-trips through a YAML parser, and every key used is in the [configuration options reference](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). Nothing in the build is touched, so no crate is rebuilt by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Kon6DPzicxxWU1dMEqG7p

---
_Generated by [Claude Code](https://claude.ai/code/session_018Kon6DPzicxxWU1dMEqG7p)_