### PR TITLE
perf(events)!: box the two variants that sized every dispatched event

### DIFF
--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -864,7 +864,10 @@ impl StanzaHandler for CallHandler {
                             drop(event_permit);
                             drop(_transition_guard);
                             if dispatch_call {
-                                client.core.event_bus.dispatch(Event::IncomingCall(call));
+                                client
+                                    .core
+                                    .event_bus
+                                    .dispatch(Event::IncomingCall(Box::new(call)));
                             }
                             replay_initial_group_controls(&client, buffered_initial_group_controls)
                                 .await;
@@ -1007,7 +1010,10 @@ impl StanzaHandler for CallHandler {
                         drop(event_permit);
                     }
                     if dispatch_call {
-                        client.core.event_bus.dispatch(Event::IncomingCall(call));
+                        client
+                            .core
+                            .event_bus
+                            .dispatch(Event::IncomingCall(Box::new(call)));
                     }
                     #[cfg(feature = "voip-runtime")]
                     replay_initial_group_controls(&client, buffered_initial_group_controls).await;
@@ -1204,7 +1210,10 @@ fn apply_waiting_room_update(
 async fn replay_initial_group_controls(client: &Client, controls: Vec<IncomingCall>) {
     for call in controls {
         if apply_current_group_control(client, &call).await {
-            client.core.event_bus.dispatch(Event::IncomingCall(call));
+            client
+                .core
+                .event_bus
+                .dispatch(Event::IncomingCall(Box::new(call)));
         }
     }
 }
@@ -3015,10 +3024,7 @@ mod tests {
         assert_eq!(sends.load(std::sync::atomic::Ordering::SeqCst), 0);
         assert!(matches!(
             global_rx.try_recv().as_deref(),
-            Ok(Event::IncomingCall(IncomingCall {
-                action: CallAction::Accept { .. },
-                ..
-            }))
+            Ok(Event::IncomingCall(call)) if matches!(call.action, CallAction::Accept { .. })
         ));
         assert!(!cancelled);
     }
@@ -3665,10 +3671,8 @@ mod tests {
         );
         assert!(matches!(
             global_rx.try_recv().as_deref(),
-            Ok(Event::IncomingCall(IncomingCall {
-                action: CallAction::VideoState { .. },
-                ..
-            }))
+            Ok(Event::IncomingCall(call))
+                if matches!(call.action, CallAction::VideoState { .. })
         ));
         let enabled = tokio::time::timeout(std::time::Duration::from_secs(2), enabled_waiter)
             .await

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -273,7 +273,7 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
                 .has_incomplete_participant_information(
                     notification.has_incomplete_participant_information,
                 )
-                .action(action)
+                .action(Box::new(action))
                 .build(),
         ));
     }

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -1223,7 +1223,7 @@ mod tests {
             Some("5511999999999"),
             "old owner comes from notification.participant"
         );
-        match &group_update.action {
+        match &*group_update.action {
             GroupNotificationAction::ChangeNumber {
                 new_owner,
                 sub_group_suggestions,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -2659,13 +2659,9 @@ mod tests {
         assert_eq!(R::from_server(429, "something-else"), None);
     }
 
-    /// Every dispatched event is one `Arc<Event>` allocation sized by the
-    /// largest variant, whatever the payload actually is — so one fat variant
-    /// taxes `Event::Presence` (48 bytes of payload) and every aggregated read
-    /// receipt's per-participant fan-out alike. Boxing `IncomingCall` (432) and
-    /// `GroupUpdate`'s action (288 of its 528) took the enum from 528 bytes to
-    /// this ceiling, which `LoggedOut` (328) now sets, with `TemporaryBan`
-    /// (312) behind it.
+    /// `size_of::<Event>()` sizes every dispatched event (see the boxed
+    /// variants' docs for why). The ceiling is set by `LoggedOut` (328), with
+    /// `TemporaryBan` (312) behind it.
     ///
     /// The number is not sacred; the order of magnitude is. Raising it means a
     /// new variant just made every event bigger, and the fix is almost always

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -935,7 +935,12 @@ pub enum Event {
 
     /// Incoming `<call>` stanza from the server (offer, preaccept, accept,
     /// reject, terminate). Mirror of WA Web's inbound call signaling.
-    IncomingCall(IncomingCall),
+    ///
+    /// Boxed for the same reason as [`Event::HistorySync`]: at 432 bytes it was
+    /// one of the two variants setting the size of every `Event`, and every
+    /// dispatched event is one `Arc` allocation of that size whatever its
+    /// payload. A `<presence>` is not obliged to pay for a call offer.
+    IncomingCall(Box<IncomingCall>),
 
     /// A call that must not ring (e.g. an offer replayed from the offline queue on reconnect).
     /// Surfaced separately from [`IncomingCall`] so a consumer cannot accidentally auto-accept a
@@ -2336,8 +2341,13 @@ pub struct GroupUpdate {
     /// Whether participant identity information was incomplete in the source stanza.
     #[builder(default)]
     pub has_incomplete_participant_information: bool,
-    /// The specific action
-    pub action: crate::stanza::groups::GroupNotificationAction,
+    /// The specific action.
+    ///
+    /// Boxed, like the `action` of every sync-action payload in this file
+    /// (`ContactUpdate`, `PinUpdate`, `MuteUpdate`, …): at 288 bytes it made
+    /// `GroupUpdate` the largest variant of `Event`, and `Event` is what sizes
+    /// the single `Arc` allocation every dispatch makes, group update or not.
+    pub action: Box<crate::stanza::groups::GroupNotificationAction>,
 }
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]
@@ -2649,13 +2659,37 @@ mod tests {
         assert_eq!(R::from_server(429, "something-else"), None);
     }
 
+    /// Every dispatched event is one `Arc<Event>` allocation sized by the
+    /// largest variant, whatever the payload actually is — so one fat variant
+    /// taxes `Event::Presence` (48 bytes of payload) and every aggregated read
+    /// receipt's per-participant fan-out alike. Boxing `IncomingCall` (432) and
+    /// `GroupUpdate`'s action (288 of its 528) took the enum from 528 bytes to
+    /// this ceiling, which `LoggedOut` (328) now sets, with `TemporaryBan`
+    /// (312) behind it.
+    ///
+    /// The number is not sacred; the order of magnitude is. Raising it means a
+    /// new variant just made every event bigger, and the fix is almost always
+    /// to box that variant's payload rather than to edit this line.
+    #[test]
+    fn event_stays_under_its_size_ceiling() {
+        const CEILING: usize = 328;
+        let size = size_of::<Event>();
+        assert!(
+            size <= CEILING,
+            "size_of::<Event>() is {size}, over the {CEILING}-byte ceiling: some \
+             variant's payload grew and now every dispatched event pays for it"
+        );
+    }
+
     #[test]
     fn group_update_builder_defaults_additive_scalar_fields() {
         let update = GroupUpdate::builder()
             .group_jid("120363000000000001@g.us".parse().unwrap())
             .timestamp(DateTime::<Utc>::UNIX_EPOCH)
             .is_lid_addressing_mode(false)
-            .action(crate::stanza::groups::GroupNotificationAction::Unlocked)
+            .action(Box::new(
+                crate::stanza::groups::GroupNotificationAction::Unlocked,
+            ))
             .build();
 
         assert_eq!(update.action_index, 0);


### PR DESCRIPTION
## Summary

`CoreEventBus::dispatch` materialises each event into exactly one `Arc<Event>`, so that allocation is sized by the largest variant of `Event`, whatever the payload being dispatched. `size_of::<Event>()` was 528 bytes, set by `GroupUpdate` (528, of which the inline `GroupNotificationAction` is 288) and `IncomingCall` (432). A `Presence` event carries 48 bytes of payload and paid for a call offer; an aggregated read receipt from a 32-member group paid it once per participant it fans out to.

- `Event::IncomingCall` now holds `Box<IncomingCall>`, following the `HistorySync(Box<LazyHistorySync>)` precedent in the same enum.
- `GroupUpdate.action` is now `Box<GroupNotificationAction>`, like the `action` of every sync-action payload in the same file (`ContactUpdate`, `PinUpdate`, `MuteUpdate`, …).
- A new `event_stays_under_its_size_ceiling` test pins the 328-byte ceiling so a future fat variant is caught where it is introduced. The ceiling is now set by `LoggedOut` (328) and `TemporaryBan` (312), both inline payloads that could be boxed the same way in a follow-up. They are left alone here to keep the breaking surface to what this change documents.

## Measured

| | before | after |
|---|---:|---:|
| `size_of::<Event>()` | 528 B | 328 B |
| per-dispatch `Arc<Event>` allocation | 544 B | 344 B |

Both steps are load-bearing: boxing only `GroupUpdate.action` leaves 440 B (set by `IncomingCall`). Wall time is not the claim and did not move measurably; both sizes land in fast allocator bins. The claim is 200 bytes off every event a connected client dispatches.

## Breaking

Two mechanical changes for consumers:

- A by-value match arm `Event::IncomingCall(c)` now binds `Box<IncomingCall>`. Field reads and `&call` coercions are unchanged; a pattern that destructures the struct inside the variant must bind first or deref with `&*`.
- `GroupUpdate::builder().action(x)` takes `Box::new(x)`, and a `match` on `update.action` that names `GroupNotificationAction` variants needs `&*`.

The serialized form is identical: `Box<T>` serializes as `T`. `examples/voip-cli` needed no change (verified by compiling it); nothing under `tests/`, `plugins/` or `src/bot.rs` references either shape.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings`
- [x] `cargo test -p wacore -p whatsapp-rust --lib --all-features`
- [ ] CI

CI note: the Semver Checks job is informational and currently red on `main` as well; this PR is a deliberate breaking change and is titled as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_