### PR TITLE
fix(bot): carry the inbound-only metadata into MessageContext

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2331,8 +2331,8 @@ mod tests {
         let ephemeral = wacore::types::events::InboundMessage::builder()
             .message(Arc::new(wa::Message::default()))
             .info(Arc::new(react_info(
-                "15551230000@s.whatsapp.net",
-                "15551230000@s.whatsapp.net",
+                "12025550100@s.whatsapp.net",
+                "12025550100@s.whatsapp.net",
                 "MSGID01",
                 false,
             )))

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -109,6 +109,14 @@ pub struct MessageContext {
     pub message: Arc<wa::Message>,
     pub info: MessageInfo,
     pub client: Arc<Client>,
+    /// Disappearing-message timer of the chat this message arrived in, in
+    /// seconds, when the stanza carried one. Mirrors
+    /// [`InboundMessage::ephemeral_expiration`](wacore::types::events::InboundMessage::ephemeral_expiration).
+    pub ephemeral_expiration: Option<u32>,
+    /// For a decrypted newsletter comment, the key of the post it replies to.
+    /// Mirrors
+    /// [`InboundMessage::comment_target`](wacore::types::events::InboundMessage::comment_target).
+    pub comment_target: Option<Box<wa::MessageKey>>,
 }
 
 impl MessageContext {
@@ -119,19 +127,32 @@ impl MessageContext {
         Self::from_arc(Arc::new(message.clone()), info, client)
     }
 
+    /// Builds a context from a message and its info alone; the inbound-only
+    /// metadata (`ephemeral_expiration`, `comment_target`) is absent because
+    /// this constructor never sees the stanza it came from.
     pub fn from_arc(message: Arc<wa::Message>, info: &MessageInfo, client: Arc<Client>) -> Self {
         Self {
             message,
             info: info.clone(),
             client,
+            ephemeral_expiration: None,
+            comment_target: None,
         }
     }
 
+    /// Builds a context from a dispatched [`InboundMessage`], carrying every
+    /// field a handler could read off the event, not only `message` and `info`.
+    ///
+    /// [`InboundMessage`]: wacore::types::events::InboundMessage
     pub fn from_inbound(
         inbound: &wacore::types::events::InboundMessage,
         client: Arc<Client>,
     ) -> Self {
-        Self::from_arc(Arc::clone(&inbound.message), &inbound.info, client)
+        Self {
+            ephemeral_expiration: inbound.ephemeral_expiration,
+            comment_target: inbound.comment_target.clone(),
+            ..Self::from_arc(Arc::clone(&inbound.message), &inbound.info, client)
+        }
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.bot.send_message", level = "debug", skip_all, fields(chat = %self.info.source.chat.observe()), err(Debug)))]
@@ -2291,6 +2312,64 @@ mod tests {
             MessageContext::from_arc(Arc::clone(&original), &MessageInfo::default(), bot.client());
 
         assert!(std::ptr::eq(Arc::as_ptr(&ctx.message), original_ptr));
+    }
+
+    #[tokio::test]
+    async fn from_inbound_keeps_the_inbound_only_metadata() {
+        let backend = create_test_sqlite_backend().await;
+        let bot = Bot::builder()
+            .with_backend_arc(backend)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("Failed to build bot");
+
+        // A message in a disappearing chat: the timer rides the event, not the
+        // shared info, and must still reach the handler's context.
+        let ephemeral = wacore::types::events::InboundMessage::builder()
+            .message(Arc::new(wa::Message::default()))
+            .info(Arc::new(react_info(
+                "15551230000@s.whatsapp.net",
+                "15551230000@s.whatsapp.net",
+                "MSGID01",
+                false,
+            )))
+            .ephemeral_expiration(86400)
+            .build();
+        let ctx = MessageContext::from_inbound(&ephemeral, bot.client());
+        assert_eq!(ctx.ephemeral_expiration, Some(86400));
+        assert!(ctx.comment_target.is_none());
+
+        // A newsletter comment: the parent post key rides the same way.
+        let parent = wa::MessageKey {
+            remote_jid: Some("120363000000000001@newsletter".to_string()),
+            id: Some("POSTID01".to_string()),
+            ..Default::default()
+        };
+        let comment = wacore::types::events::InboundMessage::builder()
+            .message(Arc::new(wa::Message::default()))
+            .info(Arc::new(react_info(
+                "120363000000000001@newsletter",
+                "120363000000000001@newsletter",
+                "MSGID02",
+                false,
+            )))
+            .comment_target(Box::new(parent.clone()))
+            .build();
+        let ctx = MessageContext::from_inbound(&comment, bot.client());
+        assert_eq!(ctx.comment_target.as_deref(), Some(&parent));
+        assert!(ctx.ephemeral_expiration.is_none());
+
+        // The info-only constructor has no stanza to read them from.
+        let plain = MessageContext::from_arc(
+            Arc::new(wa::Message::default()),
+            &MessageInfo::default(),
+            bot.client(),
+        );
+        assert!(plain.ephemeral_expiration.is_none());
+        assert!(plain.comment_target.is_none());
     }
 
     async fn test_context_with_info(info: MessageInfo) -> MessageContext {

--- a/src/features/comments.rs
+++ b/src/features/comments.rs
@@ -9,7 +9,8 @@
 //!
 //! Incoming comments are decrypted transparently on the receive path and
 //! dispatched as their inner body `Message`; the parent post key surfaces on
-//! `MessageInfo::comment_target`.
+//! `InboundMessage::comment_target` (and `MessageContext::comment_target` for
+//! a bot handler).
 
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -627,8 +627,9 @@ impl Client {
             let (agg_msg_id, agg_key, users) =
                 wacore::stanza::receipt::parse_participants(part_node);
             // The event's `message_ids` are owned `MessageId`s, so the borrowed
-            // id is copied into one (inline, for an ordinary 22-character id)
-            // once here instead of cloning both candidates first.
+            // id is copied into one (inline on 64-bit targets for an ordinary
+            // 22-character id) once here instead of cloning both candidates
+            // first.
             let fan_out_id: wacore_binary::MessageId = agg_msg_id
                 .as_deref()
                 .or(agg_key.as_deref())

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -626,8 +626,9 @@ impl Client {
         if let Some(part_node) = nr.get_optional_child("participants") {
             let (agg_msg_id, agg_key, users) =
                 wacore::stanza::receipt::parse_participants(part_node);
-            // The event's `message_ids` are `String`, so the borrowed compact id
-            // is widened once here instead of cloning both candidates first.
+            // The event's `message_ids` are owned `MessageId`s, so the borrowed
+            // id is copied into one (inline, for an ordinary 22-character id)
+            // once here instead of cloning both candidates first.
             let fan_out_id: wacore_binary::MessageId = agg_msg_id
                 .as_deref()
                 .or(agg_key.as_deref())

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -374,6 +374,11 @@ pub const PSA_USER: &str = "0";
 /// A message id, inline: WhatsApp ids are 20–32 hex/base64 characters, and
 /// every client-generated one is 22, so the common case pays no heap
 /// allocation per message, per receipt id and per dedup-cache key.
+///
+/// The inline budget is `size_of::<String>()`, 24 bytes on a 64-bit target.
+/// On a 32-bit target (wasm32, ESP32) it is 12, so a 22-character id still
+/// heap-allocates there: no worse than the `String` it replaced, and the
+/// `&str` surface is the same, but the allocation saving is 64-bit-only.
 pub type MessageId = CompactString;
 pub type MessageServerId = i32;
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Follow-up to #1390, which merged with three review findings still open (CodeRabbit and cubic both raised the first).

- **`MessageContext` lost two fields a bot handler could read.** #1390 moved `ephemeral_expiration` and `comment_target` off the shared `MessageInfo` onto `InboundMessage`, but `MessageContext::from_inbound` copied only `message` and `info`, so `BotBuilder::on_message` callbacks no longer saw the chat's disappearing-message timer or a newsletter comment's parent post key. Both are now fields of `MessageContext`, populated by `from_inbound`; the info-only constructors (`from_arc`, `from_parts`) leave them `None` because they never see the stanza. A test covers a disappearing-chat message, a newsletter comment and the info-only constructor.
- **Stale comment in the receipt fan-out** still described the ids as `String`.
- **`MessageId` doc** now states that the inline budget is `size_of::<String>()`: 24 bytes on 64-bit, 12 on wasm32/ESP32, so a 22-character id still heap-allocates on a 32-bit target. That is no worse than the `String` it replaced and the `&str` surface is identical, but the saving is 64-bit-only.

Not acted on: CodSpeed flagged `identity_probe_misses[8]` at −10% on #1390. That benchmark exercises `try_get_identity` misses, which the PR did not touch (its only change in `signal_cache.rs` was a lint attribute on a session enum), the other three fan-out arms of the same benchmark were untouched, and CodSpeed marked the comparison as taken across different runtime environments.

## Compatibility

`MessageContext` gains two public fields. Code that constructs it through `from_arc`/`from_parts`/`from_inbound` is unaffected; a struct literal would need the two new fields.

## Validation

- `cargo fmt --all`, `cargo clippy -p whatsapp-rust --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust --no-deps` clean.
- `cargo test -p whatsapp-rust --lib bot::tests` passes (28, including the new one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_