### PR TITLE
perf(client): keep the group device memos warm at scale; batched registry reads; client_group_scale bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,11 @@ name = "client_dm_send"
 harness = false
 required-features = ["bench-harness"]
 
+[[bench]]
+name = "client_group_scale"
+harness = false
+required-features = ["bench-harness"]
+
 # The `Cache<Jid, _>` lookup shape `chat_lanes` runs per inbound message. No
 # `required-features`: it reaches only the public cache, so it builds (and is
 # regression-gated) in a plain `cargo bench`.

--- a/benches/client_group_scale.rs
+++ b/benches/client_group_scale.rs
@@ -49,8 +49,12 @@ fn shared(label: &'static str, groups: usize) -> &'static GroupScaleHarness {
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .expect("fixture registry");
-    map.entry((label, groups))
-        .or_insert_with(|| Box::leak(Box::new(GroupScaleHarness::new(groups, SCALE_GROUP_MEMBERS))))
+    map.entry((label, groups)).or_insert_with(|| {
+        Box::leak(Box::new(GroupScaleHarness::new(
+            groups,
+            SCALE_GROUP_MEMBERS,
+        )))
+    })
 }
 
 /// One warm pass over every group, per group.

--- a/benches/client_group_scale.rs
+++ b/benches/client_group_scale.rs
@@ -1,0 +1,75 @@
+//! Client-level group device resolution, swept across the number of groups
+//! an account is active in.
+//!
+//! `client_group_send` sweeps one group across its size and holds the memo
+//! warm by construction, so it cannot see what an account in many groups
+//! gets from the per-group device memo. This target builds a client holding
+//! `GROUP_COUNTS` groups of `SCALE_GROUP_MEMBERS` members each and asks the
+//! two questions that decide whether a warm group send re-resolves its
+//! members:
+//!
+//! - `warm_resolve_pass`: one pass over every group through the memoized
+//!   resolver, the shape of a bot answering in each of its groups in turn.
+//!   With the memo bounded at 64 entries and evicting oldest-first this was
+//!   a cliff: every group past the 64th missed on every pass, and a miss at
+//!   64 members re-resolves every member.
+//! - `resolve_after_unrelated_refresh`: one group's device-list refresh
+//!   through the real registry write path, then a pass over every *other*
+//!   group. Whether those are re-stamped or recomputed is decided by the
+//!   topology log, which used to overflow on any refresh past ~85 members.
+//!
+//! Not covered, so no number here is over-read: no Signal sessions and no
+//! sends (the resolver is what is measured, not the encrypt), the
+//! `InMemoryBackend` (a registry miss into SQLite is a separate cost, and a
+//! larger one), and a single member device per member.
+
+use divan::black_box;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use whatsapp_rust::bench_support::{GROUP_COUNTS, GroupScaleHarness, SCALE_GROUP_MEMBERS};
+
+fn main() {
+    divan::main();
+}
+
+/// Few, long samples: every sample is a full pass over the groups, and the
+/// fixture's memo state is what the benchmark is about, so the runs must not
+/// be so many that the sampled steady state drifts from the warm one.
+const SAMPLE_COUNT: u32 = 10;
+const SAMPLE_SIZE: u32 = 5;
+
+/// One fixture per (benchmark, group count), leaked for the process lifetime,
+/// for the reasons `client_group_send` gives: building one seeds tens of
+/// thousands of registry and mapping entries, and the refresh benchmark
+/// mutates its fixture's topology in a way the warm one must not inherit.
+fn shared(label: &'static str, groups: usize) -> &'static GroupScaleHarness {
+    static FIXTURES: OnceLock<Mutex<HashMap<(&'static str, usize), &'static GroupScaleHarness>>> =
+        OnceLock::new();
+    let mut map = FIXTURES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("fixture registry");
+    map.entry((label, groups))
+        .or_insert_with(|| Box::leak(Box::new(GroupScaleHarness::new(groups, SCALE_GROUP_MEMBERS))))
+}
+
+/// One warm pass over every group, per group.
+#[divan::bench(args = GROUP_COUNTS, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn warm_resolve_pass(bencher: divan::Bencher, groups: usize) {
+    let harness = shared("warm", groups);
+    bencher
+        .counter(divan::counter::ItemsCount::new(groups))
+        .bench(|| black_box(harness.resolve_all()));
+}
+
+/// Refresh group 0's device lists, then one pass over every other group.
+#[divan::bench(args = GROUP_COUNTS, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn resolve_after_unrelated_refresh(bencher: divan::Bencher, groups: usize) {
+    let harness = shared("refresh", groups);
+    bencher
+        .counter(divan::counter::ItemsCount::new(groups - 1))
+        .bench(|| {
+            harness.refresh_group_registry(0);
+            black_box(harness.resolve_range(1, harness.group_count()))
+        });
+}

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1208,19 +1208,24 @@ pub struct GroupScaleHarness {
 /// A fictitious member number: the reserved 555-01XX block, widened by a
 /// synthetic area-code index so the sweep can mint tens of thousands of
 /// distinct numbers. Never overlaps `member_user`'s range (its area codes
-/// start at 200 + index / 100, which the `NPAS` table never reaches). The
-/// area code must stay three digits, so the namespace ends at 70,000
+/// start at 200 + index / 100, which the `NPAS` table never reaches), and
+/// steps over 555 itself, which is an exchange and not an area code. The
+/// area code must stay three digits, so the namespace ends at 69,900
 /// members: a sweep past it would wrap onto index 0's number and merge two
 /// members' devices, which is a wrong fixture rather than a slower one.
 fn scale_member_pn(index: usize) -> String {
-    assert!(index < 70_000, "scale member PN namespace exhausted");
-    format!("1{:03}555{:04}", 200 + index / 100, 100 + index % 100)
+    assert!(index < 69_900, "scale member PN namespace exhausted");
+    let npa = 200 + index / 100;
+    let npa = if npa >= 555 { npa + 1 } else { npa };
+    format!("1{npa:03}555{:04}", 100 + index % 100)
 }
 
 /// A member LID in a block of its own, so no index can land on the own
-/// account's `100000000000001`.
+/// account's `100000000000001`. Five digits of index keep the LID at the
+/// fifteen the real ones have.
 fn scale_member_lid(index: usize) -> String {
-    format!("1000000001{:05}", index)
+    assert!(index < 100_000, "scale member LID namespace exhausted");
+    format!("1000000001{index:05}")
 }
 
 impl GroupScaleHarness {

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1208,13 +1208,19 @@ pub struct GroupScaleHarness {
 /// A fictitious member number: the reserved 555-01XX block, widened by a
 /// synthetic area-code index so the sweep can mint tens of thousands of
 /// distinct numbers. Never overlaps `member_user`'s range (its area codes
-/// start at 200 + index / 100, which the `NPAS` table never reaches).
+/// start at 200 + index / 100, which the `NPAS` table never reaches). The
+/// area code must stay three digits, so the namespace ends at 70,000
+/// members: a sweep past it would wrap onto index 0's number and merge two
+/// members' devices, which is a wrong fixture rather than a slower one.
 fn scale_member_pn(index: usize) -> String {
-    format!("1{:03}555{:04}", 200 + index / 100 % 700, 100 + index % 100)
+    assert!(index < 70_000, "scale member PN namespace exhausted");
+    format!("1{:03}555{:04}", 200 + index / 100, 100 + index % 100)
 }
 
+/// A member LID in a block of its own, so no index can land on the own
+/// account's `100000000000001`.
 fn scale_member_lid(index: usize) -> String {
-    format!("1000000000{:05}", index)
+    format!("1000000001{:05}", index)
 }
 
 impl GroupScaleHarness {

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1018,3 +1018,220 @@ async fn build_receive_fixture() -> ReceiveFixture {
         subscription,
     }
 }
+
+// ===========================================================================
+// Group-scale fixture: many groups, many members, no crypto.
+// ===========================================================================
+
+/// Group counts the scale sweep runs. The claim under test is how the
+/// per-group device memo behaves as a function of how many groups an account
+/// is active in, so the sweep has to cross the bound the memo used to have
+/// (64) by a wide margin on both sides.
+pub const GROUP_COUNTS: &[usize] = &[16, 64, 256];
+
+/// Members per group in the scale sweep. Large enough that a recompute is
+/// dominated by per-member work, small enough that 256 groups of them build
+/// in seconds under instrumentation.
+pub const SCALE_GROUP_MEMBERS: usize = 64;
+
+/// A client holding `groups` groups of `members` distinct members each, with
+/// the registry, the LID↔PN mappings, the group metadata and the device memos
+/// a client that has sent to all of them holds.
+///
+/// No Signal sessions and no sends: the questions this fixture answers — is a
+/// warm group's device list served from the memo, and what does one group's
+/// device-list refresh cost every other group — are settled before any crypto
+/// runs, and a send fixture at this scale would spend all of its time
+/// establishing sessions that never get used.
+pub struct GroupScaleHarness {
+    runtime: tokio::runtime::Runtime,
+    client: Arc<Client>,
+    groups: Vec<(Jid, Arc<GroupInfo>)>,
+    own_sending_jid: Jid,
+}
+
+/// A fictitious member number: the reserved 555-01XX block, widened by a
+/// synthetic area-code index so the sweep can mint tens of thousands of
+/// distinct numbers. Never overlaps `member_user`'s range (its area codes
+/// start at 200 + index / 100, which the `NPAS` table never reaches).
+fn scale_member_pn(index: usize) -> String {
+    format!("1{:03}555{:04}", 200 + index / 100 % 700, 100 + index % 100)
+}
+
+fn scale_member_lid(index: usize) -> String {
+    format!("1000000000{:05}", index)
+}
+
+impl GroupScaleHarness {
+    /// Build the fixture and resolve every group once, so the memos hold
+    /// whatever they can hold for this many groups.
+    pub fn new(groups: usize, members: usize) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let (client, group_list, own) = runtime.block_on(build_scale_fixture(groups, members));
+        let harness = Self {
+            runtime,
+            client,
+            groups: group_list,
+            own_sending_jid: own,
+        };
+        harness.resolve_all();
+        harness
+    }
+
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Resolve every group's device list through the memoized resolver, in
+    /// order, the way a client round-robining over its groups does. Returns
+    /// the memo counters for this pass only.
+    pub fn resolve_all(&self) -> crate::client::DeviceMemoStats {
+        self.resolve_range(0, self.groups.len())
+    }
+
+    /// Resolve groups `[from, to)` once and return the memo outcomes.
+    pub fn resolve_range(&self, from: usize, to: usize) -> crate::client::DeviceMemoStats {
+        let before = self.client.device_memo_stats();
+        self.runtime.block_on(async {
+            for (group, info) in &self.groups[from..to] {
+                let _ = self
+                    .client
+                    .resolve_group_devices_memoized(group, info, &self.own_sending_jid)
+                    .await
+                    .expect("offline resolve");
+            }
+        });
+        self.client.device_memo_stats().since(&before)
+    }
+
+    /// Re-publish group `index`'s member records through the real usync
+    /// write path, which is what a device-list refresh for that group does.
+    /// Returns the topology generation before and after.
+    pub fn refresh_group_registry(&self, index: usize) -> (u64, u64) {
+        self.runtime.block_on(async {
+            let (_, info) = &self.groups[index];
+            let mut records = Vec::with_capacity(info.participants.len());
+            for participant in &info.participants {
+                if participant.user == self.own_sending_jid.user {
+                    continue;
+                }
+                records.push(DeviceListRecord {
+                    user: Arc::from(participant.user.as_str()),
+                    devices: vec![DeviceInfo::new(0, None)].into_boxed_slice(),
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                });
+            }
+            let before = self.client.device_topology.current();
+            let guard = self.client.device_topology.lock_registry().await;
+            self.client
+                .update_device_lists_guarded(records, &guard)
+                .await
+                .expect("registry batch write");
+            drop(guard);
+            (before, self.client.device_topology.current())
+        })
+    }
+
+    /// The client's `memory_report()`, rendered.
+    pub fn memory_report(&self) -> String {
+        self.runtime
+            .block_on(async { self.client.memory_report().await.to_string() })
+    }
+}
+
+async fn build_scale_fixture(
+    groups: usize,
+    members: usize,
+) -> (Arc<Client>, Vec<(Jid, Arc<GroupInfo>)>, Jid) {
+    let backend = Arc::new(InMemoryBackend::new());
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager"),
+    );
+    let (client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        Arc::new(SinkTransportFactory),
+        Arc::new(NoopHttpClient),
+        None,
+    )
+    .await;
+
+    let own_pn = Jid::new(OWN_USER, Server::Pn);
+    let own_lid = Jid::new("100000000000001", Server::Lid);
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+        .await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(own_lid)))
+        .await;
+    seed_registry(&client, OWN_USER, &[0, 1]).await;
+    // Our own record is inserted first, so it is the first the bounded
+    // registry cache evicts once the members outnumber its capacity; the
+    // backend row is what answers for it then.
+    let mut backend_records: Vec<DeviceListRecord> = Vec::with_capacity(groups * members + 1);
+    backend_records.push(DeviceListRecord {
+        user: Arc::from(OWN_USER),
+        devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(1, None)].into_boxed_slice(),
+        timestamp: wacore::time::now_secs(),
+        phash: None,
+        raw_id: None,
+    });
+
+    // Distinct members across groups, the worst case for every per-user
+    // cache. LID-addressed, with the PN mapping known, as a current group is.
+    let mut group_list = Vec::with_capacity(groups);
+    for g in 0..groups {
+        let mut participants = Vec::with_capacity(members + 1);
+        for m in 0..members {
+            let index = g * members + m;
+            let pn = scale_member_pn(index);
+            let lid = scale_member_lid(index);
+            seed_registry(&client, &lid, &[0]).await;
+            backend_records.push(DeviceListRecord {
+                user: Arc::from(lid.as_str()),
+                devices: vec![DeviceInfo::new(0, None)].into_boxed_slice(),
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            });
+            client
+                .lid_pn_cache
+                .add(&crate::lid_pn_cache::LidPnEntry::new(
+                    lid.as_str(),
+                    pn.as_str(),
+                    crate::lid_pn_cache::LearningSource::Usync,
+                ))
+                .await;
+            participants.push(Jid::new(lid.as_str(), Server::Lid));
+        }
+        participants.push(own_pn.to_non_ad());
+        let info = Arc::new(GroupInfo::new(participants, AddressingMode::Lid));
+        let group: Jid = format!("12036300000000{g:04}@g.us")
+            .parse()
+            .expect("group jid");
+        client
+            .get_group_cache()
+            .insert(group.clone(), Arc::clone(&info))
+            .await;
+        group_list.push((group, info));
+    }
+
+    client
+        .persistence_manager
+        .backend()
+        .update_device_lists(backend_records)
+        .await
+        .expect("seed device rows");
+
+    install_offline_socket(&client).await;
+    (client, group_list, own_pn)
+}

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -160,8 +160,12 @@ impl CacheStores {
 pub struct CacheConfig {
     /// Group metadata cache (time_to_live). Default: 1h TTL, 250 entries.
     pub group_cache: CacheEntryConfig,
-    /// Device registry cache (time_to_live). Default: 1h TTL, 5000 entries
-    /// (holds a large group's per-member device set; a near-max group is ~1024).
+    /// Device registry cache (time_to_live): one entry per contact whose
+    /// device list is known. Default: 1h TTL, 20000 entries. It only ever
+    /// holds what has been resolved, so the bound costs nothing until an
+    /// account approaches it; past it, the per-group device memos still
+    /// answer warm sends, and a memo recompute reads the evicted members in
+    /// one batched backend query rather than one query each.
     pub device_registry_cache: CacheEntryConfig,
     /// LID-to-phone cache. WAWebLidPnCache uses plain Maps with no expiry
     /// and no size cap; evicting a still-valid mapping silently downgrades
@@ -215,6 +219,15 @@ pub struct CacheConfig {
     /// Soft cap: a live lane is never evicted, so the map may briefly exceed
     /// this under concurrent fan-out instead of breaking tracker ordering.
     pub group_distribution_locks_capacity: u64,
+    /// Per-group resolved-device memo capacity: the device list a group send
+    /// fans out to plus its member index, ~10 KiB at 256 members. Also bounds
+    /// the SKDM warm-target memo, which is keyed the same way. Eviction is
+    /// least-recently-used, so an account active in more groups than this
+    /// re-resolves only its least active ones; below it, a warm send never
+    /// re-resolves. Default: 512.
+    pub group_devices_memo_capacity: u64,
+    /// Per-1:1-chat resolved-device memo capacity. Default: 512.
+    pub dm_devices_memo_capacity: u64,
     /// Per-chat resend rate-limiter capacity: one token-bucket entry per group
     /// recently driving retry resends. Keep above the count of concurrently
     /// storming groups: eviction is FIFO and fail-open (an evicted bucket is
@@ -299,6 +312,11 @@ impl std::fmt::Debug for CacheConfig {
                 &self.group_distribution_locks_capacity,
             )
             .field(
+                "group_devices_memo_capacity",
+                &self.group_devices_memo_capacity,
+            )
+            .field("dm_devices_memo_capacity", &self.dm_devices_memo_capacity)
+            .field(
                 "resend_rate_limiter_capacity",
                 &self.resend_rate_limiter_capacity,
             )
@@ -340,9 +358,11 @@ impl Default for CacheConfig {
 
         Self {
             group_cache: CacheEntryConfig::new(one_hour, 250),
-            // One entry per group member; 1000 was below a near-max (~1024) group,
-            // so large-group warm sends thrashed to the serial per-user DB path.
-            device_registry_cache: CacheEntryConfig::new(one_hour, 5_000),
+            // One entry per contact. 5000 was below an account in a few
+            // dozen mid-sized groups, whose every memo recompute then paid a
+            // backend read per member; the bound is a ceiling, not a
+            // preallocation, so a small account pays nothing for it.
+            device_registry_cache: CacheEntryConfig::new(one_hour, 20_000),
             lid_pn_cache: CacheEntryConfig::new(None, u64::MAX),
             recent_messages: CacheEntryConfig::new(five_min, 0),
             // 1h so the MAX_DECRYPT_RETRIES cap survives spaced redeliveries; a
@@ -360,6 +380,12 @@ impl Default for CacheConfig {
             session_locks_capacity: 10_000,
             chat_lanes_capacity: 5_000,
             group_distribution_locks_capacity: 512,
+            // 64 was a hard cliff: the memo evicted oldest-first, so an
+            // account rotating over 65 groups had a hit rate of exactly zero
+            // and every group send re-resolved every member (~470 us at 256
+            // members before any crypto ran).
+            group_devices_memo_capacity: 512,
+            dm_devices_memo_capacity: 512,
             resend_rate_limiter_capacity: 4_096,
             sent_message_ttl_secs: 7200,
             // Bounded by default: seed only the still-relevant slice of history

--- a/src/client/device_memo_stats.rs
+++ b/src/client/device_memo_stats.rs
@@ -242,9 +242,10 @@ impl DeviceMemoCounters {
 pub struct GroupDevicesMemoStats {
     pub hits: u64,
     pub restamps: u64,
-    /// No entry for the group: first send, or a capacity/TTL eviction. The
-    /// memo holds 64 groups, so a client rotating over more than that reports
-    /// its eviction rate here.
+    /// No entry for the group: first send, or a capacity eviction. The memo
+    /// holds `CacheConfig::group_devices_memo_capacity` groups, least
+    /// recently used evicted first, so a client active in more than that
+    /// reports its eviction rate here.
     pub miss_absent: u64,
     /// An entry existed, built from a different `Arc<GroupInfo>`.
     pub miss_group_info: u64,

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -4195,7 +4195,7 @@ mod tests {
         use wacore::types::message::AddressingMode;
 
         let mut participants = Vec::with_capacity(members);
-        let mut lid_to_pn = std::collections::HashMap::with_capacity(members);
+        let mut lid_to_pn = HashMap::with_capacity(members);
         for i in 0..members {
             let lid_user = wacore_binary::CompactString::from(format!("1000000{i:08}"));
             let pn_user = wacore_binary::CompactString::from(format!("5511{i:09}"));

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use log::{debug, info, warn};
+use std::collections::HashMap;
 use std::sync::Arc;
 use wacore_binary::{Jid, JidExt as _, Server};
 
@@ -193,7 +194,7 @@ impl Client {
                 return Ok(Arc::clone(&memo.devices));
             } else if self
                 .device_topology
-                .unchanged_for(memo.generation, |user| memo.members.contains(user))
+                .unchanged_for(memo.generation, &memo.members)
             {
                 // Stale stamp, but every change since it touched only users
                 // outside this group: re-stamp instead of recomputing, so
@@ -393,7 +394,7 @@ impl Client {
             // (log overflow, member touched) falls through to the recompute.
             if self
                 .device_topology
-                .unchanged_for(memo.generation, |user| memo.members.contains(user))
+                .unchanged_for(memo.generation, &memo.members)
             {
                 self.dm_devices_memo
                     .insert(
@@ -833,6 +834,8 @@ impl Client {
         }
 
         let mut prepared = Vec::with_capacity(records.len());
+        let mut cache_rows = Vec::with_capacity(records.len());
+        let mut lookups = Vec::with_capacity(records.len());
         let mut to_delete: Vec<Arc<str>> = Vec::new();
 
         for mut record in records {
@@ -841,22 +844,26 @@ impl Client {
             let canonical_key: Arc<str> = Arc::from(lookup.canonical_key());
             record.user = Arc::clone(&canonical_key);
 
-            let record_for_cache = record.clone();
-            // Same alias rule as update_device_list: record every lookup key.
-            self.device_registry_cache
-                .insert(
-                    guard,
-                    Arc::clone(&canonical_key),
-                    Arc::new(record_for_cache),
-                    lookup.all_keys().chain(std::iter::once(&*original_user)),
-                )
-                .await;
-
+            cache_rows.push((Arc::clone(&canonical_key), Arc::new(record.clone())));
             if *canonical_key != *original_user {
-                to_delete.push(original_user);
+                to_delete.push(Arc::clone(&original_user));
             }
+            lookups.push((lookup, original_user));
             prepared.push(record);
         }
+
+        // Same alias rule as update_device_list: every lookup key is recorded,
+        // the whole batch as one topology change. Collected first: the
+        // borrowed key iterator must not be held across the insert awaits.
+        let touched: Vec<&str> = lookups
+            .iter()
+            .flat_map(|(lookup, original_user)| {
+                lookup.all_keys().chain(std::iter::once(&**original_user))
+            })
+            .collect();
+        self.device_registry_cache
+            .insert_batch(guard, cache_rows, touched.iter().copied())
+            .await;
 
         let backend = self.persistence_manager.backend();
         backend
@@ -1316,6 +1323,141 @@ impl Client {
         }
 
         None
+    }
+
+    /// Backend rows for `keys`, each promoted into the registry cache and
+    /// keyed by the user its row is stored under. One backend call for the
+    /// whole set: the per-key form is a serialized write-queue round trip
+    /// each, which for a cold 256-member group was ~22 ms of SQLite before a
+    /// single device was resolved. An empty row is never a valid device set
+    /// (WA Web always keeps device 0), so it is neither promoted nor
+    /// returned and callers read its absence as a miss.
+    async fn fetch_registry_rows(
+        &self,
+        keys: &[&str],
+    ) -> HashMap<Arc<str>, Arc<wacore::store::traits::DeviceListRecord>> {
+        if keys.is_empty() {
+            return HashMap::new();
+        }
+        let rows = match self
+            .persistence_manager
+            .backend()
+            .get_devices_batch(keys)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                warn!(
+                    "device registry: batched DB lookup failed for {} keys: {e}",
+                    keys.len()
+                );
+                return HashMap::new();
+            }
+        };
+        let mut out = HashMap::with_capacity(rows.len());
+        for record in rows {
+            if record.devices.is_empty() {
+                continue;
+            }
+            let record = Arc::new(record);
+            self.device_registry_cache
+                .promote(Arc::clone(&record.user), Arc::clone(&record))
+                .await;
+            out.insert(Arc::clone(&record.user), record);
+        }
+        out
+    }
+
+    /// Owned registry records for `users`, positionally, from the cache or
+    /// one batched backend read for every user the cache does not hold.
+    /// The batched sibling of [`load_device_record_for_jid`], for a usync
+    /// response that carries one record per member.
+    pub(crate) async fn load_device_records_batch(
+        &self,
+        users: &[&Jid],
+    ) -> Vec<Option<wacore::store::traits::DeviceListRecord>> {
+        let mut out: Vec<Option<wacore::store::traits::DeviceListRecord>> =
+            Vec::with_capacity(users.len());
+        let mut pending: Vec<(usize, UserLookupKeys)> = Vec::new();
+        for (index, jid) in users.iter().enumerate() {
+            let lookup = self.resolve_lookup_keys_for_jid(jid).await;
+            let mut cached = None;
+            for key in lookup.all_keys() {
+                if let Some(record) = self.device_registry_cache.get(key).await {
+                    // Cold load-modify-persist path: callers mutate the owned record.
+                    cached = Some((*record).clone());
+                    break;
+                }
+            }
+            if cached.is_none() {
+                pending.push((index, lookup));
+            }
+            out.push(cached);
+        }
+        if pending.is_empty() {
+            return out;
+        }
+        let keys: Vec<&str> = pending
+            .iter()
+            .flat_map(|(_, lookup)| lookup.all_keys())
+            .collect();
+        let rows = self.fetch_registry_rows(&keys).await;
+        for (index, lookup) in &pending {
+            if let Some(record) = lookup.all_keys().find_map(|key| rows.get(key)) {
+                out[*index] = Some((**record).clone());
+            }
+        }
+        out
+    }
+
+    /// Registry devices for many users at once: the cache is probed per
+    /// user, then ONE backend read covers every user it could not answer.
+    /// Returns the resolved device JIDs and the users still unresolved (no
+    /// usable record anywhere), in that order. Same invariants as
+    /// [`get_devices_from_registry`]: an empty record is a miss, and a
+    /// backend row is promoted into the cache.
+    pub(crate) async fn get_devices_from_registry_batch(
+        &self,
+        jids: Vec<Jid>,
+    ) -> (Vec<Jid>, Vec<Jid>) {
+        let mut devices = Vec::with_capacity(jids.len() * 2);
+        let mut pending: Vec<(Jid, UserLookupKeys)> = Vec::new();
+        'users: for jid in jids {
+            let lookup = self.resolve_lookup_keys_for_jid(&jid).await;
+            for key in lookup.all_keys() {
+                if let Some(record) = self.device_registry_cache.get(key).await {
+                    let found = Self::reconstruct_device_jids(&jid, &record);
+                    if !found.is_empty() {
+                        devices.extend(found);
+                        continue 'users;
+                    }
+                }
+            }
+            pending.push((jid, lookup));
+        }
+        if pending.is_empty() {
+            return (devices, Vec::new());
+        }
+        // Distinct users never share a lookup key, so the list needs no
+        // deduplication.
+        let keys: Vec<&str> = pending
+            .iter()
+            .flat_map(|(_, lookup)| lookup.all_keys())
+            .collect();
+        let rows = self.fetch_registry_rows(&keys).await;
+        let mut missing = Vec::new();
+        for (jid, lookup) in pending {
+            let found = lookup
+                .all_keys()
+                .find_map(|key| rows.get(key))
+                .map(|record| Self::reconstruct_device_jids(&jid, record))
+                .filter(|found| !found.is_empty());
+            match found {
+                Some(found) => devices.extend(found),
+                None => missing.push(jid),
+            }
+        }
+        (devices, missing)
     }
 
     /// Look up device JIDs from the device registry (cache + DB) for a single user.

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -1796,11 +1796,15 @@ mod tests {
         );
 
         // Log overflow past the memo's stamp: cannot prove cleanliness,
-        // must recompute.
+        // must recompute. One change wider than the whole log is the
+        // cheapest way to overflow it.
         setup_device_record(&client, user_a, &[0]).await;
-        for _ in 0..300 {
-            client.device_topology.record(["5511000000003"]);
-        }
+        let flood: Vec<String> = (0..=crate::client::device_topology::TOPOLOGY_LOG_CAPACITY)
+            .map(|i| format!("5511{i:09}"))
+            .collect();
+        client
+            .device_topology
+            .record(flood.iter().map(String::as_str));
         let after_overflow = client
             .resolve_group_devices_memoized(&group, &group_info, &group_info.participants[0])
             .await

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -37,7 +37,7 @@ use super::member_index::MemberIndex;
 ///
 /// A bound, not a preallocation: the deque grows into it, because a session
 /// that never touches a group never writes an entry.
-const TOPOLOGY_LOG_CAPACITY: usize = 4096;
+pub(crate) const TOPOLOGY_LOG_CAPACITY: usize = 4096;
 
 struct TopologyLog {
     /// (generation, the users that change touched), oldest first.

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -17,20 +17,33 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use portable_atomic::AtomicU64;
-use wacore_binary::CompactString;
 
-/// Bounded log length. Sized so a burst (e.g. a usync response for a large
-/// group) still fits; overflow just disables the scoped-revalidation fast
-/// path until affected memos recompute once.
+use super::member_index::MemberIndex;
+
+/// Bound on the fingerprints the log retains, summed over every change still
+/// in it. A change costs 8 bytes per user it touched: a single mapping or
+/// registry write is one to three entries, a device-list refresh for a
+/// 256-member group (three identifiers per member, recorded as ONE change)
+/// is ~6 KiB, so the log holds several such refreshes before it overflows.
+/// Overflow just disables the scoped-revalidation fast path for memos older
+/// than the evicted change, which then recompute once.
 ///
-/// A length bound, not a preallocation: the deque grows into it, because a
-/// session that never touches a group never writes an entry and would
-/// otherwise carry the full 8 KiB for nothing.
-const TOPOLOGY_LOG_CAPACITY: usize = 256;
+/// Fingerprints rather than the identifiers themselves for the same reason
+/// `MemberIndex` uses them: the only question ever asked is "did a change
+/// touch this memo's members", and a collision can only force a recompute.
+/// As a ring of strings the log overflowed on any refresh past ~85 members,
+/// which made every other group's memo recompute for a refresh that touched
+/// one group.
+///
+/// A bound, not a preallocation: the deque grows into it, because a session
+/// that never touches a group never writes an entry.
+const TOPOLOGY_LOG_CAPACITY: usize = 4096;
 
 struct TopologyLog {
-    /// (generation, canonical user touched).
-    entries: VecDeque<(u64, CompactString)>,
+    /// (generation, the users that change touched), oldest first.
+    entries: VecDeque<(u64, MemberIndex)>,
+    /// Fingerprints held across `entries`, the quantity the bound is on.
+    fingerprints: usize,
     /// Highest generation evicted from `entries` (0 = nothing evicted).
     /// A memo older than this cannot be proven clean and must recompute.
     floor: u64,
@@ -56,6 +69,7 @@ impl DeviceTopology {
             generation: AtomicU64::new(0),
             log: std::sync::Mutex::new(TopologyLog {
                 entries: VecDeque::new(),
+                fingerprints: 0,
                 floor: 0,
             }),
             registry_mutation: async_lock::Mutex::new(()),
@@ -80,16 +94,24 @@ impl DeviceTopology {
     }
 
     fn record_change<'a>(&self, users: impl IntoIterator<Item = &'a str>) {
+        // Fingerprinted before taking the lock: a refresh for a large group
+        // records hundreds of identifiers in one change, and hashing them is
+        // the bulk of the work.
+        let touched = MemberIndex::from_users(users);
         let mut log = self.log.lock().unwrap_or_else(|p| p.into_inner());
         let generation = self.generation.load(Ordering::Acquire) + 1;
-        for user in users {
-            if log.entries.len() == TOPOLOGY_LOG_CAPACITY
-                && let Some((evicted_gen, _)) = log.entries.pop_front()
+        // A change that touched nobody cannot invalidate a memo, so it needs
+        // no entry; the generation still moves so its writer's snapshot
+        // ordering is unchanged.
+        if !touched.is_empty() {
+            log.fingerprints += touched.len();
+            log.entries.push_back((generation, touched));
+            while log.fingerprints > TOPOLOGY_LOG_CAPACITY
+                && let Some((evicted_gen, evicted)) = log.entries.pop_front()
             {
+                log.fingerprints -= evicted.len();
                 log.floor = evicted_gen;
             }
-            log.entries
-                .push_back((generation, CompactString::from(user)));
         }
         // Publish the generation only after the log holds the users, so a
         // reader that observes the new generation can always find (or rule
@@ -114,22 +136,26 @@ impl DeviceTopology {
         let mut log = self.log.lock().unwrap_or_else(|p| p.into_inner());
         let generation = self.generation.load(Ordering::Acquire) + 1;
         log.entries.clear();
+        log.fingerprints = 0;
         log.floor = generation;
         self.generation.store(generation, Ordering::Release);
     }
 
-    /// Whether every change after `since` only touched users for which
-    /// `is_member` returns false. `false` on any doubt (log overflow past
-    /// `since`), so callers recompute.
-    pub(crate) fn unchanged_for(&self, since: u64, is_member: impl Fn(&str) -> bool) -> bool {
+    /// Whether every change after `since` only touched users outside
+    /// `members`. `false` on any doubt (log overflow past `since`, a
+    /// fingerprint collision), so callers recompute.
+    pub(crate) fn unchanged_for(&self, since: u64, members: &MemberIndex) -> bool {
         let log = self.log.lock().unwrap_or_else(|p| p.into_inner());
         if log.floor > since {
             return false;
         }
+        // Entries are in generation order, so the changes after `since` are
+        // a suffix.
         log.entries
             .iter()
-            .filter(|(generation, _)| *generation > since)
-            .all(|(_, user)| !is_member(user))
+            .rev()
+            .take_while(|(generation, _)| *generation > since)
+            .all(|(_, touched)| !members.intersects(touched))
     }
 }
 
@@ -172,6 +198,24 @@ impl DeviceRegistryCache {
         touched: impl IntoIterator<Item = &'a str>,
     ) {
         self.cache.insert(key, record).await;
+        self.topology.record_registry(guard, touched);
+    }
+
+    /// Batched [`insert`](Self::insert): every record lands in the cache and
+    /// the batch is logged as ONE topology change. A usync response for a
+    /// large group is hundreds of records; recorded one at a time they were
+    /// hundreds of generation bumps and lock round trips, and enough log
+    /// entries to overflow it, so a refresh that touched one group forced
+    /// every other group's memo to recompute.
+    pub(crate) async fn insert_batch<'a>(
+        &self,
+        guard: &DeviceRegistryMutationGuard<'_>,
+        records: impl IntoIterator<Item = (Arc<str>, Arc<wacore::store::traits::DeviceListRecord>)>,
+        touched: impl IntoIterator<Item = &'a str>,
+    ) {
+        for (key, record) in records {
+            self.cache.insert(key, record).await;
+        }
         self.topology.record_registry(guard, touched);
     }
 
@@ -225,7 +269,11 @@ impl DeviceRegistryCache {
 
 #[cfg(test)]
 mod tests {
-    use super::{DeviceTopology, TOPOLOGY_LOG_CAPACITY};
+    use super::{DeviceTopology, MemberIndex, TOPOLOGY_LOG_CAPACITY};
+
+    fn members(users: &[&str]) -> MemberIndex {
+        MemberIndex::from_users(users.iter().copied())
+    }
 
     /// The whole point of the log: a memo whose generation went stale proves
     /// none of the changed users are in its group and re-stamps itself.
@@ -236,9 +284,9 @@ mod tests {
         topology.record(["someone-else"]);
 
         assert!(topology.current() > stamped, "the generation must advance");
-        assert!(topology.unchanged_for(stamped, |user| user == "member"));
+        assert!(topology.unchanged_for(stamped, &members(&["member"])));
         assert!(
-            !topology.unchanged_for(stamped, |user| user == "someone-else"),
+            !topology.unchanged_for(stamped, &members(&["someone-else"])),
             "a change touching a member cannot be proven clean"
         );
     }
@@ -253,19 +301,56 @@ mod tests {
             topology.record([format!("user-{i}").as_str()]);
         }
 
-        assert_eq!(
-            topology.log.lock().unwrap().entries.len(),
-            TOPOLOGY_LOG_CAPACITY,
-            "the log grew past its bound"
+        let held = topology.log.lock().unwrap().fingerprints;
+        assert!(
+            held <= TOPOLOGY_LOG_CAPACITY,
+            "the log grew past its bound: {held} fingerprints"
         );
         assert!(
-            !topology.unchanged_for(stamped, |_| false),
+            !topology.unchanged_for(stamped, &members(&[])),
             "a generation behind the floor cannot be proven clean"
         );
         // Everything still in the log stays answerable, which is what the
         // eviction is trading the old entries for.
         let floor = topology.log.lock().unwrap().floor;
-        assert!(topology.unchanged_for(floor, |user| user == "absent"));
+        assert!(topology.unchanged_for(floor, &members(&["absent"])));
+    }
+
+    /// One change over many users is one log entry costing one fingerprint
+    /// per user: a refresh for a large group must fit without evicting the
+    /// changes before it, or every memo older than the refresh recomputes.
+    #[test]
+    fn a_large_batch_is_one_change_and_fits() {
+        let topology = DeviceTopology::new();
+        topology.record(["earlier"]);
+        let stamped = topology.current();
+        let refreshed: Vec<String> = (0..768).map(|i| format!("member-{i}")).collect();
+        topology.record(refreshed.iter().map(String::as_str));
+
+        assert_eq!(topology.current(), stamped + 1, "one bump for the batch");
+        assert_eq!(topology.log.lock().unwrap().entries.len(), 2);
+        assert!(topology.unchanged_for(stamped, &members(&["unrelated"])));
+        assert!(!topology.unchanged_for(stamped, &members(&["member-500"])));
+        // The change before the batch is still in the log, so a memo stamped
+        // before it is still provably clean of both.
+        assert!(topology.unchanged_for(stamped - 1, &members(&["unrelated"])));
+    }
+
+    /// A single change larger than the whole bound cannot be kept: it lifts
+    /// the floor to its own generation, so every memo older than it recomputes
+    /// and one stamped after it is unaffected.
+    #[test]
+    fn an_oversized_change_poisons_only_what_precedes_it() {
+        let topology = DeviceTopology::new();
+        let stamped = topology.current();
+        let huge: Vec<String> = (0..TOPOLOGY_LOG_CAPACITY + 1)
+            .map(|i| format!("member-{i}"))
+            .collect();
+        topology.record(huge.iter().map(String::as_str));
+
+        assert!(!topology.unchanged_for(stamped, &members(&[])));
+        assert!(topology.unchanged_for(topology.current(), &members(&["member-1"])));
+        assert_eq!(topology.log.lock().unwrap().fingerprints, 0);
     }
 
     /// A global change clears the log, so the generations it published must
@@ -279,9 +364,9 @@ mod tests {
 
         assert!(topology.log.lock().unwrap().entries.is_empty());
         assert!(
-            !topology.unchanged_for(stamped, |_| false),
+            !topology.unchanged_for(stamped, &members(&[])),
             "an emptied log must not read as nothing having changed"
         );
-        assert!(topology.unchanged_for(topology.current(), |_| true));
+        assert!(topology.unchanged_for(topology.current(), &members(&["a"])));
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -3,15 +3,6 @@
 use super::*;
 use wacore::net::DisconnectReason;
 
-/// Max groups with a cached resolved-device snapshot. LRU eviction covers
-/// accounts in more groups; an evicted entry just recomputes on next send.
-const GROUP_DEVICES_MEMO_CAPACITY: u64 = 64;
-
-/// Max 1:1 chats with a cached resolved-device snapshot. Higher than the
-/// group bound because a bot's active DM set is typically much wider; each
-/// entry is only the device list plus its member set.
-const DM_DEVICES_MEMO_CAPACITY: u64 = 512;
-
 /// `authenticated_generation` when no connection has published one.
 ///
 /// Not zero: that is a real generation, the one a freshly built client is on,
@@ -568,10 +559,10 @@ impl Client {
             device_memos_enabled: cache_config.cache_stores.device_registry_cache.is_none()
                 && cache_config.cache_stores.lid_pn_cache.is_none(),
             group_devices_memo: Cache::builder()
-                .max_capacity(GROUP_DEVICES_MEMO_CAPACITY)
+                .max_capacity(cache_config.group_devices_memo_capacity)
                 .build(),
             dm_devices_memo: Cache::builder()
-                .max_capacity(DM_DEVICES_MEMO_CAPACITY)
+                .max_capacity(cache_config.dm_devices_memo_capacity)
                 .build(),
             #[cfg(test)]
             dm_devices_memo_recomputes: AtomicU64::new(0),
@@ -582,7 +573,7 @@ impl Client {
                 .evict_guard(|m| Arc::strong_count(m) <= 1)
                 .build(),
             skdm_warm_memo: Cache::builder()
-                .max_capacity(GROUP_DEVICES_MEMO_CAPACITY)
+                .max_capacity(cache_config.group_devices_memo_capacity)
                 .build(),
             stanza_router: Self::create_stanza_router(),
             synchronous_ack: false,

--- a/src/client/member_index.rs
+++ b/src/client/member_index.rs
@@ -36,7 +36,7 @@ fn fingerprint_hasher() -> &'static RandomState {
     HASHER.get_or_init(RandomState::new)
 }
 
-fn fingerprint(user: &str) -> u64 {
+pub(crate) fn fingerprint(user: &str) -> u64 {
     fingerprint_hasher().hash_one(user)
 }
 
@@ -47,15 +47,46 @@ impl MemberIndex {
         }
     }
 
+    /// Index one set of identifiers in a single call.
+    pub(crate) fn from_users<'a>(users: impl IntoIterator<Item = &'a str>) -> Self {
+        let users = users.into_iter();
+        let mut builder = Self::builder(users.size_hint().0);
+        for user in users {
+            builder.insert(user);
+        }
+        builder.build()
+    }
+
     /// Whether `user` may be a member. `true` is "possibly", `false` is
     /// definite — see the type's note on which direction is safe.
+    #[cfg(test)]
     pub(crate) fn contains(&self, user: &str) -> bool {
         self.fingerprints.binary_search(&fingerprint(user)).is_ok()
     }
 
-    #[cfg(test)]
+    /// Whether the two indexes share a fingerprint, with the same asymmetry
+    /// as [`contains`](Self::contains): `true` is "possibly". A merge walk
+    /// over the two sorted slices, so a topology change that touched hundreds
+    /// of users is checked against a memo in one pass.
+    pub(crate) fn intersects(&self, other: &MemberIndex) -> bool {
+        let (mut left, mut right) = (self.fingerprints.iter(), other.fingerprints.iter());
+        let (mut l, mut r) = (left.next(), right.next());
+        while let (Some(a), Some(b)) = (l, r) {
+            match a.cmp(b) {
+                std::cmp::Ordering::Equal => return true,
+                std::cmp::Ordering::Less => l = left.next(),
+                std::cmp::Ordering::Greater => r = right.next(),
+            }
+        }
+        false
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.fingerprints.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.fingerprints.is_empty()
     }
 }
 

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -583,9 +583,11 @@ mod tests {
             )])
             .await;
 
-        assert!(topology.unchanged_for(before, |user| user == "unrelated"));
-        assert!(!topology.unchanged_for(before, |user| user == "pn1"));
-        assert!(!topology.unchanged_for(before, |user| user == "lid1"));
+        use crate::client::member_index::MemberIndex;
+        let members = |user: &str| MemberIndex::from_users([user]);
+        assert!(topology.unchanged_for(before, &members("unrelated")));
+        assert!(!topology.unchanged_for(before, &members("pn1")));
+        assert!(!topology.unchanged_for(before, &members("lid1")));
     }
 
     #[tokio::test]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -251,6 +251,7 @@ where
             // Re-queued entries move behind everything inserted so far, bit
             // cleared, so each can earn at most one more pass per hit and the
             // scan cannot cycle.
+            let requeued = !second_chance.is_empty();
             for (seq, hash) in second_chance {
                 let fresh = self.next_seq;
                 self.next_seq += 1;
@@ -267,6 +268,9 @@ where
                         self.capacity_evictions = self.capacity_evictions.saturating_add(1);
                     }
                 }
+                // Every candidate had a chance to spend; the next pass over
+                // the same entries finds them unreferenced.
+                None if requeued => continue,
                 None => {
                     self.capacity_eviction_blocks = self.capacity_eviction_blocks.saturating_add(1);
                     break;
@@ -1176,6 +1180,21 @@ mod tests {
             cache.insert(format!("b{i}"), i).await;
         }
         assert_eq!(cache.get_no_touch("a").await, None);
+    }
+
+    /// When every entry has been hit since the last pass, the pass that spends
+    /// their chances must not end the eviction: the cache stays at capacity.
+    #[tokio::test]
+    async fn an_all_referenced_pass_still_evicts() {
+        let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(1).build();
+        cache.insert("a".to_string(), 1).await;
+        cache.get("a").await;
+        cache.insert("b".to_string(), 2).await;
+        let stats = cache.capacity_stats().await;
+        assert_eq!(stats.entries, 1);
+        assert_eq!(stats.eviction_blocks, 0);
+        assert_eq!(cache.get_no_touch("a").await, None);
+        assert_eq!(cache.get_no_touch("b").await, Some(2));
     }
 
     #[tokio::test]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -37,8 +37,15 @@ struct CacheEntry<V> {
     // matching moka's timer semantics.
     inserted_at: Instant,
     last_accessed_at: Instant,
-    /// FIFO sequence number; the key for this entry in `CacheInner::order`.
+    /// Eviction sequence number; the key for this entry in `CacheInner::order`.
     seq: u64,
+    /// Set by every hit, cleared by the eviction scan: the second-chance bit
+    /// of CLOCK. A hit costs one relaxed store under the read lock; the
+    /// reordering it earns is paid by the eviction that would have dropped
+    /// the entry, which re-queues it at the back instead. Moving the entry
+    /// on the hit itself needed the write lock, and once every entry was
+    /// being moved on every pass a warm read cost three times what it had.
+    referenced: portable_atomic::AtomicBool,
 }
 
 /// One table slot: the key, its hash, and the entry.
@@ -64,7 +71,8 @@ pub(crate) struct CapacityStats {
 
 /// Portable, runtime-agnostic in-process cache.
 ///
-/// - Max capacity with FIFO eviction
+/// - Max capacity with second-chance (CLOCK) eviction: least recently used
+///   leaves first, and a hit costs one atomic store
 /// - TTL (time-to-live) and TTI (time-to-idle)
 /// - Single-flight `get_with`
 ///
@@ -92,9 +100,11 @@ struct CacheInner<K, V> {
     /// the same state, which the `Borrow` contract keeps consistent with `K`.
     hasher: RandomState,
     table: HashTable<Slot<K, V>>,
-    /// FIFO eviction order, `seq -> hash`. Eviction is `pop_first()` (O(log n))
-    /// and a targeted `remove_key` is O(log n) via the entry's stored `seq`.
-    /// The hash plus the seq find the slot in `table`, so no key is stored here.
+    /// Eviction order, `seq -> hash`, oldest first; an entry given a second
+    /// chance is re-keyed to the back. Eviction walks from the front (O(log n)
+    /// per step) and a targeted `remove_key` is O(log n) via the entry's
+    /// stored `seq`. The hash plus the seq find the slot in `table`, so no key
+    /// is stored here.
     ///
     /// Left empty for a cache that has no capacity bound: nothing could ever
     /// pop it, so maintaining it would spend a `BTreeMap` node per entry on a
@@ -160,39 +170,6 @@ where
         self.table.iter().map(|slot| (&slot.key, &slot.entry))
     }
 
-    /// Whether `entry` has aged into the older half of the eviction order and
-    /// is worth moving to the back under the write lock. Half is the
-    /// tolerance: a hot entry then costs one write per `cap / 2` inserts
-    /// instead of one per read, and after a touch it is never among the next
-    /// `cap / 2` evicted. A cache without a bound never renews.
-    fn needs_order_renewal(&self, entry: &CacheEntry<V>, max_capacity: Option<u64>) -> bool {
-        match max_capacity {
-            Some(cap) if self.track_order => self.next_seq.saturating_sub(entry.seq) > cap / 2,
-            _ => false,
-        }
-    }
-
-    /// Move `key`'s entry to the back of the eviction order, if it is still
-    /// the entry observed (a re-insert already gave it a fresh sequence).
-    fn renew_order<Q>(&mut self, key: &Q, observed_seq: u64)
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        let hash = self.hash_of(key);
-        let seq = self.next_seq;
-        let Some(slot) = self.table.find_mut(hash, |slot| slot.key.borrow() == key) else {
-            return;
-        };
-        if slot.entry.seq != observed_seq {
-            return;
-        }
-        slot.entry.seq = seq;
-        self.next_seq += 1;
-        self.order.remove(&observed_seq);
-        self.order.insert(seq, hash);
-    }
-
     /// Bytes the table and the eviction order themselves hold, on top of the
     /// entries: hashbrown's buckets (a slot plus a control byte each, at its
     /// power-of-two capacity) and one B-tree node share per ordered entry.
@@ -241,48 +218,58 @@ where
             .is_some()
     }
 
-    /// Evict oldest-first until below `cap`. With an `evict_guard`, skips entries
-    /// the guard reports as held (see [`PortableCacheBuilder::evict_guard`]).
+    /// Evict until below `cap`: oldest first, except that an entry hit since
+    /// it was last considered gets a second chance (its bit is cleared and it
+    /// re-queues at the back), so what leaves is the least recently *used*
+    /// entry rather than the least recently inserted. With an `evict_guard`,
+    /// entries the guard reports as held are skipped so a later lookup cannot
+    /// mint a duplicate; if every entry is held, the cache runs over capacity
+    /// for a while rather than dropping a live one (see
+    /// [`PortableCacheBuilder::evict_guard`]).
     fn evict_to_capacity(&mut self, cap: u64, evict_guard: Option<fn(&V) -> bool>) {
         while self.table.len() as u64 >= cap {
-            match evict_guard {
-                // Unguarded caches keep the single-pass pop_first() fast path.
-                None => match self.order.pop_first() {
-                    Some((seq, hash)) => {
-                        if self.remove_by_seq(hash, seq) {
-                            self.capacity_evictions = self.capacity_evictions.saturating_add(1);
-                        }
+            let mut victim = None;
+            let mut second_chance = Vec::new();
+            for (&seq, &hash) in self.order.iter() {
+                let Some(slot) = self.table.find(hash, |slot| slot.entry.seq == seq) else {
+                    continue;
+                };
+                if evict_guard.is_some_and(|is_evictable| !is_evictable(&slot.entry.value)) {
+                    continue;
+                }
+                if slot
+                    .entry
+                    .referenced
+                    .swap(false, std::sync::atomic::Ordering::Relaxed)
+                {
+                    second_chance.push((seq, hash));
+                    continue;
+                }
+                victim = Some((seq, hash));
+                break;
+            }
+            // Re-queued entries move behind everything inserted so far, bit
+            // cleared, so each can earn at most one more pass per hit and the
+            // scan cannot cycle.
+            for (seq, hash) in second_chance {
+                let fresh = self.next_seq;
+                self.next_seq += 1;
+                self.order.remove(&seq);
+                if let Some(slot) = self.table.find_mut(hash, |slot| slot.entry.seq == seq) {
+                    slot.entry.seq = fresh;
+                    self.order.insert(fresh, hash);
+                }
+            }
+            match victim {
+                Some((seq, hash)) => {
+                    self.order.remove(&seq);
+                    if self.remove_by_seq(hash, seq) {
+                        self.capacity_evictions = self.capacity_evictions.saturating_add(1);
                     }
-                    None => break,
-                },
-                // Guarded: skip entries a live task still holds so a later lookup
-                // can't mint a duplicate; if every entry is held, allow temporary
-                // over-capacity rather than dropping a live entry.
-                Some(is_evictable) => {
-                    let mut victim = None;
-                    for (&seq, &hash) in self.order.iter() {
-                        if self
-                            .table
-                            .find(hash, |slot| slot.entry.seq == seq)
-                            .is_some_and(|slot| is_evictable(&slot.entry.value))
-                        {
-                            victim = Some((seq, hash));
-                            break;
-                        }
-                    }
-                    match victim {
-                        Some((seq, hash)) => {
-                            self.order.remove(&seq);
-                            if self.remove_by_seq(hash, seq) {
-                                self.capacity_evictions = self.capacity_evictions.saturating_add(1);
-                            }
-                        }
-                        None => {
-                            self.capacity_eviction_blocks =
-                                self.capacity_eviction_blocks.saturating_add(1);
-                            break;
-                        }
-                    }
+                }
+                None => {
+                    self.capacity_eviction_blocks = self.capacity_eviction_blocks.saturating_add(1);
+                    break;
                 }
             }
         }
@@ -319,6 +306,7 @@ where
                     inserted_at: now,
                     last_accessed_at: now,
                     seq,
+                    referenced: portable_atomic::AtomicBool::new(false),
                 },
             },
             |slot| slot.hash,
@@ -556,7 +544,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let (value, renew_at, renew_order) = {
+        let (value, renew_at) = {
             let guard = self.inner.read().await;
             let entry = guard.get(key)?;
             // Read the clock after the lookup: a miss has no timestamp to
@@ -579,31 +567,29 @@ where
                 }
                 return None;
             }
+            if guard.track_order {
+                entry
+                    .referenced
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+            }
             (
                 entry.value.clone(),
                 self.needs_tti_renewal(entry, now).then_some(now),
-                guard
-                    .needs_order_renewal(entry, self.max_capacity)
-                    .then_some(entry.seq),
             )
         };
 
-        if renew_at.is_some() || renew_order.is_some() {
+        if let Some(now) = renew_at {
             let mut guard = self.inner.write().await;
             // Re-decide under the lock: the key may have been invalidated (the
             // miss leaves it that way) or already refreshed by a racing renewal
             // or insert, whose newer stamp this lookup must leave alone.
-            if let Some(now) = renew_at
-                && let Some(entry) = guard.get_mut(key)
+            if let Some(entry) = guard.get_mut(key)
                 && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
                 #[cfg(test)]
                 self.tti_renewals
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            }
-            if let Some(observed_seq) = renew_order {
-                guard.renew_order(key, observed_seq);
             }
         }
 
@@ -906,6 +892,17 @@ where
     }
 
     /// Evict expired entries and clean up unused init locks.
+    /// Test-only read that leaves the second-chance bit alone, so a test can
+    /// observe eviction order without feeding it.
+    #[cfg(test)]
+    async fn get_no_touch<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.read().await.get(key).map(|e| e.value.clone())
+    }
+
     pub async fn run_pending_tasks(&self) {
         let now = self.entry_time();
         let mut guard = self.inner.write().await;
@@ -1153,22 +1150,32 @@ mod tests {
         assert_eq!(cache.entry_count(), 8);
     }
 
-    /// Renewal costs a write lock, so a fresh entry is not renewed on every
-    /// read: only once it has aged into the older half of the order.
+    /// A hit never takes the write lock or moves the entry: the second
+    /// chance is spent by the eviction that reaches it, which re-queues it
+    /// once and drops it the next time round if nothing read it again.
     #[tokio::test]
-    async fn a_fresh_entry_is_not_reordered_on_every_read() {
-        let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(8).build();
+    async fn a_hit_is_spent_by_one_eviction_pass() {
+        let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(4).build();
         cache.insert("a".to_string(), 1).await;
         let seq_before = cache.inner.read().await.get("a").map(|e| e.seq);
-        for _ in 0..3 {
-            cache.get("a").await;
-        }
-        assert_eq!(cache.inner.read().await.get("a").map(|e| e.seq), seq_before);
-        for i in 0..5u32 {
+        cache.get("a").await;
+        assert_eq!(
+            cache.inner.read().await.get("a").map(|e| e.seq),
+            seq_before,
+            "a hit must not reorder under the read lock"
+        );
+        // Filling past capacity reaches `a` first; the hit re-queues it
+        // behind the fillers instead of evicting it.
+        for i in 0..4u32 {
             cache.insert(format!("b{i}"), i).await;
         }
-        cache.get("a").await;
+        assert_eq!(cache.get_no_touch("a").await, Some(1));
         assert!(cache.inner.read().await.get("a").map(|e| e.seq) > seq_before);
+        // Not read since: the next pass over it evicts.
+        for i in 4..8u32 {
+            cache.insert(format!("b{i}"), i).await;
+        }
+        assert_eq!(cache.get_no_touch("a").await, None);
     }
 
     #[tokio::test]
@@ -1222,6 +1229,7 @@ mod tests {
             inserted_at: inserted,
             last_accessed_at: inserted,
             seq: 0,
+            referenced: portable_atomic::AtomicBool::new(false),
         };
 
         assert!(!cache.is_expired(&entry, inserted + tti - Duration::from_nanos(1)));
@@ -1255,6 +1263,7 @@ mod tests {
             inserted_at: stamped,
             last_accessed_at: stamped,
             seq: 0,
+            referenced: portable_atomic::AtomicBool::new(false),
         };
 
         assert!(!cache.needs_tti_renewal(&entry, stamped));
@@ -1295,6 +1304,7 @@ mod tests {
             inserted_at: stamped,
             last_accessed_at: stamped,
             seq: 0,
+            referenced: portable_atomic::AtomicBool::new(false),
         };
 
         // Never late: gone by `real_access + tti` at the very latest.

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -1139,9 +1139,17 @@ mod tests {
         cache.insert("cold".to_string(), 2).await;
         for i in 0..64u32 {
             cache.insert(format!("filler-{i}"), i).await;
-            assert_eq!(cache.get("hot").await, Some(1), "hot entry evicted after {i} inserts");
+            assert_eq!(
+                cache.get("hot").await,
+                Some(1),
+                "hot entry evicted after {i} inserts"
+            );
         }
-        assert_eq!(cache.get("cold").await, None, "an unread entry must age out");
+        assert_eq!(
+            cache.get("cold").await,
+            None,
+            "an unread entry must age out"
+        );
         assert_eq!(cache.entry_count(), 8);
     }
 

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -95,6 +95,77 @@ pub struct PortableCache<K, V> {
     tti_renewals: Arc<portable_atomic::AtomicU64>,
 }
 
+/// What the eviction walk asks the slot table, through one `dyn` hook so the
+/// walk itself is compiled once. The walk is the bulk of the eviction code
+/// and every `K`/`V` pair would otherwise carry its own copy; the table
+/// probes it wraps are small.
+enum ClockOp {
+    /// Is the entry held, hit since the last pass, or a victim?
+    Classify { seq: u64, hash: u64 },
+    /// Re-key the entry to `fresh`. Answers `Victim` when found, `Skip` when
+    /// the slot is gone.
+    Reseq { seq: u64, hash: u64, fresh: u64 },
+}
+
+enum ClockVerdict {
+    Skip,
+    SecondChance,
+    Victim,
+}
+
+enum ClockWalk {
+    Victim {
+        seq: u64,
+        hash: u64,
+    },
+    /// No victim, but at least one entry spent its second chance; the next
+    /// pass over the same entries finds them unreferenced.
+    Requeued,
+    /// Nothing evictable at all.
+    Blocked,
+}
+
+/// One pass of the second-chance walk over `order`, oldest first: the first
+/// unreferenced, unheld entry is the victim; entries hit since the last pass
+/// have their bit cleared (by `probe`) and re-queue behind everything
+/// inserted so far, so each can earn at most one more pass per hit and the
+/// scan cannot cycle.
+fn clock_walk(
+    order: &mut BTreeMap<u64, u64>,
+    next_seq: &mut u64,
+    probe: &mut dyn FnMut(ClockOp) -> ClockVerdict,
+) -> ClockWalk {
+    let mut victim = None;
+    let mut second_chance = Vec::new();
+    for (&seq, &hash) in order.iter() {
+        match probe(ClockOp::Classify { seq, hash }) {
+            ClockVerdict::Skip => continue,
+            ClockVerdict::SecondChance => second_chance.push((seq, hash)),
+            ClockVerdict::Victim => {
+                victim = Some((seq, hash));
+                break;
+            }
+        }
+    }
+    let requeued = !second_chance.is_empty();
+    for (seq, hash) in second_chance {
+        let fresh = *next_seq;
+        *next_seq += 1;
+        order.remove(&seq);
+        if matches!(
+            probe(ClockOp::Reseq { seq, hash, fresh }),
+            ClockVerdict::Victim
+        ) {
+            order.insert(fresh, hash);
+        }
+    }
+    match victim {
+        Some((seq, hash)) => ClockWalk::Victim { seq, hash },
+        None if requeued => ClockWalk::Requeued,
+        None => ClockWalk::Blocked,
+    }
+}
+
 struct CacheInner<K, V> {
     /// Hashes keys once at insert; lookups with a borrowed `Q` hash through
     /// the same state, which the `Borrow` contract keeps consistent with `K`.
@@ -228,41 +299,40 @@ where
     /// [`PortableCacheBuilder::evict_guard`]).
     fn evict_to_capacity(&mut self, cap: u64, evict_guard: Option<fn(&V) -> bool>) {
         while self.table.len() as u64 >= cap {
-            let mut victim = None;
-            let mut second_chance = Vec::new();
-            for (&seq, &hash) in self.order.iter() {
-                let Some(slot) = self.table.find(hash, |slot| slot.entry.seq == seq) else {
-                    continue;
-                };
-                if evict_guard.is_some_and(|is_evictable| !is_evictable(&slot.entry.value)) {
-                    continue;
+            let table = &mut self.table;
+            let walk = clock_walk(&mut self.order, &mut self.next_seq, &mut |op| match op {
+                ClockOp::Classify { seq, hash } => {
+                    match table.find(hash, |slot| slot.entry.seq == seq) {
+                        None => ClockVerdict::Skip,
+                        Some(slot)
+                            if evict_guard
+                                .is_some_and(|is_evictable| !is_evictable(&slot.entry.value)) =>
+                        {
+                            ClockVerdict::Skip
+                        }
+                        Some(slot)
+                            if slot
+                                .entry
+                                .referenced
+                                .swap(false, std::sync::atomic::Ordering::Relaxed) =>
+                        {
+                            ClockVerdict::SecondChance
+                        }
+                        Some(_) => ClockVerdict::Victim,
+                    }
                 }
-                if slot
-                    .entry
-                    .referenced
-                    .swap(false, std::sync::atomic::Ordering::Relaxed)
-                {
-                    second_chance.push((seq, hash));
-                    continue;
+                ClockOp::Reseq { seq, hash, fresh } => {
+                    match table.find_mut(hash, |slot| slot.entry.seq == seq) {
+                        Some(slot) => {
+                            slot.entry.seq = fresh;
+                            ClockVerdict::Victim
+                        }
+                        None => ClockVerdict::Skip,
+                    }
                 }
-                victim = Some((seq, hash));
-                break;
-            }
-            // Re-queued entries move behind everything inserted so far, bit
-            // cleared, so each can earn at most one more pass per hit and the
-            // scan cannot cycle.
-            let requeued = !second_chance.is_empty();
-            for (seq, hash) in second_chance {
-                let fresh = self.next_seq;
-                self.next_seq += 1;
-                self.order.remove(&seq);
-                if let Some(slot) = self.table.find_mut(hash, |slot| slot.entry.seq == seq) {
-                    slot.entry.seq = fresh;
-                    self.order.insert(fresh, hash);
-                }
-            }
-            match victim {
-                Some((seq, hash)) => {
+            });
+            match walk {
+                ClockWalk::Victim { seq, hash } => {
                     self.order.remove(&seq);
                     if self.remove_by_seq(hash, seq) {
                         self.capacity_evictions = self.capacity_evictions.saturating_add(1);
@@ -270,8 +340,8 @@ where
                 }
                 // Every candidate had a chance to spend; the next pass over
                 // the same entries finds them unreferenced.
-                None if requeued => continue,
-                None => {
+                ClockWalk::Requeued => continue,
+                ClockWalk::Blocked => {
                     self.capacity_eviction_blocks = self.capacity_eviction_blocks.saturating_add(1);
                     break;
                 }

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -160,6 +160,55 @@ where
         self.table.iter().map(|slot| (&slot.key, &slot.entry))
     }
 
+    /// Whether `entry` has aged into the older half of the eviction order and
+    /// is worth moving to the back under the write lock. Half is the
+    /// tolerance: a hot entry then costs one write per `cap / 2` inserts
+    /// instead of one per read, and after a touch it is never among the next
+    /// `cap / 2` evicted. A cache without a bound never renews.
+    fn needs_order_renewal(&self, entry: &CacheEntry<V>, max_capacity: Option<u64>) -> bool {
+        match max_capacity {
+            Some(cap) if self.track_order => self.next_seq.saturating_sub(entry.seq) > cap / 2,
+            _ => false,
+        }
+    }
+
+    /// Move `key`'s entry to the back of the eviction order, if it is still
+    /// the entry observed (a re-insert already gave it a fresh sequence).
+    fn renew_order<Q>(&mut self, key: &Q, observed_seq: u64)
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        let seq = self.next_seq;
+        let Some(slot) = self.table.find_mut(hash, |slot| slot.key.borrow() == key) else {
+            return;
+        };
+        if slot.entry.seq != observed_seq {
+            return;
+        }
+        slot.entry.seq = seq;
+        self.next_seq += 1;
+        self.order.remove(&observed_seq);
+        self.order.insert(seq, hash);
+    }
+
+    /// Bytes the table and the eviction order themselves hold, on top of the
+    /// entries: hashbrown's buckets (a slot plus a control byte each, at its
+    /// power-of-two capacity) and one B-tree node share per ordered entry.
+    fn structural_bytes(&self) -> usize {
+        // A `BTreeMap<u64, u64>` leaf holds up to 11 pairs and averages
+        // roughly two thirds full, so the per-entry share is a little over
+        // the pair itself; 8 bytes of overhead is the conservative round-up.
+        const ORDER_NODE_SHARE: usize = 2 * size_of::<u64>() + 8;
+        let order = if self.track_order {
+            self.order.len() * ORDER_NODE_SHARE
+        } else {
+            0
+        };
+        wacore::stats::hash_table_bytes(self.table.capacity(), size_of::<Slot<K, V>>()) + order
+    }
+
     fn clear(&mut self) {
         self.table.clear();
         self.order.clear();
@@ -507,7 +556,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let (value, renew_at) = {
+        let (value, renew_at, renew_order) = {
             let guard = self.inner.read().await;
             let entry = guard.get(key)?;
             // Read the clock after the lookup: a miss has no timestamp to
@@ -533,21 +582,28 @@ where
             (
                 entry.value.clone(),
                 self.needs_tti_renewal(entry, now).then_some(now),
+                guard
+                    .needs_order_renewal(entry, self.max_capacity)
+                    .then_some(entry.seq),
             )
         };
 
-        if let Some(now) = renew_at {
+        if renew_at.is_some() || renew_order.is_some() {
             let mut guard = self.inner.write().await;
             // Re-decide under the lock: the key may have been invalidated (the
             // miss leaves it that way) or already refreshed by a racing renewal
             // or insert, whose newer stamp this lookup must leave alone.
-            if let Some(entry) = guard.get_mut(key)
+            if let Some(now) = renew_at
+                && let Some(entry) = guard.get_mut(key)
                 && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
                 #[cfg(test)]
                 self.tti_renewals
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            if let Some(observed_seq) = renew_order {
+                guard.renew_order(key, observed_seq);
             }
         }
 
@@ -727,16 +783,22 @@ where
         guard.iter().fold(init, |acc, (k, e)| f(acc, k, &e.value))
     }
 
-    /// Entry count plus estimated retained bytes, summing `per_entry` under a
-    /// single awaited read guard so the pair is mutually consistent (and never
-    /// the empty best-effort snapshot [`iter`](Self::iter) can degrade to).
+    /// Entry count plus estimated retained bytes: the table and eviction
+    /// order the cache itself holds, plus `per_entry` summed over the entries,
+    /// under a single awaited read guard so the pair is mutually consistent
+    /// (and never the empty best-effort snapshot [`iter`](Self::iter) can
+    /// degrade to). Callers charge only what their entries point at; the
+    /// slots and order nodes are charged here, once, for every cache.
     pub async fn memory_stats(
         &self,
         mut per_entry: impl FnMut(&K, &V) -> usize,
     ) -> wacore::stats::CollectionStats {
         let guard = self.inner.read().await;
         let bytes: usize = guard.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
-        wacore::stats::CollectionStats::new(guard.len() as u64, bytes as u64)
+        wacore::stats::CollectionStats::new(
+            guard.len() as u64,
+            (bytes + guard.structural_bytes()) as u64,
+        )
     }
 
     /// Eager snapshot iterator over `(Arc<K>, V)`: snapshot, not lazy. Includes
@@ -1065,6 +1127,40 @@ mod tests {
                 eviction_blocks: 1,
             }
         );
+    }
+
+    /// A bounded cache is least-recently-used, not first-in-first-out: an
+    /// entry that keeps being read outlives everything inserted after it,
+    /// while an entry never read again is evicted in insertion order.
+    #[tokio::test]
+    async fn a_read_entry_outlives_entries_inserted_after_it() {
+        let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(8).build();
+        cache.insert("hot".to_string(), 1).await;
+        cache.insert("cold".to_string(), 2).await;
+        for i in 0..64u32 {
+            cache.insert(format!("filler-{i}"), i).await;
+            assert_eq!(cache.get("hot").await, Some(1), "hot entry evicted after {i} inserts");
+        }
+        assert_eq!(cache.get("cold").await, None, "an unread entry must age out");
+        assert_eq!(cache.entry_count(), 8);
+    }
+
+    /// Renewal costs a write lock, so a fresh entry is not renewed on every
+    /// read: only once it has aged into the older half of the order.
+    #[tokio::test]
+    async fn a_fresh_entry_is_not_reordered_on_every_read() {
+        let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(8).build();
+        cache.insert("a".to_string(), 1).await;
+        let seq_before = cache.inner.read().await.get("a").map(|e| e.seq);
+        for _ in 0..3 {
+            cache.get("a").await;
+        }
+        assert_eq!(cache.inner.read().await.get("a").map(|e| e.seq), seq_before);
+        for i in 0..5u32 {
+            cache.insert(format!("b{i}"), i).await;
+        }
+        cache.get("a").await;
+        assert!(cache.inner.read().await.get("a").map(|e| e.seq) > seq_before);
     }
 
     #[tokio::test]

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -14,15 +14,18 @@ use wacore_binary::Jid;
 const DEVICE_REFRESH_MAX_ATTEMPTS: usize = 3;
 
 #[inline]
-fn device_response_contains_user(response: &DeviceListResponse, user: &str) -> bool {
-    response
-        .device_lists
-        .iter()
-        .any(|device_list| device_list.user.user == user)
-        || response
-            .lid_mappings
+/// Every user a device-list response speaks for, in both namespaces, as the
+/// member set a topology change is checked against.
+fn device_response_users(response: &DeviceListResponse) -> crate::client::member_index::MemberIndex {
+    crate::client::member_index::MemberIndex::from_users(
+        response
+            .device_lists
             .iter()
-            .any(|mapping| mapping.phone_number == user || mapping.lid == user)
+            .map(|device_list| device_list.user.user.as_str())
+            .chain(response.lid_mappings.iter().flat_map(|mapping| {
+                [mapping.phone_number.as_str(), mapping.lid.as_str()]
+            })),
+    )
 }
 
 pub use wacore::iq::usync::{
@@ -59,35 +62,17 @@ impl Client {
         &self,
         jids: Vec<Jid>,
     ) -> Result<Vec<Jid>, anyhow::Error> {
-        let input_len = jids.len();
-        let mut jids_to_fetch: Vec<Jid> = Vec::with_capacity(input_len);
-        let mut all_devices = Vec::with_capacity(input_len * 2);
-
-        // Resolve the LOCAL registry scan concurrently (the network usync below is
-        // already one batched IQ) — a cold-cache large group would otherwise
-        // serialize 256+ per-user cache/DB reads. Order is irrelevant (phash sorts,
-        // encrypt fan-out is order-agnostic). A None result means an empty/corrupt
-        // record, which falls through to the network below (WA Web always keeps
-        // device 0). The stream owns each JID and is drained incrementally, so
-        // no second result Vec is materialized.
-        use futures::StreamExt;
-        // Bounded fan-out over the independent per-user registry reads.
-        const DEVICE_LIST_RESOLVE_CONCURRENCY: usize = 16;
-        let mut resolved = futures::stream::iter(jids.into_iter().map(Jid::into_non_ad))
-            .map(|jid| async move {
-                let devices = self.get_devices_from_registry(&jid).await;
-                (jid, devices)
-            })
-            .buffer_unordered(DEVICE_LIST_RESOLVE_CONCURRENCY);
-
-        while let Some((jid, devices)) = resolved.next().await {
-            match devices {
-                Some(devices) => all_devices.extend(devices),
-                None => {
-                    jids_to_fetch.push(jid);
-                }
-            }
-        }
+        // One batched registry pass: the cache answers per user, and every
+        // user it cannot answer goes to the backend in ONE read. The
+        // previous per-user fan-out (16 concurrent `get_devices`) bought
+        // nothing, because the backend read is on the single write permit
+        // and the permit re-serialized them. Order is irrelevant (phash
+        // sorts, encrypt fan-out is order-agnostic). An unresolved user is
+        // one with no usable record anywhere (WA Web always keeps device 0,
+        // so an empty record counts as none) and falls through to the
+        // network below.
+        let jids: Vec<Jid> = jids.into_iter().map(Jid::into_non_ad).collect();
+        let (mut all_devices, mut jids_to_fetch) = self.get_devices_from_registry_batch(jids).await;
 
         if !jids_to_fetch.is_empty() {
             wacore::types::jid::sort_dedup_by_user(&mut jids_to_fetch);
@@ -250,9 +235,7 @@ impl Client {
         let registry_guard = self.device_topology.lock_registry().await;
         if !self
             .device_topology
-            .unchanged_for(topology_generation, |user| {
-                device_response_contains_user(response, user)
-            })
+            .unchanged_for(topology_generation, &device_response_users(response))
         {
             return Ok(None);
         }
@@ -283,12 +266,20 @@ impl Client {
         // Signal sessions or registry snapshot are discarded.
         let mut pending_identity_resets = Vec::new();
 
+        // The existing records for the whole response in one alias-aware
+        // (LID <-> PN) batch, so a response covering a large group does not
+        // pay a serialized backend read per member before it can be applied.
+        let users: Vec<&Jid> = response
+            .device_lists
+            .iter()
+            .map(|user_list| &user_list.user)
+            .collect();
+        let mut existing_records = self.load_device_records_batch(&users).await.into_iter();
+
         for user_list in &response.device_lists {
             // Update device registry (single source of truth for device lists).
             // Preserve key_index values from existing records (set via account_sync)
-            // Use alias-aware lookup (resolves LID ↔ PN) to find
-            // existing record regardless of which key it was stored under
-            let mut existing_record = self.load_device_record_for_jid(&user_list.user).await;
+            let mut existing_record = existing_records.next().flatten();
 
             // Decode key-index-list if present (WA Web: handleKeyIndexResult)
             let decoded_key_index = user_list

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -16,15 +16,20 @@ const DEVICE_REFRESH_MAX_ATTEMPTS: usize = 3;
 #[inline]
 /// Every user a device-list response speaks for, in both namespaces, as the
 /// member set a topology change is checked against.
-fn device_response_users(response: &DeviceListResponse) -> crate::client::member_index::MemberIndex {
+fn device_response_users(
+    response: &DeviceListResponse,
+) -> crate::client::member_index::MemberIndex {
     crate::client::member_index::MemberIndex::from_users(
         response
             .device_lists
             .iter()
             .map(|device_list| device_list.user.user.as_str())
-            .chain(response.lid_mappings.iter().flat_map(|mapping| {
-                [mapping.phone_number.as_str(), mapping.lid.as_str()]
-            })),
+            .chain(
+                response
+                    .lid_mappings
+                    .iter()
+                    .flat_map(|mapping| [mapping.phone_number.as_str(), mapping.lid.as_str()]),
+            ),
     )
 }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -94,6 +94,41 @@ struct DeviceRow {
 
 /// Max ids per `eq_any` list, under SQLite's default 999 host-parameter limit.
 const ID_PARAM_CHUNK: usize = 900;
+
+/// The `device_registry` columns a record is rebuilt from, in
+/// [`DeviceRegistryRow`] order.
+const DEVICE_REGISTRY_COLUMNS: (
+    device_registry::user_id,
+    device_registry::devices_json,
+    device_registry::timestamp,
+    device_registry::phash,
+    device_registry::raw_id,
+) = (
+    device_registry::user_id,
+    device_registry::devices_json,
+    device_registry::timestamp,
+    device_registry::phash,
+    device_registry::raw_id,
+);
+
+type DeviceRegistryRow = (String, String, i32, Option<String>, Option<i32>);
+
+fn device_registry_row_to_record(
+    (user, devices_json, timestamp, phash, raw_id): DeviceRegistryRow,
+) -> Result<DeviceListRecord> {
+    // Decoded as a `Vec` and converted, so this reuses the `Vec<DeviceInfo>`
+    // codec the crate already instantiates rather than stamping a second one
+    // for `Box<[_]>`.
+    let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
+        .map_err(|e| StoreError::Serialization(Box::new(e)))?;
+    Ok(DeviceListRecord {
+        user: Arc::from(user),
+        devices: devices.into_boxed_slice(),
+        timestamp: timestamp as i64,
+        phash: phash.map(Box::<str>::from),
+        raw_id: raw_id.map(|r| r as u32),
+    })
+}
 /// Eight bound columns per row keep this below SQLite's default 999-parameter
 /// limit while bounding Diesel's temporary insert-expression allocation.
 const MSG_SECRET_INSERT_CHUNK_SIZE: usize = 100;
@@ -3235,37 +3270,44 @@ impl ProtocolStore for SqliteStore {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            let row: Option<(String, String, i32, Option<String>, Option<i32>)> =
-                device_registry::table
-                    .select((
-                        device_registry::user_id,
-                        device_registry::devices_json,
-                        device_registry::timestamp,
-                        device_registry::phash,
-                        device_registry::raw_id,
-                    ))
-                    .filter(device_registry::user_id.eq(&user))
+            let row: Option<DeviceRegistryRow> = device_registry::table
+                .select(DEVICE_REGISTRY_COLUMNS)
+                .filter(device_registry::user_id.eq(&user))
+                .filter(device_registry::device_id.eq(device_id))
+                .first(&mut *conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            row.map(device_registry_row_to_record).transpose()
+        })
+        .await
+    }
+
+    async fn get_devices_batch(&self, users: &[&str]) -> Result<Vec<DeviceListRecord>> {
+        if users.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Same queue as `get_devices`, for the same reason: every row that
+        // comes back is promoted into the registry cache unconditionally.
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let users: Vec<String> = users.iter().map(|user| user.to_string()).collect();
+        self.with_semaphore(move || -> Result<Vec<DeviceListRecord>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let mut records = Vec::with_capacity(users.len());
+            for chunk in users.chunks(ID_PARAM_CHUNK) {
+                let rows: Vec<DeviceRegistryRow> = device_registry::table
+                    .select(DEVICE_REGISTRY_COLUMNS)
+                    .filter(device_registry::user_id.eq_any(chunk.iter().map(String::as_str)))
                     .filter(device_registry::device_id.eq(device_id))
-                    .first(&mut *conn)
-                    .optional()
+                    .load(&mut *conn)
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
-            match row {
-                Some((user, devices_json, timestamp, phash, raw_id)) => {
-                    // Decoded as a `Vec` and converted, so this reuses the
-                    // `Vec<DeviceInfo>` codec the crate already instantiates
-                    // rather than stamping a second one for `Box<[_]>`.
-                    let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
-                        .map_err(|e| StoreError::Serialization(Box::new(e)))?;
-                    Ok(Some(DeviceListRecord {
-                        user: Arc::from(user),
-                        devices: devices.into_boxed_slice(),
-                        timestamp: timestamp as i64,
-                        phash: phash.map(Box::<str>::from),
-                        raw_id: raw_id.map(|r| r as u32),
-                    }))
+                for row in rows {
+                    records.push(device_registry_row_to_record(row)?);
                 }
-                None => Ok(None),
             }
+            Ok(records)
         })
         .await
     }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -119,8 +119,8 @@ fn device_registry_row_to_record(
     // Decoded as a `Vec` and converted, so this reuses the `Vec<DeviceInfo>`
     // codec the crate already instantiates rather than stamping a second one
     // for `Box<[_]>`.
-    let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
-        .map_err(|e| StoreError::Serialization(Box::new(e)))?;
+    let devices: Vec<DeviceInfo> =
+        serde_json::from_str(&devices_json).map_err(|e| StoreError::Serialization(Box::new(e)))?;
     Ok(DeviceListRecord {
         user: Arc::from(user),
         devices: devices.into_boxed_slice(),
@@ -7035,6 +7035,7 @@ mod read_routing_tests {
             "promoted into device_registry_cache unconditionally, so a stale row \
              overwrites a newer entry and sends omit a linked device",
         ),
+        ("get_devices_batch", "same as get_devices"),
         (
             "get_tc_token",
             "prepare_privacy_token schedules off this timestamp, so a stale read \

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -650,7 +650,12 @@ const RESERVED_ITERATION_FIELD: u32 = super::local_field::COUNTER_RESERVATION_FI
 impl SenderKeyRecord {
     pub fn new_empty() -> Self {
         Self {
-            states: VecDeque::with_capacity(consts::MAX_SENDER_KEY_STATES),
+            // Not pre-sized to `MAX_SENDER_KEY_STATES`: a receive-side record
+            // holds one state for the life of the chain and only a rotation
+            // adds a second, so the four spare 256-byte slots were a 1 KiB
+            // allocation per sender learned — 255 of them on joining a large
+            // group — that the first `group_decrypt` clone dropped anyway.
+            states: VecDeque::new(),
             lease: CounterLease::default(),
         }
     }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -780,6 +780,14 @@ impl ProtocolStore for InMemoryBackend {
         Ok(self.state.lock().await.device_lists.get(user).cloned())
     }
 
+    async fn get_devices_batch(&self, users: &[&str]) -> Result<Vec<DeviceListRecord>> {
+        let state = self.state.lock().await;
+        Ok(users
+            .iter()
+            .filter_map(|user| state.device_lists.get(*user).cloned())
+            .collect())
+    }
+
     async fn delete_devices(&self, user: &str) -> Result<()> {
         self.state.lock().await.device_lists.remove(user);
         Ok(())

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -888,6 +888,22 @@ pub trait ProtocolStore: Send + Sync {
     /// Get all known devices for a user.
     async fn get_devices(&self, user: &str) -> Result<Option<DeviceListRecord>>;
 
+    /// Batched variant of `get_devices`: the records stored under any of
+    /// `users`, in no particular order, with absent users left out. Backends
+    /// should override with one query; the default loops for correctness.
+    /// Resolving a cold large group reads one record per member, and a
+    /// round trip per member through the write queue cost ~30x one
+    /// `IN (...)` query at 256 members on SQLite.
+    async fn get_devices_batch(&self, users: &[&str]) -> Result<Vec<DeviceListRecord>> {
+        let mut records = Vec::with_capacity(users.len());
+        for user in users {
+            if let Some(record) = self.get_devices(user).await? {
+                records.push(record);
+            }
+        }
+        Ok(records)
+    }
+
     /// Delete a device list record, forcing a network re-fetch on next query.
     async fn delete_devices(&self, user: &str) -> Result<()>;
 


### PR DESCRIPTION
The groups-at-scale half of the second parallel exploration, after #1388–#1396. Every group-send optimisation merged so far assumes the per-group device memo answers a warm send; this PR is about the accounts for which it did not.

## The cliff

`group_devices_memo` held 64 entries and evicted oldest-first, so an account rotating over 65 groups had a hit rate of exactly zero: every send re-resolved every member (`resolve_group_devices_uncached`: a registry probe per member, a `MemberIndex` rebuild, a fresh phash), and `skdm_warm_memo`, which shares the bound and the key, died with it, so the whole warm-send path was inert for exactly this workload. The topology log that lets a memo re-stamp instead of recompute was a 256-slot ring of strings, and a device-list refresh recorded one change per record, so any refresh past ~85 members overflowed it and forced every other group's memo to recompute for a change that touched one group.

## Changes

- **`CacheConfig::group_devices_memo_capacity` (default 512) and `dm_devices_memo_capacity`** replace the private constants; the SKDM warm-target memo follows the group bound.
- **`PortableCache` evicts least-recently-used.** A read moves an entry to the back of the order once it has aged into the older half, so a hot entry costs one write lock per `cap / 2` inserts rather than one per read, and an account past the bound degrades to re-resolving its least active groups instead of all of them. `memory_stats` now also charges the table slots and order nodes the cache itself holds, which every report understated by 60–210 B per entry.
- **The topology log holds fingerprint sets per change** (bounded at 4096 fingerprints in total, the same `MemberIndex` the memos use), a registry batch is recorded as ONE change, and `unchanged_for` merge-walks the memo's index against each change. A 256-member refresh is now one entry of ~768 fingerprints; the log held ~85 members before.
- **`ProtocolStore::get_devices_batch`** (defaulted to a loop; one chunked `IN (...)` on SQLite, on the write queue for the same reason `get_devices` is) — used by `get_user_devices_owned` and by the usync response path in place of one backend round trip per member. The exploration measured the per-member form at 22.1 ms against 0.68 ms for one query at 256 members on a file-backed store; the previous `buffer_unordered(16)` fan-out bought nothing because the write permit re-serialized it.
- **`device_registry_cache` default 5000 → 20000 entries.** A ceiling, not a preallocation: the cache only holds what has been resolved.
- **`SenderKeyRecord::new_empty` no longer pre-sizes five states**: 1 KiB per sender learned (255 of them on joining a large group), dropped by the first decrypt anyway.
- **`client_group_scale` bench** on a new `GroupScaleHarness`: 16 / 64 / 256 groups of 64 members, a warm pass over every group and a pass after one group's device-list refresh through the real registry write path. Runs on the CodSpeed client shard.

## Numbers

`client_group_scale`, per pass, medians (main vs this branch, same box):

| bench | 16 groups | 64 groups | 256 groups |
| --- | --- | --- | --- |
| `warm_resolve_pass` | 2.18 → 2.13 µs | 7.74 → 7.85 µs | **33.4 ms → 33.0 µs** |
| `resolve_after_unrelated_refresh` | 133 → 70.6 µs | 404 → 142 µs | **32.8 ms → 376 µs** |

At 16 and 64 groups the warm pass was already all hits and is unchanged; at 256 it was all misses (every group re-resolved on every pass) and is now all hits. After a 64-member refresh the other groups re-stamp at ~1.5 µs each instead of recomputing; at 256 groups the old bound made them miss outright.

## Not in this PR

- Reporting the LID↔PN cache's two side maps (`persisted`, `contact_hash_to_lid`, the largest unreported structure at ~7 MB for 51k mappings) and restructuring them: reporting-only changes to `MemoryReport` collide with another open PR; the structural change is its own piece of work.
- Sharding `sender_key_locks`: measured at 85 ns/op with no contention, not a bottleneck.
- The usync response's per-mapping `String` allocations (~15 µs per 256-member refresh).

## Verification

- `cargo clippy -p wacore -p wacore-libsignal -p whatsapp-rust-sqlite-storage -p whatsapp-rust --all-targets --features bench-harness -- -D warnings` clean
- `cargo test -p whatsapp-rust --lib` (1871), `cargo test -p whatsapp-rust-sqlite-storage --lib` (82), `cargo test -p wacore-libsignal --lib` (242), `cargo test -p wacore --lib -- store` pass

CI note: `Semver Checks (informational)` is red on `main` as well and is not this PR's; no fix exists for it in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_