### PR TITLE
perf(send): resolve a DM's Signal addresses once per device-memo entry; client-level DM send bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,6 +340,11 @@ name = "client_receive"
 harness = false
 required-features = ["bench-harness"]
 
+[[bench]]
+name = "client_dm_send"
+harness = false
+required-features = ["bench-harness"]
+
 # The `Cache<Jid, _>` lookup shape `chat_lanes` runs per inbound message. No
 # `required-features`: it reaches only the public cache, so it builds (and is
 # regression-gated) in a plain `cargo bench`.

--- a/benches/client_dm_send.rs
+++ b/benches/client_dm_send.rs
@@ -1,0 +1,76 @@
+//! Client-level 1:1 send, swept across the recipient's device count.
+//!
+//! `wacore`'s `bench_dm_send` covers the stanza preparation with sessions
+//! already in hand; this is everything the client does around it on a warm
+//! repeat DM: the wire-namespace decision, the memoized device resolution,
+//! the LID/PN mapping lookups on the way to each device's Signal address,
+//! the session pre-check, the per-device lock keys, and the marshal and noise
+//! encrypt before the sink.
+//!
+//! Two addressing shapes, because they are two per-device code paths (see
+//! `DmAddressing`): a migrated account sending to a LID, where no device
+//! needs a mapping lookup, and an unmigrated account sending to a PN with a
+//! known LID, where every device's address is looked up at each resolution
+//! point. A repeat DM to the same recipient is the common case, so the sweep
+//! is over the recipient's device count (1 = a phone, 5 = the maximum with
+//! four companions) at a fixed one companion of our own.
+//!
+//! Not covered, so no number here is over-read: the SQLite backend (the
+//! fixture stores in memory), first contact (the fixture is warm), and the
+//! socket write (the transport drops the frame).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use whatsapp_rust::bench_support::{DmAddressing, DmSendHarness};
+
+fn main() {
+    divan::main();
+}
+
+/// The recipient's device count: a phone alone, a phone with one linked
+/// device, and the ceiling of four linked devices.
+const PEER_DEVICES: &[usize] = &[1, 2, 5];
+
+/// Every measured send advances each pairwise ratchet by one and re-arms the
+/// coalesced signal flush; neither crosses a threshold, so the budget only
+/// keeps the run short.
+const SAMPLE_COUNT: u32 = 20;
+const SAMPLE_SIZE: u32 = 20;
+
+/// One fixture per (benchmark, addressing, device count), leaked for the
+/// process lifetime, for the reasons `client_group_send` gives: a fixture is
+/// several acknowledged X3DH exchanges and two warm-up sends, and a shared one
+/// would carry ratchet state and an armed flush worker between benchmarks.
+fn shared(
+    label: &'static str,
+    addressing: DmAddressing,
+    peer_devices: usize,
+) -> &'static DmSendHarness {
+    type Key = (&'static str, DmAddressing, usize);
+    static FIXTURES: OnceLock<Mutex<HashMap<Key, &'static DmSendHarness>>> = OnceLock::new();
+    let mut map = FIXTURES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("fixture registry");
+    map.entry((label, addressing, peer_devices))
+        .or_insert_with(|| Box::leak(Box::new(DmSendHarness::new(peer_devices, addressing))))
+}
+
+/// A migrated account's repeat DM to a LID recipient.
+#[divan::bench(args = PEER_DEVICES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn warm_dm_send_lid(bencher: divan::Bencher, peer_devices: usize) {
+    let harness = shared("warm_dm_send_lid", DmAddressing::Lid, peer_devices);
+    bencher.bench(|| harness.warm_send());
+}
+
+/// An unmigrated account's repeat DM to a PN whose LID it knows: the wire
+/// stays PN, every device's Signal address upgrades to LID.
+#[divan::bench(args = PEER_DEVICES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn warm_dm_send_pn_with_known_lid(bencher: divan::Bencher, peer_devices: usize) {
+    let harness = shared(
+        "warm_dm_send_pn_with_known_lid",
+        DmAddressing::PnWithKnownLid,
+        peer_devices,
+    );
+    bencher.bench(|| harness.warm_send());
+}

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -563,6 +563,172 @@ async fn install_offline_socket(client: &Arc<Client>) {
     client.enter_live_mode_for_tests();
 }
 
+/// The recipient of the DM fixture, from the same reserved block and outside
+/// every range the other fixtures draw from.
+const DM_PEER_USER: &str = "19045550180";
+/// Its LID; ours is `100000000000001`.
+const DM_PEER_LID: &str = "100000000000002";
+
+/// How the DM fixture addresses its recipient. The two are different code
+/// paths per device, not a cosmetic switch: see each variant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DmAddressing {
+    /// A 1:1-LID-migrated account sending to a LID. The recipient's devices
+    /// resolve under the LID and our companions are re-addressed to ours, so
+    /// no device needs a PN→LID lookup on the way to its Signal address. The
+    /// shape every migrated account sends in.
+    Lid,
+    /// An unmigrated account sending to a PN whose LID it knows. The wire
+    /// stays PN (the server rejects a LID stanza from such an account) while
+    /// every device's Signal address upgrades to LID, which is a mapping
+    /// lookup per device at each place the send resolves addresses.
+    PnWithKnownLid,
+}
+
+/// A logged-in client holding a resolved 1:1 recipient with `peer_devices`
+/// devices plus our own companion, warmed to the steady state a repeat DM
+/// starts from: every session acknowledged, the device memo populated.
+///
+/// The DM counterpart of [`GroupSendHarness`]; the same offline construction
+/// (sink transport, in-memory store, pre-seeded registry) and the same
+/// warm-up discipline. What it adds is the LID/PN mapping, which the group
+/// fixture never exercises and which is the per-device term a DM pays.
+pub struct DmSendHarness {
+    runtime: tokio::runtime::Runtime,
+    client: Arc<Client>,
+    to: Jid,
+}
+
+impl DmSendHarness {
+    pub fn new(peer_devices: usize, addressing: DmAddressing) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let (client, to) = runtime.block_on(build_dm_fixture(peer_devices, addressing));
+        Self {
+            runtime,
+            client,
+            to,
+        }
+    }
+
+    /// One warm DM send through the real `Client::send_message`, from the
+    /// recipient resolution to the frame the noise socket writes.
+    pub fn warm_send(&self) {
+        self.runtime.block_on(async {
+            self.client
+                .send_message(self.to.clone(), wa::Message::text("bench"))
+                .await
+                .expect("offline DM send must reach the sink");
+        });
+    }
+
+    /// Per-term outcomes of the DM device memo so far; see
+    /// [`GroupSendHarness::memo_stats`].
+    pub fn memo_stats(&self) -> crate::client::DeviceMemoStats {
+        self.client.device_memo_stats()
+    }
+}
+
+async fn build_dm_fixture(peer_devices: usize, addressing: DmAddressing) -> (Arc<Client>, Jid) {
+    use wacore::types::lid_pn::{LearningSource, LidPnEntry};
+
+    assert!(peer_devices >= 1, "a recipient has at least its primary");
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager"),
+    );
+    let (client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        Arc::new(SinkTransportFactory),
+        Arc::new(NoopHttpClient),
+        None,
+    )
+    .await;
+
+    let own_pn = Jid::new(OWN_USER, Server::Pn);
+    let own_lid = Jid::new("100000000000001", Server::Lid);
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+        .await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(own_lid.clone())))
+        .await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLidMigrated(
+            addressing == DmAddressing::Lid,
+        ))
+        .await;
+
+    // The mapping a client that has exchanged messages with the peer holds.
+    // Seeded before the registry so the topology generation the memo stamps
+    // is past the write, as a warm client's is.
+    client
+        .lid_pn_cache
+        .add(&LidPnEntry::new(
+            DM_PEER_LID,
+            DM_PEER_USER,
+            LearningSource::Usync,
+        ))
+        .await;
+
+    let devices: Vec<u16> = (0..peer_devices)
+        .map(|d| u16::try_from(d).expect("device id fits"))
+        .collect();
+    // The registry is keyed by whichever user the lookup tries, so the same
+    // record sits under both of the peer's identifiers.
+    seed_registry(&client, DM_PEER_USER, &devices).await;
+    seed_registry(&client, DM_PEER_LID, &devices).await;
+    seed_registry(&client, OWN_USER, &[0, 1]).await;
+
+    // Sessions live under the Signal address the send resolves to, which is
+    // the LID for the peer in both shapes (WA Web's SignalAddress upgrades
+    // PN→LID whenever the mapping is known). Every one is acknowledged: a
+    // repeat DM re-encrypts to every device on every send, so a one-way
+    // X3DH would measure first contact forever, as `GroupSendHarness`
+    // explains for the companion.
+    let peer_lid = Jid::new(DM_PEER_LID, Server::Lid);
+    for device in &devices {
+        establish_acknowledged_session(&client, &peer_lid.with_device(*device)).await;
+    }
+    // Our companion is re-addressed to our LID for a LID recipient and stays
+    // PN otherwise (our own mapping is not in the cache, as it is not on a
+    // client that never sent itself a message).
+    let companion = match addressing {
+        DmAddressing::Lid => own_lid.with_device(1),
+        DmAddressing::PnWithKnownLid => own_pn.with_device(1),
+    };
+    establish_acknowledged_session(&client, &companion).await;
+
+    install_offline_socket(&client).await;
+
+    let to = match addressing {
+        DmAddressing::Lid => peer_lid,
+        DmAddressing::PnWithKnownLid => Jid::new(DM_PEER_USER, Server::Pn),
+    };
+
+    // Two sends outside every measurement: the first fills the device memo,
+    // the second is the first true repeat. A benchmark measures send three
+    // onwards.
+    for _ in 0..2 {
+        client
+            .send_message(to.clone(), wa::Message::text("warm-up"))
+            .await
+            .expect("offline DM send must reach the sink");
+    }
+    settle_signal_flush_worker(&client).await;
+
+    (client, to)
+}
+
 /// The peer of the receive fixture, from the same reserved block as the group
 /// members and outside every range they draw from.
 const PEER_USER: &str = "19045550190";

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -2771,16 +2771,25 @@ impl Client {
                 .await?;
 
             // Resolved once per memo entry: the session pre-check, the lock
-            // keys and the encrypt fan-out all address the same devices.
+            // keys and the encrypt fan-out all address the same devices. The
+            // list is built from `devices()` itself, so it is parallel by
+            // construction and the memo accepts it; a refusal still serves
+            // this send from the local value.
+            let resolved_here;
             let addressing = match dm_devices.signal_addressing() {
                 Some(addressing) => addressing,
                 None => {
                     let encryption = self.resolve_encryption_jids(dm_devices.devices()).await;
                     let mut lock_keys = encryption.clone();
                     sort_session_lock_keys(&mut lock_keys);
-                    dm_devices.signal_addressing_or_init(wacore::send::DmSignalAddressing::new(
-                        encryption, lock_keys,
-                    ))
+                    let built = wacore::send::DmSignalAddressing::new(encryption, lock_keys);
+                    match dm_devices.signal_addressing_or_init(built) {
+                        Ok(memoized) => memoized,
+                        Err(refused) => {
+                            resolved_here = refused;
+                            &resolved_here
+                        }
+                    }
                 }
             };
             self.ensure_e2e_sessions_resolved(addressing.encryption())

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -298,6 +298,15 @@ where
     Box::pin(future)
 }
 
+/// Sort and deduplicate session lock keys into the one acquisition order.
+/// INVARIANT: every caller of `session_guards_for` passes keys that went
+/// through here, which is what keeps two sends overlapping on a device from
+/// deadlocking; the DM memo stores the sorted result and serves it as is.
+fn sort_session_lock_keys(keys: &mut Vec<Jid>) {
+    keys.sort_unstable_by(wacore::types::jid::cmp_for_lock_order);
+    keys.dedup_by(|a, b| wacore::types::jid::cmp_for_lock_order(a, b).is_eq());
+}
+
 /// True when every SKDM target belongs to our own account (PN or LID user).
 /// Own devices are never memoized warm (WA Web's `!isMeDevice` guard on
 /// `markHasSenderKey`), so an own-only `needs` set is the permanent
@@ -2761,7 +2770,21 @@ impl Client {
                 )
                 .await?;
 
-            self.ensure_e2e_sessions(dm_devices.devices()).await?;
+            // Resolved once per memo entry: the session pre-check, the lock
+            // keys and the encrypt fan-out all address the same devices.
+            let addressing = match dm_devices.signal_addressing() {
+                Some(addressing) => addressing,
+                None => {
+                    let encryption = self.resolve_encryption_jids(dm_devices.devices()).await;
+                    let mut lock_keys = encryption.clone();
+                    sort_session_lock_keys(&mut lock_keys);
+                    dm_devices.signal_addressing_or_init(wacore::send::DmSignalAddressing::new(
+                        encryption, lock_keys,
+                    ))
+                }
+            };
+            self.ensure_e2e_sessions_resolved(addressing.encryption())
+                .await?;
 
             let mut extra_stanza_nodes = extra_stanza_nodes;
             // tctoken applies to 1:1 chats; status reactions share the fanout
@@ -2775,8 +2798,7 @@ impl Client {
                 debug!(target: "Client/TcToken", "Scheduled tc token issuance after send for {}", to.observe());
             }
 
-            let lock_jids = self.build_session_lock_keys(dm_devices.devices()).await;
-            let _session_guards = self.session_guards_for(&lock_jids).await;
+            let _session_guards = self.session_guards_for(addressing.lock_keys()).await;
 
             let mut store_adapter = self.signal_adapter();
 
@@ -2881,12 +2903,17 @@ impl Client {
     /// session locks (e.g. DM sends that encrypt for recipient + own devices).
     /// Resolve encryption JIDs and sort for deadlock-free lock acquisition.
     pub(crate) async fn build_session_lock_keys(&self, device_jids: &[Jid]) -> Vec<Jid> {
+        let mut keys = self.resolve_encryption_jids(device_jids).await;
+        sort_session_lock_keys(&mut keys);
+        keys
+    }
+
+    /// [`Self::resolve_encryption_jid`] over a device list, in order.
+    pub(crate) async fn resolve_encryption_jids(&self, device_jids: &[Jid]) -> Vec<Jid> {
         let mut keys: Vec<Jid> = Vec::with_capacity(device_jids.len());
         for jid in device_jids {
             keys.push(self.resolve_encryption_jid(jid).await);
         }
-        keys.sort_unstable_by(wacore::types::jid::cmp_for_lock_order);
-        keys.dedup_by(|a, b| wacore::types::jid::cmp_for_lock_order(a, b).is_eq());
         keys
     }
 
@@ -3872,6 +3899,145 @@ mod tests {
              inbound message: {window}"
         );
         assert_eq!(window.skdm_targets.hits, REGIME_SENDS, "{window}");
+    }
+
+    /// A warm DM resolves each device's Signal address once, memoizes it on
+    /// the device-memo entry, and serves it to every later send; a mapping
+    /// change for the peer produces a fresh entry re-resolved under the new
+    /// LID rather than a stale address. The lock keys the entry carries are in
+    /// the one acquisition order `session_guards_for` requires.
+    #[tokio::test]
+    async fn repeat_dm_sends_serve_memoized_signal_addressing() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+        use wacore::types::jid::cmp_for_lock_order;
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own = Jid::from_str("5511000000001@s.whatsapp.net").unwrap();
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(own.clone())))
+            .await;
+
+        // An unmigrated account sending to a PN whose LID it knows: the wire
+        // stays PN, every device's Signal address upgrades to LID.
+        let peer = Jid::from_str("5511000000020@s.whatsapp.net").unwrap();
+        let peer_lid = "200000000000020";
+        for (user, devices) in [
+            (own.user.as_str(), &[0u16][..]),
+            (peer.user.as_str(), &[0, 1]),
+        ] {
+            let record = DeviceListRecord {
+                user: user.into(),
+                devices: devices.iter().map(|d| DeviceInfo::new(*d, None)).collect(),
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            };
+            client
+                .device_registry_cache
+                .raw_insert_for_tests(Arc::from(user), Arc::new(record))
+                .await;
+        }
+        client
+            .add_lid_pn_mapping(
+                peer_lid,
+                &peer.user,
+                crate::lid_pn_cache::LearningSource::Usync,
+            )
+            .await
+            .expect("seeding the peer's lid-pn pair");
+        let sessions_under = |lid: &str| {
+            let client = Arc::clone(&client);
+            let lid = Jid::from_str(&format!("{lid}@lid")).unwrap();
+            async move {
+                for device in [0, 1] {
+                    crate::test_utils::seed_peer_session(&client, &lid.with_device(device)).await;
+                }
+            }
+        };
+        sessions_under(peer_lid).await;
+
+        let resolve = || async {
+            client
+                .resolve_dm_devices_memoized(
+                    &peer,
+                    &peer,
+                    &own,
+                    None,
+                    crate::cache::Freshness::CachePreferred,
+                )
+                .await
+                .expect("memoized DM resolve")
+        };
+
+        client
+            .send_message(peer.clone(), wa::Message::text("first"))
+            .await
+            .expect("first DM");
+        let first = resolve().await;
+        let addressing = first
+            .signal_addressing()
+            .expect("a send memoizes the Signal addressing on the entry it used");
+        assert_eq!(addressing.encryption().len(), first.devices().len());
+        for (device, address) in first.devices().iter().zip(addressing.encryption()) {
+            assert!(device.is_pn(), "the fan-out is PN-addressed: {device}");
+            assert!(
+                address.is_lid(),
+                "the Signal address upgrades to LID: {address}"
+            );
+            assert_eq!(address.user.as_str(), peer_lid);
+            assert_eq!(address.device, device.device);
+        }
+        assert!(
+            addressing
+                .lock_keys()
+                .windows(2)
+                .all(|pair| cmp_for_lock_order(&pair[0], &pair[1]).is_lt()),
+            "lock keys must be sorted and deduplicated in lock order"
+        );
+
+        client
+            .send_message(peer.clone(), wa::Message::text("second"))
+            .await
+            .expect("second DM");
+        let second = resolve().await;
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a repeat DM must serve the same memo entry, addressing included"
+        );
+
+        // The peer remaps to a new LID: the mapping change bumps the topology
+        // the entry is stamped with, so the next send re-resolves under it.
+        let new_lid = "200000000000021";
+        client
+            .add_lid_pn_mapping(
+                new_lid,
+                &peer.user,
+                crate::lid_pn_cache::LearningSource::Usync,
+            )
+            .await
+            .expect("remapping the peer");
+        sessions_under(new_lid).await;
+        client
+            .send_message(peer.clone(), wa::Message::text("third"))
+            .await
+            .expect("third DM");
+        let third = resolve().await;
+        assert!(
+            !Arc::ptr_eq(&first, &third),
+            "a mapping change must produce a fresh entry"
+        );
+        let addressing = third
+            .signal_addressing()
+            .expect("re-resolved on the fresh entry");
+        assert!(
+            addressing
+                .encryption()
+                .iter()
+                .all(|address| address.user.as_str() == new_lid),
+            "the fresh entry addresses the new LID: {:?}",
+            addressing.encryption()
+        );
     }
 
     /// The counters would be worthless if they only ever reported hits, so

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -76,7 +76,7 @@ pub use dm::*;
 pub use encrypt::*;
 pub use group::*;
 pub use peer::*;
-pub use resolved_devices::{ResolvedDmDevices, ResolvedGroupDevices};
+pub use resolved_devices::{DmSignalAddressing, ResolvedDmDevices, ResolvedGroupDevices};
 pub use status::*;
 
 #[cfg(test)]

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -276,13 +276,15 @@ pub async fn prepare_dm_stanza(
     let own_other_devices = resolved_devices.own_other_devices();
     let total_devices = resolved_devices.devices().len();
     // The memoized addresses are parallel to `devices()`, which is the
-    // recipient partition followed by our companions.
+    // recipient partition followed by our companions. A list of any other
+    // length is not one this set produced, so it is ignored rather than
+    // trusted, and the fan-out resolves per device as it does without a memo.
     let (recipient_addresses, own_addresses) = match resolved_devices.signal_addressing() {
-        Some(addressing) => {
+        Some(addressing) if addressing.encryption().len() == total_devices => {
             let (recipient, own) = addressing.encryption().split_at(recipient_devices.len());
             (Some(recipient), Some(own))
         }
-        None => (None, None),
+        _ => (None, None),
     };
 
     let phash = resolved_devices.phash();

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -275,6 +275,15 @@ pub async fn prepare_dm_stanza(
     let recipient_devices = resolved_devices.recipient_devices();
     let own_other_devices = resolved_devices.own_other_devices();
     let total_devices = resolved_devices.devices().len();
+    // The memoized addresses are parallel to `devices()`, which is the
+    // recipient partition followed by our companions.
+    let (recipient_addresses, own_addresses) = match resolved_devices.signal_addressing() {
+        Some(addressing) => {
+            let (recipient, own) = addressing.encryption().split_at(recipient_devices.len());
+            (Some(recipient), Some(own))
+        }
+        None => (None, None),
+    };
 
     let phash = resolved_devices.phash();
 
@@ -324,6 +333,7 @@ pub async fn prepare_dm_stanza(
             hide_decrypt_fail,
             mediatype,
             &mut participant_nodes,
+            recipient_addresses,
         )
         .await?;
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;
@@ -362,6 +372,7 @@ pub async fn prepare_dm_stanza(
             hide_decrypt_fail,
             mediatype,
             &mut participant_nodes,
+            own_addresses,
         )
         .await?;
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -681,6 +681,9 @@ pub async fn ensure_sessions_for_devices_resolved(
         signal_addresses.is_none_or(|addrs| addrs.len() == devices.len()),
         "signal addresses must be parallel to the device list"
     );
+    // A list that is not parallel to `devices` cannot be indexed by device;
+    // resolving per device is always correct, so that is the fallback.
+    let signal_addresses = signal_addresses.filter(|addrs| addrs.len() == devices.len());
     // Per-device LID upgrade map: encryption_overrides[i] mirrors devices[i].
     // None = use devices[i] as-is; Some(jid) = use this LID-upgraded version.
     // The Vec replaces a HashMap<&Jid, Jid> that paid hash + alloc per insert

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -677,12 +677,10 @@ pub async fn ensure_sessions_for_devices_resolved(
     devices: &[Jid],
     signal_addresses: Option<&[Jid]>,
 ) -> Result<SessionPlan> {
-    debug_assert!(
-        signal_addresses.is_none_or(|addrs| addrs.len() == devices.len()),
-        "signal addresses must be parallel to the device list"
-    );
     // A list that is not parallel to `devices` cannot be indexed by device;
-    // resolving per device is always correct, so that is the fallback.
+    // resolving per device is always correct, so that is the fallback in
+    // every build rather than a debug-only assertion that would make a
+    // malformed caller panic in tests and silently degrade in release.
     let signal_addresses = signal_addresses.filter(|addrs| addrs.len() == devices.len());
     // Per-device LID upgrade map: encryption_overrides[i] mirrors devices[i].
     // None = use devices[i] as-is; Some(jid) = use this LID-upgraded version.

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -500,8 +500,11 @@ pub async fn encrypt_for_devices_into(
     hide_decrypt_fail: bool,
     mediatype: Option<&str>,
     participant_nodes: &mut Vec<Node>,
+    signal_addresses: Option<&[Jid]>,
 ) -> Result<EncryptFanoutSummary> {
-    let plan = ensure_sessions_for_devices(runtime, stores, resolver, devices).await?;
+    let plan =
+        ensure_sessions_for_devices_resolved(runtime, stores, resolver, devices, signal_addresses)
+            .await?;
     let RawEncryptAttempt {
         result: raw,
         first_error,
@@ -660,6 +663,24 @@ pub async fn ensure_sessions_for_devices(
     resolver: &dyn SendContextResolver,
     devices: &[Jid],
 ) -> Result<SessionPlan> {
+    ensure_sessions_for_devices_resolved(runtime, stores, resolver, devices, None).await
+}
+
+/// [`ensure_sessions_for_devices`] for a caller that already resolved each
+/// device's Signal address: `signal_addresses[i]` is what `devices[i]`
+/// encrypts under (the device itself when no LID upgrade applies), so no
+/// mapping is looked up here. `None` resolves per device as before.
+pub async fn ensure_sessions_for_devices_resolved(
+    runtime: &dyn Runtime,
+    stores: &mut SignalStores<'_>,
+    resolver: &dyn SendContextResolver,
+    devices: &[Jid],
+    signal_addresses: Option<&[Jid]>,
+) -> Result<SessionPlan> {
+    debug_assert!(
+        signal_addresses.is_none_or(|addrs| addrs.len() == devices.len()),
+        "signal addresses must be parallel to the device list"
+    );
     // Per-device LID upgrade map: encryption_overrides[i] mirrors devices[i].
     // None = use devices[i] as-is; Some(jid) = use this LID-upgraded version.
     // The Vec replaces a HashMap<&Jid, Jid> that paid hash + alloc per insert
@@ -681,14 +702,18 @@ pub async fn ensure_sessions_for_devices(
     for (idx, device_jid) in devices.iter().enumerate() {
         // Resolved once per device: both the session probe and the prekey
         // branch below want it, and the lookup is a boxed `async_trait` call
-        // into an async-locked cache.
-        let lid_jid = if device_jid.is_pn() {
-            resolver
+        // into an async-locked cache. A caller-resolved address that equals
+        // the device is "no upgrade", the same answer the lookup gives.
+        let lid_jid: Option<Cow<'_, Jid>> = match signal_addresses {
+            Some(addrs) => {
+                let addr = &addrs[idx];
+                (addr != device_jid).then_some(Cow::Borrowed(addr))
+            }
+            None if device_jid.is_pn() => resolver
                 .get_lid_for_phone(&device_jid.user)
                 .await
-                .map(|lid_user| Jid::lid_device(lid_user, device_jid.device))
-        } else {
-            None
+                .map(|lid_user| Cow::Owned(Jid::lid_device(lid_user, device_jid.device))),
+            None => None,
         };
         // WhatsApp Web's SignalAddress.toString() normalizes PN → LID before
         // creating signal addresses. We do the same: check LID session FIRST.
@@ -708,7 +733,7 @@ pub async fn ensure_sessions_for_devices(
                     &mut encryption_overrides,
                     devices.len(),
                     idx,
-                    lid_jid.clone(),
+                    lid_jid.clone().into_owned(),
                 );
                 continue;
             }
@@ -728,7 +753,12 @@ pub async fn ensure_sessions_for_devices(
                 lid_jid.observe(),
                 device_jid.observe()
             );
-            record_encryption_override(&mut encryption_overrides, devices.len(), idx, lid_jid);
+            record_encryption_override(
+                &mut encryption_overrides,
+                devices.len(),
+                idx,
+                lid_jid.into_owned(),
+            );
         }
         indices_needing_prekeys.push(idx);
     }

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -96,11 +96,64 @@ impl ResolvedGroupDevices {
 pub struct ResolvedDmDevices {
     partitioned: super::dm::PartitionedDmDevices,
     phash: OnceLock<CompactString>,
+    /// Resolved once per memo entry, like the phash, and under the same
+    /// contract: a PN→LID mapping learned for any member of this fan-out
+    /// bumps the topology generation the entry is stamped with, so the entry
+    /// (and this cell with it) is rebuilt rather than served stale.
+    signal: OnceLock<DmSignalAddressing>,
+}
+
+/// The Signal addresses of one DM fan-out.
+///
+/// A device is encrypted to under its LID whenever the mapping is known (WA
+/// Web's `SignalAddress.toString()`), and a warm send resolved that mapping
+/// three times per device on its way to the wire: once for the session
+/// pre-check, once for the lock keys, once in the encrypt fan-out. Each was a
+/// cache lookup plus a `Jid` clone. Resolving once and memoizing beside the
+/// device set removes the repeats and the per-send sort of the lock keys.
+pub struct DmSignalAddressing {
+    /// Parallel to [`ResolvedDmDevices::devices`]: the address device `i`
+    /// encrypts under, which is the device itself when no upgrade applies.
+    encryption: Box<[Jid]>,
+    /// [`Self::encryption`] sorted and deduplicated in lock order, the one
+    /// order every session-lock acquisition must use.
+    lock_keys: Box<[Jid]>,
+}
+
+impl DmSignalAddressing {
+    pub fn new(encryption: Vec<Jid>, lock_keys: Vec<Jid>) -> Self {
+        Self {
+            encryption: encryption.into_boxed_slice(),
+            lock_keys: lock_keys.into_boxed_slice(),
+        }
+    }
+
+    pub fn encryption(&self) -> &[Jid] {
+        &self.encryption
+    }
+
+    pub fn lock_keys(&self) -> &[Jid] {
+        &self.lock_keys
+    }
+}
+
+impl crate::stats::HeapSize for DmSignalAddressing {
+    fn heap_bytes(&self) -> usize {
+        (self.encryption.len() + self.lock_keys.len()) * size_of::<Jid>()
+            + self
+                .encryption
+                .iter()
+                .chain(self.lock_keys.iter())
+                .map(|j| j.heap_bytes())
+                .sum::<usize>()
+    }
 }
 
 impl crate::stats::HeapSize for ResolvedDmDevices {
     fn heap_bytes(&self) -> usize {
-        self.partitioned.heap_bytes() + self.phash.get().map_or(0, |p| p.heap_bytes())
+        self.partitioned.heap_bytes()
+            + self.phash.get().map_or(0, |p| p.heap_bytes())
+            + self.signal.get().map_or(0, |s| s.heap_bytes())
     }
 }
 
@@ -112,7 +165,20 @@ impl ResolvedDmDevices {
         Self {
             partitioned: super::dm::partition_dm_devices(all_devices, own_jid, own_lid),
             phash: OnceLock::new(),
+            signal: OnceLock::new(),
         }
+    }
+
+    /// The memoized Signal addressing, if a send has resolved it.
+    pub fn signal_addressing(&self) -> Option<&DmSignalAddressing> {
+        self.signal.get()
+    }
+
+    /// Memoize `addressing`, or return what an earlier send memoized. The
+    /// caller resolved it from this same immutable device set, so whichever
+    /// racer wins the cell holds the same answer.
+    pub fn signal_addressing_or_init(&self, addressing: DmSignalAddressing) -> &DmSignalAddressing {
+        self.signal.get_or_init(|| addressing)
     }
 
     /// Every device the stanza encrypts for, in partition order.

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -121,6 +121,9 @@ pub struct DmSignalAddressing {
 }
 
 impl DmSignalAddressing {
+    /// `encryption` must be parallel to the device set this is memoized on;
+    /// [`ResolvedDmDevices::signal_addressing_or_init`] refuses any other
+    /// length, and a consumer treats one as "not memoized".
     pub fn new(encryption: Vec<Jid>, lock_keys: Vec<Jid>) -> Self {
         Self {
             encryption: encryption.into_boxed_slice(),
@@ -177,8 +180,19 @@ impl ResolvedDmDevices {
     /// Memoize `addressing`, or return what an earlier send memoized. The
     /// caller resolved it from this same immutable device set, so whichever
     /// racer wins the cell holds the same answer.
-    pub fn signal_addressing_or_init(&self, addressing: DmSignalAddressing) -> &DmSignalAddressing {
-        self.signal.get_or_init(|| addressing)
+    ///
+    /// Refused, and handed back, when `addressing` does not carry one address
+    /// per device: such a list cannot be indexed by device, and a memo entry
+    /// lives across sends, so a malformed one must never be installed. The
+    /// caller may still use the returned value for its own send.
+    pub fn signal_addressing_or_init(
+        &self,
+        addressing: DmSignalAddressing,
+    ) -> Result<&DmSignalAddressing, DmSignalAddressing> {
+        if addressing.encryption().len() != self.devices().len() {
+            return Err(addressing);
+        }
+        Ok(self.signal.get_or_init(|| addressing))
     }
 
     /// Every device the stanza encrypts for, in partition order.

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -5369,6 +5369,7 @@ mod local_identity_change_on_send {
                 false,
                 None,
                 nodes,
+                None,
             )
             .await
             .expect("fan-out into the caller's buffer")
@@ -5469,6 +5470,7 @@ mod local_identity_change_on_send {
                 false,
                 None,
                 &mut nodes,
+                None,
             )
             .await
             .expect("one bad device must not abort the fan-out");


### PR DESCRIPTION
The DM-send half of the parallel exploration behind #1393 / #1394. The client crate had a group-send and a receive benchmark but no 1:1 send benchmark, so the per-device term the exploration attributed to the DM path was an estimate. This PR adds the benchmark first and then the change it was estimated for, measured against it. The honest headline is the benchmark: the change itself is below noise in wall time.

## Benchmark

`benches/client_dm_send.rs` on a new `DmSendHarness` in `bench_support`: one warm DM through the real `Client::send_message`, from the wire-namespace decision through the memoized device resolution, the LID/PN mapping lookups, the session pre-check, the per-device lock keys and the marshal + noise encrypt to the sink. Swept over the peer's device count (1 / 2 / 5) in the two per-device addressing shapes, which are two different code paths per device:

- `warm_dm_send_lid`: a 1:1-LID-migrated account sending to a LID (no device needs a mapping lookup).
- `warm_dm_send_pn_with_known_lid`: an unmigrated account sending to a PN whose LID it knows (the wire stays PN, every device's Signal address upgrades to LID, so each resolution point looked the mapping up).

Every session is acknowledged and the fixture is warm before sampling, for the reasons `GroupSendHarness` gives. Registered as a `bench-harness` target so it runs on the CodSpeed client shard.

## Single resolution

A warm DM resolved each device's PN→LID mapping three times on the way out: `ensure_e2e_sessions` (via `resolve_lid_mappings`), `build_session_lock_keys` (via `resolve_encryption_jid`), and the encrypt fan-out (via `SendContextResolver::get_lid_for_phone`). Each was a cache lookup plus a `Jid` clone, and the lock keys were sorted per send. `ResolvedDmDevices` now carries a `DmSignalAddressing` memo (the per-device Signal address, parallel to `devices()`, plus the sorted and deduplicated lock keys), filled on the first send of a memo entry and served to every later one. `encrypt_for_devices_into` takes the pre-resolved addresses and `ensure_sessions_for_devices_resolved` skips the lookup when given them; the existing `ensure_sessions_for_devices` delegates with `None`, so the group path is unchanged.

Invalidation comes for free from the device memo's contract: the entry is stamped with the topology generation, and a mapping learned for any member of the fan-out bumps it, so the entry (and this memo with it) is rebuilt rather than served stale. The lock-order invariant is kept by construction: the stored keys go through the same `sort_session_lock_keys` every other caller of `session_guards_for` uses, and the new test asserts they are sorted and deduplicated in lock order, that a repeat send serves the same entry, and that remapping the peer produces a fresh entry addressed under the new LID (`repeat_dm_sends_serve_memoized_signal_addressing`).

## Numbers

| bench (median, two runs) | before | after |
| --- | --- | --- |
| `warm_dm_send_lid` 1 / 2 / 5 | 39.7–41.2 / 55.6–56.3 / 88.1–90.1 µs | 39.9–40.8 / 55.1–56.8 / 88.6–90.7 µs |
| `warm_dm_send_pn_with_known_lid` 1 / 2 / 5 | 41.5–42.3 / 56.9–58.6 / 90.9–93.7 µs | 41.0–42.1 / 56.5–57.3 / 90.2–94.5 µs |

Both shapes are within run-to-run noise after the change: the per-device lookup term is under 1% of a send on this host, where each pairwise encrypt costs ~11 µs (software SHA-256). What the change removes is deterministic (N lookups, 2N clones and a sort per send), so CodSpeed's instruction count on this PR is the precise figure; the wall-clock claim is only that nothing regressed.

## Verification

- `cargo clippy -p wacore -p whatsapp-rust --all-targets --features bench-harness -- -D warnings` clean
- `cargo test -p wacore --lib send::` (153), `cargo test -p whatsapp-rust --lib -- send:: lid_pn sessions device_registry` (329 + the new test) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_