### PR TITLE
perf(store): batch the flush's deletes; drop the redundant device_id indexes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -59,7 +59,7 @@ jobs:
             packages: -p wacore -p wacore-noise
             features: --features voip-mlow,bench-internals
           - name: proto-signal
-            packages: -p wacore-binary -p wacore-libsignal -p wacore-appstate
+            packages: -p wacore-binary -p wacore-libsignal -p wacore-appstate -p whatsapp-rust-sqlite-storage
           # The client crate's own benchmarks. Its fixture needs crate-private
           # internals a bench target cannot otherwise reach, so it builds with
           # the non-default `bench-harness` feature. Its own shard rather than a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,6 +4291,7 @@ dependencies = [
  "buffa",
  "buffa-build",
  "bytes",
+ "codspeed-divan-compat",
  "diesel",
  "diesel_migrations",
  "libsqlite3-sys",

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -37,7 +37,12 @@ buffa-build = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 portable-atomic = { workspace = true }
+
+[[bench]]
+name = "signal_flush"
+harness = false
 
 [lints]
 workspace = true

--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -1,0 +1,204 @@
+//! Signal-store write cost on a file-backed SQLite database.
+//!
+//! The client-level flush benchmark stores through `InMemoryBackend`, so the
+//! storage engine's own cost per flushed row is excluded there by
+//! construction. This is the other half: what one `SignalStore` write costs
+//! against a real database file, with WAL and the crate's pragmas, for the
+//! shapes the flush actually issues.
+//!
+//! - **Insert.** `put_sessions_batch` of fresh addresses: a first contact or
+//!   an offline drain establishing sessions. An upsert that only changes the
+//!   record touches no index, so fresh rows are what make an index's write
+//!   cost visible.
+//! - **Delete, per row vs. batched.** The flush used to delete one address
+//!   per backend call, each a `spawn_blocking`, a pool checkout and a WAL
+//!   commit; the batched form is one transaction.
+//!
+//! One database per benchmark, opened once for the process and grown by every
+//! iteration: rows are never reused, so an insert is always an insert.
+
+use bytes::Bytes;
+use divan::black_box;
+use std::sync::{Arc, OnceLock};
+use wacore::store::traits::SignalStore;
+use whatsapp_rust_sqlite_storage::SqliteStore;
+
+fn main() {
+    divan::main();
+    for db in DBS.iter().filter_map(OnceLock::get) {
+        db.remove_files();
+    }
+}
+
+const BATCH_SIZES: &[usize] = &[1, 8, 64];
+
+/// A flushed session record is a few hundred bytes; the size only has to be
+/// realistic enough that the row write is not dominated by the key.
+const RECORD_LEN: usize = 256;
+
+struct Db {
+    runtime: tokio::runtime::Runtime,
+    store: SqliteStore,
+    path: std::path::PathBuf,
+    next: portable_atomic::AtomicU64,
+}
+
+impl Db {
+    fn open(tag: &str) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let path =
+            std::env::temp_dir().join(format!("wa-signal-flush-{}-{tag}.db", std::process::id()));
+        remove_db_files(&path);
+        let url = path.to_str().expect("utf-8 temp path").to_owned();
+        let store = runtime
+            .block_on(SqliteStore::new(&url))
+            .expect("open file-backed store");
+        Self {
+            runtime,
+            store,
+            path,
+            next: portable_atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn remove_files(&self) {
+        remove_db_files(&self.path);
+    }
+
+    /// `n` addresses this database has never seen, with a record each.
+    fn fresh_sessions(&self, n: usize) -> Vec<(Arc<str>, Bytes)> {
+        let record = Bytes::from(vec![0x5A; RECORD_LEN]);
+        (0..n)
+            .map(|_| {
+                let id = self.next.fetch_add(1, portable_atomic::Ordering::Relaxed);
+                (
+                    Arc::from(format!("1000000{id:08}@lid").as_str()),
+                    record.clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn fresh_prekeys(&self, n: usize) -> Vec<(u32, Bytes)> {
+        let record = Bytes::from(vec![0x3C; 64]);
+        (0..n)
+            .map(|_| {
+                let id = self.next.fetch_add(1, portable_atomic::Ordering::Relaxed);
+                (
+                    u32::try_from(id + 1).expect("prekey id fits"),
+                    record.clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn inserted_sessions(&self, n: usize) -> Vec<Arc<str>> {
+        let batch = self.fresh_sessions(n);
+        self.runtime
+            .block_on(self.store.put_sessions_batch(&batch))
+            .expect("seed sessions");
+        batch.into_iter().map(|(address, _)| address).collect()
+    }
+
+    fn inserted_prekeys(&self, n: usize) -> Vec<u32> {
+        let batch = self.fresh_prekeys(n);
+        self.runtime
+            .block_on(self.store.store_prekeys_batch(&batch, true))
+            .expect("seed prekeys");
+        batch.into_iter().map(|(id, _)| id).collect()
+    }
+}
+
+fn remove_db_files(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm", "-journal"] {
+        let mut name = path.as_os_str().to_owned();
+        name.push(suffix);
+        let _ = std::fs::remove_file(name);
+    }
+}
+
+const DB_SLOTS: usize = 5;
+static DBS: [OnceLock<Db>; DB_SLOTS] = [const { OnceLock::new() }; DB_SLOTS];
+
+fn db(slot: usize, tag: &str) -> &'static Db {
+    DBS[slot].get_or_init(|| Db::open(tag))
+}
+
+/// Fresh rows through the batched upsert, the shape a flush writes new
+/// sessions in.
+#[divan::bench(args = BATCH_SIZES)]
+fn insert_sessions_batch(bencher: divan::Bencher, n: usize) {
+    let db = db(0, "insert");
+    bencher
+        .with_inputs(|| db.fresh_sessions(n))
+        .bench_values(|batch| {
+            db.runtime
+                .block_on(db.store.put_sessions_batch(black_box(&batch)))
+                .expect("insert batch");
+        });
+}
+
+/// One backend call per address: what the flush issued before batching.
+#[divan::bench(args = BATCH_SIZES)]
+fn delete_sessions_each(bencher: divan::Bencher, n: usize) {
+    let db = db(1, "delete-each");
+    bencher
+        .with_inputs(|| db.inserted_sessions(n))
+        .bench_values(|addresses| {
+            db.runtime.block_on(async {
+                for address in &addresses {
+                    db.store
+                        .delete_session(black_box(address))
+                        .await
+                        .expect("delete session");
+                }
+            });
+        });
+}
+
+/// The same rows through one transaction.
+#[divan::bench(args = BATCH_SIZES)]
+fn delete_sessions_batch(bencher: divan::Bencher, n: usize) {
+    let db = db(2, "delete-batch");
+    bencher
+        .with_inputs(|| db.inserted_sessions(n))
+        .bench_values(|addresses| {
+            db.runtime
+                .block_on(db.store.delete_sessions_batch(black_box(&addresses)))
+                .expect("delete batch");
+        });
+}
+
+/// Consumed one-time pre-keys, one call each: an offline drain of `n` `pkmsg`s.
+#[divan::bench(args = BATCH_SIZES)]
+fn remove_prekeys_each(bencher: divan::Bencher, n: usize) {
+    let db = db(3, "prekeys-each");
+    bencher
+        .with_inputs(|| db.inserted_prekeys(n))
+        .bench_values(|ids| {
+            db.runtime.block_on(async {
+                for id in &ids {
+                    db.store
+                        .remove_prekey(black_box(*id))
+                        .await
+                        .expect("remove prekey");
+                }
+            });
+        });
+}
+
+/// The same pre-keys through one transaction.
+#[divan::bench(args = BATCH_SIZES)]
+fn remove_prekeys_batch(bencher: divan::Bencher, n: usize) {
+    let db = db(4, "prekeys-batch");
+    bencher
+        .with_inputs(|| db.inserted_prekeys(n))
+        .bench_values(|ids| {
+            db.runtime
+                .block_on(db.store.remove_prekeys_batch(black_box(&ids)))
+                .expect("remove batch");
+        });
+}

--- a/storages/sqlite-storage/migrations/2026-09-03-000000_drop_redundant_device_id_indexes/down.sql
+++ b/storages/sqlite-storage/migrations/2026-09-03-000000_drop_redundant_device_id_indexes/down.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS idx_identities_device_id ON identities (device_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_device_id ON sessions (device_id);
+CREATE INDEX IF NOT EXISTS idx_prekeys_device_id ON prekeys (device_id);
+CREATE INDEX IF NOT EXISTS idx_sender_keys_device_id ON sender_keys (device_id);

--- a/storages/sqlite-storage/migrations/2026-09-03-000000_drop_redundant_device_id_indexes/up.sql
+++ b/storages/sqlite-storage/migrations/2026-09-03-000000_drop_redundant_device_id_indexes/up.sql
@@ -1,0 +1,10 @@
+-- The four Signal tables are keyed PRIMARY KEY (address|id, device_id), and
+-- every hot query filters on that key, so the standalone device_id index
+-- added with multi-account support only ever cost a third b-tree write per
+-- inserted or deleted row. Nothing selective reads it: it has one distinct
+-- value per account, and the only device_id-alone scans are account
+-- teardown, where a table scan is fine.
+DROP INDEX IF EXISTS idx_identities_device_id;
+DROP INDEX IF EXISTS idx_sessions_device_id;
+DROP INDEX IF EXISTS idx_prekeys_device_id;
+DROP INDEX IF EXISTS idx_sender_keys_device_id;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1934,6 +1934,36 @@ impl SignalStore for SqliteStore {
             .await
     }
 
+    /// One transaction, one `IN` list per chunk: the per-address delete is a
+    /// `spawn_blocking`, a pool checkout and a WAL commit each, and the flush
+    /// issues these for every entry it dropped.
+    async fn delete_identities_batch(&self, items: &[Arc<str>]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let device_id = self.device_id;
+        let items = Arc::new(items.to_vec());
+        self.with_retry("delete_identities_batch", || {
+            let items = items.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                conn.transaction(|conn| {
+                    for chunk in items.chunks(ID_PARAM_CHUNK) {
+                        diesel::delete(
+                            identities::table
+                                .filter(identities::device_id.eq(device_id))
+                                .filter(
+                                    identities::address.eq_any(chunk.iter().map(|a| a.as_ref())),
+                                ),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
+            })
+        })
+        .await
+    }
+
     async fn get_session(&self, address: &str) -> Result<Option<Bytes>> {
         Ok(self
             .get_session_for_device(address, self.device_id)
@@ -2043,6 +2073,32 @@ impl SignalStore for SqliteStore {
     async fn delete_session(&self, address: &str) -> Result<()> {
         self.delete_session_for_device(address, self.device_id)
             .await
+    }
+
+    /// See `delete_identities_batch`.
+    async fn delete_sessions_batch(&self, items: &[Arc<str>]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let device_id = self.device_id;
+        let items = Arc::new(items.to_vec());
+        self.with_retry("delete_sessions_batch", || {
+            let items = items.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                conn.transaction(|conn| {
+                    for chunk in items.chunks(ID_PARAM_CHUNK) {
+                        diesel::delete(
+                            sessions::table
+                                .filter(sessions::device_id.eq(device_id))
+                                .filter(sessions::address.eq_any(chunk.iter().map(|a| a.as_ref()))),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
+            })
+        })
+        .await
     }
 
     async fn store_prekey(&self, id: u32, record: &[u8], uploaded: bool) -> Result<()> {
@@ -2301,6 +2357,32 @@ impl SignalStore for SqliteStore {
         .await
     }
 
+    /// See `delete_identities_batch`.
+    async fn remove_prekeys_batch(&self, items: &[u32]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let device_id = self.device_id;
+        let items = Arc::new(items.to_vec());
+        self.with_retry("remove_prekeys_batch", || {
+            let items = items.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                conn.transaction(|conn| {
+                    for chunk in items.chunks(ID_PARAM_CHUNK) {
+                        diesel::delete(
+                            prekeys::table
+                                .filter(prekeys::device_id.eq(device_id))
+                                .filter(prekeys::id.eq_any(chunk.iter().map(|id| *id as i32))),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
+            })
+        })
+        .await
+    }
+
     async fn get_max_prekey_id(&self) -> Result<u32> {
         let device_id = self.device_id;
         self.read_query(move |conn| {
@@ -2500,6 +2582,34 @@ impl SignalStore for SqliteStore {
     async fn delete_sender_key(&self, address: &str) -> Result<()> {
         self.delete_sender_key_for_device(address, self.device_id)
             .await
+    }
+
+    /// See `delete_identities_batch`.
+    async fn delete_sender_keys_batch(&self, items: &[Arc<str>]) -> Result<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let device_id = self.device_id;
+        let items = Arc::new(items.to_vec());
+        self.with_retry("delete_sender_keys_batch", || {
+            let items = items.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                conn.transaction(|conn| {
+                    for chunk in items.chunks(ID_PARAM_CHUNK) {
+                        diesel::delete(
+                            sender_keys::table
+                                .filter(sender_keys::device_id.eq(device_id))
+                                .filter(
+                                    sender_keys::address.eq_any(chunk.iter().map(|a| a.as_ref())),
+                                ),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
+            })
+        })
+        .await
     }
 }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1725,9 +1725,11 @@ impl SignalStoreCache {
                     state.reservation_pending.remove(address);
                 }
             }
-            for address in &deleted_keys {
-                backend.delete_session(address).await?;
-                state.reservation_pending.remove(address);
+            if !deleted_keys.is_empty() {
+                backend.delete_sessions_batch(&deleted_keys).await?;
+                for address in &deleted_keys {
+                    state.reservation_pending.remove(address);
+                }
             }
 
             for key in &dirty_keys {
@@ -1798,11 +1800,11 @@ impl SignalStoreCache {
                             deletable.push(*id);
                         }
                     }
-                    for id in &deletable {
-                        backend.remove_prekey(*id).await?;
-                    }
-                    for id in &deletable {
-                        removed.remove(id);
+                    if !deletable.is_empty() {
+                        backend.remove_prekeys_batch(&deletable).await?;
+                        for id in &deletable {
+                            removed.remove(id);
+                        }
                     }
                 }
             }
@@ -1829,8 +1831,8 @@ impl SignalStoreCache {
             if !batch.is_empty() {
                 backend.put_identities_batch(&batch).await?;
             }
-            for address in &deleted_keys {
-                backend.delete_identity(address).await?;
+            if !deleted_keys.is_empty() {
+                backend.delete_identities_batch(&deleted_keys).await?;
             }
 
             for key in &dirty_keys {
@@ -1849,6 +1851,7 @@ impl SignalStoreCache {
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
 
             let mut batch: Vec<(Arc<str>, bytes::Bytes)> = Vec::new();
+            let mut deleted: Vec<Arc<str>> = Vec::new();
             for name in &dirty_keys {
                 match state.cache.get(name.as_ref()) {
                     Some(Some(record)) => {
@@ -1857,11 +1860,14 @@ impl SignalStoreCache {
                             .map_err(|e| anyhow::anyhow!("sender key serialize for {name}: {e}"))?;
                         batch.push((name.clone(), bytes::Bytes::from(bytes)));
                     }
-                    Some(None) => {
-                        backend.delete_sender_key(name).await?;
-                        state.wire_gate_pending.remove(name);
-                    }
+                    Some(None) => deleted.push(name.clone()),
                     None => {}
+                }
+            }
+            if !deleted.is_empty() {
+                backend.delete_sender_keys_batch(&deleted).await?;
+                for name in &deleted {
+                    state.wire_gate_pending.remove(name);
                 }
             }
             if !batch.is_empty() {

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -563,6 +563,17 @@ pub trait SignalStore: Send + Sync {
     /// Delete an identity key.
     async fn delete_identity(&self, address: &str) -> Result<()>;
 
+    /// Delete several identity keys. The flush issues one call per address
+    /// it dropped, and an identity reset drops many at once, so a backend with
+    /// transactions should override this with a single one; the default is the
+    /// per-address loop.
+    async fn delete_identities_batch(&self, addresses: &[Arc<str>]) -> Result<()> {
+        for address in addresses {
+            self.delete_identity(address).await?;
+        }
+        Ok(())
+    }
+
     // --- Session Operations ---
 
     /// Get an encrypted session for an address.
@@ -582,6 +593,16 @@ pub trait SignalStore: Send + Sync {
 
     /// Delete a session.
     async fn delete_session(&self, address: &str) -> Result<()>;
+
+    /// Delete several sessions in one backend operation. Same contract as
+    /// [`Self::delete_identities_batch`]: the default loops, a transactional
+    /// backend should not.
+    async fn delete_sessions_batch(&self, addresses: &[Arc<str>]) -> Result<()> {
+        for address in addresses {
+            self.delete_session(address).await?;
+        }
+        Ok(())
+    }
 
     /// Check if a session exists. Default implementation uses `get_session`.
     async fn has_session(&self, address: &str) -> Result<bool> {
@@ -636,6 +657,16 @@ pub trait SignalStore: Send + Sync {
     /// Remove a pre-key.
     async fn remove_prekey(&self, id: u32) -> Result<()>;
 
+    /// Remove several pre-keys in one backend operation: an offline drain
+    /// consumes one per `pkmsg`, and the flush deletes them together once
+    /// their sessions are durable. The default loops.
+    async fn remove_prekeys_batch(&self, ids: &[u32]) -> Result<()> {
+        for id in ids {
+            self.remove_prekey(*id).await?;
+        }
+        Ok(())
+    }
+
     /// Get the maximum pre-key ID currently stored, or 0 if none exist.
     /// Used for migration when `next_pre_key_id` counter is not yet initialized.
     async fn get_max_prekey_id(&self) -> Result<u32>;
@@ -673,6 +704,14 @@ pub trait SignalStore: Send + Sync {
 
     /// Delete a sender key.
     async fn delete_sender_key(&self, address: &str) -> Result<()>;
+
+    /// Delete several sender keys in one backend operation. The default loops.
+    async fn delete_sender_keys_batch(&self, addresses: &[Arc<str>]) -> Result<()> {
+        for address in addresses {
+            self.delete_sender_key(address).await?;
+        }
+        Ok(())
+    }
 }
 
 /// WhatsApp app state synchronization storage.


### PR DESCRIPTION
The persistence half of the parallel exploration behind #1393 / #1394. Measured first: a new file-backed benchmark, then the two changes against it.

## Benchmark

`storages/sqlite-storage/benches/signal_flush.rs` opens a real SQLite file (WAL, the crate's pragmas) and measures the write shapes the signal-cache flush issues: fresh-row inserts through `put_sessions_batch`, and deletes of sessions and consumed pre-keys, one backend call per row (what the flush did) versus one transaction. The client-level `flush_signal_cache_steady` stores through `InMemoryBackend`, so the engine's own per-row cost was invisible until now. Wired into the `proto-signal` CodSpeed shard.

## Batched deletes

Every delete in `SignalStoreCache::flush` was its own backend call: a `spawn_blocking`, a pool checkout and a WAL commit, about 60 µs each on disk, for every session, identity, sender key and consumed pre-key the flush dropped. That is the offline-drain and identity-reset shape. `SignalStore` gains `delete_sessions_batch`, `delete_identities_batch`, `delete_sender_keys_batch` and `remove_prekeys_batch`, defaulting to the old per-item loop so every other backend and every test double is unchanged; `SqliteStore` overrides each with one transaction and chunked `IN` lists, and the flush calls the batch forms.

| bench (median) | per row | batched |
| --- | --- | --- |
| `delete_sessions` × 8 | 515 µs | 89 µs |
| `delete_sessions` × 64 | 4.40 ms | 221 µs |
| `remove_prekeys` × 8 | 502 µs | 85 µs |
| `remove_prekeys` × 64 | 4.14 ms | 154 µs |

A single row costs the same either way (one commit), so the warm steady state, which rarely deletes, is unaffected.

## Redundant `device_id` indexes

`sessions`, `identities`, `prekeys` and `sender_keys` are keyed `PRIMARY KEY (address|id, device_id)`, and every hot query filters on that key. The standalone `idx_*_device_id` indexes from the multi-account migration are non-selective (one value per account) and cost a third b-tree write per inserted or deleted row; the only `device_id`-alone reads are account teardown, and `has_signal_state_for_user` filters on `address LIKE 'user…'` which the primary key serves. A migration drops the four; its `down.sql` recreates them. Measured effect is small: `insert_sessions_batch` × 64 goes 674 → 634 µs, within run-to-run noise at the smaller sizes, because the per-commit fsync dominates. Included because it is the correct schema and costs nothing, not as the headline.

## Verification

- `cargo clippy -p wacore -p whatsapp-rust-sqlite-storage -p whatsapp-rust --all-targets -- -D warnings` clean
- `cargo test -p wacore --lib signal_cache` (83), `cargo test -p whatsapp-rust-sqlite-storage` (84, migrations applied) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_