### PR TITLE
perf(handlers): shrink the inbound non-message stanza path; inbound_stanza bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,15 @@ name = "client_dm_send"
 harness = false
 required-features = ["bench-harness"]
 
+# The inbound counterpart: the non-message stanzas (`<receipt>`, `<presence>`,
+# `<notification>`, `<ack>`) the read loop handles without a decrypt. Its
+# regression signal is bytes per stanza, not wall time; the target's own header
+# says why.
+[[bench]]
+name = "inbound_stanza"
+harness = false
+required-features = ["bench-harness"]
+
 # The `Cache<Jid, _>` lookup shape `chat_lanes` runs per inbound message. No
 # `required-features`: it reaches only the public cache, so it builds (and is
 # regression-gated) in a plain `cargo bench`.

--- a/benches/inbound_stanza.rs
+++ b/benches/inbound_stanza.rs
@@ -1,0 +1,186 @@
+//! Client-level inbound non-message stanzas: `<receipt>`, `<presence>`,
+//! `<notification>` and `<ack>`, from the decoded stanza to the dispatched
+//! event.
+//!
+//! `client_receive` covers the `<message>` path, where a Signal decrypt
+//! dominates everything around it. These four are the rest of the read loop —
+//! no crypto, so what they measure *is* the machinery: classification, the
+//! handler's boxed future, the parse, and the event bus. On an offline drain
+//! they are also the bulk of the queue.
+//!
+//! **The metric to read here is bytes and allocations per stanza, not wall
+//! time.** Every row's body is a few hundred nanoseconds of branch-heavy work
+//! against a fixture that shares a runtime with an ack worker, so timings move
+//! more between runs than any change worth making moves them; the allocation
+//! columns (`divan::AllocProfiler` is wired in below) are exact. The regression
+//! this target exists to catch is a per-stanza heap block growing back — an
+//! `.await` on an unboxed handler arm re-inflates the notification future the
+//! way it was before PR "perf(handlers)".
+//!
+//! Every stanza runs twice: once with nothing subscribed to its event kind and
+//! once with a subscriber. That is not redundancy — the subscriber is what
+//! decides how much of the pipeline runs. `has_handler_for` gates the receipt
+//! parse, steers `processes_inline`, and is what makes an `Arc<Event>` exist at
+//! all.
+//!
+//! What it does not cover, stated once so no number here is over-read:
+//!
+//! - **The read loop's task spawn.** Stanzas enter at `process_node`, which is
+//!   what the spawned task calls; the spawn itself is not measured.
+//! - **The socket write.** The transport `<ack>` a `<receipt>` or
+//!   `<notification>` owes is marshalled and noise-encrypted by a worker; the
+//!   sink transport drops the frame.
+//! - **Stanza construction.** Each row builds its stanza once, before
+//!   sampling, and re-submits it. Nothing on these paths dedupes, so a repeat
+//!   is the same work as a fresh one.
+
+use divan::black_box;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use whatsapp_rust::bench_support::ReceiveHarness;
+
+fn main() {
+    divan::main();
+}
+
+/// Byte and allocation counts per row. The point of the target: see the module
+/// header.
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
+/// Few, large samples, matching `client_receive`: the fixture's flush worker
+/// fires on its own 25 ms clock and a coalesced flush that lands mid-sample is
+/// amortised over a long sample rather than moving a short one.
+const SAMPLE_COUNT: u32 = 20;
+const SAMPLE_SIZE: u32 = 50;
+
+/// A reconnect drains its offline queue in one go. 500 is the size at which the
+/// per-item cost of a drain is clearly separated from the fixed cost of
+/// entering it.
+const BURST: usize = 500;
+
+/// One harness for every row, so no row pays for a second fixture. Unlike the
+/// message rows these stanzas carry no ratchet state, so sharing cannot cross
+/// their streams.
+fn harness() -> &'static ReceiveHarness {
+    static HARNESS: OnceLock<ReceiveHarness> = OnceLock::new();
+    HARNESS.get_or_init(ReceiveHarness::new)
+}
+
+/// Submit one stanza per iteration, asserting afterwards that the subscriber
+/// saw exactly the events it should have: `expected_events` per iteration, so a
+/// stanza silently dropped by a parse failure (which is fast) cannot pass for
+/// a processed one.
+fn bench_one(
+    bencher: divan::Bencher,
+    node: Arc<wacore_binary::OwnedNodeRef>,
+    subscribed: bool,
+    expected_events: u64,
+) {
+    let harness = harness();
+    let subscription = subscribed.then(|| harness.subscribe_stanza_events());
+    let before = harness.stanza_events();
+    let mut submitted = 0u64;
+    bencher.bench_local(|| {
+        submitted += 1;
+        harness.process_nowait(black_box(Arc::clone(&node)));
+    });
+    let delivered = harness.stanza_events() - before;
+    // Dropping it before the flush keeps the assertion below about what this
+    // row submitted.
+    drop(subscription);
+    harness.flush();
+    assert_eq!(delivered, submitted * expected_events);
+}
+
+/// Same, for the drain shape: `BURST` stanzas under one `block_on`.
+fn bench_burst(
+    bencher: divan::Bencher,
+    node: Arc<wacore_binary::OwnedNodeRef>,
+    expected_events: u64,
+) {
+    let harness = harness();
+    let burst: Vec<_> = std::iter::repeat_n(node, BURST).collect();
+    let subscription = harness.subscribe_stanza_events();
+    let before = harness.stanza_events();
+    let mut submitted = 0u64;
+    bencher.bench_local(|| {
+        submitted += BURST as u64;
+        harness.process_burst(black_box(&burst));
+    });
+    let delivered = harness.stanza_events() - before;
+    drop(subscription);
+    harness.flush();
+    assert_eq!(delivered, submitted * expected_events);
+}
+
+/// A delivery `<receipt>` nobody is listening for: the read-loop shape, where
+/// the whole point is that the parse stops at the subscriber gate.
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn receipt(bencher: divan::Bencher) {
+    bench_one(bencher, harness().receipt_stanza(), false, 0);
+}
+
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn receipt_subscribed(bencher: divan::Bencher) {
+    bench_one(bencher, harness().receipt_stanza(), true, 1);
+}
+
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn presence(bencher: divan::Bencher) {
+    bench_one(bencher, harness().presence_stanza(), false, 0);
+}
+
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn presence_subscribed(bencher: divan::Bencher) {
+    bench_one(bencher, harness().presence_stanza(), true, 1);
+}
+
+/// The row the boxed-arm regression shows up in: the notification handler's
+/// future is sized for whichever arm the compiler keeps inline, whatever type
+/// this stanza actually carries.
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn notification(bencher: divan::Bencher) {
+    bench_one(bencher, harness().notification_stanza(), false, 0);
+}
+
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn notification_subscribed(bencher: divan::Bencher) {
+    bench_one(bencher, harness().notification_stanza(), true, 1);
+}
+
+/// A server `<ack>` no waiter is parked on — the shape every fire-and-forget
+/// send draws back, and the cheapest stanza the client handles.
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn ack(bencher: divan::Bencher) {
+    bench_one(bencher, harness().ack_stanza(), false, 0);
+}
+
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn ack_subscribed(bencher: divan::Bencher) {
+    bench_one(bencher, harness().ack_stanza(), true, 1);
+}
+
+// The drain rows all run subscribed: a reconnect that drains a queue into a
+// consumer is the case where the per-item cost is actually paid, and the
+// no-subscriber shape is already covered per stanza above. Divide every column
+// by `BURST` for the per-item figure.
+#[divan::bench(sample_count = 10, sample_size = 1)]
+fn burst_receipt(bencher: divan::Bencher) {
+    bench_burst(bencher, harness().receipt_stanza(), 1);
+}
+
+#[divan::bench(sample_count = 10, sample_size = 1)]
+fn burst_presence(bencher: divan::Bencher) {
+    bench_burst(bencher, harness().presence_stanza(), 1);
+}
+
+#[divan::bench(sample_count = 10, sample_size = 1)]
+fn burst_notification(bencher: divan::Bencher) {
+    bench_burst(bencher, harness().notification_stanza(), 1);
+}
+
+#[divan::bench(sample_count = 10, sample_size = 1)]
+fn burst_ack(bencher: divan::Bencher) {
+    bench_burst(bencher, harness().ack_stanza(), 1);
+}

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -752,6 +752,42 @@ impl wacore::types::events::EventHandler for MessageCounter {
     }
 }
 
+/// Counts the non-message stanza events the inbound benchmarks produce, so a
+/// "with a subscriber" row can prove the event actually reached a handler
+/// rather than being dropped by the interest bitmask.
+///
+/// Kept unsubscribed by the fixture: the same benchmarks also measure the
+/// no-subscriber shape, which is what a bot that only wants `Messages` runs,
+/// and that shape only exists while nothing is interested in these kinds.
+struct StanzaEventCounter {
+    delivered: portable_atomic::AtomicU64,
+}
+
+/// The kinds [`ReceiveHarness`]'s non-message stanzas turn into: a `<receipt>`,
+/// a `<presence>`, a `<notification type="picture">` and an `<ack>`.
+const STANZA_EVENT_KINDS: &[wacore::types::events::EventKind] = &[
+    wacore::types::events::EventKind::Receipt,
+    wacore::types::events::EventKind::Presence,
+    wacore::types::events::EventKind::PictureUpdate,
+    wacore::types::events::EventKind::ServerAck,
+];
+
+impl wacore::types::events::EventHandler for StanzaEventCounter {
+    fn handle_event(&self, event: Arc<wacore::types::events::Event>) {
+        use wacore::types::events::Event;
+        if matches!(
+            &*event,
+            Event::Receipt(_) | Event::Presence(_) | Event::PictureUpdate(_) | Event::ServerAck(_)
+        ) {
+            self.delivered.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn interest(&self) -> wacore::types::events::EventInterest {
+        wacore::types::events::EventInterest::of(STANZA_EVENT_KINDS)
+    }
+}
+
 /// A logged-in client receiving from one peer it already shares a session and
 /// a sender key with: the steady state every message after the first arrives
 /// in.
@@ -775,6 +811,7 @@ pub struct ReceiveHarness {
     group: Jid,
     group_sender_key: wacore::libsignal::protocol::SenderKeyName,
     counter: Arc<MessageCounter>,
+    stanza_counter: Arc<StanzaEventCounter>,
     /// Dropping it would unsubscribe the counter.
     _subscription: wacore::types::events::Subscription,
     next_id: portable_atomic::AtomicU64,
@@ -799,6 +836,7 @@ impl ReceiveHarness {
             group: fixture.group,
             group_sender_key: fixture.group_sender_key,
             counter: fixture.counter,
+            stanza_counter: fixture.stanza_counter,
             _subscription: fixture.subscription,
             next_id: portable_atomic::AtomicU64::new(0),
         }
@@ -902,6 +940,119 @@ impl ReceiveHarness {
         self.counter.delivered.load(Ordering::Relaxed)
     }
 
+    /// Subscribe the non-message stanza counter for as long as the returned
+    /// [`Subscription`](wacore::types::events::Subscription) is held.
+    ///
+    /// The inbound benchmarks run each stanza both ways, because the
+    /// subscriber is what decides how much of the pipeline runs at all:
+    /// `has_handler_for` gates the receipt parse and steers `processes_inline`,
+    /// and without one an event is never materialised. Neither shape is the
+    /// "real" one — a bot that only consumes `Messages` runs the first, a
+    /// client that mirrors presence and receipts runs the second.
+    pub fn subscribe_stanza_events(&self) -> wacore::types::events::Subscription {
+        self.client.subscribe_handler(
+            Arc::clone(&self.stanza_counter) as Arc<dyn wacore::types::events::EventHandler>
+        )
+    }
+
+    /// How many of the four non-message stanza events reached the subscriber.
+    pub fn stanza_events(&self) -> u64 {
+        self.stanza_counter.delivered.load(Ordering::Relaxed)
+    }
+
+    /// A `<receipt>` from the peer: the delivery acknowledgement one of our
+    /// outgoing DMs draws back, in the simple (non-aggregated) shape.
+    pub fn receipt_stanza(&self) -> Arc<wacore_binary::OwnedNodeRef> {
+        let node = wacore_binary::builder::NodeBuilder::new("receipt")
+            .attr("from", self.peer_jid.to_string())
+            .attr("id", self.next_message_id())
+            .attr("t", wacore::time::now_secs().to_string())
+            .build();
+        decoded(&node)
+    }
+
+    /// A `<presence>` from the peer. The one inbound stanza the server does
+    /// not expect an `<ack>` for, which is what makes it the control against
+    /// the acked kinds.
+    pub fn presence_stanza(&self) -> Arc<wacore_binary::OwnedNodeRef> {
+        let node = wacore_binary::builder::NodeBuilder::new("presence")
+            .attr("from", self.peer_jid.to_string())
+            .attr("type", "available")
+            .build();
+        decoded(&node)
+    }
+
+    /// A `<notification type="picture">`, the cheapest notification the client
+    /// models: one synchronous arm and a single-`String` payload. Anything the
+    /// row reports beyond that belongs to the dispatch machinery around the
+    /// arm, not to the arm.
+    pub fn notification_stanza(&self) -> Arc<wacore_binary::OwnedNodeRef> {
+        let jid = self.peer_jid.to_string();
+        let set = wacore_binary::builder::NodeBuilder::new("set")
+            .attr("jid", jid.clone())
+            .attr("id", "1700000000")
+            .build();
+        let node = wacore_binary::builder::NodeBuilder::new("notification")
+            .attr("from", jid)
+            .attr("type", "picture")
+            .attr("id", self.next_message_id())
+            .attr("t", wacore::time::now_secs().to_string())
+            .children([set])
+            .build();
+        decoded(&node)
+    }
+
+    /// A server `<ack>` for an outgoing stanza no waiter is parked on — the
+    /// shape every fire-and-forget send (receipts, acks, presence) draws back.
+    pub fn ack_stanza(&self) -> Arc<wacore_binary::OwnedNodeRef> {
+        let node = wacore_binary::builder::NodeBuilder::new("ack")
+            .attr("from", self.peer_jid.to_string())
+            .attr("class", "message")
+            .attr("id", self.next_message_id())
+            .attr("t", wacore::time::now_secs().to_string())
+            .build();
+        decoded(&node)
+    }
+
+    /// Run one stanza through the real `Client::process_node` — classification,
+    /// the handler, the event — and stop there.
+    ///
+    /// Unlike [`Self::receive`] this does *not* flush the outbound scope. The
+    /// transport `<ack>` a `<receipt>` or `<notification>` owes is handed to a
+    /// persistent worker that only runs while something else awaits, so
+    /// flushing it per stanza would fold a socket write into a measurement of
+    /// the inbound path. [`Self::flush`] settles it between benchmarks
+    /// instead.
+    pub fn process_nowait(&self, node: Arc<wacore_binary::OwnedNodeRef>) {
+        self.runtime
+            .block_on(Arc::clone(&self.client).process_node(node));
+    }
+
+    /// Run a whole batch of stanzas under one `block_on`, as an offline drain
+    /// does: the read loop hands the queue over without yielding to anything
+    /// else between items, so the per-item cost includes whatever the ack
+    /// worker gets to do in the gaps.
+    pub fn process_burst(&self, nodes: &[Arc<wacore_binary::OwnedNodeRef>]) {
+        self.runtime.block_on(async {
+            for node in nodes {
+                Arc::clone(&self.client)
+                    .process_node(Arc::clone(node))
+                    .await;
+            }
+        });
+    }
+
+    /// Let the outbound work the processed stanzas queued (their transport
+    /// `<ack>`s) finish, so it cannot leak into the next benchmark.
+    pub fn flush(&self) {
+        self.runtime.block_on(async {
+            self.client
+                .outbound_flush
+                .flush(&*self.client.runtime, std::time::Duration::from_secs(5))
+                .await;
+        });
+    }
+
     /// A fresh stanza id per built message, so dedup never sees a repeat.
     fn next_message_id(&self) -> String {
         let n = self.next_id.fetch_add(1, Ordering::Relaxed);
@@ -935,6 +1086,7 @@ struct ReceiveFixture {
     group: Jid,
     group_sender_key: wacore::libsignal::protocol::SenderKeyName,
     counter: Arc<MessageCounter>,
+    stanza_counter: Arc<StanzaEventCounter>,
     subscription: wacore::types::events::Subscription,
 }
 
@@ -1015,6 +1167,9 @@ async fn build_receive_fixture() -> ReceiveFixture {
         group,
         group_sender_key,
         counter,
+        stanza_counter: Arc::new(StanzaEventCounter {
+            delivered: portable_atomic::AtomicU64::new(0),
+        }),
         subscription,
     }
 }

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -1,6 +1,6 @@
 use crate::client::Client;
 use crate::lid_pn_cache::LearningSource;
-use crate::types::events::Event;
+use crate::types::events::{Event, EventKind};
 use log::{debug, info, warn};
 use std::sync::Arc;
 use wacore::stanza::devices::DeviceNotification;
@@ -354,13 +354,18 @@ pub(crate) async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<
     }
 
     // = addSecurityCodeChangedNotifications, which WA Web fires inside the gate.
-    client.core.event_bus.dispatch(Event::IdentityChange(
-        crate::types::events::IdentityChange::builder()
-            .user(from_jid.clone())
-            .maybe_lid_user(stanza_lid)
-            .implicit(false)
-            .build(),
-    ));
+    client
+        .core
+        .event_bus
+        .dispatch_with(EventKind::IdentityChange, || {
+            Event::IdentityChange(
+                crate::types::events::IdentityChange::builder()
+                    .user(from_jid.clone())
+                    .maybe_lid_user(stanza_lid)
+                    .implicit(false)
+                    .build(),
+            )
+        });
 
     // Re-establish the session eagerly so the next send is fast (WA Web does this
     // inside the gate too). Skip only while the offline backlog is still draining,
@@ -450,13 +455,18 @@ pub(crate) async fn handle_local_identity_change(client: &Arc<Client>, sender: J
         client.reissue_tc_token_after_identity_change(&sender).await;
     }
 
-    client.core.event_bus.dispatch(Event::IdentityChange(
-        crate::types::events::IdentityChange::builder()
-            .user(sender)
-            .maybe_lid_user(None)
-            .implicit(true)
-            .build(),
-    ));
+    client
+        .core
+        .event_bus
+        .dispatch_with(EventKind::IdentityChange, || {
+            Event::IdentityChange(
+                crate::types::events::IdentityChange::builder()
+                    .user(sender)
+                    .maybe_lid_user(None)
+                    .implicit(true)
+                    .build(),
+            )
+        });
 }
 
 /// Refresh the device list of the contact a hash-only `<update>` names.
@@ -562,27 +572,31 @@ pub(crate) async fn handle_devices_notification(client: &Arc<Client>, node: &Nod
     }
 
     // Dispatch event to notify application layer
-    let event = Event::DeviceListUpdate(
-        DeviceListUpdate::builder()
-            .user(notification.from.clone())
-            .maybe_lid_user(notification.lid_user.clone())
-            .update_type(op.operation_type.into())
-            .devices(
-                op.devices
-                    .iter()
-                    .map(|d| {
-                        DeviceNotificationInfo::builder()
-                            .device_id(d.device_id())
-                            .maybe_key_index(d.key_index)
-                            .build()
-                    })
-                    .collect(),
+    client
+        .core
+        .event_bus
+        .dispatch_with(EventKind::DeviceListUpdate, || {
+            Event::DeviceListUpdate(
+                DeviceListUpdate::builder()
+                    .user(notification.from.clone())
+                    .maybe_lid_user(notification.lid_user.clone())
+                    .update_type(op.operation_type.into())
+                    .devices(
+                        op.devices
+                            .iter()
+                            .map(|d| {
+                                DeviceNotificationInfo::builder()
+                                    .device_id(d.device_id())
+                                    .maybe_key_index(d.key_index)
+                                    .build()
+                            })
+                            .collect(),
+                    )
+                    .maybe_key_index(op.key_index.clone())
+                    .maybe_contact_hash(op.contact_hash.clone())
+                    .build(),
             )
-            .maybe_key_index(op.key_index.clone())
-            .maybe_contact_hash(op.contact_hash.clone())
-            .build(),
-    );
-    client.core.event_bus.dispatch(event);
+        });
 }
 
 /// Parsed device info from account_sync notification

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -1,5 +1,5 @@
 use crate::client::Client;
-use crate::types::events::Event;
+use crate::types::events::{Event, EventKind};
 use log::{debug, warn};
 use std::sync::Arc;
 use wacore::stanza::groups::{GroupNotification, GroupNotificationAction};
@@ -239,43 +239,48 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
         );
 
         let is_last_action = action_index + 1 == action_count;
-        client.core.event_bus.dispatch(Event::GroupUpdate(
-            GroupUpdate::builder()
-                .group_jid(notification.group_jid.clone())
-                .maybe_notification_id(clone_or_take_last(
-                    &mut notification.notification_id,
-                    is_last_action,
-                ))
-                .maybe_notify(clone_or_take_last(&mut notification.notify, is_last_action))
-                .maybe_offline(clone_or_take_last(
-                    &mut notification.offline,
-                    is_last_action,
-                ))
-                .action_index(u32::try_from(action_index).unwrap_or(u32::MAX))
-                .maybe_participant(clone_or_take_last(
-                    &mut notification.participant,
-                    is_last_action,
-                ))
-                .maybe_participant_pn(clone_or_take_last(
-                    &mut notification.participant_pn,
-                    is_last_action,
-                ))
-                .maybe_participant_username(clone_or_take_last(
-                    &mut notification.participant_username,
-                    is_last_action,
-                ))
-                .maybe_participant_country_code(clone_or_take_last(
-                    &mut notification.participant_country_code,
-                    is_last_action,
-                ))
-                .timestamp(timestamp)
-                .is_lid_addressing_mode(notification.is_lid_addressing_mode)
-                .has_incomplete_participant_information(
-                    notification.has_incomplete_participant_information,
+        client
+            .core
+            .event_bus
+            .dispatch_with(EventKind::GroupUpdate, || {
+                Event::GroupUpdate(
+                    GroupUpdate::builder()
+                        .group_jid(notification.group_jid.clone())
+                        .maybe_notification_id(clone_or_take_last(
+                            &mut notification.notification_id,
+                            is_last_action,
+                        ))
+                        .maybe_notify(clone_or_take_last(&mut notification.notify, is_last_action))
+                        .maybe_offline(clone_or_take_last(
+                            &mut notification.offline,
+                            is_last_action,
+                        ))
+                        .action_index(u32::try_from(action_index).unwrap_or(u32::MAX))
+                        .maybe_participant(clone_or_take_last(
+                            &mut notification.participant,
+                            is_last_action,
+                        ))
+                        .maybe_participant_pn(clone_or_take_last(
+                            &mut notification.participant_pn,
+                            is_last_action,
+                        ))
+                        .maybe_participant_username(clone_or_take_last(
+                            &mut notification.participant_username,
+                            is_last_action,
+                        ))
+                        .maybe_participant_country_code(clone_or_take_last(
+                            &mut notification.participant_country_code,
+                            is_last_action,
+                        ))
+                        .timestamp(timestamp)
+                        .is_lid_addressing_mode(notification.is_lid_addressing_mode)
+                        .has_incomplete_participant_information(
+                            notification.has_incomplete_participant_information,
+                        )
+                        .action(action)
+                        .build(),
                 )
-                .action(action)
-                .build(),
-        ));
+            });
     }
 
     // Also dispatch legacy generic notification for backward compatibility
@@ -489,15 +494,20 @@ pub(crate) fn handle_mex_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
         "mex notification received: op_name={op_name} offline={}",
         offline.is_some()
     );
-    client.core.event_bus.dispatch(Event::MexNotification(
-        MexNotification::builder()
-            .op_name(op_name)
-            .maybe_from(from)
-            .maybe_stanza_id(stanza_id)
-            .maybe_offline(offline)
-            .payload(payload)
-            .build(),
-    ));
+    client
+        .core
+        .event_bus
+        .dispatch_with(EventKind::MexNotification, || {
+            Event::MexNotification(
+                MexNotification::builder()
+                    .op_name(op_name)
+                    .maybe_from(from)
+                    .maybe_stanza_id(stanza_id)
+                    .maybe_offline(offline)
+                    .payload(payload)
+                    .build(),
+            )
+        });
 }
 
 /// Handle `<notification type="disappearing_mode">` — a contact changed

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -36,8 +36,19 @@ impl StanzaHandler for NotificationHandler {
     }
 }
 
-/// Dispatch notification by type. Each arm calls a separate async fn so the
-/// compiler doesn't size this future for all arms simultaneously.
+/// Dispatch notification by type.
+///
+/// Every asynchronous arm is `Box::pin`ned. Awaiting a plain async fn inlines
+/// its state machine into this one, and `async_trait` boxes *this* future on
+/// every inbound `<notification>` — so without the indirection that one
+/// allocation is sized for the union of all the arms, and a
+/// `<notification type="picture">` pays for `handle_devices_notification`'s
+/// locals. Measured on `benches/inbound_stanza`, a `<notification
+/// type="picture">` allocated 2306 bytes before — of which a single 2272-byte
+/// block was this future — and 146 bytes after. The box the arm that actually
+/// runs pays instead is a small block from a hot malloc bin, and only the arm
+/// that runs pays it. Synchronous arms need none of this: a plain call
+/// contributes no state to the caller's future.
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(name = "wa.notif.dispatch", level = "debug", skip_all)
@@ -51,22 +62,32 @@ async fn handle_notification_impl(client: &Arc<Client>, node: Arc<OwnedNodeRef>)
         .and_then(|t| NotificationType::try_from(t).ok());
 
     match parsed {
-        Some(NotificationType::Encrypt) => handle_encrypt_notification(client, nr).await,
+        Some(NotificationType::Encrypt) => Box::pin(handle_encrypt_notification(client, nr)).await,
         Some(NotificationType::ServerSync) => handle_server_sync_notification(client, nr),
-        Some(NotificationType::AccountSync) => handle_account_sync_notification(client, nr).await,
-        Some(NotificationType::Devices) => handle_devices_notification(client, nr).await,
+        Some(NotificationType::AccountSync) => {
+            Box::pin(handle_account_sync_notification(client, nr)).await
+        }
+        Some(NotificationType::Devices) => Box::pin(handle_devices_notification(client, nr)).await,
         Some(NotificationType::LinkCodeCompanionReg) => {
-            crate::pair_code::handle_pair_code_notification(client, nr).await;
+            Box::pin(crate::pair_code::handle_pair_code_notification(client, nr)).await;
         }
         Some(NotificationType::CompanionRegRefresh) => {
-            handle_companion_reg_refresh(client, nr).await
+            Box::pin(handle_companion_reg_refresh(client, nr)).await
         }
-        Some(NotificationType::Business) => handle_business_notification(client, nr).await,
+        Some(NotificationType::Business) => {
+            Box::pin(handle_business_notification(client, nr)).await
+        }
         Some(NotificationType::Picture) => handle_picture_notification(client, nr),
-        Some(NotificationType::PrivacyToken) => handle_privacy_token_notification(client, nr).await,
+        Some(NotificationType::PrivacyToken) => {
+            Box::pin(handle_privacy_token_notification(client, nr)).await
+        }
         Some(NotificationType::Status) => handle_status_notification(client, nr),
-        Some(NotificationType::Contacts) => handle_contacts_notification(client, nr).await,
-        Some(NotificationType::WGp2) => handle_group_notification(client, Arc::clone(&node)).await,
+        Some(NotificationType::Contacts) => {
+            Box::pin(handle_contacts_notification(client, nr)).await
+        }
+        Some(NotificationType::WGp2) => {
+            Box::pin(handle_group_notification(client, Arc::clone(&node))).await
+        }
         Some(NotificationType::DisappearingMode) => {
             handle_disappearing_mode_notification(client, nr)
         }
@@ -85,7 +106,10 @@ async fn handle_notification_impl(client: &Arc<Client>, node: Arc<OwnedNodeRef>)
         // not model at all, and both reach the consumer as a raw event.
         _ => {
             if let Some(parsed) = parsed
-                && crate::client::subsystem::dispatch_notification(client, parsed, &node).await
+                && Box::pin(crate::client::subsystem::dispatch_notification(
+                    client, parsed, &node,
+                ))
+                .await
             {
                 return;
             }
@@ -1834,6 +1858,50 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "the stale stanza-LID identity must be deleted by the reset"
+        );
+    }
+    /// The one heap block `async_trait` allocates per inbound `<notification>`
+    /// must stay small.
+    ///
+    /// Awaiting an unboxed async fn inlines its state machine into the caller's
+    /// future, so a single `.await` on an unboxed arm re-sizes this allocation
+    /// for the union of every arm: 2272 bytes when it was measured that way,
+    /// against 146 bytes for the whole notification once they are boxed.
+    /// Nothing else observes that — the
+    /// allocation *count* does not move, the handler's behaviour does not
+    /// change, and `benches/inbound_stanza` reports it but does not run in
+    /// nextest. Hence a unit test, and hence a ceiling (1 KiB) rather than an
+    /// exact size: the point is the order of magnitude, not the byte.
+    #[test]
+    fn notification_future_is_not_sized_for_every_arm() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let client = runtime.block_on(create_test_client());
+        let peer = "19045550180@s.whatsapp.net";
+        let node = node_to_arc(
+            NodeBuilder::new("notification")
+                .attr("from", peer)
+                .attr("type", "picture")
+                .attr("id", "N1")
+                .attr("t", "1700000000")
+                .children([NodeBuilder::new("delete").attr("jid", peer).build()])
+                .build(),
+        );
+
+        // Through `StanzaHandler::handle`, because `async_trait`'s box around
+        // it is the allocation under test; calling `handle_notification_impl`
+        // directly would leave the future on the stack.
+        let handler = NotificationHandler;
+        let largest = crate::test_alloc::min_max_block(1024, || {
+            let mut cancelled = false;
+            runtime.block_on(handler.handle(Arc::clone(&client), Arc::clone(&node), &mut cancelled))
+        });
+        assert!(
+            largest < 1024,
+            "a notification allocated {largest} bytes in one block; an `.await` on an \
+             unboxed arm of handle_notification_impl re-inflates the boxed future"
         );
     }
 }

--- a/src/handlers/notification/privacy_business.rs
+++ b/src/handlers/notification/privacy_business.rs
@@ -1,5 +1,5 @@
 use crate::client::Client;
-use crate::types::events::Event;
+use crate::types::events::{Event, EventKind};
 use log::{debug, info, warn};
 use std::sync::Arc;
 use wacore::stanza::business::BusinessNotification;
@@ -159,26 +159,6 @@ pub(crate) async fn handle_business_notification(client: &Arc<Client>, node: &No
         notification.jid
     );
 
-    let update_type = BusinessUpdateType::from(notification.notification_type.clone());
-    let verified_name = notification
-        .verified_name
-        .as_ref()
-        .and_then(|vn| vn.name.clone());
-
-    let event = Event::BusinessStatusUpdate(
-        BusinessStatusUpdate::builder()
-            .jid(notification.from.clone())
-            .update_type(update_type)
-            .timestamp(wacore::time::from_secs_or_now(notification.timestamp))
-            .maybe_target_jid(notification.jid.clone())
-            .maybe_hash(notification.hash.clone())
-            .maybe_verified_name(verified_name)
-            .product_ids(notification.product_ids.clone())
-            .collection_ids(notification.collection_ids.clone())
-            .subscriptions(notification.subscriptions.clone())
-            .build(),
-    );
-
     match notification.notification_type {
         wacore::stanza::business::BusinessNotificationType::RemoveJid
         | wacore::stanza::business::BusinessNotificationType::RemoveHash => {
@@ -215,7 +195,31 @@ pub(crate) async fn handle_business_notification(client: &Arc<Client>, node: &No
         _ => {}
     }
 
-    client.core.event_bus.dispatch(event);
+    client
+        .core
+        .event_bus
+        .dispatch_with(EventKind::BusinessStatusUpdate, || {
+            Event::BusinessStatusUpdate(
+                BusinessStatusUpdate::builder()
+                    .jid(notification.from.clone())
+                    .update_type(BusinessUpdateType::from(
+                        notification.notification_type.clone(),
+                    ))
+                    .timestamp(wacore::time::from_secs_or_now(notification.timestamp))
+                    .maybe_target_jid(notification.jid.clone())
+                    .maybe_hash(notification.hash.clone())
+                    .maybe_verified_name(
+                        notification
+                            .verified_name
+                            .as_ref()
+                            .and_then(|vn| vn.name.clone()),
+                    )
+                    .product_ids(notification.product_ids.clone())
+                    .collection_ids(notification.collection_ids.clone())
+                    .subscriptions(notification.subscriptions.clone())
+                    .build(),
+            )
+        });
 }
 
 #[cfg(test)]

--- a/src/handlers/notification/profile.rs
+++ b/src/handlers/notification/profile.rs
@@ -1,6 +1,6 @@
 use crate::client::Client;
 use crate::lid_pn_cache::LearningSource;
-use crate::types::events::Event;
+use crate::types::events::{Event, EventKind};
 use log::{debug, warn};
 use std::sync::Arc;
 use wacore::types::events::{
@@ -271,15 +271,20 @@ pub(crate) async fn handle_contacts_notification(client: &Arc<Client>, node: &No
                 "Contact number changed: {} -> {} (old_lid={:?}, new_lid={:?})",
                 old_jid.observe(), new_jid.observe(), old_lid, new_lid
             );
-            client.core.event_bus.dispatch(Event::ContactNumberChanged(
-                ContactNumberChanged::builder()
-                    .old_jid(old_jid)
-                    .new_jid(new_jid)
-                    .maybe_old_lid(old_lid)
-                    .maybe_new_lid(new_lid)
-                    .timestamp(timestamp)
-                    .build(),
-            ));
+            client
+                .core
+                .event_bus
+                .dispatch_with(EventKind::ContactNumberChanged, || {
+                    Event::ContactNumberChanged(
+                        ContactNumberChanged::builder()
+                            .old_jid(old_jid)
+                            .new_jid(new_jid)
+                            .maybe_old_lid(old_lid)
+                            .maybe_new_lid(new_lid)
+                            .timestamp(timestamp)
+                            .build(),
+                    )
+                });
         }
         "sync" => {
             let after = child

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,23 @@
 #[allow(clippy::disallowed_types)]
 pub(crate) mod test_alloc {
     use std::alloc::{GlobalAlloc, Layout, System};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
     pub(crate) static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+    /// Size of the largest single block requested since it was last reset.
+    /// Separate from `ALLOCS` because the two answer different questions: a
+    /// count catches work that should not happen at all, this catches one
+    /// allocation that should not be *that big* — a boxed future sized for
+    /// every arm of a dispatch, say, which costs one allocation either way.
+    pub(crate) static MAX_BLOCK: AtomicUsize = AtomicUsize::new(0);
 
     struct CountingAlloc;
 
     unsafe impl GlobalAlloc for CountingAlloc {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             ALLOCS.fetch_add(1, Ordering::Relaxed);
+            MAX_BLOCK.fetch_max(layout.size(), Ordering::Relaxed);
             unsafe { System.alloc(layout) }
         }
 
@@ -57,6 +65,31 @@ pub(crate) mod test_alloc {
             let after = ALLOCS.load(Ordering::Relaxed);
             drop(value);
             min = min.min(after - before);
+            if min <= expected {
+                break;
+            }
+        }
+        min
+    }
+
+    /// Smallest "largest single block" observed while running `op`, retrying
+    /// until it reaches `expected`.
+    ///
+    /// Same discipline and the same reason as [`min_allocs`]: `MAX_BLOCK` is
+    /// process-wide, so a sibling test thread's large allocation lands in this
+    /// window's maximum. Taking the minimum across windows makes that cost
+    /// iterations rather than a false failure, while a block the measured code
+    /// really does allocate is in *every* window and survives the minimum.
+    pub(crate) fn min_max_block<T>(expected: usize, mut op: impl FnMut() -> T) -> usize {
+        const BUDGET: u32 = 10_000;
+
+        let mut min = usize::MAX;
+        for _ in 0..BUDGET {
+            MAX_BLOCK.store(0, Ordering::Relaxed);
+            let value = std::hint::black_box(op());
+            let observed = MAX_BLOCK.load(Ordering::Relaxed);
+            drop(value);
+            min = min.min(observed);
             if min <= expected {
                 break;
             }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -566,6 +566,31 @@ impl Client {
     pub(crate) fn handle_receipt_inline(self: &Arc<Self>, node: Arc<OwnedNodeRef>) {
         let nr = node.get();
         let mut attrs = nr.attrs();
+        // `type` is read before anything else because it is the only attribute
+        // the subscriber gate below needs, and this runs on the read loop: a
+        // client with no Receipt handler is meant to leave here having parsed
+        // one attribute, not the whole stanza. `<receipt>` reaches this
+        // function inline exactly when nothing is subscribed
+        // (`processes_inline`), so that is the common case, not the rare one.
+        let receipt_type_cow = attrs.optional_string("type");
+        let receipt_type_str = receipt_type_cow.as_deref().unwrap_or("delivery");
+        let receipt_type = ReceiptType::parse(receipt_type_str);
+        // Retries feed the resend pipeline whether or not anything listens.
+        // Every other receipt, `enc_rekey_retry` included (its branch below
+        // only logs and dispatches), exists only to become an `Event::Receipt`,
+        // which `dispatch` drops on the floor without a subscriber — so
+        // without one, stop before the `from` JID, the `<participants>` scan
+        // (one `Jid` pair per member of a group read) and the message-id list.
+        //
+        // Gating on the raw parsed type is what lets the gate come first:
+        // `downgrade_for_feature_incapable` below only ever rewrites
+        // `Delivered` to `Sent`, so no stanza it touches can turn into the
+        // `Retry` this gate lets through.
+        if receipt_type != ReceiptType::Retry
+            && !self.core.event_bus.has_handler_for(EventKind::Receipt)
+        {
+            return;
+        }
         let from = attrs.jid("from");
         let stanza_id = match attrs.optional_string("id") {
             Some(id) => wacore_binary::MessageId::from(id.as_ref()),
@@ -574,8 +599,6 @@ impl Client {
                 return;
             }
         };
-        let receipt_type_cow = attrs.optional_string("type");
-        let receipt_type_str = receipt_type_cow.as_deref().unwrap_or("delivery");
         let participant = attrs.optional_jid("participant");
         let recipient = attrs.optional_jid("recipient");
         // participant_pn -> sender_alt so the LID-PN cache warms from receipts too.
@@ -588,22 +611,10 @@ impl Client {
             .and_then(wacore::time::from_secs)
             .unwrap_or_else(wacore::time::now_utc);
 
-        let receipt_type = ReceiptType::parse(receipt_type_str);
         // WA Web downgrades a delivery ack to "sent" (not delivered) when the receipt carries
         // <error reason="lid" type="feature-incapable"> (the LID peer can't receive it).
         let receipt_type =
             wacore::stanza::receipt::downgrade_for_feature_incapable(nr, receipt_type);
-        // Retries feed the resend pipeline whether or not anything listens.
-        // Every other receipt, `enc_rekey_retry` included (its branch below
-        // only logs and dispatches), exists only to become an `Event::Receipt`,
-        // which `dispatch` drops on the floor without a subscriber — so
-        // without one, stop before parsing `<participants>` (one `Jid` pair
-        // per member of a group read) or building the message-id list.
-        if receipt_type != ReceiptType::Retry
-            && !self.core.event_bus.has_handler_for(EventKind::Receipt)
-        {
-            return;
-        }
         let is_view = receipt_type_str == "view";
         let is_group = from.is_group();
         let default_sender = if is_group {

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -575,6 +575,16 @@ impl Client {
         let receipt_type_cow = attrs.optional_string("type");
         let receipt_type_str = receipt_type_cow.as_deref().unwrap_or("delivery");
         let receipt_type = ReceiptType::parse(receipt_type_str);
+        // `id` is the one other attribute read ahead of the gate: a receipt
+        // without one is a protocol error worth the warning whether or not
+        // anything is subscribed, and the read is a single inline copy.
+        let stanza_id = match attrs.optional_string("id") {
+            Some(id) => wacore_binary::MessageId::from(id.as_ref()),
+            None => {
+                log::warn!("Receipt stanza missing required 'id' attribute");
+                return;
+            }
+        };
         // Retries feed the resend pipeline whether or not anything listens.
         // Every other receipt, `enc_rekey_retry` included (its branch below
         // only logs and dispatches), exists only to become an `Event::Receipt`,
@@ -592,13 +602,6 @@ impl Client {
             return;
         }
         let from = attrs.jid("from");
-        let stanza_id = match attrs.optional_string("id") {
-            Some(id) => wacore_binary::MessageId::from(id.as_ref()),
-            None => {
-                log::warn!("Receipt stanza missing required 'id' attribute");
-                return;
-            }
-        };
         let participant = attrs.optional_jid("participant");
         let recipient = attrs.optional_jid("recipient");
         // participant_pn -> sender_alt so the LID-PN cache warms from receipts too.

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -181,6 +181,50 @@ mod tests {
     use super::*;
     use crate::types::message::{MessageCategory, MessageInfo, MessageSource};
 
+    /// The receipt handler gates on the raw parsed type *before* running this
+    /// downgrade, so the gate is only behaviour-preserving while no input can
+    /// come out the other side as a `Retry` (the one type it must not drop
+    /// without a subscriber). The scoping to `Delivered` is what guarantees
+    /// that; this pins it, so widening the downgrade fails here rather than
+    /// silently dropping retries on the receive path.
+    #[test]
+    fn downgrade_never_turns_a_type_into_a_retry() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let node = NodeBuilder::new("receipt")
+            .children([NodeBuilder::new("error")
+                .attr("reason", "lid")
+                .attr("type", "feature-incapable")
+                .build()])
+            .build();
+        let node = node.as_node_ref();
+
+        // Every variant; a new one belongs in this list.
+        for parsed in [
+            ReceiptType::Delivered,
+            ReceiptType::Sent,
+            ReceiptType::Sender,
+            ReceiptType::Retry,
+            ReceiptType::EncRekeyRetry,
+            ReceiptType::Read,
+            ReceiptType::ReadSelf,
+            ReceiptType::Played,
+            ReceiptType::PlayedSelf,
+            ReceiptType::ServerError,
+            ReceiptType::Inactive,
+            ReceiptType::PeerMsg,
+            ReceiptType::HistorySync,
+            ReceiptType::Other("something-new".to_string()),
+        ] {
+            let downgraded = downgrade_for_feature_incapable(&node, parsed.clone());
+            assert_eq!(
+                downgraded == ReceiptType::Retry,
+                parsed == ReceiptType::Retry,
+                "downgrading {parsed:?} changed whether it is a Retry"
+            );
+        }
+    }
+
     #[test]
     fn feature_incapable_error_downgrades_delivery_to_sent() {
         use wacore_binary::builder::NodeBuilder;

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -634,6 +634,32 @@ impl CoreEventBus {
             }
         }
     }
+
+    /// Dispatch an event that is only built when somebody is listening for
+    /// `kind`.
+    ///
+    /// [`Self::dispatch`] already costs nothing once it is called with no
+    /// interested handler — but the payload has been built by then, and for a
+    /// producer whose payload is a `Vec` (a group notification's participants,
+    /// a device list) or a set of owned strings that construction *is* the
+    /// whole cost of the notification for a consumer that does not want it.
+    /// Callers whose payload is a couple of `Jid` clones should keep using
+    /// `dispatch`: the closure buys nothing there and reads worse.
+    ///
+    /// `kind` must be the kind `build` returns; a mismatch would gate on one
+    /// kind and deliver another, so it is checked in debug builds.
+    pub fn dispatch_with(&self, kind: EventKind, build: impl FnOnce() -> Event) {
+        if !self.has_handler_for(kind) {
+            return;
+        }
+        let event = build();
+        debug_assert_eq!(
+            event.kind(),
+            kind,
+            "dispatch_with gated on a different kind than it built"
+        );
+        self.dispatch(event);
+    }
 }
 
 /// Payload of the retired [`Event::RetiredPushNameUpdate`], kept only so that


### PR DESCRIPTION
The non-message half of the second parallel exploration (receipts, presence, notifications, acks and the event bus), after #1388–#1396. The event bus itself measured as already optimal (0 allocations with no subscriber, exactly 1 `Arc<Event>` with any number); what was left is on the producers. All numbers below are from the new `benches/inbound_stanza`, release, one box; the honest metric is bytes per stanza, not wall time.

## The notification handler's future was sized for every arm

`async_trait` boxes `NotificationHandler`'s future once per inbound `<notification>`, and every arm of `handle_notification_impl` was awaited unboxed. Awaiting a plain async fn inlines its state machine into the caller's — the file's own comment claimed separate async fns already avoided this, and they do not — so that one allocation was the union of all seventeen arms: a `<notification type="picture">` paid for `handle_devices_notification`'s locals. The asynchronous arms are now `Box::pin`ned; only the arm that runs pays its own small block.

| per `<notification type="picture">` | before | after |
| --- | --- | --- |
| no subscriber | 2 allocs / 2306 B (one 2272 B block) | 2 allocs / 146 B |
| with a subscriber | 3 allocs / 2850 B | 3 allocs / 691 B |
| 500-item drain, per item | 2850 B | 690 B |

A reconnect draining 500 notifications sheds ~1.1 MB of transient allocation. Allocation count is unchanged and wall time (540 → 471 ns median) is inside the run-to-run spread. A unit test (`notification_future_is_not_sized_for_every_arm`) pins the largest single block under 1 KiB through the real `StanzaHandler::handle`; it was verified to fail at 2272 bytes with the arms un-boxed, so a future `.await` on an unboxed arm is caught in nextest.

## The receipt subscriber gate runs before the parse

`handle_receipt_inline` ran its `has_handler_for(EventKind::Receipt)` bail only after parsing `from`, `id`, `participant`, `recipient`, `participant_pn`, `offline`, `t` and the feature-incapable child scan. It now reads `type` and `id` first and bails on the type (the missing-`id` warning stays ahead of the gate, so a malformed receipt is still reported whether or not anything is subscribed). Gating on the raw type is behaviour-preserving because `downgrade_for_feature_incapable` only ever rewrites Delivered to Sent and can never produce the Retry the gate lets through; a new test in `wacore/src/stanza/receipt.rs` pins that over every variant. This path runs inline on the read loop exactly when nothing is subscribed: 383 → 345 ns per ignored receipt, small and at the edge of noise.

## Payloads built only for a listener

`CoreEventBus::dispatch_with(kind, || event)` (additive) builds the payload only when a handler for `kind` is registered. `dispatch` already costs nothing without one, but the payload has been built by then. Applied where it is more than a couple of `Jid` clones: `GroupUpdate` (a whole `GroupNotificationAction` with its participant `Vec`, once per action per notification), `DeviceListUpdate`, `IdentityChange`, `BusinessStatusUpdate`, `MexNotification`, `ContactNumberChanged`. Cheap producers keep plain `dispatch`. Not in the table above (none of its stanzas reaches those sites); the payoff is proportional to the payload, on a consumer that does not subscribe to that kind.

## The guard

`benches/inbound_stanza` on `ReceiveHarness` (feature `bench-harness`, so the CodSpeed client shard runs it): `<receipt>`, `<presence>`, `<notification>` and `<ack>` with and without a subscriber, plus a 500-stanza burst per kind, reporting bytes and allocations per stanza through divan's `AllocProfiler`.

## Not in this PR

`size_of::<Event>()` is 528 B because of `GroupUpdate` (528) and `IncomingCall` (432), so every dispatched event is a 544 B `Arc` regardless of payload; boxing those two takes it to ~280 B but changes the frozen `Event` surface, so it comes as its own `perf(events)!` PR.

## Verification

- `cargo clippy -p wacore -p whatsapp-rust --all-targets --features bench-harness -- -D warnings` clean
- `cargo test -p whatsapp-rust --lib`, `cargo test -p wacore --lib` pass, including the two new tests

CI note: `Semver Checks (informational)` is red on `main` as well and is not this PR's; no fix exists for it in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN