### PR TITLE
perf: shed resident per-chat and per-entry memory, trim per-message copies

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -795,7 +795,7 @@ message can overshoot substantially on its own.
 | `pdo_pending_requests` / `pdo_requested` | 30s TTL, 200 / 24h TTL, 512 | a repeated PDO request |
 | `sender_key_devices_cache` | 1h TTI, 500 | a redundant SKDM |
 | `session_recreate_history` | 1h TTL, 256 | one un-throttled recreate |
-| `session_locks` / `chat_lanes` / `group_distribution_locks` | 10 000 / 5 000 / 512 | nothing: an `evict_guard` refuses to evict a lock a task holds, so the map briefly exceeds capacity instead of minting a second lock for one key |
+| `session_locks` / `chat_lanes` / `group_distribution_locks` | 10 000 / 5 000 / 512 | nothing: an `evict_guard` refuses to evict a lock a task holds, so the map briefly exceeds capacity instead of minting a second lock for one key. A chat lane's worker, which holds the inbound-message future (~9 KiB) for its whole life, exits after `LANE_IDLE_TIMEOUT` (60 s) of silence; the entry then costs one closed channel until the chat's next message replaces it or FIFO eviction drops it |
 | `resend_rate_limiter` | 4 096, FIFO | fail-open by design — an evicted bucket is recreated full, so undersizing forgives rate, never over-throttles |
 | `group_devices_memo` / `skdm_warm_memo` / `dm_devices_memo` | 64 / 64 / 512 | a recompute |
 | `SignalStoreCache` sessions / identities / sender keys | 2 000 each (+1/8 slack before an eviction scan), *while flushes succeed* | nothing: only *clean* entries are evicted, so an unpersisted record is never dropped — which also means a backend that stops accepting writes leaves everything dirty and the maps grow past the cap. Correct, and the reason to watch the counts rather than trust the number |

--- a/src/client.rs
+++ b/src/client.rs
@@ -379,7 +379,8 @@ pub(crate) struct ChatLane {
     /// Held by the lane's worker for as long as it runs. A worker that has
     /// gone idle closes its queue and exits; the replacement worker takes this
     /// lock before its first message, so the two can never process the same
-    /// chat at once, whatever the old one was still draining.
+    /// chat at once, whatever the old one was still draining. Like
+    /// `enqueue_lock`, it is the chat's and is inherited by the replacement.
     pub worker_running: Arc<Mutex<()>>,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2043,11 +2043,6 @@ fn encode_ack_bytes(
     let mut buf = Vec::with_capacity(64);
     let mut encoder = Encoder::new_vec(&mut buf)?;
     encoder.write_node(&ack)?;
-    // The senders wrap this in `Bytes::from(Vec)`, which reuses the allocation
-    // only when `len == capacity` and otherwise boxes a separate shared
-    // header per frame. An ack is a few dozen bytes against the 64 reserved,
-    // so trim it here: a shrinking realloc is in place, the extra box was not.
-    buf.shrink_to_fit();
     Ok(buf)
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -376,6 +376,11 @@ type ChatStateHandler = Arc<dyn Fn(ChatStateEvent) + Send + Sync>;
 pub(crate) struct ChatLane {
     pub enqueue_lock: Arc<Mutex<()>>,
     pub queue_tx: async_channel::Sender<QueuedChatMessage>,
+    /// Held by the lane's worker for as long as it runs. A worker that has
+    /// gone idle closes its queue and exits; the replacement worker takes this
+    /// lock before its first message, so the two can never process the same
+    /// chat at once, whatever the old one was still draining.
+    pub worker_running: Arc<Mutex<()>>,
 }
 
 impl ChatLane {
@@ -2038,6 +2043,11 @@ fn encode_ack_bytes(
     let mut buf = Vec::with_capacity(64);
     let mut encoder = Encoder::new_vec(&mut buf)?;
     encoder.write_node(&ack)?;
+    // The senders wrap this in `Bytes::from(Vec)`, which reuses the allocation
+    // only when `len == capacity` and otherwise boxes a separate shared
+    // header per frame. An ack is a few dozen bytes against the 64 reserved,
+    // so trim it here: a shrinking realloc is in place, the extra box was not.
+    buf.shrink_to_fit();
     Ok(buf)
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -376,11 +376,9 @@ type ChatStateHandler = Arc<dyn Fn(ChatStateEvent) + Send + Sync>;
 pub(crate) struct ChatLane {
     pub enqueue_lock: Arc<Mutex<()>>,
     pub queue_tx: async_channel::Sender<QueuedChatMessage>,
-    /// Held by the lane's worker for as long as it runs. A worker that has
-    /// gone idle closes its queue and exits; the replacement worker takes this
-    /// lock before its first message, so the two can never process the same
-    /// chat at once, whatever the old one was still draining. Like
-    /// `enqueue_lock`, it is the chat's and is inherited by the replacement.
+    /// Held by the lane's worker for as long as it runs; a replacement
+    /// worker takes it before its first message. Why it is shared across
+    /// lane generations is explained at `create_chat_lane`.
     pub worker_running: Arc<Mutex<()>>,
 }
 

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -461,6 +461,16 @@ impl Client {
         phone_number: &str,
         source: LearningSource,
     ) -> RecordOutcome {
+        // Answered before the mutation mutex: this runs for every message
+        // whose sender carries a `sender_alt`, and in the steady state the pair
+        // is already known both ways and persisted, so the answer is `Skipped`.
+        // Taking the process-wide mutex first serialized every chat lane on
+        // the receive path behind a lock that the common case never needed.
+        // The guarded body re-checks under the lock, so a concurrent write
+        // still sees a consistent view.
+        if self.lid_pn_cache.can_skip_relearn(phone_number, lid).await {
+            return RecordOutcome::Skipped;
+        }
         let guard = self.lid_pn_cache.lock_mutation().await;
         self.record_lid_pn_in_memory_guarded(lid, phone_number, source, &guard)
             .await

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3552,6 +3552,7 @@ async fn active_chat_lane_survives_capacity_pressure() {
             ChatLane {
                 enqueue_lock: Arc::new(Mutex::new(())),
                 queue_tx,
+                worker_running: Arc::new(Mutex::new(())),
             },
             queue_rx,
         )

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -55,11 +55,19 @@ impl MessageHandler {
         let lane = client
             .chat_lanes
             .get_with_by_ref(&chat_jid, async {
-                create_chat_lane(&client, Arc::new(async_lock::Mutex::new(())))
+                create_chat_lane(
+                    &client,
+                    Arc::new(async_lock::Mutex::new(())),
+                    Arc::new(async_lock::Mutex::new(())),
+                )
             })
             .await;
 
-        // Lock serializes enqueue order for this chat
+        // Lock serializes enqueue order for this chat. The lock belongs to
+        // the chat, not the lane: a replacement lane inherits it, so a
+        // handler that reached the cache before or after the swap still
+        // enqueues in one total order, and the replacement below happens
+        // entirely under it.
         let _guard = lane.enqueue_lock.lock().await;
 
         let node = match lane.try_enqueue(node) {
@@ -78,11 +86,8 @@ impl MessageHandler {
 
         // A caller that queued behind this lock on the same stale lane finds
         // the replacement already cached and joins it instead of replacing
-        // it again. Otherwise the fresh lane is published with this message
-        // already queued: an enqueue that finds it in the cache can only land
-        // behind it, so the hand-off keeps the chat's order even for enqueues
-        // that do not share the old lane's lock.
-        let pending = std::sync::Mutex::new(Some(node));
+        // it again. Nothing is enqueued before the lane is in the cache, so a
+        // cancellation here leaves at worst an empty worker that idles out.
         let fresh = match client.chat_lanes.get(&chat_jid).await {
             Some(current) if !current.queue_tx.same_channel(&lane.queue_tx) => current,
             _ => {
@@ -90,35 +95,18 @@ impl MessageHandler {
                 client
                     .chat_lanes
                     .get_with_by_ref(&chat_jid, async {
-                        let fresh = create_chat_lane(&client, Arc::clone(&lane.worker_running));
-                        let queued = pending.lock().unwrap_or_else(|p| p.into_inner()).take();
-                        if let Some(node) = queued
-                            && let Err(e) = fresh.try_enqueue(node)
-                        {
-                            // Unreachable for a channel whose worker was just
-                            // spawned; put the node back so the retry below
-                            // reports it.
-                            let e_node = match e {
-                                async_channel::TrySendError::Full(q)
-                                | async_channel::TrySendError::Closed(q) => q.node,
-                            };
-                            *pending.lock().unwrap_or_else(|p| p.into_inner()) = Some(e_node);
-                        }
-                        fresh
+                        create_chat_lane(
+                            &client,
+                            Arc::clone(&lane.enqueue_lock),
+                            Arc::clone(&lane.worker_running),
+                        )
                     })
                     .await
             }
         };
-        // Still here when a racer published its own lane first, or when the
-        // already-replaced lane was joined above: the message goes in under
-        // that lane's own enqueue lock, like every other enqueue into it.
-        let queued = pending.lock().unwrap_or_else(|p| p.into_inner()).take();
-        if let Some(node) = queued {
-            let _fresh_guard = fresh.enqueue_lock.lock().await;
-            if let Err(e) = fresh.try_enqueue(node) {
-                warn!("Failed to enqueue message for processing: {e}");
-                *cancelled = true;
-            }
+        if let Err(e) = fresh.try_enqueue(node) {
+            warn!("Failed to enqueue message for processing: {e}");
+            *cancelled = true;
         }
 
         true
@@ -145,10 +133,14 @@ impl StanzaHandler for MessageHandler {
 /// Construct a ChatLane with a spawned worker task. Extracted to keep the
 /// init closure passed to `get_with_by_ref` small.
 ///
-/// `worker_running` is the lock the worker holds while it runs; a lane that
-/// replaces an idle-exited one passes the predecessor's so the new worker
-/// queues behind it.
-fn create_chat_lane(client: &Arc<Client>, worker_running: Arc<async_lock::Mutex<()>>) -> ChatLane {
+/// Both locks belong to the chat rather than the lane: a lane that replaces
+/// an idle-exited one passes the predecessor's, so enqueues stay in one
+/// order across the swap and the new worker queues behind the old one.
+fn create_chat_lane(
+    client: &Arc<Client>,
+    enqueue_lock: Arc<async_lock::Mutex<()>>,
+    worker_running: Arc<async_lock::Mutex<()>>,
+) -> ChatLane {
     let (tx, rx) = async_channel::unbounded::<QueuedChatMessage>();
 
     let client_for_worker = client.clone();
@@ -206,7 +198,7 @@ fn create_chat_lane(client: &Arc<Client>, worker_running: Arc<async_lock::Mutex<
         .detach();
 
     ChatLane {
-        enqueue_lock: Arc::new(async_lock::Mutex::new(())),
+        enqueue_lock,
         queue_tx: tx,
         worker_running,
     }
@@ -323,6 +315,10 @@ mod tests {
         assert!(
             Arc::ptr_eq(&first.worker_running, &second.worker_running),
             "the successor serializes behind the predecessor's running lock"
+        );
+        assert!(
+            Arc::ptr_eq(&first.enqueue_lock, &second.enqueue_lock),
+            "the chat's enqueue lock survives the swap"
         );
     }
 

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -63,11 +63,8 @@ impl MessageHandler {
             })
             .await;
 
-        // Lock serializes enqueue order for this chat. The lock belongs to
-        // the chat, not the lane: a replacement lane inherits it, so a
-        // handler that reached the cache before or after the swap still
-        // enqueues in one total order, and the replacement below happens
-        // entirely under it.
+        // Lock serializes enqueue order for this chat, the replacement
+        // below included (see `create_chat_lane` for why it outlives the lane).
         let _guard = lane.enqueue_lock.lock().await;
 
         let node = match lane.try_enqueue(node) {
@@ -133,9 +130,13 @@ impl StanzaHandler for MessageHandler {
 /// Construct a ChatLane with a spawned worker task. Extracted to keep the
 /// init closure passed to `get_with_by_ref` small.
 ///
-/// Both locks belong to the chat rather than the lane: a lane that replaces
-/// an idle-exited one passes the predecessor's, so enqueues stay in one
-/// order across the swap and the new worker queues behind the old one.
+/// Both locks belong to the chat rather than the lane, which is why they are
+/// parameters: a lane that replaces an idle-exited one passes the
+/// predecessor's, and only the chat's first lane mints new ones. Sharing
+/// `enqueue_lock` keeps every enqueue for the chat in one total order
+/// whichever lane generation a handler fetched, and the swap itself runs
+/// under it; sharing `worker_running` makes the new worker wait for the old
+/// one to finish draining, so the two never process the same chat at once.
 fn create_chat_lane(
     client: &Arc<Client>,
     enqueue_lock: Arc<async_lock::Mutex<()>>,

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -78,7 +78,11 @@ impl MessageHandler {
 
         // A caller that queued behind this lock on the same stale lane finds
         // the replacement already cached and joins it instead of replacing
-        // it again.
+        // it again. Otherwise the fresh lane is published with this message
+        // already queued: an enqueue that finds it in the cache can only land
+        // behind it, so the hand-off keeps the chat's order even for enqueues
+        // that do not share the old lane's lock.
+        let pending = std::sync::Mutex::new(Some(node));
         let fresh = match client.chat_lanes.get(&chat_jid).await {
             Some(current) if !current.queue_tx.same_channel(&lane.queue_tx) => current,
             _ => {
@@ -86,12 +90,31 @@ impl MessageHandler {
                 client
                     .chat_lanes
                     .get_with_by_ref(&chat_jid, async {
-                        create_chat_lane(&client, Arc::clone(&lane.worker_running))
+                        let fresh = create_chat_lane(&client, Arc::clone(&lane.worker_running));
+                        let queued = pending.lock().unwrap_or_else(|p| p.into_inner()).take();
+                        if let Some(node) = queued
+                            && let Err(e) = fresh.try_enqueue(node)
+                        {
+                            // Unreachable for a channel whose worker was just
+                            // spawned; put the node back so the retry below
+                            // reports it.
+                            let e_node = match e {
+                                async_channel::TrySendError::Full(q)
+                                | async_channel::TrySendError::Closed(q) => q.node,
+                            };
+                            *pending.lock().unwrap_or_else(|p| p.into_inner()) = Some(e_node);
+                        }
+                        fresh
                     })
                     .await
             }
         };
-        if let Err(e) = fresh.try_enqueue(node) {
+        // Still here when a racer published its own lane first, or when the
+        // already-replaced lane was joined above.
+        let queued = pending.lock().unwrap_or_else(|p| p.into_inner()).take();
+        if let Some(node) = queued
+            && let Err(e) = fresh.try_enqueue(node)
+        {
             warn!("Failed to enqueue message for processing: {e}");
             *cancelled = true;
         }

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -110,13 +110,15 @@ impl MessageHandler {
             }
         };
         // Still here when a racer published its own lane first, or when the
-        // already-replaced lane was joined above.
+        // already-replaced lane was joined above: the message goes in under
+        // that lane's own enqueue lock, like every other enqueue into it.
         let queued = pending.lock().unwrap_or_else(|p| p.into_inner()).take();
-        if let Some(node) = queued
-            && let Err(e) = fresh.try_enqueue(node)
-        {
-            warn!("Failed to enqueue message for processing: {e}");
-            *cancelled = true;
+        if let Some(node) = queued {
+            let _fresh_guard = fresh.enqueue_lock.lock().await;
+            if let Err(e) = fresh.try_enqueue(node) {
+                warn!("Failed to enqueue message for processing: {e}");
+                *cancelled = true;
+            }
         }
 
         true

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -8,6 +8,20 @@ use wacore::stanza::wire_tags::StanzaTag;
 /// WA Web: `WAWebMessageQueue` uses `promiseTimeout(r(), 2e4)` per queued handler.
 const MAX_MESSAGE_DELAY_MS: u64 = 20_000;
 
+/// How long a lane worker waits for its next message before exiting.
+///
+/// A worker awaits `handle_incoming_message_scoped` inline, so its task holds
+/// that future's whole state machine (~9 KiB) for as long as the worker lives,
+/// message or no message. Kept alive for the connection, that is one such
+/// future per chat that ever spoke, bounded only by `chat_lanes_capacity`;
+/// a client in a few thousand groups parked tens of MiB in idle workers. An
+/// idle worker now exits and the next message for the chat spawns a fresh
+/// one, so the cost is one task per burst of activity instead of per chat.
+///
+/// Long enough that a conversation in progress never respawns between
+/// replies; short against the hours a connection stays up.
+const LANE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Handler for `<message>` stanzas.
 ///
 /// Messages are processed sequentially per-chat using a mailbox pattern to prevent
@@ -40,15 +54,45 @@ impl MessageHandler {
         // preventing duplicate workers for the same chat (TOCTOU race).
         let lane = client
             .chat_lanes
-            .get_with_by_ref(&chat_jid, async { create_chat_lane(&client) })
+            .get_with_by_ref(&chat_jid, async {
+                create_chat_lane(&client, Arc::new(async_lock::Mutex::new(())))
+            })
             .await;
 
         // Lock serializes enqueue order for this chat
         let _guard = lane.enqueue_lock.lock().await;
 
-        if let Err(e) = lane.try_enqueue(node) {
+        let node = match lane.try_enqueue(node) {
+            Ok(()) => return true,
+            // The worker went idle and closed its queue (see
+            // `LANE_IDLE_TIMEOUT`). Replace the lane; the successor worker
+            // starts only once the idle one has finished draining.
+            Err(async_channel::TrySendError::Closed(queued)) => queued.node,
+            Err(e) => {
+                warn!("Failed to enqueue message for processing: {e}");
+                // Cancel ack so server redelivers
+                *cancelled = true;
+                return true;
+            }
+        };
+
+        // A caller that queued behind this lock on the same stale lane finds
+        // the replacement already cached and joins it instead of replacing
+        // it again.
+        let fresh = match client.chat_lanes.get(&chat_jid).await {
+            Some(current) if !current.queue_tx.same_channel(&lane.queue_tx) => current,
+            _ => {
+                client.chat_lanes.invalidate(&chat_jid).await;
+                client
+                    .chat_lanes
+                    .get_with_by_ref(&chat_jid, async {
+                        create_chat_lane(&client, Arc::clone(&lane.worker_running))
+                    })
+                    .await
+            }
+        };
+        if let Err(e) = fresh.try_enqueue(node) {
             warn!("Failed to enqueue message for processing: {e}");
-            // Cancel ack so server redelivers
             *cancelled = true;
         }
 
@@ -75,51 +119,63 @@ impl StanzaHandler for MessageHandler {
 
 /// Construct a ChatLane with a spawned worker task. Extracted to keep the
 /// init closure passed to `get_with_by_ref` small.
-fn create_chat_lane(client: &Arc<Client>) -> ChatLane {
+///
+/// `worker_running` is the lock the worker holds while it runs; a lane that
+/// replaces an idle-exited one passes the predecessor's so the new worker
+/// queues behind it.
+fn create_chat_lane(client: &Arc<Client>, worker_running: Arc<async_lock::Mutex<()>>) -> ChatLane {
     let (tx, rx) = async_channel::unbounded::<QueuedChatMessage>();
 
     let client_for_worker = client.clone();
     let spawn_generation = client
         .connection_generation
         .load(std::sync::atomic::Ordering::Acquire);
+    let running = Arc::clone(&worker_running);
 
     client
         .runtime
         .spawn(Box::pin(async move {
-            while let Ok(QueuedChatMessage {
-                node: msg_node,
-                lane_liveness, // Prevents capacity eviction until processing finishes.
-            }) = rx.recv().await
-            {
-                if client_for_worker
-                    .connection_generation
-                    .load(std::sync::atomic::Ordering::Acquire)
-                    != spawn_generation
-                {
-                    log::debug!(target: "MessageQueue", "Stale worker exiting; remaining messages will be redelivered by server");
+            // Queue behind the worker this lane replaced, if it is still
+            // draining the messages that raced its idle exit.
+            let _running = running.lock_arc().await;
+            loop {
+                // A burst is served straight off the queue; the idle timer is
+                // only armed once the queue is empty, so it costs nothing per
+                // message while the chat is busy.
+                let next = match rx.try_recv() {
+                    Ok(queued) => queued,
+                    Err(async_channel::TryRecvError::Closed) => break,
+                    Err(async_channel::TryRecvError::Empty) => {
+                        match wacore::runtime::timeout(
+                            &*client_for_worker.runtime,
+                            LANE_IDLE_TIMEOUT,
+                            rx.recv(),
+                        )
+                        .await
+                        {
+                            Ok(Ok(queued)) => queued,
+                            Ok(Err(_)) => break,
+                            Err(wacore::runtime::Elapsed) => {
+                                // Stop accepting first, then drain whatever
+                                // was enqueued before the close: an enqueue
+                                // that lands after it is told `Closed` and
+                                // replaces this lane.
+                                rx.close();
+                                while let Ok(queued) = rx.try_recv() {
+                                    if !process_queued(&client_for_worker, queued, spawn_generation)
+                                        .await
+                                    {
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+                };
+                if !process_queued(&client_for_worker, next, spawn_generation).await {
                     break;
                 }
-                // Two clock reads per message, kept: sampling or gating on lane
-                // backlog would stop reporting the single pathological message
-                // this guard exists to catch.
-                let start = wacore::time::Instant::now();
-                let client = client_for_worker.clone();
-                // Awaited inline (not boxed): the future lives in this
-                // once-per-chat worker task instead of a fresh ~31 KB heap box
-                // per message, which dominated per-message allocation churn.
-                client
-                    .handle_incoming_message_scoped(msg_node, spawn_generation)
-                    .await;
-                let elapsed = start.elapsed();
-                if elapsed.as_millis() as u64 > MAX_MESSAGE_DELAY_MS {
-                    warn!(
-                        target: "MessageQueue",
-                        "Message processing took {:.1}s (MAX_MESSAGE_DELAY is {}s)",
-                        elapsed.as_secs_f64(),
-                        MAX_MESSAGE_DELAY_MS / 1000
-                    );
-                }
-                drop(lane_liveness);
             }
         }))
         .detach();
@@ -127,5 +183,147 @@ fn create_chat_lane(client: &Arc<Client>) -> ChatLane {
     ChatLane {
         enqueue_lock: Arc::new(async_lock::Mutex::new(())),
         queue_tx: tx,
+        worker_running,
+    }
+}
+
+/// Process one queued message on its lane worker. Returns `false` when the
+/// worker belongs to a torn-down connection and must stop.
+async fn process_queued(
+    client: &Arc<Client>,
+    QueuedChatMessage {
+        node: msg_node,
+        lane_liveness, // Prevents capacity eviction until processing finishes.
+    }: QueuedChatMessage,
+    spawn_generation: u64,
+) -> bool {
+    if client
+        .connection_generation
+        .load(std::sync::atomic::Ordering::Acquire)
+        != spawn_generation
+    {
+        log::debug!(target: "MessageQueue", "Stale worker exiting; remaining messages will be redelivered by server");
+        return false;
+    }
+    // Two clock reads per message, kept: sampling or gating on lane
+    // backlog would stop reporting the single pathological message
+    // this guard exists to catch.
+    let start = wacore::time::Instant::now();
+    // Awaited inline (not boxed): the future lives in this
+    // once-per-chat worker task instead of a fresh ~9 KB heap box
+    // per message, which dominated per-message allocation churn.
+    Arc::clone(client)
+        .handle_incoming_message_scoped(msg_node, spawn_generation)
+        .await;
+    let elapsed = start.elapsed();
+    if elapsed.as_millis() as u64 > MAX_MESSAGE_DELAY_MS {
+        warn!(
+            target: "MessageQueue",
+            "Message processing took {:.1}s (MAX_MESSAGE_DELAY is {}s)",
+            elapsed.as_secs_f64(),
+            MAX_MESSAGE_DELAY_MS / 1000
+        );
+    }
+    drop(lane_liveness);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::node_to_owned_ref;
+    use wacore_binary::builder::NodeBuilder;
+    use wacore_binary::jid::Jid;
+
+    fn message_for(chat: &Jid, id: &str) -> Arc<wacore_binary::OwnedNodeRef> {
+        node_to_owned_ref(
+            &NodeBuilder::new("message")
+                .attr("from", chat.clone())
+                .attr("id", id)
+                .build(),
+        )
+    }
+
+    /// An idle worker closes its queue and exits; the next message for the
+    /// chat gets a fresh lane whose worker queues behind the old one.
+    #[tokio::test(start_paused = true)]
+    async fn an_idle_lane_worker_exits_and_the_next_message_respawns_it() {
+        let client = crate::test_utils::create_test_client().await;
+        let chat: Jid = "120363000000000031@g.us".parse().unwrap();
+
+        let mut cancelled = false;
+        assert!(
+            MessageHandler::handle_inline(
+                Arc::clone(&client),
+                message_for(&chat, "A"),
+                &mut cancelled
+            )
+            .await
+        );
+        assert!(!cancelled);
+        let first = client.chat_lanes.get(&chat).await.expect("lane created");
+        let first_tx = first.queue_tx.clone();
+        assert!(!first_tx.is_closed());
+
+        // Paused time: the sleep advances the clock instead of waiting.
+        tokio::time::sleep(LANE_IDLE_TIMEOUT + std::time::Duration::from_secs(1)).await;
+        for _ in 0..100 {
+            if first_tx.is_closed() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(first_tx.is_closed(), "idle worker must close its queue");
+        assert!(
+            first.worker_running.try_lock().is_some(),
+            "an exited worker must release its running lock"
+        );
+
+        let mut cancelled = false;
+        assert!(
+            MessageHandler::handle_inline(
+                Arc::clone(&client),
+                message_for(&chat, "B"),
+                &mut cancelled
+            )
+            .await
+        );
+        assert!(
+            !cancelled,
+            "a message after the idle exit is accepted, not redelivered"
+        );
+        let second = client.chat_lanes.get(&chat).await.expect("lane replaced");
+        assert!(!second.queue_tx.same_channel(&first_tx));
+        assert!(!second.queue_tx.is_closed());
+        assert!(
+            Arc::ptr_eq(&first.worker_running, &second.worker_running),
+            "the successor serializes behind the predecessor's running lock"
+        );
+    }
+
+    /// A message enqueued in the window between the idle check and the close
+    /// is still processed by the exiting worker, and a message after the close
+    /// is not lost.
+    #[tokio::test(start_paused = true)]
+    async fn a_lane_that_stays_busy_never_exits() {
+        let client = crate::test_utils::create_test_client().await;
+        let chat: Jid = "120363000000000032@g.us".parse().unwrap();
+        let mut cancelled = false;
+        MessageHandler::handle_inline(Arc::clone(&client), message_for(&chat, "A"), &mut cancelled)
+            .await;
+        let lane = client.chat_lanes.get(&chat).await.expect("lane created");
+        for i in 0..5 {
+            tokio::time::sleep(LANE_IDLE_TIMEOUT / 2).await;
+            MessageHandler::handle_inline(
+                Arc::clone(&client),
+                message_for(&chat, &format!("M{i}")),
+                &mut cancelled,
+            )
+            .await;
+            assert!(!cancelled);
+        }
+        let same = client.chat_lanes.get(&chat).await.expect("lane kept");
+        assert!(same.queue_tx.same_channel(&lane.queue_tx));
+        assert!(!lane.queue_tx.is_closed());
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use wacore::libsignal::crypto::DecryptionError;
 use wacore::libsignal::protocol::SenderKeyStore;
-use wacore::libsignal::protocol::group_decrypt;
+use wacore::libsignal::protocol::group_decrypt_shared;
 use wacore::libsignal::protocol::{
     CiphertextMessage, DecryptionResult, IdentityChange, OwnedCiphertextMessage,
     PreKeySignalMessage, SignalMessage, SignalProtocolError, UsePQRatchet, message_decrypt,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -38,11 +38,50 @@ fn push_enc_payload(bucket: &mut Vec<EncPayload>, stanza_enc_count: usize, paylo
     bucket.push(payload);
 }
 
+/// A `StdRng` that seeds itself on first draw.
+///
+/// The decrypt loop needs a CSPRNG only on the DH-ratchet step, which most
+/// stanzas never take; an eagerly seeded `StdRng` pulled 32 bytes of entropy
+/// and ran a ChaCha key schedule per stanza for a generator that was then
+/// dropped unused. `ThreadRng` would avoid the seeding but is `!Send`, and
+/// this lives across the awaits of a spawned lane worker.
+#[derive(Default)]
+struct LazyStdRng(Option<rand::rngs::StdRng>);
+
+impl LazyStdRng {
+    #[inline]
+    fn get(&mut self) -> &mut rand::rngs::StdRng {
+        self.0
+            .get_or_insert_with(rand::make_rng::<rand::rngs::StdRng>)
+    }
+}
+
+impl rand::TryRng for LazyStdRng {
+    type Error = std::convert::Infallible;
+
+    #[inline]
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.get().try_next_u32()
+    }
+
+    #[inline]
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        self.get().try_next_u64()
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.get().try_fill_bytes(dst)
+    }
+}
+
+impl rand::TryCryptoRng for LazyStdRng {}
+
 async fn decrypt_session_message(
     message: &mut ParsedSessionMessage,
     signal_address: &wacore::libsignal::protocol::ProtocolAddress,
     adapter: &mut crate::store::signal_adapter::SignalProtocolStoreAdapter,
-    rng: &mut rand::rngs::StdRng,
+    rng: &mut LazyStdRng,
 ) -> Result<DecryptionResult, SignalProtocolError> {
     match message {
         ParsedSessionMessage::Retained(message) => {
@@ -731,7 +770,7 @@ impl Client {
         let _t = wacore::telemetry::timer(wacore::telemetry::DECRYPT_DURATION);
 
         let mut adapter = self.signal_adapter();
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = LazyStdRng::default();
         let mut outcome = SessionBatchOutcome::default();
         // Buffer plaintexts to handle after the ratchet lock drops (see the drain
         // below for why that's safe).
@@ -1481,7 +1520,6 @@ impl Client {
             .await;
 
         for payload in payloads {
-            let ciphertext = &payload.ciphertext[..];
             let padding_version = payload.padding_version;
             let enc_index = payload.enc_index;
             let enc_type = payload.enc_type.as_wire_str();
@@ -1495,7 +1533,14 @@ impl Client {
 
             let decrypt_result = {
                 let _chain_guard = chain_lock.lock().await;
-                group_decrypt(ciphertext, &mut adapter.sender_key_store, &sender_key_name).await
+                // A refcount bump: the skmsg stays a slice of the frame buffer
+                // through parsing rather than being copied per message.
+                group_decrypt_shared(
+                    payload.ciphertext.clone(),
+                    &mut adapter.sender_key_store,
+                    &sender_key_name,
+                )
+                .await
             };
 
             match decrypt_result {
@@ -1958,7 +2003,7 @@ impl Client {
         signal_address: &wacore::libsignal::protocol::ProtocolAddress,
         parsed_message: &mut ParsedSessionMessage,
         adapter: &mut crate::store::signal_adapter::SignalProtocolStoreAdapter,
-        rng: &mut rand::rngs::StdRng,
+        rng: &mut LazyStdRng,
         enc_type: &'static str,
         padding_version: u8,
         enc_index: usize,

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -9,6 +9,7 @@
 //! same missing key run the initializer once.
 
 use async_lock::{Mutex as AsyncMutex, RwLock};
+use hashbrown::HashTable;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{BuildHasher, Hash, RandomState};
@@ -40,6 +41,20 @@ struct CacheEntry<V> {
     seq: u64,
 }
 
+/// One table slot: the key, its hash, and the entry.
+///
+/// The hash is kept so the table can grow without re-hashing every key and so
+/// the FIFO side can address a slot by `(hash, seq)` instead of holding a
+/// second copy of the key. Before this, `order` was a `BTreeMap<u64, K>`: every
+/// entry carried its key twice, and for a `String`, `Jid` or `SenderMessageId`
+/// key that second copy was a second heap allocation held for the entry's
+/// whole lifetime, across every cache the client keeps.
+struct Slot<K, V> {
+    key: K,
+    hash: u64,
+    entry: CacheEntry<V>,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CapacityStats {
     pub entries: u64,
@@ -51,31 +66,42 @@ pub(crate) struct CapacityStats {
 ///
 /// - Max capacity with FIFO eviction
 /// - TTL (time-to-live) and TTI (time-to-idle)
-/// - Single-flight `get_with` / `get_with_by_ref`
+/// - Single-flight `get_with`
+///
+/// Uses `async_lock::RwLock` (runtime-agnostic, works on wasm32), so this
+/// compiles and runs on every target.
+///
+/// Both lazy and best-effort: expired entries are only removed lazily on
+/// access or in `run_pending_tasks`. `entry_count` may include
+/// expired-but-not-yet-evicted entries.
 pub struct PortableCache<K, V> {
     inner: Arc<RwLock<CacheInner<K, V>>>,
-    /// Per-key init locks for single-flight `get_with`.
+    /// Shared single-flight init-lock registry (see `InitLocks`).
     init_locks: Arc<InitLocks>,
     max_capacity: Option<u64>,
     ttl: Option<Duration>,
     tti: Option<Duration>,
-    /// Optional predicate gating capacity eviction: returns `true` if a value may
-    /// be evicted. Used by coordination-lock caches to protect an entry a live task
-    /// still holds (e.g. an `Arc<Mutex>` mid-lock), which would otherwise be
-    /// FIFO-evicted and re-minted, letting two writers race the guarded resource.
+    /// See [`PortableCacheBuilder::evict_guard`].
     evict_guard: Option<fn(&V) -> bool>,
-    /// Stores made by the TTI renewal path. Lets a test assert that a burst of
-    /// concurrent lookups renews once rather than once per queued writer.
     #[cfg(test)]
     tti_renewals: Arc<portable_atomic::AtomicU64>,
 }
 
 struct CacheInner<K, V> {
-    map: HashMap<K, CacheEntry<V>>,
-    /// FIFO eviction order keyed by monotonic sequence. `seq -> key`, so eviction
-    /// is `pop_first()` (O(log n)) and a targeted `remove_key` is O(log n) via the
-    /// entry's stored `seq` — instead of an O(n) scan over an insertion list.
-    order: BTreeMap<u64, K>,
+    /// Hashes keys once at insert; lookups with a borrowed `Q` hash through
+    /// the same state, which the `Borrow` contract keeps consistent with `K`.
+    hasher: RandomState,
+    table: HashTable<Slot<K, V>>,
+    /// FIFO eviction order, `seq -> hash`. Eviction is `pop_first()` (O(log n))
+    /// and a targeted `remove_key` is O(log n) via the entry's stored `seq`.
+    /// The hash plus the seq find the slot in `table`, so no key is stored here.
+    ///
+    /// Left empty for a cache that has no capacity bound: nothing could ever
+    /// pop it, so maintaining it would spend a `BTreeMap` node per entry on a
+    /// structure that is never read. The unbounded LID↔PN caches hold tens
+    /// of thousands of entries for the life of the process.
+    order: BTreeMap<u64, u64>,
+    track_order: bool,
     /// Next FIFO sequence to assign.
     next_seq: u64,
     capacity_evictions: u64,
@@ -86,14 +112,57 @@ impl<K, V> CacheInner<K, V>
 where
     K: Hash + Eq + Clone,
 {
-    fn new() -> Self {
+    fn new(track_order: bool) -> Self {
         Self {
-            map: HashMap::new(),
+            hasher: RandomState::new(),
+            table: HashTable::new(),
             order: BTreeMap::new(),
+            track_order,
             next_seq: 0,
             capacity_evictions: 0,
             capacity_eviction_blocks: 0,
         }
+    }
+
+    #[inline]
+    fn hash_of<Q: Hash + ?Sized>(&self, key: &Q) -> u64 {
+        self.hasher.hash_one(key)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.table.len()
+    }
+
+    fn get<Q>(&self, key: &Q) -> Option<&CacheEntry<V>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &slot.entry)
+    }
+
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut CacheEntry<V>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find_mut(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &mut slot.entry)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&K, &CacheEntry<V>)> {
+        self.table.iter().map(|slot| (&slot.key, &slot.entry))
+    }
+
+    fn clear(&mut self) {
+        self.table.clear();
+        self.order.clear();
     }
 
     /// Borrowed removal: the `order` side is keyed by the entry's own `seq`,
@@ -104,22 +173,34 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let entry = self.map.remove(key)?;
-        self.order.remove(&entry.seq);
-        Some(entry)
+        let hash = self.hash_of(key);
+        let (slot, _) = self
+            .table
+            .find_entry(hash, |slot| slot.key.borrow() == key)
+            .ok()?
+            .remove();
+        self.order.remove(&slot.entry.seq);
+        Some(slot.entry)
     }
 
-    /// Evict entries until under `cap`. Outlined and never-inlined so the guarded
-    /// scan is compiled once per `<K, V>` (not duplicated into every `insert_new`
-    /// inline site), keeping the binary-size cost of the guard path small.
-    #[inline(never)]
+    /// Remove the slot the FIFO side named by `(hash, seq)`.
+    fn remove_by_seq(&mut self, hash: u64, seq: u64) -> bool {
+        self.table
+            .find_entry(hash, |slot| slot.entry.seq == seq)
+            .ok()
+            .map(|occupied| occupied.remove())
+            .is_some()
+    }
+
+    /// Evict oldest-first until below `cap`. With an `evict_guard`, skips entries
+    /// the guard reports as held (see [`PortableCacheBuilder::evict_guard`]).
     fn evict_to_capacity(&mut self, cap: u64, evict_guard: Option<fn(&V) -> bool>) {
-        while self.map.len() as u64 >= cap {
+        while self.table.len() as u64 >= cap {
             match evict_guard {
                 // Unguarded caches keep the single-pass pop_first() fast path.
                 None => match self.order.pop_first() {
-                    Some((_, oldest_key)) => {
-                        if self.map.remove(&oldest_key).is_some() {
+                    Some((seq, hash)) => {
+                        if self.remove_by_seq(hash, seq) {
                             self.capacity_evictions = self.capacity_evictions.saturating_add(1);
                         }
                     }
@@ -127,21 +208,23 @@ where
                 },
                 // Guarded: skip entries a live task still holds so a later lookup
                 // can't mint a duplicate; if every entry is held, allow temporary
-                // over-capacity rather than dropping a live entry. Remove by seq so
-                // the key isn't cloned.
+                // over-capacity rather than dropping a live entry.
                 Some(is_evictable) => {
-                    let mut victim_seq = None;
-                    for (seq, k) in self.order.iter() {
-                        if self.map.get(k).is_some_and(|e| is_evictable(&e.value)) {
-                            victim_seq = Some(*seq);
+                    let mut victim = None;
+                    for (&seq, &hash) in self.order.iter() {
+                        if self
+                            .table
+                            .find(hash, |slot| slot.entry.seq == seq)
+                            .is_some_and(|slot| is_evictable(&slot.entry.value))
+                        {
+                            victim = Some((seq, hash));
                             break;
                         }
                     }
-                    match victim_seq {
-                        Some(seq) => {
-                            if let Some(oldest_key) = self.order.remove(&seq)
-                                && self.map.remove(&oldest_key).is_some()
-                            {
+                    match victim {
+                        Some((seq, hash)) => {
+                            self.order.remove(&seq);
+                            if self.remove_by_seq(hash, seq) {
                                 self.capacity_evictions = self.capacity_evictions.saturating_add(1);
                             }
                         }
@@ -173,16 +256,32 @@ where
 
         let seq = self.next_seq;
         self.next_seq += 1;
-        self.order.insert(seq, key.clone());
-        self.map.insert(
-            key,
-            CacheEntry {
-                value,
-                inserted_at: now,
-                last_accessed_at: now,
-                seq,
+        let hash = self.hash_of(&key);
+        if self.track_order {
+            self.order.insert(seq, hash);
+        }
+        self.table.insert_unique(
+            hash,
+            Slot {
+                key,
+                hash,
+                entry: CacheEntry {
+                    value,
+                    inserted_at: now,
+                    last_accessed_at: now,
+                    seq,
+                },
             },
+            |slot| slot.hash,
         );
+    }
+
+    /// Drop expired entries and the FIFO records that named them.
+    fn retain_unexpired(&mut self, mut is_expired: impl FnMut(&CacheEntry<V>) -> bool) {
+        let table = &mut self.table;
+        let order = &mut self.order;
+        table.retain(|slot| !is_expired(&slot.entry));
+        order.retain(|seq, hash| table.find(*hash, |slot| slot.entry.seq == *seq).is_some());
     }
 }
 
@@ -343,7 +442,9 @@ where
         );
 
         PortableCache {
-            inner: Arc::new(RwLock::new(CacheInner::new())),
+            inner: Arc::new(RwLock::new(CacheInner::new(
+                self.max_capacity.is_some_and(|cap| cap != u64::MAX),
+            ))),
             init_locks: Arc::new(InitLocks::new()),
             max_capacity: self.max_capacity,
             ttl: self.ttl,
@@ -408,7 +509,7 @@ where
     {
         let (value, renew_at) = {
             let guard = self.inner.read().await;
-            let entry = guard.map.get(key)?;
+            let entry = guard.get(key)?;
             // Read the clock after the lookup: a miss has no timestamp to
             // compare, and lookups that miss are a large share of the calls
             // (every negative registry probe, every warm-up).
@@ -421,7 +522,7 @@ where
                 let observed = (entry.seq, entry.inserted_at);
                 drop(guard);
                 let mut wguard = self.inner.write().await;
-                if let Some(e) = wguard.map.get(key)
+                if let Some(e) = wguard.get(key)
                     && (e.seq, e.inserted_at) == observed
                     && self.is_expired(e, now)
                 {
@@ -440,7 +541,7 @@ where
             // Re-decide under the lock: the key may have been invalidated (the
             // miss leaves it that way) or already refreshed by a racing renewal
             // or insert, whose newer stamp this lookup must leave alone.
-            if let Some(entry) = guard.map.get_mut(key)
+            if let Some(entry) = guard.get_mut(key)
                 && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
@@ -457,7 +558,7 @@ where
         let now = self.entry_time();
         let mut guard = self.inner.write().await;
 
-        if let Some(entry) = guard.map.get_mut(&key) {
+        if let Some(entry) = guard.get_mut(&key) {
             entry.value = value;
             entry.inserted_at = now;
             entry.last_accessed_at = now;
@@ -490,19 +591,18 @@ where
         let mut guard = self.inner.write().await;
 
         if guard
-            .map
             .get(key)
             .is_some_and(|entry| self.is_expired(entry, now))
         {
             guard.remove_key(key);
         }
 
-        let (next, result) = update(guard.map.get(key).map(|entry| &entry.value));
+        let (next, result) = update(guard.get(key).map(|entry| &entry.value));
         let Some(next) = next else {
             return result;
         };
 
-        if let Some(entry) = guard.map.get_mut(key) {
+        if let Some(entry) = guard.get_mut(key) {
             entry.value = next;
             entry.inserted_at = now;
             entry.last_accessed_at = now;
@@ -524,7 +624,7 @@ where
         let now = self.entry_time();
         let mut guard = self.inner.write().await;
 
-        if let Some(entry) = guard.map.get_mut(&key) {
+        if let Some(entry) = guard.get_mut(&key) {
             let ret = value.clone();
             entry.value = value;
             entry.inserted_at = now;
@@ -572,8 +672,7 @@ where
     /// contention.
     pub async fn clear(&self) {
         let mut guard = self.inner.write().await;
-        guard.map.clear();
-        guard.order.clear();
+        guard.clear();
     }
 
     /// Sync invalidate. Spins briefly if the lock is held; kept for moka API
@@ -582,8 +681,7 @@ where
     pub fn invalidate_all(&self) {
         for _ in 0..64 {
             if let Some(mut guard) = self.inner.try_write() {
-                guard.map.clear();
-                guard.order.clear();
+                guard.clear();
                 return;
             }
             std::hint::spin_loop();
@@ -599,16 +697,13 @@ where
     }
 
     pub fn entry_count(&self) -> u64 {
-        self.inner
-            .try_read()
-            .map(|g| g.map.len() as u64)
-            .unwrap_or(0)
+        self.inner.try_read().map(|g| g.len() as u64).unwrap_or(0)
     }
 
     pub(crate) async fn capacity_stats(&self) -> CapacityStats {
         let guard = self.inner.read().await;
         CapacityStats {
-            entries: guard.map.len() as u64,
+            entries: guard.len() as u64,
             evictions: guard.capacity_evictions,
             eviction_blocks: guard.capacity_eviction_blocks,
         }
@@ -629,10 +724,7 @@ where
     /// degrade to an empty walk under write contention.
     pub async fn fold_entries<A>(&self, init: A, mut f: impl FnMut(A, &K, &V) -> A) -> A {
         let guard = self.inner.read().await;
-        guard
-            .map
-            .iter()
-            .fold(init, |acc, (k, e)| f(acc, k, &e.value))
+        guard.iter().fold(init, |acc, (k, e)| f(acc, k, &e.value))
     }
 
     /// Entry count plus estimated retained bytes, summing `per_entry` under a
@@ -643,8 +735,8 @@ where
         mut per_entry: impl FnMut(&K, &V) -> usize,
     ) -> wacore::stats::CollectionStats {
         let guard = self.inner.read().await;
-        let bytes: usize = guard.map.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
-        wacore::stats::CollectionStats::new(guard.map.len() as u64, bytes as u64)
+        let bytes: usize = guard.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
+        wacore::stats::CollectionStats::new(guard.len() as u64, bytes as u64)
     }
 
     /// Eager snapshot iterator over `(Arc<K>, V)`: snapshot, not lazy. Includes
@@ -669,7 +761,6 @@ where
 
     fn snapshot(guard: &CacheInner<K, V>) -> Vec<(Arc<K>, V)> {
         guard
-            .map
             .iter()
             .map(|(k, e)| (Arc::new(k.clone()), e.value.clone()))
             .collect()
@@ -757,12 +848,7 @@ where
         let now = self.entry_time();
         let mut guard = self.inner.write().await;
 
-        guard.map.retain(|_, entry| !self.is_expired(entry, now));
-
-        // Drop order entries whose keys were just expired out of the map.
-        // Borrow fields separately to satisfy the borrow checker.
-        let CacheInner { map, order, .. } = &mut *guard;
-        order.retain(|_, k| map.contains_key(k));
+        guard.retain_unexpired(|entry| self.is_expired(entry, now));
 
         drop(guard);
 
@@ -818,7 +904,7 @@ mod tests {
         assert_eq!(cache.get("key").await.as_deref(), Some("value"));
 
         let guard = cache.inner.read().await;
-        let entry = guard.map.get("key").expect("inserted cache entry");
+        let entry = guard.get("key").expect("inserted cache entry");
         assert_eq!(entry.inserted_at, Instant::ZERO);
         assert_eq!(entry.last_accessed_at, Instant::ZERO);
     }
@@ -1131,14 +1217,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache
-                .inner
-                .read()
-                .await
-                .map
-                .get("k")
-                .unwrap()
-                .last_accessed_at
+            cache.inner.read().await.get("k").unwrap().last_accessed_at
         };
         let before = stamp(cache.clone()).await;
 
@@ -1168,14 +1247,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache
-                .inner
-                .read()
-                .await
-                .map
-                .get("k")
-                .unwrap()
-                .last_accessed_at
+            cache.inner.read().await.get("k").unwrap().last_accessed_at
         };
         let before = stamp(cache.clone()).await;
 
@@ -1204,7 +1276,7 @@ mod tests {
 
         let identity = |cache: PortableCache<String, u32>| async move {
             let guard = cache.inner.read().await;
-            let e = guard.map.get("k").unwrap();
+            let e = guard.get("k").unwrap();
             (e.seq, e.inserted_at)
         };
 
@@ -1260,14 +1332,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache
-                .inner
-                .read()
-                .await
-                .map
-                .get("k")
-                .unwrap()
-                .last_accessed_at
+            cache.inner.read().await.get("k").unwrap().last_accessed_at
         };
         let before = stamp(cache.clone()).await;
         assert_eq!(cache.tti_renewals(), 0);
@@ -1480,6 +1545,81 @@ mod tests {
                 "a hit reads once, to decide expiry"
             );
         }
+    }
+
+    /// A key wrapper that counts its clones. The cache used to clone every
+    /// key into its FIFO index, a second heap allocation per entry for the
+    /// life of the entry; the FIFO side now addresses slots by `(hash, seq)`.
+    #[derive(Debug)]
+    struct CountingKey(String, Arc<AtomicUsize>);
+
+    impl PartialEq for CountingKey {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+    impl Eq for CountingKey {}
+    impl Hash for CountingKey {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            self.0.hash(state);
+        }
+    }
+
+    impl Clone for CountingKey {
+        fn clone(&self) -> Self {
+            self.1.fetch_add(1, Ordering::Relaxed);
+            Self(self.0.clone(), Arc::clone(&self.1))
+        }
+    }
+
+    #[tokio::test]
+    async fn an_insert_stores_the_key_once_and_never_clones_it() {
+        let clones = Arc::new(AtomicUsize::new(0));
+        let cache: PortableCache<CountingKey, u32> =
+            PortableCache::builder().max_capacity(8).build();
+        for i in 0..16u32 {
+            cache
+                .insert(CountingKey(format!("k{i}"), Arc::clone(&clones)), i)
+                .await;
+        }
+        assert_eq!(
+            cache.entry_count(),
+            8,
+            "FIFO eviction still bounds the cache"
+        );
+        assert_eq!(
+            clones.load(Ordering::Relaxed),
+            0,
+            "insert, eviction and the FIFO index must not clone the key"
+        );
+        cache
+            .remove(&CountingKey("k12".into(), Arc::clone(&clones)))
+            .await;
+        cache
+            .invalidate(&CountingKey("k13".into(), Arc::clone(&clones)))
+            .await;
+        assert_eq!(clones.load(Ordering::Relaxed), 0);
+        assert_eq!(cache.entry_count(), 6);
+    }
+
+    #[tokio::test]
+    async fn an_unbounded_cache_keeps_no_fifo_index() {
+        let unbounded: PortableCache<String, u32> = PortableCache::builder().build();
+        let effectively_unbounded: PortableCache<String, u32> =
+            PortableCache::builder().max_capacity(u64::MAX).build();
+        let bounded: PortableCache<String, u32> = PortableCache::builder().max_capacity(8).build();
+        for cache in [&unbounded, &effectively_unbounded, &bounded] {
+            for i in 0..4u32 {
+                cache.insert(format!("k{i}"), i).await;
+            }
+            assert_eq!(cache.get("k2").await, Some(2));
+        }
+        assert!(unbounded.inner.read().await.order.is_empty());
+        assert!(effectively_unbounded.inner.read().await.order.is_empty());
+        assert_eq!(bounded.inner.read().await.order.len(), 4);
+        // Removal on the unbounded caches still works without the index.
+        assert_eq!(unbounded.remove("k1").await, Some(1));
+        assert_eq!(unbounded.entry_count(), 3);
     }
 
     #[tokio::test]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -594,14 +594,13 @@ impl Client {
         let receipt_type =
             wacore::stanza::receipt::downgrade_for_feature_incapable(nr, receipt_type);
         // Retries feed the resend pipeline whether or not anything listens.
-        // Every other receipt exists only to become an `Event::Receipt`, which
-        // `dispatch` drops on the floor without a subscriber — so without one,
-        // stop before parsing `<participants>` (one `Jid` pair per member of
-        // a group read) or building the message-id list.
-        if !matches!(
-            receipt_type,
-            ReceiptType::Retry | ReceiptType::EncRekeyRetry
-        ) && !self.core.event_bus.has_handler_for(EventKind::Receipt)
+        // Every other receipt, `enc_rekey_retry` included (its branch below
+        // only logs and dispatches), exists only to become an `Event::Receipt`,
+        // which `dispatch` drops on the floor without a subscriber — so
+        // without one, stop before parsing `<participants>` (one `Jid` pair
+        // per member of a group read) or building the message-id list.
+        if receipt_type != ReceiptType::Retry
+            && !self.core.event_bus.has_handler_for(EventKind::Receipt)
         {
             return;
         }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -593,6 +593,18 @@ impl Client {
         // <error reason="lid" type="feature-incapable"> (the LID peer can't receive it).
         let receipt_type =
             wacore::stanza::receipt::downgrade_for_feature_incapable(nr, receipt_type);
+        // Retries feed the resend pipeline whether or not anything listens.
+        // Every other receipt exists only to become an `Event::Receipt`, which
+        // `dispatch` drops on the floor without a subscriber — so without one,
+        // stop before parsing `<participants>` (one `Jid` pair per member of
+        // a group read) or building the message-id list.
+        if !matches!(
+            receipt_type,
+            ReceiptType::Retry | ReceiptType::EncRekeyRetry
+        ) && !self.core.event_bus.has_handler_for(EventKind::Receipt)
+        {
+            return;
+        }
         let is_view = receipt_type_str == "view";
         let is_group = from.is_group();
         let default_sender = if is_group {
@@ -628,12 +640,6 @@ impl Client {
                 from.observe(),
                 users.len()
             );
-            // Pure event production from here on: `dispatch` would drop every
-            // one of these on the floor without a subscriber, so skip building
-            // N receipts (each with a `Jid` clone and a `Vec<String>`) up front.
-            if !self.core.event_bus.has_handler_for(EventKind::Receipt) {
-                return;
-            }
             for user in users {
                 // Missing `<user t>` means the server didn't disambiguate the
                 // per-user time; fall back to the stanza-level `t`.

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -1,17 +1,9 @@
 use crate::error::{BinaryError, Result};
-use crate::jid::{JidRef, push_jid_to_compact};
+use crate::jid::{JidRef, jid_ref_to_compact};
 use crate::node::{AttrsRef, NodeContentRef, NodeRef, NodeStr, ValueRef};
 use crate::token;
 use compact_str::CompactString;
 use std::borrow::Cow;
-
-/// Format a JidRef directly into CompactString using direct push operations,
-/// bypassing `fmt::Display` and `dyn Write` dispatch entirely.
-fn jid_ref_to_compact(j: &JidRef<'_>) -> CompactString {
-    let mut s = CompactString::with_capacity(j.user.len() + 20);
-    push_jid_to_compact(&j.user, j.server, j.agent, j.device, &mut s);
-    s
-}
 
 /// Each byte's two output characters, so unpacking is one load and one 2-byte
 /// store per input byte instead of two shifts, two lookups and two bounds

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -1103,6 +1103,24 @@ pub fn push_jid_to_compact(
     write_jid!(infallible buf, user, server, agent, device);
 }
 
+/// Render a borrowed JID into a `CompactString` sized to what it actually
+/// takes, so a group id or a LID that fits the 24 inline bytes never touches
+/// the heap. Reserving `user.len() + 20` up front, as the decoder used to,
+/// exceeded the inline budget for every user longer than four characters and
+/// heap-allocated unconditionally — once per JID token in a device-list or
+/// usync response.
+pub fn jid_ref_to_compact(j: &JidRef<'_>) -> CompactString {
+    let mut writer = JidStackWriter::new();
+    if write_jid_fallible(&mut writer, &j.user, j.server, j.agent, j.device).is_ok() {
+        return CompactString::from(writer.as_str());
+    }
+    // A user part too long for the stack buffer (never seen on the wire)
+    // still renders, just back through the heap.
+    let mut s = CompactString::with_capacity(j.user.len() + 20);
+    push_jid_to_compact(&j.user, j.server, j.agent, j.device, &mut s);
+    s
+}
+
 /// Stack writer sized for any realistic JID, so `Display` can emit a single
 /// `write_str`: a `ToString`-backed `String` then reserves once at the exact
 /// length instead of reallocating per fragment. Overflow errors out and the

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+use bytes::Bytes;
 use std::cell::RefCell;
 
 use rand::{CryptoRng, Rng, RngExt};
@@ -17,8 +18,8 @@ use crate::protocol::{
 };
 use crate::store::sender_key_name::SenderKeyName;
 
-/// Reusable buffer for cryptographic operations (encryption and decryption).
-/// Named generically since it's used for both ENCRYPTION_BUFFER and DECRYPTION_BUFFER.
+/// Reusable encrypt scratch: the ciphertext is copied out right-sized, so the
+/// buffer stays on the thread for the next message.
 struct CryptoBuffer {
     buffer: Vec<u8>,
 }
@@ -44,12 +45,6 @@ impl CryptoBuffer {
         &mut self.buffer
     }
 
-    /// Takes ownership of the buffer contents, replacing with a fresh pre-allocated buffer.
-    /// More efficient than `mem::take` + `reserve` since we swap with an already-allocated buffer.
-    fn take_buffer(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.buffer, Vec::with_capacity(Self::INITIAL_CAPACITY))
-    }
-
     /// Copy the written bytes into a right-sized box, keeping the buffer for the
     /// next (small) message instead of handing away its capacity. A one-off
     /// large message's capacity is released here so it is not retained on this
@@ -65,7 +60,6 @@ impl CryptoBuffer {
 
 thread_local! {
     static ENCRYPTION_BUFFER: RefCell<CryptoBuffer> = RefCell::new(CryptoBuffer::new());
-    static DECRYPTION_BUFFER: RefCell<CryptoBuffer> = RefCell::new(CryptoBuffer::new());
 }
 
 /// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
@@ -210,6 +204,22 @@ pub async fn group_decrypt(
     sender_key_store: &mut dyn SenderKeyStore,
     sender_key_name: &SenderKeyName,
 ) -> Result<Vec<u8>> {
+    group_decrypt_shared(
+        Bytes::copy_from_slice(skm_bytes),
+        sender_key_store,
+        sender_key_name,
+    )
+    .await
+}
+
+/// [`group_decrypt`] for a caller that already holds the skmsg as `Bytes`
+/// (the receive path slices it out of the frame buffer): the message is
+/// parsed in place, so the whole skmsg is never copied.
+pub async fn group_decrypt_shared(
+    skm_bytes: Bytes,
+    sender_key_store: &mut dyn SenderKeyStore,
+    sender_key_name: &SenderKeyName,
+) -> Result<Vec<u8>> {
     let skm = SenderKeyMessage::try_from(skm_bytes)?;
 
     let chain_id = skm.chain_id();
@@ -261,36 +271,40 @@ pub async fn group_decrypt(
 
     let sender_key = get_sender_key(sender_key_state, skm.iteration())?;
 
-    let plaintext = DECRYPTION_BUFFER.with(|buffer| {
-        let mut buf_wrapper = buffer.borrow_mut();
-        let buf = buf_wrapper.get_buffer();
-        let ciphertext = skm.ciphertext()?;
-        if let Err(e) = aes_256_cbc_decrypt_into(
-            ciphertext,
-            sender_key.cipher_key(),
-            sender_key.iv(),
-            buf,
-        ) {
-            match e {
-                DecryptionErrorCrypto::BadKeyOrIv => {
-                    log::error!(
-                        "incoming sender key state corrupt for group {} sender {} (chain ID {chain_id})",
-                        sender_key_name.group_id(),
-                        sender_key_name.sender_id()
-                    );
-                    return Err(SignalProtocolError::InvalidSenderKeySession);
-                }
-                DecryptionErrorCrypto::BadCiphertext(msg) => {
-                    log::error!("sender key decryption failed: {msg}");
-                    return Err(SignalProtocolError::InvalidMessage(
-                        CiphertextMessageType::SenderKey,
-                        "decryption failed",
-                    ));
-                }
+    // Decrypt straight into the plaintext the caller keeps. CBC output is never
+    // longer than its input, so one exact reservation covers it. The
+    // thread-local scratch used here before handed its buffer away on every
+    // message and replaced it with a fresh 1 KiB allocation — one allocation
+    // per message either way, but the handed-away buffer also carried whatever
+    // capacity an earlier large message had grown it to, and the plaintext
+    // becomes the `Bytes` the message is dispatched and committed as, so that
+    // slack stayed pinned for the message's whole lifetime.
+    let ciphertext = skm.ciphertext()?;
+    let mut plaintext = Vec::with_capacity(ciphertext.len());
+    if let Err(e) = aes_256_cbc_decrypt_into(
+        ciphertext,
+        sender_key.cipher_key(),
+        sender_key.iv(),
+        &mut plaintext,
+    ) {
+        match e {
+            DecryptionErrorCrypto::BadKeyOrIv => {
+                log::error!(
+                    "incoming sender key state corrupt for group {} sender {} (chain ID {chain_id})",
+                    sender_key_name.group_id(),
+                    sender_key_name.sender_id()
+                );
+                return Err(SignalProtocolError::InvalidSenderKeySession);
+            }
+            DecryptionErrorCrypto::BadCiphertext(msg) => {
+                log::error!("sender key decryption failed: {msg}");
+                return Err(SignalProtocolError::InvalidMessage(
+                    CiphertextMessageType::SenderKey,
+                    "decryption failed",
+                ));
             }
         }
-        Ok::<Vec<u8>, SignalProtocolError>(buf_wrapper.take_buffer())
-    })?;
+    }
 
     sender_key_store
         .store_sender_key(sender_key_name, record)

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -45,7 +45,7 @@ pub use crate::store::sender_key_name::SenderKeyName;
 use error::Result;
 pub use error::SignalProtocolError;
 pub use group_cipher::{
-    create_sender_key_distribution_message, group_decrypt, group_encrypt,
+    create_sender_key_distribution_message, group_decrypt, group_decrypt_shared, group_encrypt,
     process_sender_key_distribution_message,
 };
 pub use identity_key::{IdentityKey, IdentityKeyPair};

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -888,7 +888,16 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
     type Error = SignalProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self> {
-        Self::try_from(bytes_from_slice(value))
+        // Validate before copying, so a malformed payload is rejected without
+        // ever owning it.
+        let (message_version, chain_id, iteration, ciphertext_range) = Self::parse(value)?;
+        Ok(SenderKeyMessage {
+            message_version,
+            chain_id,
+            iteration,
+            serialized: bytes_from_slice(value),
+            ciphertext_range,
+        })
     }
 }
 

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -721,7 +721,10 @@ pub struct SenderKeyMessage {
     message_version: u8,
     chain_id: u32,
     iteration: u32,
-    serialized: Box<[u8]>,
+    /// Reference-counted, as for [`SignalMessage`]: a received skmsg is a
+    /// slice of its frame buffer, so parsing it shares that allocation rather
+    /// than copying the whole message once per group message.
+    serialized: Bytes,
     /// Where the ciphertext sits inside `serialized`, as for [`SignalMessage`].
     /// A group message is decoded once per recipient device, so pointing at the
     /// bytes already owned here keeps the per-message copy out of the receive
@@ -766,11 +769,14 @@ impl SenderKeyMessage {
             .map_err(|_| SignalProtocolError::SignatureValidationFailed)?;
         serialized.extend_from_slice(&signature);
 
+        // Filled to exactly its reserved length, so `Bytes::from` takes the
+        // boxed-slice path and `into_serialized` recovers the allocation.
+        debug_assert_eq!(serialized.len(), serialized.capacity());
         Ok(Self {
             message_version,
             chain_id,
             iteration,
-            serialized: serialized.into_boxed_slice(),
+            serialized: Bytes::from(serialized),
             ciphertext_range,
         })
     }
@@ -832,20 +838,12 @@ impl SenderKeyMessage {
 
     #[inline]
     pub fn into_serialized(self) -> Box<[u8]> {
-        self.serialized
+        bytes_into_boxed_slice(self.serialized)
     }
-}
 
-impl AsRef<[u8]> for SenderKeyMessage {
-    fn as_ref(&self) -> &[u8] {
-        &self.serialized
-    }
-}
-
-impl TryFrom<&[u8]> for SenderKeyMessage {
-    type Error = SignalProtocolError;
-
-    fn try_from(value: &[u8]) -> Result<Self> {
+    /// Parse the wire form without taking ownership: version byte, the
+    /// protobuf, and where the ciphertext sits inside `value`.
+    fn parse(value: &[u8]) -> Result<(u8, u32, u32, Range<usize>)> {
         if value.len() < 1 + Self::SIGNATURE_LEN {
             return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
         }
@@ -874,16 +872,38 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
         let Some(ciphertext) = view.ciphertext else {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         };
-        // The view borrows `value`, and `serialized` below is a byte-identical
-        // copy of it, so the offsets carry over unchanged.
         let ciphertext_range = subslice_range(value, ciphertext)
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        Ok((message_version, chain_id, iteration, ciphertext_range))
+    }
+}
 
+impl AsRef<[u8]> for SenderKeyMessage {
+    fn as_ref(&self) -> &[u8] {
+        &self.serialized
+    }
+}
+
+impl TryFrom<&[u8]> for SenderKeyMessage {
+    type Error = SignalProtocolError;
+
+    fn try_from(value: &[u8]) -> Result<Self> {
+        Self::try_from(bytes_from_slice(value))
+    }
+}
+
+/// Zero-copy parse: the message keeps `value` as its storage, so a slice of a
+/// received frame is retained by refcount instead of copied.
+impl TryFrom<Bytes> for SenderKeyMessage {
+    type Error = SignalProtocolError;
+
+    fn try_from(value: Bytes) -> Result<Self> {
+        let (message_version, chain_id, iteration, ciphertext_range) = Self::parse(&value)?;
         Ok(SenderKeyMessage {
             message_version,
             chain_id,
             iteration,
-            serialized: Box::from(value),
+            serialized: value,
             ciphertext_range,
         })
     }

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -311,6 +311,11 @@ impl GroupInfo {
             }
             self.participants.push(jid.clone());
         }
+        // Membership changes arrive one notification at a time and the list
+        // is read for hours between them, so trade a realloc per change for
+        // no doubling slack: a group that grew past its allocation by one
+        // member otherwise kept a second, empty copy of itself resident.
+        self.participants.shrink_to_fit();
         if let Some(pairs) = pairs {
             self.store_pairs(pairs);
         }
@@ -322,6 +327,7 @@ impl GroupInfo {
     pub fn remove_participants(&mut self, users_to_remove: &[&str]) {
         self.participants
             .retain(|p| !users_to_remove.iter().any(|u| *u == p.user));
+        self.participants.shrink_to_fit();
         // Each name can be either side of a mapping. The phone side is
         // resolved through the reverse index first, so a phone number shared
         // by two LIDs drops exactly the one that index names — which is what

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -679,14 +679,21 @@ pub async fn ensure_sessions_for_devices(
     let mut reusable_addr = crate::types::jid::make_reusable_protocol_address();
 
     for (idx, device_jid) in devices.iter().enumerate() {
+        // Resolved once per device: both the session probe and the prekey
+        // branch below want it, and the lookup is a boxed `async_trait` call
+        // into an async-locked cache.
+        let lid_jid = if device_jid.is_pn() {
+            resolver
+                .get_lid_for_phone(&device_jid.user)
+                .await
+                .map(|lid_user| Jid::lid_device(lid_user, device_jid.device))
+        } else {
+            None
+        };
         // WhatsApp Web's SignalAddress.toString() normalizes PN → LID before
         // creating signal addresses. We do the same: check LID session FIRST.
         // This prevents using stale PN sessions when a newer LID session exists.
-        if device_jid.is_pn()
-            && let Some(lid_user) = resolver.get_lid_for_phone(&device_jid.user).await
-        {
-            // Construct the LID JID with the same device ID
-            let lid_jid = Jid::lid_device(lid_user, device_jid.device);
+        if let Some(lid_jid) = &lid_jid {
             lid_jid.reset_protocol_address(&mut reusable_addr);
 
             if has_session_or_report(stores.session_store, &reusable_addr, resolver, devices)
@@ -697,7 +704,12 @@ pub async fn ensure_sessions_for_devices(
                     lid_jid.observe(),
                     device_jid.observe()
                 );
-                record_encryption_override(&mut encryption_overrides, devices.len(), idx, lid_jid);
+                record_encryption_override(
+                    &mut encryption_overrides,
+                    devices.len(),
+                    idx,
+                    lid_jid.clone(),
+                );
                 continue;
             }
         }
@@ -710,10 +722,7 @@ pub async fn ensure_sessions_for_devices(
         // No session found - need to fetch prekeys and create session.
         // Keep device_jid for prekey fetch (server returns bundles keyed by this),
         // but normalize to LID for the actual session creation.
-        if device_jid.is_pn()
-            && let Some(lid_user) = resolver.get_lid_for_phone(&device_jid.user).await
-        {
-            let lid_jid = Jid::lid_device(lid_user, device_jid.device);
+        if let Some(lid_jid) = lid_jid {
             log::debug!(
                 "Will create LID session {} for PN {} (no existing session)",
                 lid_jid.observe(),
@@ -814,123 +823,144 @@ pub async fn ensure_sessions_for_devices(
 
         // Parallel session establishment via process_prekey_bundle. Each
         // recipient device has an independent Signal session and an
-        // independent prekey bundle, so the X3DH derivation runs on a
-        // separate task per device, bounded at ENCRYPT_FANOUT_CONCURRENCY.
-        // Spawning goes through `Runtime::spawn` (the platform-agnostic
-        // abstraction) plus a oneshot channel for result delivery —
-        // `FuturesUnordered` handles the in-flight window.
+        // independent prekey bundle, so the X3DH derivations run on
+        // ENCRYPT_FANOUT_CONCURRENCY tasks. One task per chunk, not per
+        // device, as in the encrypt fan-out below: spawning per device cost a
+        // task, a oneshot channel, a boxed future and two boxed store clones
+        // for every device of a cold cohort, which is exactly when the cohort
+        // is largest. `process_prekey_bundle` writes through the Arc-backed
+        // cache, so one store clone serving a whole chunk persists every
+        // session it establishes.
         let prekey_bundles = std::sync::Arc::new(prekey_bundles);
         let total = indices_needing_prekeys.len();
-        let mut next_spawn = 0usize;
+        let num_chunks = ENCRYPT_FANOUT_CONCURRENCY.min(total);
 
-        let make_session_task = |spawn_idx: usize| {
-            let idx = indices_needing_prekeys[spawn_idx];
-            let lookup_jid = devices[idx].clone();
-            let encryption_jid = encryption_override_at(&encryption_overrides, idx)
-                .cloned()
-                .unwrap_or_else(|| lookup_jid.clone());
-            let counted_at_fetch =
-                batch_refused || server_named.iter().any(|device| device.jid == lookup_jid);
-
+        let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
+        for chunk_idx in 0..num_chunks {
+            let chunk_start = chunk_idx * total / num_chunks;
+            let chunk_end = (chunk_idx + 1) * total / num_chunks;
+            // The 'static task can't borrow devices/encryption_overrides.
+            // `encryption_jid` is `None` when the device keys under its own
+            // address, so the common case clones one `Jid`, not two.
+            let jobs: Vec<(Jid, Option<Jid>, bool)> = (chunk_start..chunk_end)
+                .map(|spawn_idx| {
+                    let idx = indices_needing_prekeys[spawn_idx];
+                    let lookup_jid = devices[idx].clone();
+                    let encryption_jid =
+                        encryption_override_at(&encryption_overrides, idx).cloned();
+                    let counted_at_fetch =
+                        batch_refused || server_named.iter().any(|device| device.jid == lookup_jid);
+                    (lookup_jid, encryption_jid, counted_at_fetch)
+                })
+                .collect();
+            let chunk_len = jobs.len();
             let bundles = prekey_bundles.clone();
             let mut session_store = stores.session_store.clone_box();
             let mut identity_store = stores.identity_store.clone_box();
 
-            spawn_oneshot(runtime, async move {
+            let task = spawn_oneshot(runtime, async move {
                 let mut addr = crate::types::jid::make_reusable_protocol_address();
-                encryption_jid.reset_protocol_address(&mut addr);
-
-                let Some(bundle) = bundles.get(&lookup_jid) else {
-                    // No key material this round (usually the 406 cascade); the next
-                    // send re-fetches. Debug avoids one warn per skipped device.
-                    log::debug!(
-                        "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
-                        addr
-                    );
-                    return SessionOutcome::Dropped {
-                        jid: lookup_jid,
-                        reason: (!counted_at_fetch).then_some(UnkeyableDevice::NoBundle),
-                        error: None,
-                    };
-                };
-
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-                // No UntrustedIdentity recovery: WA Web's isTrustedIdentity is
-                // unconditional Ok(true) (TOFU), and save_identity inside
-                // process_prekey_bundle persists rotations transparently.
-                match process_prekey_bundle(
-                    &addr,
-                    &mut *session_store,
-                    &mut *identity_store,
-                    bundle,
-                    &mut rng,
-                    UsePQRatchet::No,
-                )
-                .await
-                {
-                    // Surface a replaced identity so the caller can react
-                    // (resolver has no 'static handle into this spawned task).
-                    Ok(IdentityChange::ReplacedExisting) => {
-                        SessionOutcome::Established(Some(encryption_jid))
-                    }
-                    Ok(IdentityChange::NewOrUnchanged) => SessionOutcome::Established(None),
-                    Err(error) => SessionOutcome::Dropped {
-                        jid: lookup_jid,
-                        reason: Some(UnkeyableDevice::SessionSetup),
-                        error: Some(
-                            anyhow::Error::new(error)
-                                .context(format!("failed to process pre-key bundle for {addr}")),
-                        ),
-                    },
-                }
-            })
-        };
+                let mut out = Vec::with_capacity(jobs.len());
+                for (lookup_jid, encryption_jid, counted_at_fetch) in jobs {
+                    encryption_jid
+                        .as_ref()
+                        .unwrap_or(&lookup_jid)
+                        .reset_protocol_address(&mut addr);
 
-        let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
-        while next_spawn < total && in_flight.len() < ENCRYPT_FANOUT_CONCURRENCY {
-            in_flight.push(make_session_task(next_spawn));
-            next_spawn += 1;
+                    let Some(bundle) = bundles.get(&lookup_jid) else {
+                        // No key material this round (usually the 406 cascade); the next
+                        // send re-fetches. Debug avoids one warn per skipped device.
+                        log::debug!(
+                            "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
+                            addr
+                        );
+                        out.push(SessionOutcome::Dropped {
+                            jid: lookup_jid,
+                            reason: (!counted_at_fetch).then_some(UnkeyableDevice::NoBundle),
+                            error: None,
+                        });
+                        continue;
+                    };
+
+                    // No UntrustedIdentity recovery: WA Web's isTrustedIdentity is
+                    // unconditional Ok(true) (TOFU), and save_identity inside
+                    // process_prekey_bundle persists rotations transparently.
+                    out.push(
+                        match process_prekey_bundle(
+                            &addr,
+                            &mut *session_store,
+                            &mut *identity_store,
+                            bundle,
+                            &mut rng,
+                            UsePQRatchet::No,
+                        )
+                        .await
+                        {
+                            // Surface a replaced identity so the caller can react
+                            // (resolver has no 'static handle into this spawned task).
+                            Ok(IdentityChange::ReplacedExisting) => SessionOutcome::Established(
+                                Some(encryption_jid.unwrap_or(lookup_jid)),
+                            ),
+                            Ok(IdentityChange::NewOrUnchanged) => SessionOutcome::Established(None),
+                            Err(error) => SessionOutcome::Dropped {
+                                jid: lookup_jid,
+                                reason: Some(UnkeyableDevice::SessionSetup),
+                                error: Some(anyhow::Error::new(error).context(format!(
+                                    "failed to process pre-key bundle for {addr}"
+                                ))),
+                            },
+                        },
+                    );
+                }
+                out
+            });
+            in_flight.push(async move { (chunk_len, task.await) });
         }
-        while let Some(spawn_result) = in_flight.next().await {
-            match spawn_result {
-                // Some(jid) => establishing this session replaced a stored
-                // identity; notify the client so it can react off-path.
-                Ok(SessionOutcome::Established(Some(changed_jid))) => {
-                    resolver.on_local_identity_change(&changed_jid)
-                }
-                Ok(SessionOutcome::Established(None)) => {}
-                // Isolate the failure to this device so one participant can't abort
-                // the cohort's SKDM (matching WA Web GroupKeyDistributionMsg's
-                // per-device try/catch). The sessionless device is dropped by the
-                // fan-out below, which skips it when tallying its own drops.
-                Ok(SessionOutcome::Dropped { jid, reason, error }) => {
-                    if let Some(reason) = reason {
-                        resolver.on_unkeyable_devices(reason, 1);
-                    }
-                    unkeyed_devices.push(jid);
-                    if let Some(error) = error {
-                        log::warn!("Group session setup failed for a device, skipping it: {error}");
-                        if first_error.is_none() {
-                            first_error = Some(error);
-                        }
-                    }
-                }
+        while let Some((chunk_len, spawn_result)) = in_flight.next().await {
+            let outcomes = match spawn_result {
+                Ok(outcomes) => outcomes,
                 Err(error) => {
-                    // The task took the device's identity with it, so this drop
-                    // cannot join `unkeyed_devices` — and must not be counted
-                    // here either, or the encrypt fan-out (which will fail for
-                    // the same device) would count it a second time.
+                    // The task took the devices' identities with it, so these
+                    // drops cannot join `unkeyed_devices` — and must not be
+                    // counted here either, or the encrypt fan-out (which will
+                    // fail for the same devices) would count them a second time.
                     log::warn!(
-                        "Session-establishment task did not deliver a result; skipping device."
+                        "Session-establishment task did not deliver a result; skipping {chunk_len} device(s)."
                     );
                     if first_error.is_none() {
                         first_error = Some(anyhow::Error::new(error));
                     }
+                    continue;
                 }
-            }
-            if next_spawn < total {
-                in_flight.push(make_session_task(next_spawn));
-                next_spawn += 1;
+            };
+            for outcome in outcomes {
+                match outcome {
+                    // Some(jid) => establishing this session replaced a stored
+                    // identity; notify the client so it can react off-path.
+                    SessionOutcome::Established(Some(changed_jid)) => {
+                        resolver.on_local_identity_change(&changed_jid)
+                    }
+                    SessionOutcome::Established(None) => {}
+                    // Isolate the failure to this device so one participant can't abort
+                    // the cohort's SKDM (matching WA Web GroupKeyDistributionMsg's
+                    // per-device try/catch). The sessionless device is dropped by the
+                    // fan-out below, which skips it when tallying its own drops.
+                    SessionOutcome::Dropped { jid, reason, error } => {
+                        if let Some(reason) = reason {
+                            resolver.on_unkeyable_devices(reason, 1);
+                        }
+                        unkeyed_devices.push(jid);
+                        if let Some(error) = error {
+                            log::warn!(
+                                "Group session setup failed for a device, skipping it: {error}"
+                            );
+                            if first_error.is_none() {
+                                first_error = Some(error);
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -256,9 +256,21 @@ impl<V> UserIndexedCache<V> {
     }
 
     fn insert(&mut self, key: Arc<str>, value: V) -> Option<V> {
-        self.users
-            .insert(user_fingerprint(user_of_protocol_address(&key)));
-        self.map.insert(key, value)
+        // Overwrites are the common case — every send and decrypt writes its
+        // address back — and an address already in the map already has its
+        // user in the index, so the fingerprint (a scan for the separator and
+        // a hash of the user) is only computed for a new key.
+        match self.map.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                Some(occupied.insert(value))
+            }
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                self.users
+                    .insert(user_fingerprint(user_of_protocol_address(vacant.key())));
+                vacant.insert(value);
+                None
+            }
+        }
     }
 
     /// Stamp to take before a cold read releases the lock.
@@ -519,8 +531,11 @@ impl SessionStoreState {
         }
         self.cache
             .insert(addr.clone(), SessionEntry::Present(Arc::new(record)));
-        self.dirty.insert(addr.clone());
-        self.deleted.remove(&addr);
+        // `deleted` is empty on every ordinary write-back; skip its hash.
+        if !self.deleted.is_empty() {
+            self.deleted.remove(&addr);
+        }
+        self.dirty.insert(addr);
     }
 
     fn checkout(&mut self, address: &str) -> CachedSessionCheckout {


### PR DESCRIPTION
## Summary

Follow-up to #1353, #1354 and #1388, same rules: every change keeps output and public API byte-identical (the two additions are `SenderKeyMessage: TryFrom<Bytes>` and `group_decrypt_shared`), and each one was verified against the surrounding code rather than the pattern alone. This round targets two things the earlier passes did not reach: memory a connected client keeps **per chat** and **per cache entry** for hours, and the copies still paid **per group message**.

| metric | main | this PR | delta |
| --- | ---: | ---: | ---: |
| bin size (stripped) | 10.42 MiB | 10.35 MiB | −73.56 KiB (−0.69%) |
| `.text whatsapp_rust` | 1.97 MiB | 1.90 MiB | −72.85 KiB (−3.61%) |
| llvm-lines whatsapp-rust lib | 820,848 | 789,935 | −30,913 (−3.77%) |

## Resident memory

**Chat lane workers exit when idle** (`src/handlers/message.rs`). A lane's worker awaits `handle_incoming_message_scoped` inline, so its spawned task holds that future's whole state machine — measured at 9,296 B in a debug probe — for as long as the worker lives, message or no message. Kept alive for the connection, that is one such future per chat that ever spoke, bounded only by `chat_lanes_capacity` (5 000): a client in a few thousand groups parked tens of MiB in idle workers. A worker now closes its queue after 60 s of silence and exits; the next message for the chat is told `Closed` and replaces the lane. Both locks belong to the chat rather than the lane and are inherited by the replacement: `enqueue_lock`, so every enqueue for the chat takes one total order whichever lane generation the handler fetched (the swap itself runs under it), and `worker_running`, which the successor worker takes before its first message so a draining tail can never interleave with it. The idle timer is armed only when the queue is empty, so a busy chat pays nothing per message. Two tests under Tokio's paused clock pin the exit, the respawn and both lock hand-offs; a lane that keeps receiving never exits. CodSpeed: `bench_chat_lane_create` −47% memory, −60% time at 256 and 4 096 lanes.

**`PortableCache` stores each key once** (`src/portable_cache.rs`). The FIFO index was `BTreeMap<u64, K>`: every entry carried its key twice, and for a `String`, `Jid` or `SenderMessageId` key that second copy was a second heap allocation held for the entry's whole life, across all ~20 caches the client keeps. The map is now a `hashbrown::HashTable` keyed by the hash stored in the slot, and the index is `seq -> hash`; eviction and targeted removal find the slot by `(hash, seq)`. A cache with no capacity bound — the four unbounded LID↔PN maps — keeps no FIFO index at all, since nothing could ever pop it. `an_insert_stores_the_key_once_and_never_clones_it` (a clone-counting key) and `an_unbounded_cache_keeps_no_fifo_index` pin both. The `BTreeMap<u64, u64>` is also one instantiation shared by every cache instead of one per key type, which is where most of the 73 KiB of `.text` comes from.

**`GroupInfo::participants` shrinks after every membership change** (`wacore/src/client/context.rs`). `push` doubles; a 1 025-member group held a 2 048-slot buffer, and `retain` never released it.

## Per message

- **`SenderKeyMessage` holds `Bytes`** (`wacore/libsignal/src/protocol/protocol.rs`). It was the one envelope still parsed with `Box::from(value)` — one allocation and a full memcpy of the skmsg per group message — while `SignalMessage` and `PreKeySignalMessage` already shared their frame slice. `group_decrypt_shared` takes the `EncPayload`'s `Bytes` (a refcount bump into the frame buffer); `group_decrypt(&[u8])` forwards to it, and `into_serialized` recovers the allocation on the send path as before. The borrowed form validates before it copies. CodSpeed: `bench_group_decrypt_message` 1,584 B → 592 B, `bench_group_in_order_decrypt_with_backlog` 1,519 B → 511 B.
- **`group_decrypt` writes into an exact-size plaintext** (`group_cipher.rs`). The thread-local scratch handed its buffer away on every message and replaced it with a fresh 1 KiB `Vec` — so it allocated per message anyway — and the handed-away buffer carried whatever capacity an earlier large message had grown it to. That `Vec` becomes the `Bytes` the message is dispatched and committed as, so the slack stayed pinned for the message's lifetime. CBC output is never longer than its input, so one reservation of `ciphertext.len()` covers it; `DECRYPTION_BUFFER` and `take_buffer` are gone.
- **The LID↔PN relearn check runs before the mutation mutex** (`src/client/lid_pn.rs`). `record_lid_pn_in_memory` runs for every message whose sender carries a `sender_alt`, and in the steady state the pair is known both ways and persisted, so the answer is `Skipped` — but every chat lane first serialized on one process-wide `async_lock::Mutex` to find that out. The guarded body still re-checks under the lock.
- **Receipts without a subscriber return before parsing** (`src/receipt.rs`). The aggregated branch gated *after* `parse_participants` had built two `Jid`s and two `CompactString`s per `<user>` of a group read, and the simple branch never gated at all. One check after `receipt_type` is resolved covers both; only `retry` is exempt, because it feeds the resend pipeline regardless.
- **The decrypt loop seeds its `StdRng` lazily** (`src/message/receive.rs`). `rand::make_rng::<StdRng>()` per stanza pulled 32 bytes of entropy and ran a ChaCha key schedule for a generator only the DH-ratchet step draws from. `ThreadRng` would avoid the seeding but is `!Send` across the lane worker's awaits, so a `LazyStdRng` wrapper seeds on first draw.
- **Decoded JID tokens render into a right-sized `CompactString`** (`wacore/binary/src/decoder.rs`, `jid.rs`). `with_capacity(user.len() + 20)` exceeded the 24-byte inline budget for any user longer than four characters, so every JID token in a device-list or usync response heap-allocated even when the rendered JID (a group id, a LID) fit inline.

## Per send

- **Session establishment spawns one task per chunk** (`wacore/src/send/encrypt.rs`). The encrypt fan-out two functions down was already chunked, with a comment saying why; `ensure_sessions_for_devices` still spawned a task, a oneshot, a boxed future and two boxed store clones per device needing a prekey — the whole cohort on a cold group send. Same `ENCRYPT_FANOUT_CONCURRENCY` partitioning, same per-device outcomes; a lost chunk is reported with its device count.
- **`get_lid_for_phone` runs once per device** in the same function; the prekey branch re-ran the boxed `async_trait` lookup the session probe had just done.
- **Session write-back** (`wacore/src/store/signal_cache.rs`): `UserIndexedCache::insert` goes through the `entry` API so the user fingerprint (separator scan + hash) is computed only for a new key, not on the overwrite every send and decrypt performs; `put_with_key` skips the `deleted` set while it is empty, which is every ordinary write-back.

## Refuted or deliberately left out

- `MessageInfo` boxing (`meta_info`, `comment_target`, `device_sent_meta`, ~330 B of rarely-present fields inline) and `MessageId = String` → `CompactString`: real, but both change public field types. Separate PR.
- The skipped-message-key layout (`MessageKey` at 136 B inline plus a 32 B `Bytes` for a seed-only key): a 5× win on lossy chains, but it spans the generated `SessionStructure` types and their round-trip tests.
- `SenderKeyRecord` is deep-cloned out of the cache on every group load (`Arc::unwrap_or_clone` while the cache keeps its `Arc`). The per-state hot fields are already `Arc`/`Copy`, so the clone is the `VecDeque` plus a `SenderKeyStateStructure` per state; a checkout path like the session store's would remove it but needs the same `CheckedOut` marker machinery. Not this PR.
- The decoder's one `Box<[..]>` per node with attributes or children: a bump arena would make it O(1) per frame, but it goes through the `Yokeable` impl Miri gates and changes `AttrsRef`/`NodeContentRef`. A project, not a patch.
- Trimming the ack `Vec` so `Bytes::from` reuses it: `AckNode` is a hand-written encoder with no size plan, and a shrinking `realloc` crosses a size class on jemalloc, so neither exact sizing nor `shrink_to_fit` is a clear win over the one shared header. Tried and reverted in review.
- `session_locks` / `message_retry_counts` keyed by `String` rather than `Arc<str>`: with the duplicate key gone this saves ~8 B/entry. Not worth the diff.

## Compatibility

No public API removed or changed. Added: `SenderKeyMessage: TryFrom<Bytes>`, `group_decrypt_shared`, `wacore_binary::jid::jid_ref_to_compact`. `ChatLane` (`pub(crate)`) gains `worker_running`. `agent_docs/observability.md` notes the lane idle exit.

## Validation

```
cargo fmt --all --check
cargo test -p wacore-binary                                   # 147 unit + integration
cargo test -p wacore-libsignal --lib                          # 241 passed
cargo test -p wacore --lib                                    # 1566 passed, 1 ignored
cargo test -p whatsapp-rust --lib                             # 1865 passed, 1 ignored
cargo clippy -p whatsapp-rust -p wacore -p wacore-binary -p wacore-libsignal --all-targets -- -D warnings
```

The size gate's numbers are in the table above: the per-cache `BTreeMap<u64, K>` instantiations collapse into one `BTreeMap<u64, u64>`, and no new sort or generic fan-out was added. Full matrix, wasm32, Miri and CodSpeed on CI. Semver Checks (informational) is red for `waproto` fields a whatspec regeneration already on `main` removed; this branch does not touch `waproto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN