### PR TITLE
perf(binary): one-pass outbound marshal, single-pass message attribute resolution, one parked inflate state per thread

### DIFF
--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -128,9 +128,12 @@ impl Client {
             self.resolve_sent_node_waiters(&Arc::new(node.clone()));
         }
 
-        // Exact two-pass sizing: typical stanzas are a few hundred bytes, so
-        // the 1 KiB default reserve of the one-pass path mostly over-allocates.
-        wacore_binary::marshal::marshal_exact(&node).map_err(|e| {
+        // One pass over the tree, into a buffer reserved from the node's own
+        // byte lengths. The exact two-pass sizing this replaced bought a
+        // perfectly sized buffer with a second full traversal — and the buffer
+        // is transient (it goes straight into the frame), while the traversal
+        // is paid on every send and grows with the fan-out width.
+        wacore_binary::marshal::marshal_shallow(&node).map_err(|e| {
             error!("Failed to marshal node: {e:?}");
             SocketError::Marshal(e).into()
         })

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::marshal::{
     marshal, marshal_auto, marshal_exact, marshal_ref, marshal_ref_auto, marshal_ref_exact,
-    marshal_to, unmarshal_ref,
+    marshal_shallow, marshal_to, unmarshal_ref,
 };
 use wacore_binary::node::Node;
 use wacore_binary::util::{FORMAT_COMPRESSED, unpack};
@@ -228,14 +228,24 @@ fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
         .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
-// The exact (plan + hint replay) strategy is the production send path for
-// message plaintext, so its worst case — many children, JID-heavy — gets its
-// own pin.
+// The shallow (estimate + single pass) strategy is the production send path
+// for message plaintext, so its worst case — many children, JID-heavy — gets
+// its own pin, against the exact (plan + hint replay) strategy it replaced on
+// the same shape. The sampled estimate is what the pair measures: many
+// children is where sampling has the most room to be wrong, and a reserve that
+// undershoots shows up here as the `Vec` growth it costs.
 #[divan::bench]
 fn bench_marshal_exact_many_children(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_many_children_node)
         .bench_refs(|node| black_box(marshal_exact(black_box(node)).unwrap()));
+}
+
+#[divan::bench]
+fn bench_marshal_shallow_many_children(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(create_many_children_node)
+        .bench_refs(|node| black_box(marshal_shallow(black_box(node)).expect("marshal_shallow")));
 }
 
 // Strategy comparison on one shape.
@@ -251,6 +261,13 @@ fn bench_marshal_exact_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_large_node)
         .bench_refs(|node| black_box(marshal_exact(black_box(node)).unwrap()));
+}
+
+#[divan::bench]
+fn bench_marshal_shallow_large(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(create_large_node)
+        .bench_refs(|node| black_box(marshal_shallow(black_box(node)).expect("marshal_shallow")));
 }
 
 #[divan::bench]

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -11,7 +11,7 @@
 use divan::black_box;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::jid::Jid;
-use wacore_binary::marshal::marshal_exact;
+use wacore_binary::marshal::{marshal_exact, marshal_shallow};
 use wacore_binary::node::Node;
 
 fn main() {
@@ -83,14 +83,23 @@ fn create_skdm_fanout_node(width: usize) -> Node {
 // warm stanza grew a per-participant node") apart from a group that is merely
 // redistributing.
 //
-// `marshal_exact`, not `marshal_auto`: every outbound stanza goes through
-// `Client::marshal_node_for_send`, which picks the two-pass exact strategy.
-// The two differ in exactly what this sweep is measuring — one-pass reserves
-// and grows, two-pass plans the size first and replays a hint tape — so the
-// wrong one would track a path no group send takes.
+// Both marshal strategies, swept together: `marshal_shallow` is what
+// `Client::marshal_node_for_send` sends through today, and `marshal_exact` is
+// what it sent through before. They differ in exactly what this sweep
+// measures — one pass into a buffer reserved from a sampled estimate, against
+// a size-and-hint pass followed by a write pass — and the gap between them is
+// proportional to the width, so keeping the old arm is what makes the
+// replacement's slope readable rather than merely asserted.
 #[divan::bench(args = [8, 32, 128, 512])]
 fn bench_marshal_exact_group_fanout(bencher: divan::Bencher, width: usize) {
     bencher
         .with_inputs(|| create_skdm_fanout_node(width))
-        .bench_refs(|node| black_box(marshal_exact(black_box(node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_exact(black_box(node)).expect("marshal_exact")));
+}
+
+#[divan::bench(args = [8, 32, 128, 512])]
+fn bench_marshal_shallow_group_fanout(bencher: divan::Bencher, width: usize) {
+    bencher
+        .with_inputs(|| create_skdm_fanout_node(width))
+        .bench_refs(|node| black_box(marshal_shallow(black_box(node)).expect("marshal_shallow")));
 }

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -331,9 +331,21 @@ impl<'a> Decoder<'a> {
     }
 
     /// Decode packed nibble/hex into a stack buffer, then create CompactString.
-    /// Max unpacked length is 254 bytes (127 packed × 2), so the stack buffer
+    /// Max unpacked length is 254 bytes (127 packed × 2), so the large buffer
     /// is always sufficient. Short values (≤24 bytes) are stored inline.
+    ///
+    /// The buffer is scratch, never input: `decode_packed_*` write exactly
+    /// `len * 2` bytes and only that prefix is read back, so nothing depends
+    /// on the zeros. Sizing it from that decoded length — known before the
+    /// buffer is declared — keeps the initialization proportional to the value
+    /// instead of to the format's 254-byte worst case, which a release build's
+    /// optimizer may or may not elide on its own. The array stays initialized
+    /// either way, so this needs no `unsafe` and nothing for Miri to prove.
     fn read_packed(&mut self, tag: u8) -> Result<CompactString> {
+        /// Covers every packed value a message stanza carries: a 22-character
+        /// id and a 10-digit timestamp both land well inside it.
+        const SMALL_PACKED: usize = 32;
+
         let packed_len_byte = self.read_u8()?;
         let is_half_byte = (packed_len_byte & 0x80) != 0;
         let len = (packed_len_byte & 0x7F) as usize;
@@ -343,12 +355,28 @@ impl<'a> Decoder<'a> {
         }
 
         let packed_data = self.read_bytes(len)?;
-        let mut buf = [0u8; 254];
+        if len * 2 <= SMALL_PACKED {
+            let mut buf = [0u8; SMALL_PACKED];
+            Self::decode_packed_into(tag, packed_data, &mut buf, is_half_byte)
+        } else {
+            let mut buf = [0u8; 254];
+            Self::decode_packed_into(tag, packed_data, &mut buf, is_half_byte)
+        }
+    }
+
+    /// Shared tail of [`read_packed`], over a scratch buffer the caller sized:
+    /// `buf` must hold `packed_data.len() * 2` bytes.
+    fn decode_packed_into(
+        tag: u8,
+        packed_data: &[u8],
+        buf: &mut [u8],
+        is_half_byte: bool,
+    ) -> Result<CompactString> {
         let mut pos = 0;
 
         match tag {
-            token::HEX_8 => Self::decode_packed_hex(packed_data, &mut buf, &mut pos),
-            token::NIBBLE_8 => Self::decode_packed_nibble(packed_data, &mut buf, &mut pos)?,
+            token::HEX_8 => Self::decode_packed_hex(packed_data, buf, &mut pos),
+            token::NIBBLE_8 => Self::decode_packed_nibble(packed_data, buf, &mut pos)?,
             _ => return Err(BinaryError::InvalidToken(tag)),
         }
 

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -331,21 +331,9 @@ impl<'a> Decoder<'a> {
     }
 
     /// Decode packed nibble/hex into a stack buffer, then create CompactString.
-    /// Max unpacked length is 254 bytes (127 packed × 2), so the large buffer
+    /// Max unpacked length is 254 bytes (127 packed × 2), so the stack buffer
     /// is always sufficient. Short values (≤24 bytes) are stored inline.
-    ///
-    /// The buffer is scratch, never input: `decode_packed_*` write exactly
-    /// `len * 2` bytes and only that prefix is read back, so nothing depends
-    /// on the zeros. Sizing it from that decoded length — known before the
-    /// buffer is declared — keeps the initialization proportional to the value
-    /// instead of to the format's 254-byte worst case, which a release build's
-    /// optimizer may or may not elide on its own. The array stays initialized
-    /// either way, so this needs no `unsafe` and nothing for Miri to prove.
     fn read_packed(&mut self, tag: u8) -> Result<CompactString> {
-        /// Covers every packed value a message stanza carries: a 22-character
-        /// id and a 10-digit timestamp both land well inside it.
-        const SMALL_PACKED: usize = 32;
-
         let packed_len_byte = self.read_u8()?;
         let is_half_byte = (packed_len_byte & 0x80) != 0;
         let len = (packed_len_byte & 0x7F) as usize;
@@ -355,28 +343,12 @@ impl<'a> Decoder<'a> {
         }
 
         let packed_data = self.read_bytes(len)?;
-        if len * 2 <= SMALL_PACKED {
-            let mut buf = [0u8; SMALL_PACKED];
-            Self::decode_packed_into(tag, packed_data, &mut buf, is_half_byte)
-        } else {
-            let mut buf = [0u8; 254];
-            Self::decode_packed_into(tag, packed_data, &mut buf, is_half_byte)
-        }
-    }
-
-    /// Shared tail of [`read_packed`], over a scratch buffer the caller sized:
-    /// `buf` must hold `packed_data.len() * 2` bytes.
-    fn decode_packed_into(
-        tag: u8,
-        packed_data: &[u8],
-        buf: &mut [u8],
-        is_half_byte: bool,
-    ) -> Result<CompactString> {
+        let mut buf = [0u8; 254];
         let mut pos = 0;
 
         match tag {
-            token::HEX_8 => Self::decode_packed_hex(packed_data, buf, &mut pos),
-            token::NIBBLE_8 => Self::decode_packed_nibble(packed_data, buf, &mut pos)?,
+            token::HEX_8 => Self::decode_packed_hex(packed_data, &mut buf, &mut pos),
+            token::NIBBLE_8 => Self::decode_packed_nibble(packed_data, &mut buf, &mut pos)?,
             _ => return Err(BinaryError::InvalidToken(tag)),
         }
 

--- a/wacore/binary/src/lib.rs
+++ b/wacore/binary/src/lib.rs
@@ -22,7 +22,7 @@ pub use jid::{
 };
 pub use marshal::{
     marshal, marshal_auto, marshal_exact, marshal_ref, marshal_ref_auto, marshal_ref_exact,
-    marshal_ref_to, marshal_ref_to_vec, marshal_to, marshal_to_vec,
+    marshal_ref_to, marshal_ref_to_vec, marshal_shallow, marshal_to, marshal_to_vec,
 };
 pub use node::{
     Attrs, Node, NodeContent, NodeContentRef, NodeRef, NodeStr, NodeValue, OwnedNodeRef,

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -4,7 +4,7 @@ use crate::{
     BinaryError, Node, NodeRef, Result,
     decoder::Decoder,
     encoder::{Encoder, build_marshaled_node_plan, build_marshaled_node_ref_plan},
-    node::{NodeContent, NodeContentRef},
+    node::{NodeContent, NodeContentRef, NodeValue},
 };
 
 const DEFAULT_MARSHAL_CAPACITY: usize = 1024;
@@ -16,6 +16,18 @@ const AUTO_MAX_HINT_CAPACITY: usize = 512 * 1024;
 const AUTO_ATTR_ESTIMATE: usize = 24;
 const AUTO_CHILD_ESTIMATE: usize = 96;
 const AUTO_GRANDCHILD_ESTIMATE: usize = 40;
+
+/// Per node, before its own strings: `write_list_start`'s widest form
+/// (`LIST_16`: tag + u16), plus slack.
+const SHALLOW_NODE_OVERHEAD: usize = 4;
+/// A JID never encodes longer than its user plus the tag, agent, device,
+/// integrator and server-token bytes around it.
+const SHALLOW_JID_OVERHEAD: usize = 12;
+/// Children measured individually before the rest are extrapolated from them.
+const SHALLOW_CHILD_SAMPLE: usize = 32;
+/// Ceiling on the shallow reserve. An estimate this far out is a bug in the
+/// estimator, and past it one `Vec` growth is cheaper than trusting the guess.
+const SHALLOW_MAX_CAPACITY: usize = 4 * 1024 * 1024;
 
 /// Decode node bytes: the buffer without the format byte, which is what the
 /// receive path holds after [`unpack`](crate::util::unpack) and what
@@ -102,6 +114,22 @@ pub fn marshal_exact(node: &Node) -> Result<Vec<u8>> {
     Ok(payload)
 }
 
+/// Serialize a `Node` in one pass, into a buffer reserved from a shallow size
+/// estimate.
+///
+/// The reserve comes from the node's own byte lengths, which bound the
+/// encoding from above: a key, a token value, a JID and a packed id all encode
+/// shorter than they measure, so the sum overshoots by a modest constant and
+/// the write allocates exactly once. An undershoot — a tree whose sampled
+/// children are unrepresentative — costs a `Vec` growth, never a wrong
+/// encoding, which is what lets the estimate sample rather than walk.
+///
+/// Against [`marshal_exact`]: one traversal instead of two, at the price of a
+/// buffer that is a little larger than the payload.
+pub fn marshal_shallow(node: &Node) -> Result<Vec<u8>> {
+    marshal_with_capacity(node, shallow_capacity_node(node))
+}
+
 /// Zero-copy serialization of a `NodeRef` directly into a writer.
 /// This avoids the allocation overhead of converting to an owned `Node` first.
 pub fn marshal_ref_to(node: &NodeRef<'_>, writer: &mut impl Write) -> Result<()> {
@@ -164,6 +192,75 @@ fn marshal_ref_with_capacity(node: &NodeRef<'_>, capacity: usize) -> Result<Vec<
     let mut payload = Vec::with_capacity(capacity);
     marshal_ref_to_vec(node, &mut payload)?;
     Ok(payload)
+}
+
+/// Upper bound on a node's encoded size, from the lengths it already carries.
+///
+/// Breadth is sampled, depth is not. Sampling bounds the walk exactly where the
+/// tree is wide — the fan-out shapes this exists for — while a chain of narrow
+/// nodes is walked in full, because there the estimate costs no more than the
+/// encoder's own recursion over the same nodes and a depth cutoff would guess
+/// at whatever payload sits below it.
+fn shallow_capacity_node(node: &Node) -> usize {
+    let mut estimate = 0;
+    accumulate_shallow_estimate(node, &mut estimate);
+    estimate.min(SHALLOW_MAX_CAPACITY)
+}
+
+/// What a raw string of `len` bytes costs on the wire: the `BINARY_8`/`_20`/
+/// `_32` tag and its length field. Every other encoding of the same string —
+/// a token, a packed id, a JID — is shorter, which is what makes the sum of
+/// these an upper bound rather than a guess.
+#[inline]
+fn shallow_string_estimate(len: usize) -> usize {
+    const BINARY_20_LIMIT: usize = 1 << 20;
+    let header = if len < 256 {
+        2
+    } else if len < BINARY_20_LIMIT {
+        4
+    } else {
+        5
+    };
+    len + header
+}
+
+#[inline]
+fn shallow_value_estimate(value: &NodeValue) -> usize {
+    match value {
+        NodeValue::String(text) => shallow_string_estimate(text.len()),
+        NodeValue::Jid(jid) => jid.user.len() + SHALLOW_JID_OVERHEAD,
+    }
+}
+
+fn accumulate_shallow_estimate(node: &Node, estimate: &mut usize) {
+    *estimate += SHALLOW_NODE_OVERHEAD + shallow_string_estimate(node.tag.len());
+    for (key, value) in node.attrs.iter() {
+        *estimate += shallow_string_estimate(key.len()) + shallow_value_estimate(value);
+    }
+
+    match &node.content {
+        Some(NodeContent::Bytes(bytes)) => *estimate += shallow_string_estimate(bytes.len()),
+        Some(NodeContent::String(text)) => *estimate += shallow_string_estimate(text.len()),
+        Some(NodeContent::Nodes(children)) => {
+            if *estimate >= SHALLOW_MAX_CAPACITY {
+                return;
+            }
+            let sampled = children.len().min(SHALLOW_CHILD_SAMPLE);
+            let before = *estimate;
+            for child in &children[..sampled] {
+                accumulate_shallow_estimate(child, estimate);
+            }
+            // Every child past the sample is charged the sample's mean, rounded
+            // up. A fan-out is homogeneous by construction — one `<to>` per
+            // device — so this lands within the per-node slack; a tree that
+            // hides its bulk past the 32nd child pays one growth for it.
+            let remaining = children.len() - sampled;
+            if remaining > 0 {
+                *estimate += (*estimate - before).div_ceil(sampled) * remaining;
+            }
+        }
+        None => {}
+    }
 }
 
 #[inline]

--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -71,9 +71,13 @@ impl<'a> InflateReader<'a> {
     /// record genuinely exceeds it. Allocated per reader, never retained.
     const CHUNK: usize = 64 * 1024;
     /// Cap on retained free-list entries, so concurrently-alive readers on one
-    /// thread don't grow the pool unbounded. Sequential readers are the norm and
-    /// leave one entry parked; the cap only binds when readers nest.
-    const POOL_MAX: usize = 4;
+    /// thread don't grow the pool unbounded. Sequential readers are the norm —
+    /// a bootstrap history sync inflates its blobs one after another — and one
+    /// parked entry is all that case ever checks out, so a deeper pool only
+    /// retains ~46 KB of zlib state per extra slot, per thread that ever
+    /// inflated anything, for the life of the process. Nested readers still
+    /// work; they just build their state instead of finding it parked.
+    const POOL_MAX: usize = 1;
 
     pub fn new(input: &'a [u8], max: u64) -> Self {
         let decomp = INFLATE_POOL.with(|p| p.borrow_mut().pop()).map_or_else(

--- a/wacore/binary/tests/marshal_shallow.rs
+++ b/wacore/binary/tests/marshal_shallow.rs
@@ -1,0 +1,196 @@
+//! `marshal_shallow` is what `Client::marshal_node_for_send` puts on the wire,
+//! so two things have to hold for every shape a send produces: it must agree
+//! with `marshal_exact` byte for byte, and its reserve must cover the encoding
+//! on the first try — one allocation per call is the whole point of estimating
+//! instead of planning.
+//!
+//! The allocation half shares this binary with the equality half because the
+//! counting allocator is process-global; a min-delta over many windows is what
+//! keeps a sibling test's allocations out of the measurement.
+
+// Host-only allocation-count harness; std's 64-bit atomic is fine (never built
+// for embedded targets).
+#![allow(clippy::disallowed_types)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::jid::Jid;
+use wacore_binary::marshal::{marshal_exact, marshal_shallow};
+use wacore_binary::node::Node;
+
+struct CountingAlloc;
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+/// A device JID per index, spread over users the way a real fan-out resolves:
+/// a device id past 255 would silently leave the `AD_JID` encoding and measure
+/// a second wire shape. Numbers are reserved-for-fiction NANP.
+fn device_jid(index: usize) -> Jid {
+    const DEVICES_PER_USER: usize = 4;
+    let user = 19045550180u64 + (index / DEVICES_PER_USER) as u64;
+    Jid::pn_device(user.to_string(), (index % DEVICES_PER_USER) as u16)
+}
+
+fn dm_message() -> Node {
+    NodeBuilder::new("message")
+        .attr("to", "19045550181@s.whatsapp.net")
+        .attr("id", "3EB0A1B2C3D4E5F60718")
+        .attr("type", "text")
+        .attr("t", "1760000000")
+        .attr("edit", "1")
+        .attr("category", "peer")
+        .children(vec![
+            NodeBuilder::new("enc")
+                .attr("v", "2")
+                .attr("type", "msg")
+                .bytes(vec![0xAB; 256])
+                .build(),
+        ])
+        .build()
+}
+
+fn group_message() -> Node {
+    NodeBuilder::new("message")
+        .attr("to", "120363000000000001@g.us")
+        .attr("id", "3EB0A1B2C3D4E5F60719")
+        .attr("type", "text")
+        .attr("t", "1760000000")
+        .children(vec![
+            NodeBuilder::new("enc")
+                .attr("v", "2")
+                .attr("type", "skmsg")
+                .bytes(vec![0xCD; 256])
+                .build(),
+        ])
+        .build()
+}
+
+fn receipt() -> Node {
+    NodeBuilder::new("receipt")
+        .attr("to", "19045550182@s.whatsapp.net")
+        .attr("id", "3EB0A9252A8F12B7E2")
+        .attr("type", "read")
+        .attr("t", "1760000000")
+        .build()
+}
+
+fn ack_shaped() -> Node {
+    NodeBuilder::new("ack")
+        .attr("to", "100000000000002@lid")
+        .attr("id", "3EB0A9252A8F12B7E3")
+        .attr("class", "message")
+        .build()
+}
+
+/// The per-device fan-out a first send emits: a `<to>` per recipient device,
+/// each wrapping its own `<enc>`, with string-typed JIDs.
+fn fanout(width: usize) -> Node {
+    let recipients: Vec<Node> = (0..width)
+        .map(|i| {
+            NodeBuilder::new("to")
+                .attr("jid", device_jid(i).to_string())
+                .children(vec![
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "pkmsg")
+                        .bytes(vec![0xEF; 128])
+                        .build(),
+                ])
+                .build()
+        })
+        .collect();
+    NodeBuilder::new("message")
+        .attr("to", "19045550183@s.whatsapp.net")
+        .attr("id", "3EB0A1B2C3D4E5F6071A")
+        .attr("type", "text")
+        .children(recipients)
+        .build()
+}
+
+/// The sender-key distribution shape: the same fan-out under a
+/// `<participants>` wrapper, with typed [`Jid`] attributes as
+/// `build_participant_node` passes them.
+fn skdm_fanout(width: usize) -> Node {
+    let recipients: Vec<Node> = (0..width)
+        .map(|i| {
+            NodeBuilder::new("to")
+                .attr("jid", device_jid(i))
+                .children(vec![
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "msg")
+                        .bytes(vec![0xAB; 128])
+                        .build(),
+                ])
+                .build()
+        })
+        .collect();
+    NodeBuilder::new("message")
+        .attr("to", "120363000000000001@g.us")
+        .attr("id", "3EB0A1B2C3D4E5F6071B")
+        .attr("type", "text")
+        .children(vec![
+            NodeBuilder::new("participants")
+                .children(recipients)
+                .build(),
+        ])
+        .build()
+}
+
+fn send_shapes() -> Vec<(&'static str, Node)> {
+    vec![
+        ("dm", dm_message()),
+        ("group", group_message()),
+        ("receipt", receipt()),
+        ("ack", ack_shaped()),
+        ("fanout 8", fanout(8)),
+        ("fanout 64", fanout(64)),
+        ("skdm fanout 8", skdm_fanout(8)),
+        ("skdm fanout 512", skdm_fanout(512)),
+    ]
+}
+
+#[test]
+fn shallow_encodes_every_send_shape_exactly_as_the_exact_path_did() {
+    for (name, node) in send_shapes() {
+        let exact = marshal_exact(&node).expect("marshal_exact");
+        let shallow = marshal_shallow(&node).expect("marshal_shallow");
+        assert_eq!(shallow, exact, "{name}: encoding must not change");
+    }
+}
+
+#[test]
+fn shallow_reserves_enough_to_allocate_once() {
+    for (name, node) in send_shapes() {
+        // Min-delta over many windows: the counter is process-global and
+        // harness threads bleed sporadic allocations, but if the reserve
+        // really covers the encoding, at least one window lands on exactly
+        // the output buffer.
+        let mut min_delta = u64::MAX;
+        for _ in 0..64 {
+            let before = ALLOCS.load(Ordering::Relaxed);
+            let payload = marshal_shallow(&node).expect("marshal_shallow");
+            let after = ALLOCS.load(Ordering::Relaxed);
+            assert!(!payload.is_empty());
+            min_delta = min_delta.min(after - before);
+        }
+        assert_eq!(
+            min_delta, 1,
+            "{name}: the shallow reserve must cover the encoding, so the output \
+             buffer is the only allocation"
+        );
+    }
+}

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1168,32 +1168,21 @@ pub fn is_sender_key_distribution_only(msg: &mut wa::Message) -> bool {
     only
 }
 
-// Declares the enum and both of its key mappings from a single list, so a wire
-// key can never end up in one direction and not the other.
+// Declares the enum from a single list so the slot count follows the variant
+// count; the wire key itself lives once per variant, in `#[wire = ...]`, and
+// `WireEnum` derives `TryFrom<&str>` and `as_str()` from it.
 macro_rules! message_attrs {
     ($($variant:ident => $key:literal),+ $(,)?) => {
-        #[derive(Clone, Copy)]
+        #[derive(Clone, Copy, crate::WireEnum)]
         enum MessageAttr {
-            $($variant,)+
+            $(
+                #[wire = $key]
+                $variant,
+            )+
         }
 
         impl MessageAttr {
             const COUNT: usize = [$(stringify!($variant)),+].len();
-
-            #[inline]
-            fn from_key(key: &str) -> Option<Self> {
-                match key {
-                    $($key => Some(Self::$variant),)+
-                    _ => None,
-                }
-            }
-
-            #[inline]
-            fn key(self) -> &'static str {
-                match self {
-                    $(Self::$variant => $key,)+
-                }
-            }
         }
     };
 }
@@ -1241,7 +1230,7 @@ impl<'a> MessageAttrs<'a> {
         let mut slots = [None; MessageAttr::COUNT];
         for (key, value) in node.attrs.as_slice() {
             // First occurrence wins, as a scan for the key would have found it.
-            if let Some(attr) = MessageAttr::from_key(key)
+            if let Ok(attr) = MessageAttr::try_from(&**key)
                 && slots[attr as usize].is_none()
             {
                 slots[attr as usize] = Some(value);
@@ -1259,7 +1248,7 @@ impl<'a> MessageAttrs<'a> {
     }
 
     fn missing(&mut self, attr: MessageAttr) {
-        let key = attr.key();
+        let key = attr.as_str();
         self.errors
             .push(wacore_binary::BinaryError::AttrParse(format!(
                 "Required attribute '{key}' not found"
@@ -1275,7 +1264,7 @@ impl<'a> MessageAttrs<'a> {
         attr: MessageAttr,
     ) -> wacore_binary::Result<std::borrow::Cow<'a, str>> {
         self.optional_string(attr)
-            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.key().to_string()))
+            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.as_str().to_string()))
     }
 
     fn optional_jid(&mut self, attr: MessageAttr) -> Option<wacore_binary::Jid> {
@@ -1313,7 +1302,7 @@ impl<'a> MessageAttrs<'a> {
 
     fn required_jid(&self, attr: MessageAttr) -> wacore_binary::Result<wacore_binary::Jid> {
         self.optional_jid_result(attr)?
-            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.key().to_string()))
+            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.as_str().to_string()))
     }
 
     fn optional_u64(&mut self, attr: MessageAttr) -> Option<u64> {
@@ -1321,7 +1310,7 @@ impl<'a> MessageAttrs<'a> {
         match text.parse::<u64>() {
             Ok(value) => Some(value),
             Err(e) => {
-                let key = attr.key();
+                let key = attr.as_str();
                 self.errors
                     .push(wacore_binary::BinaryError::AttrParse(format!(
                         "Failed to parse u64 from '{text}' for key '{key}': {e}"
@@ -1339,7 +1328,7 @@ impl<'a> MessageAttrs<'a> {
         match text.parse::<i64>() {
             Ok(value) => value,
             Err(e) => {
-                let key = attr.key();
+                let key = attr.as_str();
                 self.errors
                     .push(wacore_binary::BinaryError::AttrParse(format!(
                         "Failed to parse i64 from '{text}' for key '{key}': {e}"

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1168,6 +1168,192 @@ pub fn is_sender_key_distribution_only(msg: &mut wa::Message) -> bool {
     only
 }
 
+// Declares the enum and both of its key mappings from a single list, so a wire
+// key can never end up in one direction and not the other.
+macro_rules! message_attrs {
+    ($($variant:ident => $key:literal),+ $(,)?) => {
+        #[derive(Clone, Copy)]
+        enum MessageAttr {
+            $($variant,)+
+        }
+
+        impl MessageAttr {
+            const COUNT: usize = [$(stringify!($variant)),+].len();
+
+            #[inline]
+            fn from_key(key: &str) -> Option<Self> {
+                match key {
+                    $($key => Some(Self::$variant),)+
+                    _ => None,
+                }
+            }
+
+            #[inline]
+            fn key(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $key,)+
+                }
+            }
+        }
+    };
+}
+
+message_attrs! {
+    Id => "id",
+    From => "from",
+    AddressingMode => "addressing_mode",
+    Participant => "participant",
+    ParticipantPn => "participant_pn",
+    ParticipantLid => "participant_lid",
+    Recipient => "recipient",
+    SenderPn => "sender_pn",
+    SenderLid => "sender_lid",
+    Category => "category",
+    Type => "type",
+    ServerId => "server_id",
+    Offline => "offline",
+    Sts => "sts",
+    VerifiedLevel => "verified_level",
+    VerifiedName => "verified_name",
+    PeerRecipientPn => "peer_recipient_pn",
+    Notify => "notify",
+    Timestamp => "t",
+    Edit => "edit",
+}
+
+/// The attributes [`parse_message_info`] reads off a `<message>` stanza,
+/// resolved in a single pass.
+///
+/// `AttrParserRef` answers a key by scanning the attribute slice, and that
+/// parser asks twenty questions, so a stanza's attributes were walked twenty
+/// times over to answer what one walk answers. Naming the set up front turns
+/// every read into an array index; the accessors below then apply exactly the
+/// rules `AttrParserRef` applies — same coercions, same error text, same order
+/// of errors, and a repeated key still resolving to its first occurrence — so
+/// only the lookup changed.
+struct MessageAttrs<'a> {
+    slots: [Option<&'a wacore_binary::node::ValueRef<'a>>; MessageAttr::COUNT],
+    errors: Vec<wacore_binary::BinaryError>,
+}
+
+impl<'a> MessageAttrs<'a> {
+    fn resolve(node: &'a wacore_binary::NodeRef<'a>) -> Self {
+        let mut slots = [None; MessageAttr::COUNT];
+        for (key, value) in node.attrs.as_slice() {
+            // First occurrence wins, as a scan for the key would have found it.
+            if let Some(attr) = MessageAttr::from_key(key)
+                && slots[attr as usize].is_none()
+            {
+                slots[attr as usize] = Some(value);
+            }
+        }
+        Self {
+            slots,
+            errors: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn get(&self, attr: MessageAttr) -> Option<&'a wacore_binary::node::ValueRef<'a>> {
+        self.slots[attr as usize]
+    }
+
+    fn missing(&mut self, attr: MessageAttr) {
+        let key = attr.key();
+        self.errors
+            .push(wacore_binary::BinaryError::AttrParse(format!(
+                "Required attribute '{key}' not found"
+            )));
+    }
+
+    fn optional_string(&self, attr: MessageAttr) -> Option<std::borrow::Cow<'a, str>> {
+        self.get(attr).map(|value| value.as_str())
+    }
+
+    fn required_string(
+        &self,
+        attr: MessageAttr,
+    ) -> wacore_binary::Result<std::borrow::Cow<'a, str>> {
+        self.optional_string(attr)
+            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.key().to_string()))
+    }
+
+    fn optional_jid(&mut self, attr: MessageAttr) -> Option<wacore_binary::Jid> {
+        let value = self.get(attr)?;
+        match value.to_jid() {
+            Some(jid) => Some(jid),
+            None => {
+                // to_jid() only returns None if it's a String that failed to parse
+                if let wacore_binary::node::ValueRef::String(s) = value {
+                    self.errors
+                        .push(wacore_binary::BinaryError::AttrParse(format!(
+                            "Invalid JID: {s}"
+                        )));
+                }
+                None
+            }
+        }
+    }
+
+    fn optional_jid_result(
+        &self,
+        attr: MessageAttr,
+    ) -> wacore_binary::Result<Option<wacore_binary::Jid>> {
+        match self.get(attr) {
+            None => Ok(None),
+            Some(wacore_binary::node::ValueRef::Jid(jid)) => Ok(Some(jid.to_owned())),
+            Some(wacore_binary::node::ValueRef::String(value)) => {
+                use std::str::FromStr as _;
+                wacore_binary::Jid::from_str(value)
+                    .map(Some)
+                    .map_err(wacore_binary::BinaryError::from)
+            }
+        }
+    }
+
+    fn required_jid(&self, attr: MessageAttr) -> wacore_binary::Result<wacore_binary::Jid> {
+        self.optional_jid_result(attr)?
+            .ok_or_else(|| wacore_binary::BinaryError::MissingAttr(attr.key().to_string()))
+    }
+
+    fn optional_u64(&mut self, attr: MessageAttr) -> Option<u64> {
+        let text = self.optional_string(attr)?;
+        match text.parse::<u64>() {
+            Ok(value) => Some(value),
+            Err(e) => {
+                let key = attr.key();
+                self.errors
+                    .push(wacore_binary::BinaryError::AttrParse(format!(
+                        "Failed to parse u64 from '{text}' for key '{key}': {e}"
+                    )));
+                None
+            }
+        }
+    }
+
+    fn unix_time(&mut self, attr: MessageAttr) -> i64 {
+        let Some(text) = self.optional_string(attr) else {
+            self.missing(attr);
+            return 0;
+        };
+        match text.parse::<i64>() {
+            Ok(value) => value,
+            Err(e) => {
+                let key = attr.key();
+                self.errors
+                    .push(wacore_binary::BinaryError::AttrParse(format!(
+                        "Failed to parse i64 from '{text}' for key '{key}': {e}"
+                    )));
+                0
+            }
+        }
+    }
+
+    fn into_errors(self) -> Vec<wacore_binary::BinaryError> {
+        self.errors
+    }
+}
+
 /// Parse a message stanza into a `MessageInfo` struct.
 ///
 /// This is a pure function that extracts message metadata from a node's
@@ -1184,28 +1370,28 @@ pub fn parse_message_info(
     };
     use wacore_binary::{JidExt as _, STATUS_BROADCAST_USER, Server};
 
-    let mut attrs = node.attrs();
-    let id = attrs.required_string("id")?;
+    let mut attrs = MessageAttrs::resolve(node);
+    let id = attrs.required_string(MessageAttr::Id)?;
     anyhow::ensure!(
         !id.is_empty(),
         "message stanza has an empty required 'id' attribute"
     );
     let id = CompactString::from(id.as_ref());
-    let from = attrs.required_jid("from")?;
+    let from = attrs.required_jid(MessageAttr::From)?;
     let addressing_mode = attrs
-        .optional_string("addressing_mode")
+        .optional_string(MessageAttr::AddressingMode)
         .and_then(|s| AddressingMode::try_from(s.as_ref()).ok());
 
     let mut source = if from.server == Server::Broadcast {
-        let participant = attrs.required_jid("participant")?;
+        let participant = attrs.required_jid(MessageAttr::Participant)?;
         let is_from_me = participant.matches_user_or_lid(own_jid, own_lid);
 
         // Match WAWebMsgParser: read participant_lid/_pn unconditionally so
         // the LID-PN cache can re-warm from the stanza.
         let sender_alt = if participant.server.is_pn_family() {
-            attrs.optional_jid("participant_lid")
+            attrs.optional_jid(MessageAttr::ParticipantLid)
         } else if participant.server.is_lid_family() {
-            attrs.optional_jid("participant_pn")
+            attrs.optional_jid(MessageAttr::ParticipantPn)
         } else {
             None
         };
@@ -1224,10 +1410,10 @@ pub fn parse_message_info(
             ..Default::default()
         }
     } else if from.is_group() {
-        let sender = attrs.required_jid("participant")?;
+        let sender = attrs.required_jid(MessageAttr::Participant)?;
         let sender_alt = match addressing_mode {
-            Some(AddressingMode::Lid) => attrs.optional_jid("participant_pn"),
-            Some(AddressingMode::Pn) => attrs.optional_jid("participant_lid"),
+            Some(AddressingMode::Lid) => attrs.optional_jid(MessageAttr::ParticipantPn),
+            Some(AddressingMode::Pn) => attrs.optional_jid(MessageAttr::ParticipantLid),
             None => None,
         };
 
@@ -1242,7 +1428,7 @@ pub fn parse_message_info(
             ..Default::default()
         }
     } else if from.matches_user_or_lid(own_jid, own_lid) {
-        let recipient = attrs.optional_jid_result("recipient")?;
+        let recipient = attrs.optional_jid_result(MessageAttr::Recipient)?;
         let chat = recipient
             .as_ref()
             .map(|r| r.to_non_ad())
@@ -1265,9 +1451,9 @@ pub fn parse_message_info(
         }
     } else {
         let sender_alt = if from.server == Server::Lid {
-            attrs.optional_jid("sender_pn")
+            attrs.optional_jid(MessageAttr::SenderPn)
         } else {
-            attrs.optional_jid("sender_lid")
+            attrs.optional_jid(MessageAttr::SenderLid)
         };
 
         MessageSource {
@@ -1297,7 +1483,7 @@ pub fn parse_message_info(
     };
 
     let category = attrs
-        .optional_string("category")
+        .optional_string(MessageAttr::Category)
         .map(|s| MessageCategory::from(s.as_ref()))
         .unwrap_or_default();
 
@@ -1306,11 +1492,11 @@ pub fn parse_message_info(
     // for an attribute nothing downstream needs, so absence is recorded as
     // `None` and an unrecognized value keeps its wire bytes.
     let stanza_type = attrs
-        .optional_string("type")
+        .optional_string(MessageAttr::Type)
         .map(|s| StanzaMessageType::from(s.as_ref()));
 
     let server_id = attrs
-        .optional_u64("server_id")
+        .optional_u64(MessageAttr::ServerId)
         .filter(|&v| (99..=2_147_476_647).contains(&v))
         .unwrap_or(0) as i32;
 
@@ -1319,24 +1505,24 @@ pub fn parse_message_info(
         source.chat.agent = 0;
     }
 
-    let is_offline = attrs.optional_string("offline").is_some();
+    let is_offline = attrs.get(MessageAttr::Offline).is_some();
 
     // Envelope enrichment (mirrors WAWebHandleMsgParser y() function).
     let server_timestamp_us = attrs
-        .optional_u64("sts")
+        .optional_u64(MessageAttr::Sts)
         .and_then(|v| i64::try_from(v).ok());
     let verified_level = attrs
-        .optional_string("verified_level")
+        .optional_string(MessageAttr::VerifiedLevel)
         .map(|s| s.into_owned());
     let verified_name_serial = attrs
-        .optional_u64("verified_name")
+        .optional_u64(MessageAttr::VerifiedName)
         .and_then(|v| i64::try_from(v).ok());
     // The display name only exists inside the <verified_name> child's cert protobuf.
     let verified_name = node
         .get_optional_child("verified_name")
         .and_then(|vn| crate::stanza::business::VerifiedName::try_from_node(vn).ok())
         .map(Box::new);
-    let peer_recipient_pn = attrs.optional_jid("peer_recipient_pn");
+    let peer_recipient_pn = attrs.optional_jid(MessageAttr::PeerRecipientPn);
 
     // <meta> child attrs (WAWebHandleMsgParser b()) and <reporting> children
     // (I() function). Both are optional; absence is the common case.
@@ -1406,24 +1592,36 @@ pub fn parse_message_info(
         })
     });
 
+    let push_name = attrs
+        .optional_string(MessageAttr::Notify)
+        .map(|s| CompactString::from(s.as_ref()))
+        .unwrap_or_default();
+    let timestamp = crate::time::from_secs_or_now(attrs.unix_time(MessageAttr::Timestamp));
+    // Parse from the borrowed attribute: `From<String>` immediately re-borrows
+    // it, so materializing a String first only buys a discarded allocation for
+    // every known variant.
+    let edit = attrs
+        .optional_string(MessageAttr::Edit)
+        .map(|s| EditAttribute::from(s.as_ref()))
+        .unwrap_or_default();
+
+    // The attribute parser accumulates non-fatal failures — an optional JID
+    // that would not parse, a `t` that is not a number — into a list this
+    // function has never inspected: the value degrades to absent or zero and
+    // the message is delivered anyway. The list is still built, in the same
+    // order and with the same text, so the day a caller wants it the behaviour
+    // it describes is the one that ran.
+    drop(attrs.into_errors());
+
     Ok(MessageInfo {
         source,
         id,
         server_id,
         r#type: stanza_type,
-        push_name: attrs
-            .optional_string("notify")
-            .map(|s| CompactString::from(s.as_ref()))
-            .unwrap_or_default(),
-        timestamp: crate::time::from_secs_or_now(attrs.unix_time("t")),
+        push_name,
+        timestamp,
         category,
-        // Parse from the borrowed attribute: `From<String>` immediately
-        // re-borrows it, so materializing a String first only buys a discarded
-        // allocation for every known variant.
-        edit: attrs
-            .optional_string("edit")
-            .map(|s| EditAttribute::from(s.as_ref()))
-            .unwrap_or_default(),
+        edit,
         is_offline,
         server_timestamp_us,
         verified_level,


### PR DESCRIPTION
The codec half of a second parallel exploration (binary protocol + protobuf message path), after #1388–#1396. The honest headline from that pass: for a steady stream of ordinary messages the codec is no longer where the time is (decoding a DM stanza plus parsing its `MessageInfo` is ~3% of a `dm_receive`). What is left is a set of small, safe wins that move every stanza by a little and a wide fan-out by a lot.

## Marshal outbound stanzas in one pass

`Client::marshal_node_for_send` used `marshal_exact`, which walks the whole tree once to compute the exact size and record a hint tape, then walks it again to write. The buffer it sized perfectly is transient (it goes straight into the frame), while the second traversal is paid on every send and grows with the fan-out width; past ~32 strings the hint tape spills and reallocates too.

`marshal_shallow` (new, `wacore/binary/src/marshal.rs`) sizes the buffer from the node's own byte lengths — the `BINARY_8/20/32` form of each tag, key, value and content, which every other encoding (token, packed id, JID) undercuts — sampling the first 32 children per level and charging the rest the sampled mean, clamped at 4 MiB. Then one write. An undershoot costs a `Vec` growth, never a wrong encoding. `marshal_exact` is untouched. `wacore/binary/tests/marshal_shallow.rs` asserts byte-identity with `marshal_exact` **and** exactly one allocation over DM, group, receipt, ack, 8/64-device fan-out and 8/512-device SKDM fan-out shapes.

| `group_fanout_benchmark` (median, both arms in one process) | `marshal_exact` | `marshal_shallow` |
| --- | --- | --- |
| 8 devices | 1.893 µs | 1.594 µs (−15.8%) |
| 32 | 5.865 µs | 5.023 µs (−14.4%) |
| 128 | 22.10 µs | 17.94 µs (−18.8%) |
| 512 | 112.9 µs | 90.32 µs (−20.0%) |

`binary_benchmark`: `marshal_*_large` 2.021 → 1.650 µs, `marshal_*_many_children` (2048 children) 279 → 224 µs. Allocations: 1 per call on all eight shapes, against 1–9 for `marshal_exact` once the tape spills. A warm group send is flat in group size (it fans out to own devices only), so the fan-out win is paid on rotation and membership change; the per-stanza ~15% is what every send gets.

## Resolve a message stanza's attributes in one pass

`parse_message_info` asked `AttrParserRef` ~20 questions, and each was a linear scan of the attribute slice: 57% of the parse was key matching. `MessageAttrs` (wacore/src/messages.rs) declares the key set once (a macro emits the enum and both mappings so a key cannot exist in one direction only), fills a slot array in a single walk of `node.attrs`, and serves every read as an array index. The accessors mirror `AttrParserRef` exactly: same coercions, same error strings, same push order, first occurrence wins on a duplicate key. `AttrParserRef` still serves the `<meta>`/`<bot>`/`<reporting>` children.

| `message_utils_benchmark::bench_parse_message_info` | before | after |
| --- | --- | --- |
| dm_pn | 325 ns | 240 ns (−26%) |
| group_lid | 311 ns | 213 ns (−31%) |
| self_sent | 270 ns | 189 ns (−30%) |
| status_broadcast | 294 ns | 213 ns (−27%) |

(Separate processes on a contended box: read the direction and magnitude, not the last digit; all four shapes moved together.)

## One parked inflate state per thread

`InflateReader`'s free list kept up to four `Inflate` states (~46 KB each) per thread that ever inflated anything, forever. Sequential readers — a bootstrap history sync inflating blobs one after another — only ever check out one, so `POOL_MAX` is now 1; nested readers still work, they build their state instead of finding it parked. RSS only, unmeasured on a live client, stated as such in the commit.

## Explored and reverted

Sizing `read_packed`'s 254-byte zero-filled scratch buffer to the value: callgrind over 200k ack decodes read 355.40M instructions before and 355.60M after — the release build already elides the memset. Committed and reverted in this branch so the measurement is on record.

## Not done

- Arena-backed `NodeRef` containers (27–49% of a wide usync response decode is glibc malloc): a large, API-visible change touching the `Yokeable`/`StableDeref` `unsafe`; left for its own PR with the Miri gate.

## Verification

- `cargo clippy -p wacore-binary -p wacore -p whatsapp-rust --all-targets -- -D warnings` clean
- `cargo test -p wacore-binary` (lib + integration incl. the new `marshal_shallow` pair), `cargo test -p wacore --lib` (1567), `cargo test -p whatsapp-rust --lib` (1867) pass

CI note: `Semver Checks (informational)` is red on `main` as well and is not this PR's; no fix exists for it in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN