### PR TITLE
fix(ci): get the MSRV job and cargo-deny green again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,12 @@ updates:
     # the pairing the job's own comment asks for.
     ignore:
       - dependency-name: dtolnay/rust-toolchain
+    # This also stops the SHA pin in `signal-durability-nightly.yml` being
+    # refreshed, which is collateral rather than intent: an ignore is per
+    # dependency, not per use. That pin is a reproducibility anchor for a
+    # nightly job rather than a floor that has to track anything, so it going
+    # stale costs less than the MSRV job breaking every week. Bump it by hand
+    # if a fix in the action ever matters there.
 
   # No docker entry: the Dockerfile builds `FROM rust:alpine` and `FROM
   # scratch`, neither of which carries a version for the updater to bump. Add

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,15 @@ updates:
       actions:
         patterns:
           - "*"
+    # The MSRV job pins `dtolnay/rust-toolchain` by a ref that names a *Rust
+    # version*, not a release of the action. The updater cannot see that: it
+    # compares the numbers, finds 1.100.0 larger than 1.94.1, and pins a
+    # toolchain `rustup` then 404s on — which is what happened, and it failed
+    # every pull request in the repository at toolchain install. The floor is
+    # raised by hand, next to `rust-version` in the root Cargo.toml, which is
+    # the pairing the job's own comment asks for.
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain
 
   # No docker entry: the Dockerfile builds `FROM rust:alpine` and `FROM
   # scratch`, neither of which carries a version for the updater to bump. Add

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -429,7 +429,15 @@ jobs:
       # Pinned rather than `@stable`: this version is the workspace MSRV
       # (`rust-version` in the root Cargo.toml). To raise the floor, bump both
       # together — a floating `stable` would silently let the declared MSRV rot.
-      - uses: dtolnay/rust-toolchain@1.100.0
+      #
+      # And it is not Dependabot's to raise. This ref is a Rust version, not a
+      # release of the action, so the updater bumps it by comparing numbers and
+      # has no way to know the toolchain has to exist and has to match the
+      # declared floor. It once moved this to 1.100.0 — numerically the largest
+      # ref, a Rust release that does not exist — and every pull request in the
+      # repository failed at `rustup`, before a line was compiled. The
+      # `dependabot.yml` entry beside this one is what keeps the pin ours.
+      - uses: dtolnay/rust-toolchain@1.94.1
       # The pre-built nextest binary is toolchain-independent — it drives this
       # MSRV cargo the same way it drives the nightly one.
       - name: Install protoc and cargo-nextest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,9 +547,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/deny.toml
+++ b/deny.toml
@@ -12,12 +12,16 @@ exclude-dev = true
 
 [advisories]
 version = 2
-# Only `unmaintained` notices are listed below, and only where no upgrade
-# exists. A real vulnerability advisory must be resolved by a version bump,
-# never by an entry here.
-ignore = [
-    { id = "RUSTSEC-2026-0150", reason = "audiopus_sys, reached through the optional `voip-libopus` feature via opus 0.3. Upstream is dormant with no fork on crates.io; the crate is a thin libopus FFI shim that we build but do not drive directly." },
-]
+# Only `unmaintained` notices belong here, and only where no upgrade exists. A
+# real vulnerability advisory must be resolved by a version bump, never by an
+# entry here.
+#
+# Empty on purpose. RUSTSEC-2026-0150 (audiopus_sys) was listed until the crate
+# left the graph entirely -- `audiopus` appears nowhere in Cargo.lock now, even
+# under `--all-features` -- and cargo-deny reports a stale ignore as
+# `advisory-not-detected`. An ignore outliving the crate it excuses is how a
+# real advisory gets waved through later under a name nobody rechecked.
+ignore = []
 
 [licenses]
 version = 2
@@ -74,6 +78,19 @@ skip = [
     # is on rand 0.10 / getrandom 0.4.
     { name = "getrandom", version = "=0.2.17" },
     { name = "rand_core", version = "=0.6.4" },
+
+    # Build-script-side duplicates, all reached only through `buffa-build`,
+    # which every crate that uses it declares under `[build-dependencies]`.
+    # Like the proc-macro entries below, they cost build time only: a build
+    # script runs at compile time and links into no shipped binary. And none of
+    # them can be collapsed from here, because each pair is two incompatible
+    # majors pulled by different parents -- the workspace is on `getrandom` 0.4
+    # via rand 0.10, while `tempfile` inside the codegen is on 0.3, and `r-efi`
+    # is simply whichever one each `getrandom` chose. Collapses when buffa
+    # upgrades, not on anything we can do to our own manifests.
+    { name = "getrandom", version = "=0.3.4" },
+    { name = "prettyplease", version = "=0.2.37" },
+    { name = "r-efi", version = "=5.3.0" },
 
     # Proc-macro-side duplicates. They cost build time only — proc macros run
     # at compile time and never link into the produced binary.

--- a/deny.toml
+++ b/deny.toml
@@ -88,6 +88,13 @@ skip = [
     # via rand 0.10, while `tempfile` inside the codegen is on 0.3, and `r-efi`
     # is simply whichever one each `getrandom` chose. Collapses when buffa
     # upgrades, not on anything we can do to our own manifests.
+    #
+    # `Cargo.lock` invites a misreading here: it carries a `rand_core` 0.9.5
+    # entry that lists `getrandom 0.3.4` as a dependency, which reads like a
+    # second, runtime path into the shipped graph. Nothing reaches that
+    # rand_core -- `cargo tree -i rand_core@0.9.5 --target all` prints nothing
+    # at all -- so the lock entry is stale and the build-dependency route below
+    # is the only one. Check with `cargo tree -i`, not by grepping the lock.
     { name = "getrandom", version = "=0.3.4" },
     { name = "prettyplease", version = "=0.2.37" },
     { name = "r-efi", version = "=5.3.0" },


### PR DESCRIPTION
Two checks have been failing on **every pull request in the repository, `main` included**. Neither is anyone's diff; both are config that stopped matching reality.

## 1. `Test Stable (MSRV)` — dies at toolchain install

```
error: could not download nonexistent rust version `1.100.0-x86_64-unknown-linux-gnu` ... 404
```

[#1384](https://github.com/oxidezap/whatsapp-rust/pull/1384) carried one line beyond the actions it meant to move:

```diff
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@1.100.0
```

That ref is a **Rust version, not a release of the action**. Dependabot compares the numbers, finds `1.100.0` larger, and pins a toolchain `rustup` 404s on — Rust 1.100 is roughly two years out. The declared floor never moved (`rust-version = "1.94"`), so the pin and the floor had also silently stopped agreeing, which is the exact rot the job's own comment says the pin exists to prevent.

Back to `1.94.1`, and Dependabot is told to leave this dependency alone — **nothing about the failure was specific to 1.100.0**: any ref it picks is a toolchain it cannot know exists, matching a floor it cannot see. Without that, next Monday's batch reintroduces it.

That ignore is per dependency rather than per use, so it also freezes the SHA pin in `signal-durability-nightly.yml`. Collateral rather than intent, and noted in `dependabot.yml`: that pin anchors reproducibility for a nightly job rather than tracking a floor, so it going stale costs less than the MSRV job breaking weekly.

## 2. `Cargo Deny` — `bans FAILED` on three duplicates

`getrandom` 0.3.4/0.4.3, `prettyplease` 0.2.37/0.3.0, `r-efi` 5.3.0/6.0.0.

None can be closed from our manifests. Each pair is two incompatible majors pulled by **different parents**: the workspace is on `getrandom` 0.4 through rand 0.10, while the `tempfile` inside buffa's codegen is on 0.3, and `r-efi` is whichever one each `getrandom` picked. Picking either side leaves the other parent unsatisfied, and no version of ours is a parent of any of them.

What decides it is where they are reached from — only through `buffa-build`, which `wacore`, `waproto` and `sqlite-storage` each declare under `[build-dependencies]`. A build script runs at compile time and links into no shipped binary, which is the same argument the proc-macro skips already make, so the new entries sit next to them.

Two pieces of dead or stale config go with it:

- **`RUSTSEC-2026-0150` ignore removed.** `audiopus` is no longer anywhere in `Cargo.lock`, even under `--all-features`; cargo-deny was reporting the entry as `advisory-not-detected`. An ignore outliving the crate it excuses is how a real advisory gets waved through later under a name nobody rechecked.
- **`chacha20` 0.10.1 → 0.10.2.** It is yanked, and reached through rand 0.10.2, so it is in every build. A patch bump on the same line; one lock entry moves.

## Checks

- `cargo deny --all-features check` — the CI command, run with cargo-deny 0.20.2 (the version `taiki-e/install-action` resolves): **`advisories ok, bans ok, licenses ok, sources ok`**, exit 0. Both the yanked and stale-ignore warnings are gone too.
- `cargo test --workspace --all-features --lib` on the bumped lock: **5245 tests, 0 failures**.
- `Test Stable (MSRV)` already passed on this branch at `77d0eef` — the first time it got past `rustup` since #1384 merged.

The one warning left is `license-not-encountered` for `0BSD`, an allowance nothing currently matches. Left alone: trimming the allow-list is a policy decision, and removing an entry only makes a future dependency fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXRWTrDqjsPYAZMHBgF7uZ