### PR TITLE
perf(send): inline encrypt up to the DM device ceiling, single-allocation skipped-key backlogs, cached group HKDF extract

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -283,10 +283,11 @@ impl Client {
     /// `is_offline` mirrors the single-entry path: skip the persist task for
     /// offline replays; mappings are re-learned from the next live event.
     ///
-    /// Takes owned `(lid, phone_number)` pairs; each `String` moves directly
-    /// into the `LidPnEntry` stored in the cache, then (via `into_iter`) into
-    /// the `LidPnMappingEntry` that's persisted — no clones on either step.
-    /// The `Vec` itself is consumed, so no copy of the outer container either.
+    /// Takes owned `(lid, phone_number)` pairs; each `String` moves into the
+    /// `Arc<str>` of the `LidPnEntry` stored in the cache. The entries stay
+    /// alive across the backend write so the persisted markers share those
+    /// `Arc<str>`s; the storage row copies them into its own `String` fields,
+    /// which is the one copy the batch makes.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.learn_lid_pn_batch", level = "debug", skip_all, fields(count = mappings.len(), is_offline = is_offline)))]
     pub(crate) async fn learn_lid_pn_mappings_batch(
         self: &Arc<Self>,

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -283,11 +283,11 @@ impl Client {
     /// `is_offline` mirrors the single-entry path: skip the persist task for
     /// offline replays; mappings are re-learned from the next live event.
     ///
-    /// Takes owned `(lid, phone_number)` pairs; each `String` moves into the
-    /// `Arc<str>` of the `LidPnEntry` stored in the cache. The entries stay
-    /// alive across the backend write so the persisted markers share those
-    /// `Arc<str>`s; the storage row copies them into its own `String` fields,
-    /// which is the one copy the batch makes.
+    /// Takes owned `(lid, phone_number)` pairs. The record path borrows them,
+    /// so each is copied once into the `Arc<str>` fields of the `LidPnEntry`
+    /// stored in the cache. The entries stay alive across the backend write so
+    /// the persisted markers share those `Arc<str>`s; the storage row copies
+    /// them a second time into its own `String` fields.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.learn_lid_pn_batch", level = "debug", skip_all, fields(count = mappings.len(), is_offline = is_offline)))]
     pub(crate) async fn learn_lid_pn_mappings_batch(
         self: &Arc<Self>,

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -579,7 +579,7 @@ impl Client {
         // After the write, not before: a failed persist stays un-marked so the
         // next live message retries instead of skipping.
         self.lid_pn_cache
-            .mark_persisted(&storage_entry.phone_number, &storage_entry.lid)
+            .mark_persisted(&entry.phone_number, &entry.lid)
             .await;
 
         if needs_migration {
@@ -617,11 +617,11 @@ impl Client {
     ) -> Result<Vec<LidPnMappingEntry>> {
         use anyhow::anyhow;
 
-        // Consume entries so `lid`/`phone_number` move into storage rather
-        // than being cloned. Only `learning_source` is allocated, and only
-        // because `LidPnMappingEntry.learning_source` is a `String` field.
+        // The storage row copies `lid`/`phone_number` into `String`s because
+        // `LidPnMappingEntry` is a `String` type; the cache's persisted marker
+        // keeps sharing the entry's `Arc<str>` pair instead.
         let storage: Vec<LidPnMappingEntry> = entries
-            .into_iter()
+            .iter()
             .map(|entry| LidPnMappingEntry {
                 lid: entry.lid.to_string(),
                 phone_number: entry.phone_number.to_string(),
@@ -637,7 +637,7 @@ impl Client {
             .await
             .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
 
-        for entry in &storage {
+        for entry in &entries {
             self.lid_pn_cache
                 .mark_persisted(&entry.phone_number, &entry.lid)
                 .await;
@@ -1645,7 +1645,10 @@ mod tests {
             .await;
         assert_eq!(retry.migration_flags, vec![true]);
 
-        client.lid_pn_cache.mark_persisted(phone, lid).await;
+        client
+            .lid_pn_cache
+            .mark_persisted(&Arc::from(phone), &Arc::from(lid))
+            .await;
         let durable = client
             .record_lid_pn_batch_in_memory(mapping(), LearningSource::Other)
             .await;

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -308,9 +308,12 @@ impl LidPnCache {
             .is_some_and(|stored| stored.as_ref() == lid)
     }
 
-    pub(crate) async fn mark_persisted(&self, phone: &str, lid: &str) {
+    /// Takes the entry's own identifiers: this map holds one pair per
+    /// persisted contact for the process lifetime, so re-allocating both
+    /// strings here would duplicate every mapping's payload a third time.
+    pub(crate) async fn mark_persisted(&self, phone: &Arc<str>, lid: &Arc<str>) {
         self.persisted
-            .insert(Arc::from(phone), Arc::from(lid))
+            .insert(Arc::clone(phone), Arc::clone(lid))
             .await;
     }
 
@@ -560,7 +563,9 @@ mod tests {
         let pn = "559980000099";
         let (lid_a, lid_b) = ("100000000000001", "100000000000002");
         assert!(!cache.is_persisted(pn, lid_a).await);
-        cache.mark_persisted(pn, lid_a).await;
+        cache
+            .mark_persisted(&Arc::from(pn), &Arc::from(lid_a))
+            .await;
         assert!(cache.is_persisted(pn, lid_a).await);
         // A remap to a new LID is not persisted (even a stale mark of the old
         // LID never satisfies the new pair), so it re-persists.
@@ -578,7 +583,7 @@ mod tests {
                 LearningSource::PeerPnMessage,
             ))
             .await;
-        cache.mark_persisted(pn, lid).await;
+        cache.mark_persisted(&Arc::from(pn), &Arc::from(lid)).await;
         assert!(cache.can_skip_relearn(pn, lid).await);
 
         // Evict the reverse (LID -> PN) entry: the fast path must stop skipping

--- a/src/pending_device_sync.rs
+++ b/src/pending_device_sync.rs
@@ -34,8 +34,11 @@ impl PendingDeviceSync {
         }
     }
 
+    /// Takes the set's allocation with it: the queue fills during an offline
+    /// drain and is empty the rest of the process lifetime, so `drain` would
+    /// pin the high-water table for nothing.
     pub(crate) fn take_all(&self) -> Vec<Jid> {
-        self.lock().drain().collect()
+        std::mem::take(&mut *self.lock()).into_iter().collect()
     }
 
     /// Users queued for the next `doPendingDeviceSync`, plus the users an

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -2546,11 +2546,25 @@ impl Client {
             .await
             {
                 Ok(prepared) => {
-                    skdm_update = Some(SkdmUpdate {
-                        to_str: to_str.clone(),
-                        devices: prepared.skdm_devices,
-                        stale_users: prepared.stale_device_users,
-                    });
+                    // Own devices are never marked warm (see
+                    // `update_sender_key_devices`), so an own-only SKDM set —
+                    // every warm send — would only be filtered back to nothing
+                    // after a device snapshot; skip building the update for it.
+                    let devices = if skdm_needs_only_own_devices(
+                        &prepared.skdm_devices,
+                        Some(own_jid),
+                        Some(own_lid),
+                    ) {
+                        Vec::new()
+                    } else {
+                        prepared.skdm_devices
+                    };
+                    skdm_update = (!devices.is_empty() || !prepared.stale_device_users.is_empty())
+                        .then(|| SkdmUpdate {
+                            to_str,
+                            devices,
+                            stale_users: prepared.stale_device_users,
+                        });
                     outbound_msg_secret = prepared.message_secret;
                     outbound_group_sender_identity = Some(prepared.sender_identity);
                     group_ack_phash = prepared.phash;

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -799,7 +799,9 @@ fn setup_session_with_backlog() -> SessionRecord {
     futures::executor::block_on(async {
         let mut rng = bench_rng();
         let mut last = Vec::new();
-        for _ in 0..=SERIALIZE_BACKLOG {
+        // The setup's own in-order message is already undelivered, so it is
+        // one of the backlog.
+        for _ in 0..SERIALIZE_BACKLOG {
             let msg = message_encrypt(
                 b"skipped",
                 &bob.address,
@@ -811,7 +813,8 @@ fn setup_session_with_backlog() -> SessionRecord {
             last = msg.serialize().to_vec();
         }
         let last = CiphertextMessage::SignalMessage(
-            wacore_libsignal::protocol::SignalMessage::try_from(last.as_slice()).unwrap(),
+            wacore_libsignal::protocol::SignalMessage::try_from(last.as_slice())
+                .expect("parse the last message"),
         );
         message_decrypt(
             &last,

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -786,6 +786,106 @@ fn bench_group_decrypt_message(bencher: divan::Bencher) {
         });
 }
 
+/// Backlog depth a store flush re-encodes for a chain receiving out of order:
+/// a busy group after an offline window. Deep enough that the per-key cost
+/// dominates the fixed record cost, well under both caps.
+const SERIALIZE_BACKLOG: usize = 200;
+
+/// Bob's session after Alice sent `SERIALIZE_BACKLOG + 1` messages of which
+/// only the last arrived, so his receiver chain holds the backlog.
+fn setup_session_with_backlog() -> SessionRecord {
+    let (mut alice, mut bob, _) = setup_dm_with_inorder_subsequent_message();
+
+    futures::executor::block_on(async {
+        let mut rng = bench_rng();
+        let mut last = Vec::new();
+        for _ in 0..=SERIALIZE_BACKLOG {
+            let msg = message_encrypt(
+                b"skipped",
+                &bob.address,
+                &mut alice.session_store,
+                &mut alice.identity_store,
+            )
+            .await
+            .expect("alice encrypt");
+            last = msg.serialize().to_vec();
+        }
+        let last = CiphertextMessage::SignalMessage(
+            wacore_libsignal::protocol::SignalMessage::try_from(last.as_slice()).unwrap(),
+        );
+        message_decrypt(
+            &last,
+            &alice.address,
+            &mut bob.session_store,
+            &mut bob.identity_store,
+            &mut bob.prekey_store,
+            &bob.signed_prekey_store,
+            &mut rng,
+            UsePQRatchet::No,
+        )
+        .await
+        .expect("bob decrypts the last message");
+
+        bob.session_store
+            .load_session(&alice.address)
+            .await
+            .expect("load session")
+            .expect("session exists")
+    })
+}
+
+/// Store-flush cost of a session with a skipped-key backlog. The empty-backlog
+/// case is a borrow of the in-memory protobuf; this is the path that rebuilds it.
+#[divan::bench]
+fn bench_session_serialize_with_backlog(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_session_with_backlog)
+        .bench_refs(|record| black_box(record.serialize().expect("serialize session")));
+}
+
+/// Bob's sender key state after Alice encrypted `SERIALIZE_BACKLOG + 1` group
+/// messages of which only the last arrived.
+fn setup_sender_key_with_backlog() -> SenderKeyRecord {
+    let (mut alice, mut bob, sender_key_name) = setup_group_with_distribution();
+
+    futures::executor::block_on(async {
+        let mut rng = bench_rng();
+        let mut last = Vec::new();
+        for _ in 0..=SERIALIZE_BACKLOG {
+            let skm = group_encrypt(
+                &mut alice.sender_key_store,
+                &sender_key_name,
+                b"skipped",
+                &mut rng,
+            )
+            .await
+            .expect("group encrypt");
+            last = skm.serialized().to_vec();
+        }
+        let bob_sender_key_name = SenderKeyName::new(
+            sender_key_name.group_id().to_string(),
+            alice.address.name().to_string(),
+        );
+        group_decrypt(&last, &mut bob.sender_key_store, &bob_sender_key_name)
+            .await
+            .expect("bob decrypts the last message");
+
+        bob.sender_key_store
+            .load_sender_key(&bob_sender_key_name)
+            .await
+            .expect("load sender key")
+            .expect("sender key exists")
+    })
+}
+
+/// Store-flush cost of a sender key record with a skipped-key backlog.
+#[divan::bench]
+fn bench_sender_key_serialize_with_backlog(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_sender_key_with_backlog)
+        .bench_refs(|record| black_box(record.serialize().expect("serialize sender key")));
+}
+
 fn setup_conversation_data() -> (User, User) {
     setup_dm_users()
 }

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 
 use buffa::MessageField;
 
-use hmac::{HmacReset, KeyInit, Mac};
+use hmac::{Hmac, HmacReset, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::protocol::counter_lease::CounterLease;
@@ -40,10 +40,23 @@ pub struct SenderMessageKey {
     seed: [u8; 32],
 }
 
+/// Group message keys run HKDF with no salt, so the extract step is HMAC
+/// keyed by a constant zero block. Same trick as `MESSAGE_KEY_EXTRACT_HMAC`
+/// on the pairwise ratchet: cloning the keyed state skips the ipad/opad key
+/// schedule (two SHA-256 compressions) on every group encrypt, every group
+/// decrypt, and every skipped key a forward jump buffers.
+static GROUP_KEY_EXTRACT_HMAC: std::sync::LazyLock<Hmac<Sha256>> = std::sync::LazyLock::new(|| {
+    Hmac::<Sha256>::new_from_slice(&[0u8; 32]).expect("32-byte HMAC key")
+});
+
 impl SenderMessageKey {
     pub fn new(iteration: u32, seed: [u8; 32]) -> Self {
+        let mut extract = GROUP_KEY_EXTRACT_HMAC.clone();
+        extract.update(&seed);
+        let prk = extract.finalize().into_bytes();
         let mut derived = [0u8; 48];
-        hkdf::Hkdf::<Sha256>::new(None, &seed)
+        hkdf::Hkdf::<Sha256>::from_prk(&prk)
+            .expect("PRK is hash-sized")
             .expand(b"WhisperGroup", &mut derived)
             .expect("valid output length");
         Self {
@@ -1009,6 +1022,26 @@ fn state_structure_pointed_bytes(state: &SenderKeyStateStructure) -> usize {
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
+    /// The cached zero-key extract must stay byte-identical to
+    /// `Hkdf::new(None, seed)`, or every group message key would desync
+    /// from the peer.
+    #[test]
+    fn sender_message_key_matches_plain_hkdf() {
+        for i in 0..16u8 {
+            let seed = [i.wrapping_mul(31).wrapping_add(7); 32];
+            let key = super::SenderMessageKey::new(u32::from(i), seed);
+
+            let mut derived = [0u8; 48];
+            hkdf::Hkdf::<sha2::Sha256>::new(None, &seed)
+                .expand(b"WhisperGroup", &mut derived)
+                .expect("valid output length");
+
+            assert_eq!(key.iv(), &derived[0..16]);
+            assert_eq!(key.cipher_key(), &derived[16..48]);
+            assert_eq!(key.iteration(), u32::from(i));
+        }
+    }
+
     use super::*;
     // The protobuf encode helpers are only needed to build fixtures here; the
     // module itself no longer encodes anything.

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -106,11 +106,24 @@ impl StoredMessageKey {
         }
     }
 
-    fn as_protobuf(&self) -> sender_key_state_structure::SenderMessageKey {
-        sender_key_state_structure::SenderMessageKey {
-            iteration: Some(self.iteration),
-            seed: Some(bytes::Bytes::copy_from_slice(&self.seed)),
+    /// The backlog as protobuf entries, with every seed a slice of one shared
+    /// buffer: a store flush re-encodes the whole backlog of every dirty state,
+    /// and a busy group's out-of-order window is hundreds of keys, so one
+    /// allocation per key per flush was the dominant flush cost. `Bytes::slice`
+    /// is a refcount bump.
+    fn as_protobuf_list(keys: &[Self]) -> Vec<sender_key_state_structure::SenderMessageKey> {
+        let mut seeds = bytes::BytesMut::with_capacity(keys.len() * 32);
+        for key in keys {
+            seeds.extend_from_slice(&key.seed);
         }
+        let seeds = seeds.freeze();
+        keys.iter()
+            .enumerate()
+            .map(|(i, key)| sender_key_state_structure::SenderMessageKey {
+                iteration: Some(key.iteration),
+                seed: Some(seeds.slice(i * 32..(i + 1) * 32)),
+            })
+            .collect()
     }
 }
 
@@ -554,11 +567,7 @@ impl SenderKeyState {
             "backlog and chain key must live only in their Copy/Arc fields; the protobuf copies stay empty"
         );
         let mut state = self.state.clone();
-        state.sender_message_keys = self
-            .message_keys
-            .iter()
-            .map(StoredMessageKey::as_protobuf)
-            .collect();
+        state.sender_message_keys = StoredMessageKey::as_protobuf_list(&self.message_keys);
         state.sender_chain_key = self
             .sender_chain
             .as_ref()
@@ -574,10 +583,7 @@ impl SenderKeyState {
         );
         let message_keys = std::sync::Arc::try_unwrap(self.message_keys)
             .unwrap_or_else(|shared| shared.as_ref().clone());
-        self.state.sender_message_keys = message_keys
-            .iter()
-            .map(StoredMessageKey::as_protobuf)
-            .collect();
+        self.state.sender_message_keys = StoredMessageKey::as_protobuf_list(&message_keys);
         self.state.sender_chain_key = self
             .sender_chain
             .as_ref()

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -1029,10 +1029,10 @@ mod tests {
     fn sender_message_key_matches_plain_hkdf() {
         for i in 0..16u8 {
             let seed = [i.wrapping_mul(31).wrapping_add(7); 32];
-            let key = super::SenderMessageKey::new(u32::from(i), seed);
+            let key = SenderMessageKey::new(u32::from(i), seed);
 
             let mut derived = [0u8; 48];
-            hkdf::Hkdf::<sha2::Sha256>::new(None, &seed)
+            hkdf::Hkdf::<Sha256>::new(None, &seed)
                 .expand(b"WhisperGroup", &mut derived)
                 .expect("valid output length");
 

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -132,13 +132,40 @@ impl SkippedKey {
         }
     }
 
-    fn to_pb(&self) -> session_structure::chain::MessageKey {
-        match self {
-            Self::Seed { index, seed } => {
-                MessageKeyGenerator::new_from_seed(seed, *index).into_pb()
+    /// A chain's backlog as protobuf entries, every seed-only key sliced out
+    /// of one shared buffer: a store flush re-encodes the backlog of every
+    /// dirty chain, and after an offline drain that is hundreds of keys, so an
+    /// allocation per key per flush was the dominant flush cost. Legacy keys
+    /// keep their boxed protobuf and clone it as before.
+    fn to_pb_list(keys: &[Self]) -> Vec<session_structure::chain::MessageKey> {
+        let seed_count = keys
+            .iter()
+            .filter(|key| matches!(key, Self::Seed { .. }))
+            .count();
+        let mut seeds = bytes::BytesMut::with_capacity(seed_count * 32);
+        for key in keys {
+            if let Self::Seed { seed, .. } = key {
+                seeds.extend_from_slice(seed);
             }
-            Self::Legacy(pb) => (**pb).clone(),
         }
+        let seeds = seeds.freeze();
+        let mut next_seed = 0;
+        keys.iter()
+            .map(|key| match key {
+                Self::Seed { index, .. } => {
+                    let seed = seeds.slice(next_seed..next_seed + 32);
+                    next_seed += 32;
+                    session_structure::chain::MessageKey {
+                        cipher_key: None,
+                        mac_key: None,
+                        iv: None,
+                        index: Some(*index),
+                        seed: Some(seed),
+                    }
+                }
+                Self::Legacy(pb) => (**pb).clone(),
+            })
+            .collect()
     }
 
     /// Heap bytes hanging off this key: only the legacy arm owns any.
@@ -273,7 +300,7 @@ impl SessionState {
     fn fill_skipped(session: &mut SessionStructure, skipped: &[SkippedKeys]) {
         for (chain, keys) in session.receiver_chains.iter_mut().zip(skipped) {
             if let Some(keys) = keys {
-                chain.message_keys = keys.iter().map(SkippedKey::to_pb).collect();
+                chain.message_keys = SkippedKey::to_pb_list(keys);
             }
         }
     }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -164,6 +164,16 @@ pub fn needs_device_identity(
 /// 16 on Oracle ARM64; 32 gives only ~10% more for double the task overhead.
 const ENCRYPT_FANOUT_CONCURRENCY: usize = 16;
 
+/// Recipient-device count up to which a send encrypts inline instead of
+/// fanning out. Five is a 1:1 recipient's ceiling (primary plus four
+/// companions), and at that size the fan-out is a net loss: an `Arc<[u8]>`
+/// copy of the plaintext, a task + oneshot per chunk, and two store clones per
+/// chunk against ~2 µs of pairwise crypto per device. `bench_dm_send_5_way_fanout`
+/// measured 77 µs spawned vs. 69 µs inline; the plateau above (8 devices inline)
+/// was within noise of 5, so the DM ceiling is the threshold rather than a tuned
+/// number.
+const INLINE_ENCRYPT_DEVICES: usize = 5;
+
 /// What one session-establishment task did with its device, shipped back to the
 /// orchestrator because a spawned task holds no borrow of the resolver.
 enum SessionOutcome {
@@ -1118,31 +1128,30 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
     // The wire-order of `<to>` participants does not need to match the input
     // device order: WA Web's `phash` (computed both client and server side)
     // sorts before hashing, as does our `participant_list_hash`.
-    if devices.len() == 1 {
-        // Single recipient device: the parallel fan-out is pure overhead here
-        // (an Arc<[u8]> copy of the plaintext, a spawned task + oneshot channel,
-        // a FuturesUnordered, and two store clones), with no parallelism to gain.
-        // Encrypt inline.
-        let device_jid = devices[0].clone();
-        let addr = encryption_override_at(&encryption_overrides, 0)
-            .unwrap_or(&devices[0])
-            .to_protocol_address();
-        let res = encrypt_one_device(
-            plaintext_to_encrypt,
-            &addr,
-            &mut *stores.session_store,
-            &mut *stores.identity_store,
-            device_jid,
-        )
-        .await;
-        push_raw_result(
-            res,
-            &mut encrypted,
-            &mut includes_prekey_message,
-            &mut first_error,
-            &unkeyed_devices,
-            &mut unkeyed_at_encrypt,
-        );
+    if devices.len() <= INLINE_ENCRYPT_DEVICES {
+        // Rationale on the constant: no parallelism worth its spawn cost at
+        // this size, so encrypt sequentially on the caller's task.
+        for (idx, device) in devices.iter().enumerate() {
+            let addr = encryption_override_at(&encryption_overrides, idx)
+                .unwrap_or(device)
+                .to_protocol_address();
+            let res = encrypt_one_device(
+                plaintext_to_encrypt,
+                &addr,
+                &mut *stores.session_store,
+                &mut *stores.identity_store,
+                device.clone(),
+            )
+            .await;
+            push_raw_result(
+                res,
+                &mut encrypted,
+                &mut includes_prekey_message,
+                &mut first_error,
+                &unkeyed_devices,
+                &mut unkeyed_at_encrypt,
+            );
+        }
     } else {
         // One task per chunk, not per device: the per-device fan-out allocated a
         // task + oneshot + two store clones for every recipient. Same parallelism,

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -1129,8 +1129,6 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
     // device order: WA Web's `phash` (computed both client and server side)
     // sorts before hashing, as does our `participant_list_hash`.
     if devices.len() <= INLINE_ENCRYPT_DEVICES {
-        // Rationale on the constant: no parallelism worth its spawn cost at
-        // this size, so encrypt sequentially on the caller's task.
         for (idx, device) in devices.iter().enumerate() {
             let addr = encryption_override_at(&encryption_overrides, idx)
                 .unwrap_or(device)


### PR DESCRIPTION
Follow-up to #1389 / #1390 / #1392, from a parallel exploration of the send path, Signal persistence and the caches. Every item was measured; the ones that moved wall time are called out, the rest are allocation-count wins and are labelled as such.

## Measured

**Encrypt inline up to the DM device ceiling** (`wacore/src/send/encrypt.rs`). The fan-out spawned a task + oneshot + two store clones per chunk and copied the padded plaintext into an `Arc<[u8]>` for any recipient set larger than one device. For 2–5 devices that is a net loss against ~2 µs of pairwise crypto per device. `INLINE_ENCRYPT_DEVICES = 5` (primary plus four companions, a 1:1 recipient's ceiling) now encrypts sequentially on the caller's task; larger sets keep the bounded fan-out.

| bench (`wacore/benches/send_receive_benchmark.rs`) | before | after |
| --- | --- | --- |
| `bench_dm_send_5_way_fanout` | 77.3 / 77.7 µs | 71.8 / 70.0 µs |
| `bench_dm_send` (1 device, unchanged path) | 34.7 µs | 34.3–35.0 µs |

## Allocation-only (wall time within noise)

- **Skipped-key backlogs encode with one allocation per state/chain.** Every flush re-encodes the backlog of each dirty sender-key state and session chain, and each seed was a fresh 32-byte `Bytes`. `StoredMessageKey::as_protobuf_list` and `SkippedKey::to_pb_list` build one shared buffer and hand out `Bytes::slice` views (200 allocations → 1 for a 200-key backlog). Two new benches in `wacore/libsignal/benches/libsignal_benchmark.rs` (`bench_session_serialize_with_backlog`, `bench_sender_key_serialize_with_backlog`) pin the path: ~11 µs / ~14.5 µs before and after, so the protobuf encode dominates and this is not a latency win.
- **Warm group sends skip the no-op `SkdmUpdate`.** An own-devices-only SKDM set (the warm steady state) was cloned into an update that `update_sender_key_devices` filtered back to empty after taking a device snapshot. The `to_str` clone goes with it. `warm_group_send` 8–512: unchanged within noise.
- **Cached zero-salt HKDF extract for group message keys** (`SenderMessageKey::new`), the same pattern `MESSAGE_KEY_EXTRACT_HMAC` already uses for pairwise keys, with a test asserting byte-equality against plain `Hkdf::new(None, seed)`. Within noise on `bench_group_decrypt_message`.
- **`LidPnCache::mark_persisted` shares the entry's `Arc<str>` pair** instead of re-allocating both identifiers for every persisted contact (this map lives for the process lifetime).
- **`PendingDeviceSync::take_all` releases the high-water table** (`mem::take` instead of `drain`), since the set fills only during an offline drain.

## Explored and refuted (not in this PR)

- `is_lid_migrated` per DM: migrated accounts short-circuit on the cached device snapshot; the ab-props lock is only read for unmigrated ones.
- Deduplicating the second `SenderKeyName` / `own_lid` clone in `prepare_group_stanza`: ~200 ns, and threading it through the request touches 17 call sites.
- Batch deletes in the Signal flush and the redundant `device_id` indexes are real but only hit offline drains / identity resets; left for a persistence-focused PR with its own fixture.

## Verification

- `cargo clippy -p wacore-libsignal -p wacore -p whatsapp-rust --all-targets --features bench-harness -- -D warnings` clean
- `cargo test -p wacore-libsignal --lib` (242), `cargo test -p wacore --lib send::` (153), `cargo test -p whatsapp-rust --lib -- lid_pn pending_device_sync send:: sender_key` (264) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_