### PR TITLE
perf(appstate): inline external blobs once, hand them out as Bytes, move actions into events

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -1493,7 +1493,8 @@ mod tests {
             error: None,
         };
 
-        let download = |_ext: &wa::ExternalBlobReference| -> anyhow::Result<Vec<u8>> {
+        let snapshot_bytes = bytes::Bytes::from(snapshot_bytes);
+        let download = |_ext: &wa::ExternalBlobReference| -> anyhow::Result<bytes::Bytes> {
             Ok(snapshot_bytes.clone())
         };
 

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -831,7 +831,7 @@ impl Client {
     async fn pre_download_external_blobs(
         &self,
         patch_lists: &[wacore::appstate::patch_decode::PatchList],
-    ) -> HashMap<String, Vec<u8>> {
+    ) -> HashMap<String, bytes::Bytes> {
         use futures::StreamExt;
 
         // Kept only so a failed download logs the right message (snapshot vs patch).
@@ -891,7 +891,9 @@ impl Client {
                         debug!(target: "Client/AppState", "Downloaded external snapshot ({} bytes)", bytes.len());
                     }
                     if let Some(path) = path {
-                        pre_downloaded.insert(path, bytes);
+                        // `Bytes::from(Vec)` moves; the resolvers below then
+                        // hand out refcounts instead of copying the blob.
+                        pre_downloaded.insert(path, bytes::Bytes::from(bytes));
                     }
                 }
                 Err(e) => match kind {
@@ -2125,7 +2127,7 @@ impl Client {
             // concurrently (independent CDN GETs, keyed by directPath).
             let pre_downloaded = self.pre_download_external_blobs(&patch_lists).await;
 
-            let download = |ext: &wa::ExternalBlobReference| -> Result<Vec<u8>> {
+            let download = |ext: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
                 if let Some(path) = &ext.direct_path {
                     if let Some(bytes) = pre_downloaded.get(path) {
                         Ok(bytes.clone())
@@ -2323,8 +2325,8 @@ impl Client {
                 // the set, which is what keeps it from reading as a full sync.
                 let full_sync = replaying_snapshot.contains(&name);
                 wacore::telemetry::appstate_mutations(mutations.len() as u64);
-                for m in mutations {
-                    self.dispatch_app_state_mutation(&m, full_sync).await;
+                for mut m in mutations {
+                    self.dispatch_app_state_mutation(&mut m, full_sync).await;
                 }
 
                 // No version write here. `process_one_patch_list` already
@@ -2512,7 +2514,7 @@ impl Client {
                 .pre_download_external_blobs(std::slice::from_ref(&pl))
                 .await;
 
-            let download = |ext: &wa::ExternalBlobReference| -> Result<Vec<u8>> {
+            let download = |ext: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
                 if let Some(path) = &ext.direct_path {
                     if let Some(bytes) = pre_downloaded.get(path) {
                         Ok(bytes.clone())
@@ -2577,9 +2579,9 @@ impl Client {
                 .await;
 
             wacore::telemetry::appstate_mutations(mutations.len() as u64);
-            for m in mutations {
+            for mut m in mutations {
                 debug!(target: "Client/AppState", "Dispatching mutation kind={} index_len={} full_sync={}", m.index.first().map(|s| s.as_str()).unwrap_or(""), m.index.len(), full_sync);
-                self.dispatch_app_state_mutation(&m, full_sync).await;
+                self.dispatch_app_state_mutation(&mut m, full_sync).await;
             }
 
             // A collection the server refused advances nothing: the processor
@@ -3142,7 +3144,7 @@ impl Client {
             let pre_downloaded = self
                 .pre_download_external_blobs(std::slice::from_ref(&list))
                 .await;
-            let download = |ext: &wa::ExternalBlobReference| -> Result<Vec<u8>> {
+            let download = |ext: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
                 let path = ext
                     .direct_path
                     .as_ref()
@@ -3161,8 +3163,8 @@ impl Client {
                 // clean apply.
                 Ok((mutations, _, list)) => {
                     wacore::telemetry::appstate_mutations(mutations.len() as u64);
-                    for m in &mutations {
-                        self.dispatch_app_state_mutation(m, false).await;
+                    for mut m in mutations {
+                        self.dispatch_app_state_mutation(&mut m, false).await;
                     }
                     if let Some(refused) = &list.error {
                         debug!(
@@ -3433,8 +3435,8 @@ impl Client {
                 // would lose a mute or an archive for good. And what they
                 // describe is the account, not the session that learned it,
                 // which is why the ordinary sync path dispatches the same way.
-                for m in &mutations {
-                    self.dispatch_app_state_mutation(m, true).await;
+                for mut m in mutations {
+                    self.dispatch_app_state_mutation(&mut m, true).await;
                 }
             }
             Ok(wacore::appstate_sync::RecoveryOutcome::Retired) => {
@@ -3548,9 +3550,12 @@ impl Client {
         }
     }
 
+    /// `&mut` so a dispatcher can move the action out of the mutation into
+    /// its event instead of deep-cloning it: a full sync dispatches every
+    /// mutation of every collection through here.
     pub(crate) async fn dispatch_app_state_mutation(
         &self,
-        m: &crate::appstate_sync::Mutation,
+        m: &mut crate::appstate_sync::Mutation,
         full_sync: bool,
     ) {
         use wacore::types::events::Event;

--- a/src/features/app_state_settings.rs
+++ b/src/features/app_state_settings.rs
@@ -19,7 +19,7 @@ use waproto::whatsapp as wa;
 /// Returns `true` if handled, `false` if the mutation is not one of them.
 pub(crate) fn dispatch_app_state_setting_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
-    m: &Mutation,
+    m: &mut Mutation,
     full_sync: bool,
 ) -> bool {
     if m.operation != wa::syncd_mutation::SyncdOperation::Set
@@ -37,15 +37,15 @@ pub(crate) fn dispatch_app_state_setting_mutation(
 
     // WA Web counts a mutation whose `isPreviewsDisabled` is absent as a
     // malformed action value and applies nothing, so there is no flag to report.
-    if let Some(val) = &m.action_value
-        && let Some(act) = val.privacy_setting_disable_link_previews_action.as_option()
+    if let Some(val) = &mut m.action_value
+        && let Some(act) = val.privacy_setting_disable_link_previews_action.take()
         && let Some(disabled) = act.is_previews_disabled
     {
         event_bus.dispatch(Event::DisableLinkPreviewsUpdate(
             DisableLinkPreviewsUpdate::builder()
                 .previews_disabled(disabled)
                 .timestamp(time)
-                .action(Box::new(act.clone()))
+                .action(Box::new(act))
                 .from_full_sync(full_sync)
                 .build(),
         ));
@@ -125,7 +125,7 @@ mod tests {
         let bus = CoreEventBus::new();
         let rec = Arc::new(Recorder::default());
         bus.subscribe_handler(rec.clone()).detach();
-        let handled = dispatch_app_state_setting_mutation(&bus, m, false);
+        let handled = dispatch_app_state_setting_mutation(&bus, &mut m.clone(), false);
         let events = rec.events.lock().unwrap().clone();
         (handled, events)
     }

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -54,7 +54,7 @@ use waproto::whatsapp as wa;
 /// it on the mutations it is not.
 pub(crate) fn dispatch_call_log_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
-    m: &Mutation,
+    m: &mut Mutation,
     full_sync: bool,
     is_own_jid: impl FnOnce(&Jid) -> bool,
 ) -> bool {
@@ -93,9 +93,9 @@ pub(crate) fn dispatch_call_log_mutation(
 
     let Some(record) = m
         .action_value
-        .as_ref()
-        .and_then(|value| value.call_log_action.as_option())
-        .and_then(|action| action.call_log_record.as_option())
+        .as_mut()
+        .and_then(|value| value.call_log_action.as_option_mut())
+        .and_then(|action| action.call_log_record.take())
     else {
         log::warn!("Skipping call_log mutation for {call_id}: missing record in action value");
         return true;
@@ -107,7 +107,7 @@ pub(crate) fn dispatch_call_log_mutation(
             .call_id(call_id)
             .from_me(from_me)
             .timestamp(timestamp)
-            .record(Box::new(record.clone()))
+            .record(Box::new(record))
             .from_full_sync(full_sync)
             .build(),
     ));
@@ -179,7 +179,8 @@ mod tests {
         let bus = CoreEventBus::new();
         let recorder = Arc::new(Recorder::default());
         bus.subscribe_handler(recorder.clone()).detach();
-        let handled = dispatch_call_log_mutation(&bus, mutation, full_sync, is_own_jid);
+        let handled =
+            dispatch_call_log_mutation(&bus, &mut mutation.clone(), full_sync, is_own_jid);
         let events = recorder.events.lock().unwrap().clone();
         (handled, events)
     }

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -82,7 +82,7 @@ pub fn message_key(
 /// Returns `true` if handled, `false` if unknown (so other handlers can try).
 pub(crate) fn dispatch_chat_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
-    m: &Mutation,
+    m: &mut Mutation,
     full_sync: bool,
 ) -> bool {
     if m.index.is_empty() {
@@ -145,14 +145,14 @@ pub(crate) fn dispatch_chat_mutation(
 
     match kind.as_str() {
         "mute" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.mute_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.mute_action.take()
             {
                 event_bus.dispatch(Event::MuteUpdate(
                     MuteUpdate::builder()
                         .jid(jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -160,14 +160,14 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "pin" | "pin_v1" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.pin_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.pin_action.take()
             {
                 event_bus.dispatch(Event::PinUpdate(
                     PinUpdate::builder()
                         .jid(jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -175,14 +175,14 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "archive" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.archive_chat_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.archive_chat_action.take()
             {
                 event_bus.dispatch(Event::ArchiveUpdate(
                     ArchiveUpdate::builder()
                         .jid(jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -190,8 +190,8 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "star" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.star_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.star_action.take()
                 && let Some((message_id, from_me, participant_jid)) =
                     parse_message_key_fields(kind, &m.index)
             {
@@ -202,7 +202,7 @@ pub(crate) fn dispatch_chat_mutation(
                         .message_id(message_id)
                         .from_me(from_me)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -220,14 +220,14 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "contact" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.contact_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.contact_action.take()
             {
                 event_bus.dispatch(Event::ContactUpdate(
                     ContactUpdate::builder()
                         .jid(jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -235,14 +235,14 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "mark_chat_as_read" | "markChatAsRead" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.mark_chat_as_read_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.mark_chat_as_read_action.take()
             {
                 event_bus.dispatch(Event::MarkChatAsReadUpdate(
                     MarkChatAsReadUpdate::builder()
                         .jid(jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -250,8 +250,8 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "deleteChat" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.delete_chat_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.delete_chat_action.take()
             {
                 // delete_media is in index[2], not in the proto (which only has messageRange)
                 let delete_media = m.index.get(2).is_none_or(|v| v != "0");
@@ -260,7 +260,7 @@ pub(crate) fn dispatch_chat_mutation(
                         .jid(jid)
                         .delete_media(delete_media)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -268,8 +268,8 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "clearChat" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.clear_chat_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.clear_chat_action.take()
             {
                 // deleteStarred/deleteMedia live in the index (index[2]/index[3]),
                 // not in ClearChatAction (which only has messageRange). WA Web's send
@@ -282,7 +282,7 @@ pub(crate) fn dispatch_chat_mutation(
                         .delete_starred(delete_starred)
                         .delete_media(delete_media)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -290,15 +290,15 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "userStatusMute" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.user_status_mute_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.user_status_mute_action.take()
             {
                 event_bus.dispatch(Event::UserStatusMuteUpdate(
                     UserStatusMuteUpdate::builder()
                         .jid(jid)
                         .muted(act.muted.unwrap_or(false))
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -306,8 +306,8 @@ pub(crate) fn dispatch_chat_mutation(
             true
         }
         "deleteMessageForMe" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.delete_message_for_me_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.delete_message_for_me_action.take()
                 && let Some((message_id, from_me, participant_jid)) =
                     parse_message_key_fields(kind, &m.index)
             {
@@ -318,7 +318,7 @@ pub(crate) fn dispatch_chat_mutation(
                         .message_id(message_id)
                         .from_me(from_me)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -1323,7 +1323,7 @@ mod registry_tests {
         let seen: Arc<Mutex<Vec<Arc<Event>>>> = Arc::new(Mutex::new(Vec::new()));
         bus.subscribe_handler(Arc::new(Recorder(seen.clone())))
             .detach();
-        let handled = dispatch_chat_mutation(&bus, m, full_sync);
+        let handled = dispatch_chat_mutation(&bus, &mut m.clone(), full_sync);
         let events = seen.lock().unwrap().clone();
         (handled, events)
     }

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -27,7 +27,7 @@ use waproto::whatsapp as wa;
 /// Returns `true` if handled, `false` if the mutation is not a label kind.
 pub(crate) fn dispatch_label_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
-    m: &Mutation,
+    m: &mut Mutation,
     full_sync: bool,
 ) -> bool {
     if m.operation != wa::syncd_mutation::SyncdOperation::Set || m.index.is_empty() {
@@ -53,14 +53,14 @@ pub(crate) fn dispatch_label_mutation(
 
     match kind {
         "label_edit" => {
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.label_edit_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.label_edit_action.take()
             {
                 event_bus.dispatch(Event::LabelEditUpdate(
                     LabelEditUpdate::builder()
                         .label_id(label_id)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -78,8 +78,8 @@ pub(crate) fn dispatch_label_mutation(
                 log::warn!("Skipping label_message mutation: missing or empty message id in index");
                 return true;
             };
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.label_association_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.label_association_action.take()
             {
                 event_bus.dispatch(Event::MessageLabelAssociationUpdate(
                     MessageLabelAssociationUpdate::builder()
@@ -87,7 +87,7 @@ pub(crate) fn dispatch_label_mutation(
                         .chat_jid(chat_jid)
                         .message_id(message_id)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -98,15 +98,15 @@ pub(crate) fn dispatch_label_mutation(
             let Some(chat_jid) = parse_association_chat_jid(kind, &m.index) else {
                 return true;
             };
-            if let Some(val) = &m.action_value
-                && let Some(act) = val.label_association_action.as_option()
+            if let Some(val) = &mut m.action_value
+                && let Some(act) = val.label_association_action.take()
             {
                 event_bus.dispatch(Event::LabelAssociationUpdate(
                     LabelAssociationUpdate::builder()
                         .label_id(label_id)
                         .chat_jid(chat_jid)
                         .timestamp(time)
-                        .action(Box::new(act.clone()))
+                        .action(Box::new(act))
                         .from_full_sync(full_sync)
                         .build(),
                 ));
@@ -376,7 +376,7 @@ mod tests {
         let bus = CoreEventBus::new();
         let rec = Arc::new(Recorder::default());
         bus.subscribe_handler(rec.clone()).detach();
-        let handled = dispatch_label_mutation(&bus, m, false);
+        let handled = dispatch_label_mutation(&bus, &mut m.clone(), false);
         let events = rec.events.lock().unwrap().clone();
         (handled, events)
     }

--- a/src/features/quick_replies.rs
+++ b/src/features/quick_replies.rs
@@ -22,7 +22,7 @@ use waproto::whatsapp as wa;
 /// Returns `true` if handled, `false` if the mutation is not a quick reply.
 pub(crate) fn dispatch_quick_reply_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
-    m: &Mutation,
+    m: &mut Mutation,
     full_sync: bool,
 ) -> bool {
     if m.operation != wa::syncd_mutation::SyncdOperation::Set
@@ -43,14 +43,14 @@ pub(crate) fn dispatch_quick_reply_mutation(
         .unwrap_or(0);
     let time = wacore::time::from_millis_or_now(ts);
 
-    if let Some(val) = &m.action_value
-        && let Some(act) = val.quick_reply_action.as_option()
+    if let Some(val) = &mut m.action_value
+        && let Some(act) = val.quick_reply_action.take()
     {
         event_bus.dispatch(Event::QuickReplyUpdate(
             QuickReplyUpdate::builder()
                 .id(id)
                 .timestamp(time)
-                .action(Box::new(act.clone()))
+                .action(Box::new(act))
                 .from_full_sync(full_sync)
                 .build(),
         ));
@@ -197,7 +197,7 @@ mod tests {
         let bus = CoreEventBus::new();
         let rec = Arc::new(Recorder::default());
         bus.subscribe_handler(rec.clone()).detach();
-        let handled = dispatch_quick_reply_mutation(&bus, m, false);
+        let handled = dispatch_quick_reply_mutation(&bus, &mut m.clone(), false);
         let events = rec.events.lock().unwrap().clone();
         (handled, events)
     }

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -82,19 +82,17 @@ fn media_encrypt_video_10mb_with_sidecar(bencher: Bencher) {
 #[divan::bench]
 fn media_encrypt_video_10mb_buffered_api(bencher: Bencher) {
     let plaintext = payload(10 * MB);
-    bencher
-        .counter(BytesCount::new(plaintext.len()))
-        .bench(|| {
-            black_box(
-                encrypt_media_with_key_and_sidecar(
-                    black_box(&plaintext),
-                    MediaType::Video,
-                    Some(&MEDIA_KEY),
-                    None,
-                )
-                .unwrap(),
+    bencher.counter(BytesCount::new(plaintext.len())).bench(|| {
+        black_box(
+            encrypt_media_with_key_and_sidecar(
+                black_box(&plaintext),
+                MediaType::Video,
+                Some(&MEDIA_KEY),
+                None,
             )
-        });
+            .expect("buffered encryption"),
+        )
+    });
 }
 
 /// The streaming upload path: 8 KiB reads, encrypt, flush whole runs to the

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -76,6 +76,27 @@ fn media_encrypt_video_10mb_with_sidecar(bencher: Bencher) {
     bench_encrypt(bencher, 10 * MB, MediaType::Video, true);
 }
 
+/// The buffered upload API on the same 10 MiB video, output buffer included:
+/// what a caller of `encrypt_media` pays, growth of the ciphertext `Vec` and
+/// all, where the arm above measures the crypto into a pre-sized buffer.
+#[divan::bench]
+fn media_encrypt_video_10mb_buffered_api(bencher: Bencher) {
+    let plaintext = payload(10 * MB);
+    bencher
+        .counter(BytesCount::new(plaintext.len()))
+        .bench(|| {
+            black_box(
+                encrypt_media_with_key_and_sidecar(
+                    black_box(&plaintext),
+                    MediaType::Video,
+                    Some(&MEDIA_KEY),
+                    None,
+                )
+                .unwrap(),
+            )
+        });
+}
+
 /// The streaming upload path: 8 KiB reads, encrypt, flush whole runs to the
 /// writer. A `Vec` writer keeps this a measurement of crypto plus buffer
 /// traffic; against a real `File` the write batching is worth much more.

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -77,8 +77,8 @@ fn media_encrypt_video_10mb_with_sidecar(bencher: Bencher) {
 }
 
 /// The buffered upload API on the same 10 MiB video, output buffer included:
-/// what a caller of `encrypt_media` pays, growth of the ciphertext `Vec` and
-/// all, where the arm above measures the crypto into a pre-sized buffer.
+/// what a caller of `encrypt_media` pays, ciphertext `Vec` allocation and all,
+/// where the arm above measures the crypto into a pre-sized buffer.
 #[divan::bench]
 fn media_encrypt_video_10mb_buffered_api(bencher: Bencher) {
     let plaintext = payload(10 * MB);

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -72,16 +72,13 @@ pub fn collect_unique_index_macs(mutations: &[wa::SyncdMutation]) -> Vec<IndexMa
 const MAC_DEDUP_SCAN_LIMIT: usize = 64;
 
 fn lookup_app_state_key(
-    keys_map: &HashMap<String, Arc<ExpandedAppStateKeys>>,
+    keys_map: &HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>>,
     key_id: &[u8],
 ) -> Result<Arc<ExpandedAppStateKeys>, crate::appstate::AppStateError> {
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD_NO_PAD;
-    let id_b64 = STANDARD_NO_PAD.encode(key_id);
     // Return the Arc (refcount bump) instead of deep-cloning the 160-byte
     // ExpandedAppStateKeys; the callback runs once per mutation (up to ~1000/patch).
     keys_map
-        .get(&id_b64)
+        .get(key_id)
         .map(Arc::clone)
         .ok_or(crate::appstate::AppStateError::KeyNotFound)
 }
@@ -101,7 +98,7 @@ fn download_external_blobs(pl: &mut PatchList, download: &BlobDownloadFn<'_>) ->
     {
         let data =
             download(ext).with_context(|| format!("download external snapshot for {name:?}"))?;
-        let snapshot = waproto::codec::syncd_snapshot_decode(data.as_slice())
+        let snapshot = waproto::codec::syncd_snapshot_decode(&data)
             .with_context(|| format!("decode external snapshot for {name:?}"))?;
         pl.snapshot = Some(snapshot);
     }
@@ -115,18 +112,25 @@ fn download_external_blobs(pl: &mut PatchList, download: &BlobDownloadFn<'_>) ->
                 .unwrap_or(0);
             let data = download(ext)
                 .with_context(|| format!("download external mutations for {name:?} v{v}"))?;
-            let ext_mutations = waproto::codec::syncd_mutations_decode(data.as_slice())
+            let ext_mutations = waproto::codec::syncd_mutations_decode(&data)
                 .with_context(|| format!("decode external mutations for {name:?} v{v}"))?;
             patch.mutations = ext_mutations.mutations;
+            // Consumed: the reference is what marks a patch as still external,
+            // so leaving it would make the next pass (`missing_key_ids_after_inline`
+            // runs before `process_one_patch_list`) download and decode the
+            // blob — routinely multi-MB — a second time.
+            patch.external_mutations = buffa::MessageField::none();
         }
     }
     Ok(())
 }
 
 /// External-blob resolver as a trait object, so the large download/decode/apply
-/// bodies below instantiate once instead of per closure type.
+/// bodies below instantiate once instead of per closure type. Returns `Bytes`
+/// so a resolver serving from a prefetch map hands out a refcount instead of
+/// copying the blob.
 pub type BlobDownloadFn<'a> =
-    dyn Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync + 'a;
+    dyn Fn(&wa::ExternalBlobReference) -> Result<bytes::Bytes> + Send + Sync + 'a;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -172,7 +176,9 @@ pub enum RecoveryOutcome {
 pub struct AppStateProcessor {
     pub backend: Arc<dyn Backend>,
     pub runtime: Arc<dyn crate::runtime::Runtime>,
-    key_cache: Arc<Mutex<HashMap<String, Arc<ExpandedAppStateKeys>>>>,
+    /// Keyed by the raw key id: the lookup runs once per mutation, and a
+    /// base64 key meant encoding (and allocating) the id for every one of them.
+    key_cache: Arc<Mutex<HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>>>>,
     /// Collections a recovery has been asked of the primary for.
     ///
     /// Held here rather than beside the connection because it has to outlive the
@@ -345,14 +351,17 @@ impl AppStateProcessor {
     ) -> std::result::Result<Arc<ExpandedAppStateKeys>, AppStateSyncError> {
         use base64::Engine;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
-        let id_b64 = STANDARD_NO_PAD.encode(key_id);
-        if let Some(cached) = self.key_cache.lock().await.get(&id_b64).cloned() {
+        if let Some(cached) = self.key_cache.lock().await.get(key_id).cloned() {
             return Ok(cached);
         }
         let key_opt = self.backend.get_sync_key(key_id).await?;
-        let key = key_opt.ok_or_else(|| AppStateSyncError::KeyNotFound(id_b64.clone()))?;
+        let key = key_opt
+            .ok_or_else(|| AppStateSyncError::KeyNotFound(STANDARD_NO_PAD.encode(key_id)))?;
         let expanded = Arc::new(expand_app_state_keys(&key.key_data));
-        self.key_cache.lock().await.insert(id_b64, expanded.clone());
+        self.key_cache
+            .lock()
+            .await
+            .insert(key_id.to_vec(), expanded.clone());
         Ok(expanded)
     }
 
@@ -1138,7 +1147,7 @@ mod external_blob_tests {
             direct_path: Some("/blob".into()),
             ..Default::default()
         }));
-        let download = |_: &wa::ExternalBlobReference| -> Result<Vec<u8>> {
+        let download = |_: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
             Err(anyhow!("simulated failure"))
         };
         assert!(download_external_blobs(&mut pl, &download).is_err());
@@ -1152,8 +1161,9 @@ mod external_blob_tests {
             direct_path: Some("/blob".into()),
             ..Default::default()
         }));
-        let download =
-            |_: &wa::ExternalBlobReference| -> Result<Vec<u8>> { Ok(vec![0xFF, 0xFF, 0xFF]) };
+        let download = |_: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
+            Ok(bytes::Bytes::from_static(&[0xFF, 0xFF, 0xFF]))
+        };
         assert!(download_external_blobs(&mut pl, &download).is_err());
     }
 
@@ -1174,16 +1184,47 @@ mod external_blob_tests {
             snapshot_ref: None,
             error: None,
         };
-        let download = |_: &wa::ExternalBlobReference| -> Result<Vec<u8>> {
+        let download = |_: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
             Err(anyhow!("simulated failure"))
         };
         assert!(download_external_blobs(&mut pl, &download).is_err());
     }
 
+    /// The missing-key probe inlines before `process_one_patch_list` inlines
+    /// again; the second pass must find nothing left to fetch.
+    #[test]
+    fn external_mutations_are_fetched_once() {
+        let mut pl = PatchList {
+            name: WAPatchName::Regular,
+            has_more_patches: false,
+            patches: vec![wa::SyncdPatch {
+                external_mutations: buffa::MessageField::some(wa::ExternalBlobReference {
+                    direct_path: Some("/mutations".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            snapshot: None,
+            snapshot_ref: None,
+            error: None,
+        };
+        let fetches = std::sync::atomic::AtomicUsize::new(0);
+        // An empty buffer decodes as a `SyncdMutations` with no mutations.
+        let download = |_: &wa::ExternalBlobReference| -> Result<bytes::Bytes> {
+            fetches.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(bytes::Bytes::new())
+        };
+        download_external_blobs(&mut pl, &download).expect("first inline");
+        download_external_blobs(&mut pl, &download).expect("second inline");
+        assert_eq!(fetches.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert!(pl.patches[0].external_mutations.is_unset());
+    }
+
     #[test]
     fn no_external_refs_is_ok() {
         let mut pl = pl_with_snapshot_ref(None);
-        let download = |_: &wa::ExternalBlobReference| -> Result<Vec<u8>> { Ok(Vec::new()) };
+        let download =
+            |_: &wa::ExternalBlobReference| -> Result<bytes::Bytes> { Ok(bytes::Bytes::new()) };
         assert!(download_external_blobs(&mut pl, &download).is_ok());
     }
 }

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -600,7 +600,9 @@ pub fn encrypt_media_with_key_and_sidecar(
         Some(key) => MediaEncryptor::with_key_and_sidecar(*key, media_type, want_sidecar)?,
         None => MediaEncryptor::new_with_sidecar(media_type, want_sidecar)?,
     };
-    let mut data_to_upload = Vec::new();
+    // Exact up front: the doubling ladder from an empty Vec copied a 16 MiB
+    // video twice over on its way to 32 MiB of capacity.
+    let mut data_to_upload = Vec::with_capacity(encrypted_len(plaintext.len()));
     enc.update(plaintext, &mut data_to_upload);
     let info = enc.finalize(&mut data_to_upload)?;
     Ok(EncryptedMedia {


### PR DESCRIPTION
Bulk-path follow-up to #1389 / #1390, from the parallel exploration of app-state sync, history sync and media. History sync and media download were already streaming/in-place and are untouched; this PR is the app-state sync path plus one media upload sizing fix.

## App-state sync

- **External patch blobs were downloaded and protobuf-decoded twice.** `missing_key_ids_after_inline` inlines external blobs before `process_one_patch_list` inlines them again. The snapshot branch was guarded (`pl.snapshot.is_none()`), the patch branch was not, so every external `SyncdPatch` blob (routinely multi-MB on a bootstrap) was cloned out of the prefetch map and decoded a second time, with the first `SyncdMutations` thrown away. `download_external_blobs` now clears `patch.external_mutations` once its mutations are inlined, which is also what makes the documented "idempotent" claim true. Test: `external_mutations_are_fetched_once`.
- **Blobs are handed out as `Bytes`.** `BlobDownloadFn` returns `bytes::Bytes` and `pre_download_external_blobs` stores `Bytes`, so the resolver closures hand out a refcount instead of `Vec::clone` per blob. (`BlobDownloadFn` is a public type alias; the signature change is the one API-visible edit.)
- **Key cache keyed by raw key id.** `lookup_app_state_key` base64-encoded the key id into a fresh `String` on every call, once per mutation. The cache is now `HashMap<Vec<u8>, _>` and the base64 form is only built for the `KeyNotFound` message.
- **Actions move into events instead of being deep-cloned.** `dispatch_app_state_mutation` takes `&mut Mutation` and the chat / label / quick-reply / call-log / setting dispatchers `take()` the action out of the mutation, so each event owns the decoded action rather than a clone of it and its strings. A full sync dispatches every mutation of every collection through here. Test helpers clone once so the test surface is unchanged.

## Media upload

- `encrypt_media_with_key_and_sidecar` started from `Vec::new()` while `encrypted_len` already exists (and is what the benchmark and doc example use), so a 16 MiB video reallocated ~20 times, copying ~32 MiB and peaking at plaintext + old + new ≈ 64 MiB instead of ≈ 32 MiB. It is now sized exactly up front. A new `media_encrypt_video_10mb_buffered_api` arm measures the buffered API as production calls it.

| bench (`wacore/benches/media_benchmark.rs`, 10 MiB video) | before | after |
| --- | --- | --- |
| `media_encrypt_video_10mb_buffered_api` | 211 ms | 211–224 ms (host noise; the pre-sized `with_sidecar` arm moved the same way) |

The crypto dominates at this size, so this one is a peak-allocation fix, not a latency one.

## Explored and not done

- `Mutation.action_value` inline `SyncActionValue` (~700 B, 84 fields): buffa's `MessageField::into_option` unboxes on decode, so boxing it again would re-allocate; no net win without a buffa API that hands the box out.
- `AppStateMutationMAC.value_mac` as `[u8; 32]`: touches the store trait and both storage backends for one 32-byte allocation per mutation; not worth the surface change on its own.
- Per-patch `state.clone()` + 4 backend round trips: deliberate (the per-patch `set_version` pairs the version with its MACs); needs a patch-count distribution before touching.

## Verification

- `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` clean
- `cargo test -p wacore --lib appstate`, `cargo test -p whatsapp-rust --lib -- appstate app_state features::` (363) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_