### PR TITLE
perf(client): trim the connect and idle footprint: boxed post-login task, leaner per-client structure, batched presence re-subscribe

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -961,6 +961,80 @@ mod tests {
         );
     }
 
+    /// The processor's key cache is bounded, so a patch list that references
+    /// more keys than it holds must still apply in full: the keys a list needs
+    /// come from the backend, and the cache only decides what the *next* list
+    /// gets to reuse.
+    #[tokio::test]
+    async fn a_patch_list_referencing_more_keys_than_the_cache_holds_still_applies() {
+        const KEYS: usize = 40;
+
+        let backend = Arc::new(MockBackend::default());
+        let processor =
+            AppStateProcessor::new(backend.clone(), Arc::new(crate::runtime_impl::TokioRuntime));
+
+        let mut patches = Vec::with_capacity(KEYS);
+        for i in 0..KEYS {
+            let key_id = format!("key-{i:02}").into_bytes();
+            let master_key = [i as u8; 32];
+            backend
+                .set_sync_key(
+                    &key_id,
+                    AppStateSyncKey {
+                        key_data: master_key.to_vec(),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("test backend should accept sync key");
+            let keys = expand_app_state_keys(&master_key);
+            let plaintext = wa::SyncActionData {
+                value: buffa::MessageField::some(wa::SyncActionValue {
+                    timestamp: Some(1000 + i as i64),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }
+            .encode_to_vec();
+            let mutation = create_encrypted_mutation(
+                wa::syncd_mutation::SyncdOperation::SET,
+                &[i as u8; 32],
+                &plaintext,
+                &keys,
+                &key_id,
+            );
+            patches.push(wa::SyncdPatch {
+                mutations: vec![mutation],
+                version: buffa::MessageField::some(wa::SyncdVersion {
+                    version: Some(i as u64 + 1),
+                }),
+                key_id: buffa::MessageField::some(wa::KeyId { id: Some(key_id) }),
+                ..Default::default()
+            });
+        }
+        let patch_list = PatchList {
+            name: WAPatchName::Regular,
+            has_more_patches: false,
+            patches,
+            snapshot: None,
+            snapshot_ref: None,
+            error: None,
+        };
+
+        let (mutations, state, _) = processor
+            .process_patch_list(patch_list, false)
+            .await
+            .expect("every key is in the backend, so every patch applies");
+
+        assert_eq!(mutations.len(), KEYS);
+        assert_eq!(state.version, KEYS as u64);
+        assert!(
+            processor.cached_key_count().await < KEYS,
+            "the cache holds fewer keys than this list referenced; that eviction \
+             is what the list had to survive"
+        );
+    }
+
     /// Builds a snapshot resync (incoming v2 over persisted v1) that carries one
     /// record, after seeding an unrelated stale MAC at v1. Returns the backend,
     /// processor, the patch list, and the stale index MAC that the resync must drop.

--- a/src/client.rs
+++ b/src/client.rs
@@ -463,6 +463,14 @@ pub struct MemoryReport {
     /// `InboundCommitBatcher::pending_stats`). Live traffic commits
     /// immediately, so outside an offline drain this is normally zero.
     pub inbound_commit_batch: CollectionStats,
+    /// Delivery receipts held back during an offline drain, to be flushed as
+    /// aggregate `<receipt>` stanzas (WA Web `sendAggregateOfflineReceipts`).
+    ///
+    /// Bounded by the same commit batch that fills it — the buffer is flushed
+    /// per batch snapshot, so it tops out at the batch's 400 messages — and
+    /// empty outside the drain. Reported because it is the largest transient
+    /// the drain retains after that batch itself.
+    pub offline_receipt_buffer: CollectionStats,
     /// `messageSecret` captures buffered for write-behind persistence — from
     /// live receives and sends as well as an offline drain, so a slow backend
     /// can saturate this with no drain in progress.
@@ -606,7 +614,7 @@ pub struct SubsystemMemory {
 impl MemoryReport {
     /// Common byte-carrying collections used by both totals and `Display`.
     /// Feature-specific collections stay beside their gated report section.
-    fn collections(&self) -> [(&'static str, &CollectionStats); 13] {
+    fn collections(&self) -> [(&'static str, &CollectionStats); 14] {
         [
             ("group_cache:", &self.group_cache),
             ("device_registry_cache:", &self.device_registry_cache),
@@ -621,6 +629,7 @@ impl MemoryReport {
             ("signal_sender_keys:", &self.signal_sender_keys),
             ("history_sync_tasks:", &self.history_sync_tasks),
             ("inbound_commit_batch:", &self.inbound_commit_batch),
+            ("offline_receipts:", &self.offline_receipt_buffer),
         ]
     }
 
@@ -657,14 +666,15 @@ impl std::fmt::Display for MemoryReport {
             writeln!(f, "  {name:<22} {:>7} entries {:>10} B", c.entries, c.bytes)
         }
         // First TTL_BOUNDED entries of collections() are the TTL-bounded
-        // caches; the next SIGNAL_CACHES are Signal store caches. The last two
-        // are transient retention: history sync, then the inbound commit batch.
-        // Adding a cache to collections() means moving this boundary, or the
-        // sections shift.
+        // caches; the next SIGNAL_CACHES are Signal store caches. The rest are
+        // transient retention: history sync, the inbound commit batch, then the
+        // offline receipt buffer. Adding a cache to collections() means moving
+        // this boundary, or the sections shift.
         const TTL_BOUNDED: usize = 8;
         const SIGNAL_CACHES: usize = 3;
         const HISTORY_SYNC: usize = TTL_BOUNDED + SIGNAL_CACHES;
         const COMMIT_BATCH: usize = HISTORY_SYNC + 1;
+        const OFFLINE_RECEIPTS: usize = COMMIT_BATCH + 1;
         let collections = self.collections();
         writeln!(f, "=== Memory Report ===")?;
         writeln!(f, "--- TTL-bounded caches ---")?;
@@ -765,6 +775,11 @@ impl std::fmt::Display for MemoryReport {
         )?;
         writeln!(f, "--- Transient retention ---")?;
         line(f, collections[COMMIT_BATCH].0, &self.inbound_commit_batch)?;
+        line(
+            f,
+            collections[OFFLINE_RECEIPTS].0,
+            &self.offline_receipt_buffer,
+        )?;
         writeln!(f, "  msg_secret_buffer:      {}", self.msg_secret_buffer)?;
         writeln!(f, "  pending_device_sync:    {}", self.pending_device_sync)?;
         #[cfg(feature = "plugins")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1264,15 +1264,15 @@ pub struct Client {
     pub(crate) inbound_commit_batch: crate::message::commit_batch::InboundCommitBatcher,
     pub(crate) media_conn: Arc<RwLock<Option<crate::mediaconn::MediaConn>>>,
 
-    pub(crate) is_logged_in: Arc<AtomicBool>,
+    pub(crate) is_logged_in: AtomicBool,
     #[cfg(feature = "client-lifecycle")]
     pub(crate) login_transition: std::sync::Mutex<()>,
-    pub(crate) is_connecting: Arc<AtomicBool>,
-    pub(crate) is_running: Arc<AtomicBool>,
+    pub(crate) is_connecting: AtomicBool,
+    pub(crate) is_running: AtomicBool,
     /// Whether the noise socket is established (connected to WhatsApp servers).
     /// Uses an AtomicBool instead of probing the noise_socket mutex to avoid
     /// TOCTOU races where `try_lock()` fails due to contention, not disconnection.
-    is_connected: Arc<AtomicBool>,
+    is_connected: AtomicBool,
 
     /// whatsmeow's `sendActiveReceipts`: 0 = inactive (default), 1 = active
     /// (presence available), 2 = forced. When 0, delivery receipts use `type="inactive"`.
@@ -1284,7 +1284,7 @@ pub struct Client {
     /// process, the next connect skips IK and falls back to XX so a stale
     /// cached `serverStaticPublic` doesn't trap us in a loop. Reset to 0 on
     /// any successful handshake (XX, IK, or XXfallback).
-    pub(crate) ik_handshake_failures: Arc<AtomicU32>,
+    pub(crate) ik_handshake_failures: AtomicU32,
     /// Terminal shutdown (process-wide). Fired ONLY by `disconnect()`.
     /// Long-lived subscribers that must outlive reconnect cycles (saver,
     /// device registry cleanup) subscribe here.
@@ -1347,7 +1347,7 @@ pub struct Client {
     /// Wrapped in Mutex to allow replacing on reconnect.
     pub(crate) message_processing_semaphore: std::sync::Mutex<Arc<async_lock::Semaphore>>,
     /// Bumped on every semaphore swap so stale Arc clones are rejected.
-    pub(crate) message_semaphore_generation: Arc<AtomicU64>,
+    pub(crate) message_semaphore_generation: AtomicU64,
 
     /// Per-device session locks for Signal protocol operations.
     /// Prevents race conditions when multiple messages from the same sender
@@ -1394,7 +1394,7 @@ pub struct Client {
     /// `OnceLock` keeps the read on that path down to an atomic load.
     pub group_cache: std::sync::OnceLock<Arc<GroupCache>>,
 
-    pub(crate) expected_disconnect: Arc<AtomicBool>,
+    pub(crate) expected_disconnect: AtomicBool,
     /// Set by `reconnect()` to suppress the "Message loop exited with an error" warning.
     /// Unlike `expected_disconnect`, this does NOT skip the reconnect backoff.
     pub(crate) intentional_reconnect: AtomicBool,
@@ -1473,7 +1473,7 @@ pub struct Client {
     /// Fired by [`Client::pause`] and [`Client::resume`], and by nothing else,
     /// so the run loop's reconnect backoff can watch it without the spurious
     /// wakes that would collapse the delay it exists to serve.
-    pub(crate) pause_state_notifier: Arc<event_listener::Event>,
+    pub(crate) pause_state_notifier: event_listener::Event,
     /// Set by [`Client::pause`] for the connection it tears down, consumed by
     /// the run loop's post-connection branch. A one-shot fact rather than a
     /// re-read of `paused`, because a [`Client::resume`] can land between the
@@ -1493,17 +1493,17 @@ pub struct Client {
     pub(crate) connection_publish: Mutex<()>,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
-    pub(crate) auto_reconnect_errors: Arc<AtomicU32>,
+    pub(crate) auto_reconnect_errors: AtomicU32,
     /// When the last successful authentication (`<success>`) landed, or unset.
     /// Gates the WA Web `resetDelay` backoff reset (see [`should_reset_backoff`]).
     /// Monotonic: it only ever answers how long the connection has been up, and
     /// a wall clock would let a resumed laptop declare a seconds-old connection
     /// stable, or a backwards adjustment withhold the reset indefinitely.
-    pub(crate) connected_at: Arc<wacore::time::AtomicInstant>,
+    pub(crate) connected_at: wacore::time::AtomicInstant,
     /// Set when an explicit backoff penalty was applied this connection (429
     /// rate-limit, manual `reconnect()`); cleared on the next `<success>`. Keeps
     /// the stability reset from erasing a deliberate penalty (WA Web `cancelReset`).
-    pub(crate) backoff_reset_suppressed: Arc<AtomicBool>,
+    pub(crate) backoff_reset_suppressed: AtomicBool,
 
     pub(crate) needs_initial_full_sync: Arc<app_state::BootstrapGate>,
 
@@ -1525,7 +1525,7 @@ pub struct Client {
     /// are user-paced, so there is nothing to gain from finer granularity.
     pub(crate) app_state_send_lock: Arc<Mutex<()>>,
     pub(crate) initial_keys_synced_notifier: Arc<event_listener::Event>,
-    pub(crate) initial_app_state_keys_received: Arc<AtomicBool>,
+    pub(crate) initial_app_state_keys_received: AtomicBool,
 
     /// Prevents concurrent prekey upload operations (matches WA Web's dedup set in `handlePreKeyLow`).
     pub(crate) prekey_upload_lock: Arc<Mutex<()>>,
@@ -1534,11 +1534,11 @@ pub struct Client {
     pub(crate) signed_pre_key_rotation_lock: Arc<Mutex<()>>,
     /// Notifier for when offline sync (ib offline stanza) is received.
     /// WhatsApp Web waits for this before sending passive tasks (prekey upload, active IQ, presence).
-    pub(crate) offline_sync_notifier: Arc<event_listener::Event>,
+    pub(crate) offline_sync_notifier: event_listener::Event,
     /// Flag indicating offline sync has completed (received ib offline stanza).
     /// Flips only AFTER the drain-tail commit, so the tail's acks still join
     /// the aggregate offline-receipt drain.
-    pub(crate) offline_sync_completed: Arc<AtomicBool>,
+    pub(crate) offline_sync_completed: AtomicBool,
     /// Highest connection generation whose drain finisher has started, held as
     /// `generation + 1` so zero reads as "none yet". Separate from
     /// `offline_sync_completed` because the finish runs off the read loop and
@@ -1549,7 +1549,7 @@ pub struct Client {
     /// completion descheduled past its own connection would otherwise claim
     /// the boolean after a teardown cleared it, and the next connection's
     /// completion would find the guard taken and never start a finisher.
-    pub(crate) offline_sync_finish_started: Arc<AtomicU64>,
+    pub(crate) offline_sync_finish_started: AtomicU64,
     /// Highest connection generation whose resume already published a terminal
     /// event, either `OfflineSyncCompleted` or `OfflineSyncInterrupted`, held
     /// as `generation + 1` so zero reads as "none yet".
@@ -1561,7 +1561,7 @@ pub struct Client {
     /// next drain's preview. A claim therefore fails both for a drain already
     /// reported and for one a *newer* drain has overtaken, and nothing has to
     /// reopen the guard for the next drain: its own higher stamp does that.
-    pub(crate) offline_terminal_reported: Arc<AtomicU64>,
+    pub(crate) offline_terminal_reported: AtomicU64,
     /// Delivery receipts buffered during offline sync, flushed as aggregate
     /// `<receipt>` stanzas at completion (WA Web `sendAggregateOfflineReceipts`).
     /// Empty (zero capacity) outside the offline window.
@@ -1601,15 +1601,15 @@ pub struct Client {
     pub(crate) offline_batch: Arc<offline_resume::OfflineBatchCoordinator>,
     /// Notifier for when the noise socket is established (before login).
     /// Use this to wait for the socket to be ready for sending messages.
-    pub(crate) socket_ready_notifier: Arc<event_listener::Event>,
+    pub(crate) socket_ready_notifier: event_listener::Event,
     /// Set to `true` only when `dispatch_connected()` fires (once the critical
     /// sync has an answer, clean or not). Reset on each new connection attempt.
     /// Used by `wait_for_connected()` to avoid a false-positive fast path when
     /// the client is logged in but critical app state hasn't been asked for yet.
-    pub(crate) is_ready: Arc<AtomicBool>,
+    pub(crate) is_ready: AtomicBool,
     /// Notifier for when the client is fully connected and logged in.
     /// Triggered after Event::Connected is dispatched.
-    pub(crate) connected_notifier: Arc<event_listener::Event>,
+    pub(crate) connected_notifier: event_listener::Event,
     /// The `connection_generation` that `<success>` finished publishing.
     ///
     /// `is_logged_in` is set by the dedup swap that has to come *before* the
@@ -1618,7 +1618,7 @@ pub struct Client {
     /// Work that bound a scope in that window had every attempt rejected as
     /// retired. This lags `connection_generation` by exactly that window, so
     /// equality means the generation a caller is about to bind is the final one.
-    pub(crate) authenticated_generation: Arc<AtomicU64>,
+    pub(crate) authenticated_generation: AtomicU64,
     /// Fired whenever the answer to *can work reach the server, and is it still
     /// worth waiting* may have changed: the session authenticated, or the client
     /// became terminal.
@@ -1633,7 +1633,7 @@ pub struct Client {
     /// the `Arc<Client>` whose drop would have been the only other way out.
     ///
     /// Every terminal transition must fire this. See [`Client::is_terminal`].
-    pub(crate) session_state_notifier: Arc<event_listener::Event>,
+    pub(crate) session_state_notifier: event_listener::Event,
     pub(crate) major_sync_task_sender: async_channel::Sender<MajorSyncTask>,
     pub(crate) pairing_cancellation_tx: Arc<Mutex<Option<async_channel::Sender<()>>>>,
     /// Asks the QR rotation task to re-render the ref it is already showing.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -366,6 +366,21 @@ impl Client {
                 ),
                 None => (0, 0),
             };
+        let offline_receipt_buffer = {
+            let buffer = self
+                .offline_receipt_buffer
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            // The `Arc`s are the drain's only remaining hold on these
+            // `MessageInfo`s by the time they are buffered, so each is charged
+            // in full: its allocation, its struct, and what it points at.
+            let bytes = buffer.capacity() * size_of::<Arc<crate::types::message::MessageInfo>>()
+                + buffer
+                    .iter()
+                    .map(|info| size_of::<crate::types::message::MessageInfo>() + info.heap_bytes())
+                    .sum::<usize>();
+            CollectionStats::new(buffer.len() as u64, bytes as u64)
+        };
         let (commit_batch_entries, commit_batch_bytes) = self.inbound_commit_batch.pending_stats();
         let inbound_commit_batch =
             CollectionStats::new(commit_batch_entries as u64, commit_batch_bytes as u64);
@@ -438,6 +453,7 @@ impl Client {
             history_sync_tasks_peak: history_sync_activity.tasks_peak as u64,
             history_sync_payload_bytes_peak: history_sync_activity.payload_bytes_peak as u64,
             inbound_commit_batch,
+            offline_receipt_buffer,
             msg_secret_buffer,
             pending_device_sync,
             session_locks: self.session_locks.entry_count(),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1938,13 +1938,6 @@ impl Client {
         // Drop stale media connection (auth tokens become invalid on reconnect)
         *self.media_conn.write().await = None;
 
-        // Clear app state key cache — keys will be re-fetched from DB on demand
-        // main took the processor out of the mutex before awaiting so the guard
-        // did not span the clear; the write-once cell has no guard to span, so
-        // the borrow is the whole of it.
-        if let Some(proc) = self.app_state_processor.get() {
-            proc.clear_key_cache().await;
-        }
         #[cfg(feature = "client-lifecycle")]
         drop(scope_close);
     }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2399,10 +2399,13 @@ mod tests {
             || std::array::from_fn::<_, CLIENTS, _>(|_| build()),
         );
 
+        // The aggregate is what is compared: dividing first would let a total
+        // up to `CLIENTS - 1` over the scaled budget round down into it.
         let bytes_per_client = bytes / CLIENTS as i64;
         let allocs_per_client = allocs / CLIENTS as u64;
         assert!(
-            bytes_per_client <= MAX_BYTES_PER_CLIENT && allocs_per_client <= MAX_ALLOCS_PER_CLIENT,
+            bytes <= MAX_BYTES_PER_CLIENT * CLIENTS as i64
+                && allocs <= MAX_ALLOCS_PER_CLIENT * CLIENTS as u64,
             "a Client costs {bytes_per_client} B in {allocs_per_client} allocations; \
              the budget is {MAX_BYTES_PER_CLIENT} B / {MAX_ALLOCS_PER_CLIENT} allocations",
         );

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2347,9 +2347,13 @@ mod tests {
     #[tokio::test]
     async fn one_client_costs_a_bounded_amount_of_fixed_structure() {
         // Generous enough that a layout change does not fail this, tight enough
-        // that a new eager `Arc` per cache (the shape this replaced) would.
+        // that a new eager `Arc` per cache (the shape this replaced) would: that
+        // shape cost ~20 allocations and ~3.9 KB more. The allocation count is
+        // the looser of the two on purpose: the minimum this window observes
+        // moved by 20 between one machine and CI (112 against 132), so the
+        // bound leaves room for that without letting the replaced shape back in.
         const MAX_BYTES_PER_CLIENT: i64 = 17_000;
-        const MAX_ALLOCS_PER_CLIENT: u64 = 130;
+        const MAX_ALLOCS_PER_CLIENT: u64 = 160;
         const CLIENTS: usize = 16;
 
         let persistence_manager = Arc::new(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -384,7 +384,15 @@ impl Client {
         let device_snapshot = persistence_manager.get_device_snapshot();
         let core = wacore::client::CoreClient::new(device_snapshot.core.clone());
 
-        let (tx, rx) = async_channel::bounded(32);
+        // `MajorSyncTask` queue. 8 slots, not 32: `async_channel` allocates the
+        // whole ring up front (~66 B/slot), so the depth is always-resident
+        // structure on every client, and this queue is empty on every idle one.
+        // The producers are history-sync and app-state notifications — rare, and
+        // history sync is separately concurrency-capped at 2 in the worker — so a
+        // backlog deeper than 8 means the worker is wedged, in which case
+        // back-pressuring a detached notification handler is the better answer
+        // than buffering more of them.
+        let (tx, rx) = async_channel::bounded(8);
 
         let device_topology = device_topology::DeviceTopology::new();
         let sent_frame_tap = Arc::new(SentFrameTap::new(core.event_bus.clone()));
@@ -397,14 +405,14 @@ impl Client {
             ),
             persistence_manager: persistence_manager.clone(),
             media_conn: Arc::new(RwLock::new(None)),
-            is_logged_in: Arc::new(AtomicBool::new(false)),
+            is_logged_in: AtomicBool::new(false),
             #[cfg(feature = "client-lifecycle")]
             login_transition: std::sync::Mutex::new(()),
-            is_connecting: Arc::new(AtomicBool::new(false)),
-            is_running: Arc::new(AtomicBool::new(false)),
-            is_connected: Arc::new(AtomicBool::new(false)),
+            is_connecting: AtomicBool::new(false),
+            is_running: AtomicBool::new(false),
+            is_connected: AtomicBool::new(false),
             send_active_receipts: AtomicU32::new(0),
-            ik_handshake_failures: Arc::new(AtomicU32::new(0)),
+            ik_handshake_failures: AtomicU32::new(0),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
             #[cfg(feature = "client-lifecycle")]
@@ -431,7 +439,7 @@ impl Client {
             message_processing_semaphore: std::sync::Mutex::new(Arc::new(
                 async_lock::Semaphore::new(1),
             )),
-            message_semaphore_generation: Arc::new(AtomicU64::new(0)),
+            message_semaphore_generation: AtomicU64::new(0),
             // Coordination caches: capacity-only eviction, no TTL/TTI.
             // These hold live mutexes and channel senders; time-based eviction
             // while tasks hold references would silently break serialisation.
@@ -455,7 +463,7 @@ impl Client {
             ab_props: Arc::new(wacore::store::ab_props::AbPropsCache::new()),
             group_cache: std::sync::OnceLock::new(),
 
-            expected_disconnect: Arc::new(AtomicBool::new(false)),
+            expected_disconnect: AtomicBool::new(false),
             intentional_reconnect: AtomicBool::new(false),
             connection_generation: Arc::new(AtomicU64::new(0)),
 
@@ -496,13 +504,13 @@ impl Client {
 
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
             paused: AtomicBool::new(false),
-            pause_state_notifier: Arc::new(event_listener::Event::new()),
+            pause_state_notifier: event_listener::Event::new(),
             pause_teardown_pending: AtomicBool::new(false),
             pause_generation: AtomicU64::new(0),
             connection_publish: Mutex::new(()),
-            auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
-            connected_at: Arc::new(wacore::time::AtomicInstant::unset()),
-            backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
+            auto_reconnect_errors: AtomicU32::new(0),
+            connected_at: wacore::time::AtomicInstant::unset(),
+            backoff_reset_suppressed: AtomicBool::new(false),
 
             needs_initial_full_sync: Arc::new(app_state::BootstrapGate::new(false)),
 
@@ -511,13 +519,13 @@ impl Client {
             app_state_syncing: app_state::SyncInFlight::new(),
             app_state_send_lock: Arc::new(Mutex::new(())),
             initial_keys_synced_notifier: Arc::new(event_listener::Event::new()),
-            initial_app_state_keys_received: Arc::new(AtomicBool::new(false)),
+            initial_app_state_keys_received: AtomicBool::new(false),
             prekey_upload_lock: Arc::new(Mutex::new(())),
             signed_pre_key_rotation_lock: Arc::new(Mutex::new(())),
-            offline_sync_notifier: Arc::new(event_listener::Event::new()),
-            offline_sync_completed: Arc::new(AtomicBool::new(false)),
-            offline_sync_finish_started: Arc::new(AtomicU64::new(0)),
-            offline_terminal_reported: Arc::new(AtomicU64::new(0)),
+            offline_sync_notifier: event_listener::Event::new(),
+            offline_sync_completed: AtomicBool::new(false),
+            offline_sync_finish_started: AtomicU64::new(0),
+            offline_terminal_reported: AtomicU64::new(0),
             offline_receipt_buffer: std::sync::Mutex::new(Vec::new()),
             inbound_commit_batch: Default::default(),
             history_sync_activity: Arc::new(crate::sync_task::HistorySyncActivity::new()),
@@ -525,11 +533,11 @@ impl Client {
             delivery_receipt_queue: std::sync::OnceLock::new(),
             transport_ack_queue: std::sync::OnceLock::new(),
             presence_subscriptions: Arc::new(std::sync::Mutex::new(HashSet::new())),
-            socket_ready_notifier: Arc::new(event_listener::Event::new()),
-            is_ready: Arc::new(AtomicBool::new(false)),
-            connected_notifier: Arc::new(event_listener::Event::new()),
-            authenticated_generation: Arc::new(AtomicU64::new(NO_AUTHENTICATED_GENERATION)),
-            session_state_notifier: Arc::new(event_listener::Event::new()),
+            socket_ready_notifier: event_listener::Event::new(),
+            is_ready: AtomicBool::new(false),
+            connected_notifier: event_listener::Event::new(),
+            authenticated_generation: AtomicU64::new(NO_AUTHENTICATED_GENERATION),
+            session_state_notifier: event_listener::Event::new(),
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pairing_qr_refresh_tx: Arc::new(Mutex::new(None)),
@@ -2334,6 +2342,74 @@ impl Drop for Connection<'_> {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    /// What one `Client` costs before it has connected, cached or received
+    /// anything: pure structure, shared `PersistenceManager` and backend
+    /// excluded (they are one per client only in the simplest deployments).
+    ///
+    /// The guard is what keeps the per-client footprint from drifting upward a
+    /// field at a time on a host running hundreds of sessions in one process.
+    /// Bounds, not exact figures: allocator sizes and struct layout are not the
+    /// contract, the order of magnitude is.
+    #[tokio::test]
+    async fn one_client_costs_a_bounded_amount_of_fixed_structure() {
+        // Generous enough that a layout change does not fail this, tight enough
+        // that a new eager `Arc` per cache (the shape this replaced) would.
+        const MAX_BYTES_PER_CLIENT: i64 = 17_000;
+        const MAX_ALLOCS_PER_CLIENT: u64 = 130;
+        const CLIENTS: usize = 16;
+
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let runtime: Arc<dyn Runtime> = Arc::new(crate::runtime_impl::TokioRuntime);
+        let transport_factory: Arc<dyn crate::transport::TransportFactory> =
+            Arc::new(crate::transport::mock::MockTransportFactory::new());
+        let http_client: Arc<dyn crate::http::HttpClient> =
+            Arc::new(crate::test_utils::MockHttpClient);
+        let cache_config = CacheConfig::default();
+
+        let build = || {
+            Client::assemble(
+                runtime.clone(),
+                persistence_manager.clone(),
+                transport_factory.clone(),
+                http_client.clone(),
+                None,
+                cache_config.clone(),
+                ClientExtensions {
+                    #[cfg(feature = "client-lifecycle")]
+                    lifecycle: None,
+                    #[cfg(feature = "plugins")]
+                    plugin_host: None,
+                },
+            )
+        };
+
+        // One client first, so process-wide lazies a first construction happens
+        // to fill are not charged to the steady state.
+        drop(build());
+
+        // A stack array, not a `Vec`: the collection holding the clients must not
+        // allocate inside the measured window.
+        let (bytes, allocs) = crate::test_alloc::min_live(
+            (
+                MAX_BYTES_PER_CLIENT * CLIENTS as i64,
+                MAX_ALLOCS_PER_CLIENT * CLIENTS as u64,
+            ),
+            || std::array::from_fn::<_, CLIENTS, _>(|_| build()),
+        );
+
+        let bytes_per_client = bytes / CLIENTS as i64;
+        let allocs_per_client = allocs / CLIENTS as u64;
+        assert!(
+            bytes_per_client <= MAX_BYTES_PER_CLIENT && allocs_per_client <= MAX_ALLOCS_PER_CLIENT,
+            "a Client costs {bytes_per_client} B in {allocs_per_client} allocations; \
+             the budget is {MAX_BYTES_PER_CLIENT} B / {MAX_ALLOCS_PER_CLIENT} allocations",
+        );
+    }
 
     /// A connection with one frame already waiting on it, and everything needed
     /// to see whether that frame ever becomes a node.

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1349,211 +1349,19 @@ impl Client {
             let needs_initial_sync = flag_set || needs_pushname_from_sync;
 
             if needs_initial_sync {
-                // === Fresh pairing path ===
-                // Like WhatsApp Web's syncCriticalData(): await critical collections before
-                // dispatching Connected, so blocklist/privacy settings are applied first.
-                debug!(
-                    target: "Client/AppState",
-                    "Starting Initial App State Sync (flag_set={flag_set}, needs_pushname={needs_pushname_from_sync})"
-                );
-
-                const CRITICAL_COLLECTIONS: [WAPatchName; 2] =
-                    [WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow];
-                // Single deadline for the whole critical path (key-share grace + batched
-                // IQ + missing-key fallback). Matches WhatsApp Web's WAWebSyncBootstrap
-                // 180s critical-data deadline. Armed before the wait so every step below
-                // is bounded by the same clock.
-                const CRITICAL_SYNC_TIMEOUT_SECS: u64 = 180;
-                let critical_deadline = wacore::time::Instant::now()
-                    + Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS);
-                // Claimed by whichever of the sync and the watchdog gets there
-                // first, and never by both. A plain "the sync finished" flag is not
-                // enough: `reconnect_immediately` sets `expected_disconnect` and
-                // then awaits seconds of bounded flushes before it closes the
-                // socket, so a sync landing in that window would abort the
-                // watchdog mid-teardown and leave the connection up, flagged for a
-                // disconnect that never comes, with `dispatch_connected` declining
-                // to announce it. The claim is also not a push_name check, which
-                // was never a reliable proxy: a business account gets push_name
-                // set from business_name at pairing (src/pair.rs) while still
-                // needing the full sync.
-                let critical_sync_settled =
-                    Arc::new(AtomicBool::new(false));
-                let timeout_client = client_clone.clone();
-                let timeout_generation = task_generation;
-                let timeout_rt = client_clone.runtime.clone();
-                let timeout_settled = critical_sync_settled.clone();
-                let critical_sync_timeout_handle = timeout_rt.spawn(Box::pin(async move {
-                    timeout_client.runtime.sleep(Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS)).await;
-                    // Check generation — if connection was replaced, this timeout is stale
-                    if timeout_client.connection_generation.load(Ordering::SeqCst)
-                        != timeout_generation
-                    {
-                        return;
-                    }
-                    if timeout_settled.swap(true, Ordering::SeqCst) {
-                        debug!(
-                            target: "Client/AppState",
-                            "Critical sync timeout fired but the sync already settled"
-                        );
-                    } else {
-                        warn!(
-                            target: "Client/AppState",
-                            "Critical app state sync produced no answer within {CRITICAL_SYNC_TIMEOUT_SECS}s. \
-                             Reconnecting to retry."
-                        );
-                        // WhatsApp Web does socketLogout here which clears device identity.
-                        // We reconnect instead — preserving credentials and keeping the
-                        // run loop active so auto-reconnect can retry the sync.
-                        timeout_client.reconnect_immediately().await;
-                    }
-                }));
-
-                // Brief grace for the auto-shared key that the primary sends at pairing
-                // (the WA Web primary path). The listener is registered before the flag
-                // check because the notifier is not sticky — a key-share landing in the
-                // load→listen gap would otherwise be missed. This wait is only an
-                // optimization to avoid a redundant explicit key request in the common
-                // fast case; if the key is late (heavy history sync) or never
-                // auto-shared, the batched sync below falls back to an explicit
-                // AppStateSyncKeyRequest bounded by `critical_deadline`, so correctness
-                // does not depend on this grace.
-                const KEY_SHARE_GRACE_SECS: u64 = 10;
-                let key_share_listener = client_clone.initial_keys_synced_notifier.listen();
-                if !client_clone
-                    .initial_app_state_keys_received
-                    .load(Ordering::Relaxed)
-                {
-                    debug!(
-                        target: "Client/AppState",
-                        "Waiting up to {KEY_SHARE_GRACE_SECS}s for the auto-shared app state key..."
-                    );
-                    let _ = rt_timeout(
-                        &*client_clone.runtime,
-                        Duration::from_secs(KEY_SHARE_GRACE_SECS),
-                        key_share_listener,
-                    )
-                    .await;
-
-                    // Check if connection was replaced while waiting
-                    check_generation!();
-                }
-
-                // Await critical collections via batched IQ before dispatching Connected.
-                // The deadline lets the missing-key fallback recover a late/never-shared
-                // key on this connection instead of stalling to the watchdog.
-                check_generation!();
-                let critical_scope = client_clone.sync_scope(Some(critical_deadline));
-                let result = client_clone
-                    .sync_collections_batched(CRITICAL_COLLECTIONS.to_vec(), critical_scope)
-                    .await;
-
-                // Whatever it says, this is the answer the watchdog was waiting
-                // for, so it stands down here rather than per branch. It cannot
-                // be the retry for a bad answer: the collection that failed
-                // would fail the same way on every reconnect, and the two would
-                // loop for good, announcing and dropping a live session every
-                // 180s, since `needs_pushname_from_sync` is derived from the
-                // persisted push name and survives even a restart. What did not
-                // sync rides along with the background sync instead, on this
-                // connection, which is also where a late app state key lands.
-                if critical_sync_settled.swap(true, Ordering::SeqCst) {
-                    // The watchdog claimed it first and is already retiring this
-                    // connection. Aborting it now would strand the teardown, and
-                    // announcing a connection it is closing would be a lie; the
-                    // replacement it brings up announces itself. detach() because
-                    // dropping the handle would abort the task.
-                    debug!(
-                        target: "Client/AppState",
-                        "Critical app state sync answered after the watchdog fired; leaving the reconnect to it"
-                    );
-                    critical_sync_timeout_handle.detach();
-                    return;
-                }
-                critical_sync_timeout_handle.abort();
-
-                // WA Web's answer to a critical collection it cannot get is to
-                // notify the primary and log out (`WAWebSyncdFatal`), which a
-                // library must not do on a consumer's behalf. Having chosen to
-                // keep the session, it owes the consumer the other half: the
-                // connection is announced and the gap is reported, because by
-                // this point `set_passive(false)` has already been sent and
-                // offline stanzas are being delivered to a consumer that still
-                // believes nothing ever connected.
-                let outcome = match result {
-                    Ok(outcome) => {
-                        if !outcome.all_synced() {
-                            warn!(
-                                target: "Client/AppState",
-                                "Critical app state sync incomplete (fatal={:?} retryable={:?} skipped={:?}); connecting anyway",
-                                outcome.fatal, outcome.retryable, outcome.skipped
-                            );
-                        }
-                        outcome
-                    }
-                    Err(e) => {
-                        client_clone.log_sync_error("critical app state sync", &e);
-                        BatchedSyncOutcome::all_retryable(&CRITICAL_COLLECTIONS)
-                    }
-                };
-                let plan = CriticalSyncPlan::from_outcome(&outcome);
-
-                if !client_clone
-                    .finish_critical_bootstrap(critical_scope, &plan, &outcome)
-                    .await
-                {
-                    return;
-                }
-
-                let critical_retry = plan.retry;
-                let critical_refused = plan.stranded;
-
-                // Spawn remaining non-critical collections in background
-                let sync_client = client_clone.clone();
-                let sync_generation = task_generation;
-                client_clone.runtime.spawn_detached(Box::pin(async move {
-                    if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
-                        debug!("App state sync cancelled: connection generation changed");
-                        return;
-                    }
-
-                    // Any critical collection the bootstrap handed over goes
-                    // first: it is the one the account actually needs.
-                    let mut to_sync = critical_retry;
-                    to_sync.extend([
-                        WAPatchName::RegularLow,
-                        WAPatchName::RegularHigh,
-                        WAPatchName::Regular,
-                    ]);
-                    let requested = to_sync.clone();
-                    let scope = sync_client.sync_scope(None);
-                    let result = sync_client.sync_collections_batched(to_sync, scope).await;
-
-                    let complete = !critical_refused
-                        && result.as_ref().is_ok_and(|outcome| outcome.all_synced());
-
-                    // Settled before the report, because reporting dispatches to
-                    // consumer handlers synchronously and one of them
-                    // disconnecting would retire the scope and take this
-                    // decision with it — leaving an unfinished bootstrap
-                    // unarmed, which is the failure this path exists to prevent.
-                    // `settle_bootstrap` is what makes the "only for this
-                    // connection" part impossible to forget.
-                    sync_client.settle_bootstrap(scope, !complete);
-
-                    // A refused critical collection is not in `requested` and
-                    // never will be retried, but it is why the bootstrap is
-                    // unfinished. Handing that to the scheduler keeps a later
-                    // clean round from standing the gate down on its behalf.
-                    sync_client.report_background_sync_stranded(
-                        "non-critical app state sync",
-                        scope,
-                        SyncSettles::InitialSync,
-                        &requested,
-                        critical_refused,
-                        result,
-                    );
-                }));
+                // Boxed, and the arm behind its own `async fn`, because a Rust
+                // async block reserves the union of every branch's live locals:
+                // inlined here, the fresh-pairing arm's watchdog handle,
+                // key-share listener, batched-sync future, outcome and plan
+                // added ~7 KB to a task that is spawned on every connection and
+                // stays parked through the whole offline drain — for a branch
+                // that runs once per device lifetime.
+                Box::pin(client_clone.run_initial_app_state_sync(
+                    task_generation,
+                    flag_set,
+                    needs_pushname_from_sync,
+                ))
+                .await;
             } else {
                 // === Reconnection path ===
                 // Pushname is already known, send presence and Connected immediately.
@@ -1576,6 +1384,231 @@ impl Client {
 
                 client_clone.dispatch_connected(task_generation).await;
             }
+        }));
+    }
+
+    /// The fresh-pairing arm of the post-login sequence: await the critical
+    /// app-state collections (WA Web's `syncCriticalData`) under a 180 s
+    /// watchdog, then hand the rest to a background sync.
+    ///
+    /// Its own `async fn` so the caller can box it — see the call site in
+    /// [`Self::handle_success`]. Returning early here is what returning from
+    /// the post-login task was before the extraction: nothing follows this arm.
+    async fn run_initial_app_state_sync(
+        self: &Arc<Self>,
+        task_generation: u64,
+        flag_set: bool,
+        needs_pushname_from_sync: bool,
+    ) {
+        macro_rules! check_generation {
+            () => {
+                if self.connection_generation.load(Ordering::SeqCst) != task_generation {
+                    debug!("Post-login task cancelled: connection generation changed");
+                    return;
+                }
+            };
+        }
+
+        // === Fresh pairing path ===
+        // Like WhatsApp Web's syncCriticalData(): await critical collections before
+        // dispatching Connected, so blocklist/privacy settings are applied first.
+        debug!(
+            target: "Client/AppState",
+            "Starting Initial App State Sync (flag_set={flag_set}, needs_pushname={needs_pushname_from_sync})"
+        );
+
+        const CRITICAL_COLLECTIONS: [WAPatchName; 2] =
+            [WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow];
+        // Single deadline for the whole critical path (key-share grace + batched
+        // IQ + missing-key fallback). Matches WhatsApp Web's WAWebSyncBootstrap
+        // 180s critical-data deadline. Armed before the wait so every step below
+        // is bounded by the same clock.
+        const CRITICAL_SYNC_TIMEOUT_SECS: u64 = 180;
+        let critical_deadline =
+            wacore::time::Instant::now() + Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS);
+        // Claimed by whichever of the sync and the watchdog gets there
+        // first, and never by both. A plain "the sync finished" flag is not
+        // enough: `reconnect_immediately` sets `expected_disconnect` and
+        // then awaits seconds of bounded flushes before it closes the
+        // socket, so a sync landing in that window would abort the
+        // watchdog mid-teardown and leave the connection up, flagged for a
+        // disconnect that never comes, with `dispatch_connected` declining
+        // to announce it. The claim is also not a push_name check, which
+        // was never a reliable proxy: a business account gets push_name
+        // set from business_name at pairing (src/pair.rs) while still
+        // needing the full sync.
+        let critical_sync_settled = Arc::new(AtomicBool::new(false));
+        let timeout_client = self.clone();
+        let timeout_generation = task_generation;
+        let timeout_rt = self.runtime.clone();
+        let timeout_settled = critical_sync_settled.clone();
+        let critical_sync_timeout_handle = timeout_rt.spawn(Box::pin(async move {
+            timeout_client.runtime.sleep(Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS)).await;
+            // Check generation — if connection was replaced, this timeout is stale
+            if timeout_client.connection_generation.load(Ordering::SeqCst)
+                != timeout_generation
+            {
+                return;
+            }
+            if timeout_settled.swap(true, Ordering::SeqCst) {
+                debug!(
+                    target: "Client/AppState",
+                    "Critical sync timeout fired but the sync already settled"
+                );
+            } else {
+                warn!(
+                    target: "Client/AppState",
+                    "Critical app state sync produced no answer within {CRITICAL_SYNC_TIMEOUT_SECS}s. \
+                     Reconnecting to retry."
+                );
+                // WhatsApp Web does socketLogout here which clears device identity.
+                // We reconnect instead — preserving credentials and keeping the
+                // run loop active so auto-reconnect can retry the sync.
+                timeout_client.reconnect_immediately().await;
+            }
+        }));
+
+        // Brief grace for the auto-shared key that the primary sends at pairing
+        // (the WA Web primary path). The listener is registered before the flag
+        // check because the notifier is not sticky — a key-share landing in the
+        // load→listen gap would otherwise be missed. This wait is only an
+        // optimization to avoid a redundant explicit key request in the common
+        // fast case; if the key is late (heavy history sync) or never
+        // auto-shared, the batched sync below falls back to an explicit
+        // AppStateSyncKeyRequest bounded by `critical_deadline`, so correctness
+        // does not depend on this grace.
+        const KEY_SHARE_GRACE_SECS: u64 = 10;
+        let key_share_listener = self.initial_keys_synced_notifier.listen();
+        if !self.initial_app_state_keys_received.load(Ordering::Relaxed) {
+            debug!(
+                target: "Client/AppState",
+                "Waiting up to {KEY_SHARE_GRACE_SECS}s for the auto-shared app state key..."
+            );
+            let _ = rt_timeout(
+                &*self.runtime,
+                Duration::from_secs(KEY_SHARE_GRACE_SECS),
+                key_share_listener,
+            )
+            .await;
+
+            // Check if connection was replaced while waiting
+            check_generation!();
+        }
+
+        // Await critical collections via batched IQ before dispatching Connected.
+        // The deadline lets the missing-key fallback recover a late/never-shared
+        // key on this connection instead of stalling to the watchdog.
+        check_generation!();
+        let critical_scope = self.sync_scope(Some(critical_deadline));
+        let result = self
+            .sync_collections_batched(CRITICAL_COLLECTIONS.to_vec(), critical_scope)
+            .await;
+
+        // Whatever it says, this is the answer the watchdog was waiting
+        // for, so it stands down here rather than per branch. It cannot
+        // be the retry for a bad answer: the collection that failed
+        // would fail the same way on every reconnect, and the two would
+        // loop for good, announcing and dropping a live session every
+        // 180s, since `needs_pushname_from_sync` is derived from the
+        // persisted push name and survives even a restart. What did not
+        // sync rides along with the background sync instead, on this
+        // connection, which is also where a late app state key lands.
+        if critical_sync_settled.swap(true, Ordering::SeqCst) {
+            // The watchdog claimed it first and is already retiring this
+            // connection. Aborting it now would strand the teardown, and
+            // announcing a connection it is closing would be a lie; the
+            // replacement it brings up announces itself. detach() because
+            // dropping the handle would abort the task.
+            debug!(
+                target: "Client/AppState",
+                "Critical app state sync answered after the watchdog fired; leaving the reconnect to it"
+            );
+            critical_sync_timeout_handle.detach();
+            return;
+        }
+        critical_sync_timeout_handle.abort();
+
+        // WA Web's answer to a critical collection it cannot get is to
+        // notify the primary and log out (`WAWebSyncdFatal`), which a
+        // library must not do on a consumer's behalf. Having chosen to
+        // keep the session, it owes the consumer the other half: the
+        // connection is announced and the gap is reported, because by
+        // this point `set_passive(false)` has already been sent and
+        // offline stanzas are being delivered to a consumer that still
+        // believes nothing ever connected.
+        let outcome = match result {
+            Ok(outcome) => {
+                if !outcome.all_synced() {
+                    warn!(
+                        target: "Client/AppState",
+                        "Critical app state sync incomplete (fatal={:?} retryable={:?} skipped={:?}); connecting anyway",
+                        outcome.fatal, outcome.retryable, outcome.skipped
+                    );
+                }
+                outcome
+            }
+            Err(e) => {
+                self.log_sync_error("critical app state sync", &e);
+                BatchedSyncOutcome::all_retryable(&CRITICAL_COLLECTIONS)
+            }
+        };
+        let plan = CriticalSyncPlan::from_outcome(&outcome);
+
+        if !self
+            .finish_critical_bootstrap(critical_scope, &plan, &outcome)
+            .await
+        {
+            return;
+        }
+
+        let critical_retry = plan.retry;
+        let critical_refused = plan.stranded;
+
+        // Spawn remaining non-critical collections in background
+        let sync_client = self.clone();
+        let sync_generation = task_generation;
+        self.runtime.spawn_detached(Box::pin(async move {
+            if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
+                debug!("App state sync cancelled: connection generation changed");
+                return;
+            }
+
+            // Any critical collection the bootstrap handed over goes
+            // first: it is the one the account actually needs.
+            let mut to_sync = critical_retry;
+            to_sync.extend([
+                WAPatchName::RegularLow,
+                WAPatchName::RegularHigh,
+                WAPatchName::Regular,
+            ]);
+            let requested = to_sync.clone();
+            let scope = sync_client.sync_scope(None);
+            let result = sync_client.sync_collections_batched(to_sync, scope).await;
+
+            let complete =
+                !critical_refused && result.as_ref().is_ok_and(|outcome| outcome.all_synced());
+
+            // Settled before the report, because reporting dispatches to
+            // consumer handlers synchronously and one of them
+            // disconnecting would retire the scope and take this
+            // decision with it — leaving an unfinished bootstrap
+            // unarmed, which is the failure this path exists to prevent.
+            // `settle_bootstrap` is what makes the "only for this
+            // connection" part impossible to forget.
+            sync_client.settle_bootstrap(scope, !complete);
+
+            // A refused critical collection is not in `requested` and
+            // never will be retried, but it is why the bootstrap is
+            // unfinished. Handing that to the scheduler keeps a later
+            // clean round from standing the gate down on its behalf.
+            sync_client.report_background_sync_stranded(
+                "non-critical app state sync",
+                scope,
+                SyncSettles::InitialSync,
+                &requested,
+                critical_refused,
+                result,
+            );
         }));
     }
 
@@ -2093,6 +2126,107 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime_impl::TokioRuntime;
+    use crate::store::persistence_manager::PersistenceManager;
+    use crate::test_utils::{MockHttpClient, create_test_backend};
+    use crate::transport::mock::MockTransportFactory;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::time::Duration;
+    use wacore::runtime::{AbortHandle, Runtime};
+
+    /// Records the concrete size of every future handed to the runtime.
+    ///
+    /// `size_of_val` on the unsized `dyn Future` behind the `Pin<Box<_>>` reads
+    /// the vtable, so what it reports is exactly the coroutine layout the boxing
+    /// allocated — the thing a task's resident cost is made of.
+    struct SizingRuntime {
+        inner: TokioRuntime,
+        sizes: Arc<std::sync::Mutex<Vec<usize>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for SizingRuntime {
+        fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+            self.sizes
+                .lock()
+                .expect("sizes mutex")
+                .push(size_of_val(&*future));
+            self.inner.spawn(future)
+        }
+
+        fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            self.sizes
+                .lock()
+                .expect("sizes mutex")
+                .push(size_of_val(&*future));
+            self.inner.spawn_detached(future);
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            self.inner.sleep(duration)
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            self.inner.spawn_blocking(f)
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            self.inner.yield_now()
+        }
+    }
+
+    /// The post-login task is spawned on every connection and stays parked in
+    /// `wait_for_offline_delivery_end` for the whole offline drain, so its
+    /// future is resident for minutes on a client with a backlog. Inlining the
+    /// fresh-pairing arm — a branch that runs once per device lifetime — put the
+    /// union of its locals in there and made it 8,224 B; boxing the arm brought
+    /// it to ~1.2 KB. This pins the shape, not the exact number: a future above
+    /// the bound means an arm has been inlined back in.
+    #[tokio::test]
+    async fn the_post_login_task_does_not_carry_the_fresh_pairing_arm() {
+        const MAX_POST_LOGIN_FUTURE_BYTES: usize = 2048;
+
+        let sizes = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let client = Client::builder()
+            .with_runtime(SizingRuntime {
+                inner: TokioRuntime,
+                sizes: sizes.clone(),
+            })
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+
+        // Only what `<success>` spawns: construction and `start_services` have
+        // already recorded theirs.
+        let before = sizes.lock().expect("sizes mutex").len();
+        let success = NodeBuilder::new("success").build();
+        client.handle_success(&success.as_node_ref()).await;
+
+        let spawned = sizes.lock().expect("sizes mutex")[before..].to_vec();
+        assert!(
+            !spawned.is_empty(),
+            "<success> must spawn the post-login task"
+        );
+        let largest = spawned.iter().copied().max().unwrap_or(0);
+        assert!(
+            largest < MAX_POST_LOGIN_FUTURE_BYTES,
+            "post-login future grew to {largest} B (spawned: {spawned:?}); \
+             the limit is {MAX_POST_LOGIN_FUTURE_BYTES} B",
+        );
+    }
 
     fn ack(attrs: &[(&'static str, &str)]) -> Node {
         attrs

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1156,19 +1156,6 @@ impl Client {
             check_generation!();
             client_clone.send_unified_session().await;
 
-            // === Establish session with primary phone for PDO ===
-            // This must happen BEFORE we exit passive mode (before offline messages arrive).
-            // PDO needs a session with device 0 to request decrypted content from our phone.
-            // Matches WhatsApp Web's bootstrapDeviceCapabilities() pattern.
-            check_generation!();
-            if let Err(e) = client_clone
-                .establish_primary_phone_session_immediate()
-                .await
-            {
-                warn!(target: "Client/PDO", "Failed to establish session with primary phone on login: {:?}", e);
-                // Don't fail login - PDO will retry via ensure_e2e_sessions fallback
-            }
-
             check_generation!();
             if !client_clone.is_connected() {
                 debug!("Skipping passive tasks: connection closed");
@@ -1198,6 +1185,18 @@ impl Client {
                     if key_client.connection_generation.load(Ordering::SeqCst) != key_generation {
                         return;
                     }
+
+                    // Diagnostics only — it reads two session rows and logs what it
+                    // found, establishing nothing (the PN→LID migration is lazy, on
+                    // the first message). It used to sit between `<success>` and the
+                    // `set_passive(false)` that gates offline delivery, where its two
+                    // serial DB reads delayed the backlog for a log line.
+                    if let Err(e) = key_client.log_primary_phone_session_state().await
+                        && !key_client.is_shutting_down()
+                    {
+                        warn!(target: "Client/PDO", "Failed to check the primary-phone session on login: {e:?}");
+                    }
+
                     if let Err(e) = key_client.upload_pre_keys_at_login().await
                         && !key_client.is_shutting_down()
                     {

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -1104,8 +1104,13 @@ impl Client {
         Ok(success_count)
     }
 
-    /// Log primary phone (device 0) session state at login.
-    /// Migration is lazy via try_pn_to_lid_migration_decrypt on first message.
+    /// Log which session (if any) exists with our own primary phone, device 0.
+    ///
+    /// Diagnostics, not a step: it establishes nothing. A LID session with the
+    /// primary is created lazily, by `try_pn_to_lid_migration_decrypt` on the
+    /// first message, and PDO's own `ensure_e2e_sessions` fallback covers the
+    /// case where none exists yet. Two DB reads for a `debug!`, so it belongs
+    /// off the login critical path — see the call site in `handle_success`.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -1115,7 +1120,7 @@ impl Client {
             err(Debug)
         )
     )]
-    pub(crate) async fn establish_primary_phone_session_immediate(&self) -> Result<()> {
+    pub(crate) async fn log_primary_phone_session_state(&self) -> Result<()> {
         let device_snapshot = self.persistence_manager.get_device_snapshot();
 
         let own_pn = device_snapshot

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1323,6 +1323,16 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
             .expect("Failed to check session");
         assert!(exists, "Session should exist after store");
     }
+    let record_before = {
+        let device_arc = pm.get_device_arc().await;
+        let device = device_arc.read().await;
+        device
+            .load_session(&signal_addr)
+            .await
+            .expect("Failed to load the stored session")
+            .serialize()
+            .expect("a stored session serializes")
+    };
 
     let (client, _rx) = Client::new(
         Arc::new(crate::runtime_impl::TokioRuntime),
@@ -1342,8 +1352,10 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
         "log_primary_phone_session_state should succeed when session exists"
     );
 
-    // Verify the session was NOT replaced (still has the same record)
-    // This is the critical assertion - if session was replaced, it would cause MAC failures
+    // The critical assertion: a replaced record is what caused the MAC failures,
+    // and `contains_session` alone cannot tell a replaced record from the original.
+    // A missing session loads as a fresh record, so existence is still checked
+    // separately.
     {
         let device_arc = pm.get_device_arc().await;
         let device = device_arc.read().await;
@@ -1352,6 +1364,16 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
             .await
             .expect("Failed to check session");
         assert!(exists, "Session should still exist after the call");
+        let record_after = device
+            .load_session(&signal_addr)
+            .await
+            .expect("Failed to load the session after the probe")
+            .serialize()
+            .expect("a stored session serializes");
+        assert_eq!(
+            record_after, record_before,
+            "the probe must leave the existing session record untouched"
+        );
     }
 
     info!("✅ test_primary_phone_session_probe_leaves_an_existing_session_alone passed");

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1298,10 +1298,8 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
     // A PN so the probe does not fail early, and a LID so it reaches the
     // session check at all: without an own LID it returns before probing.
     let own_pn = Jid::pn("559999999999");
-    pm.modify_device(|device| {
-        device.pn = Some(own_pn.clone());
-    })
-    .await;
+    pm.process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+        .await;
     pm.process_command(DeviceCommand::SetLid(Some(Jid::lid("100000000000002"))))
         .await;
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1039,10 +1039,10 @@ async fn test_offline_sync_lifecycle() {
     info!("✅ test_offline_sync_lifecycle passed");
 }
 
-/// Test that establish_primary_phone_session_immediate returns error when no PN is set.
+/// Test that log_primary_phone_session_state returns error when no PN is set.
 /// This verifies the "not logged in" guard works.
 #[tokio::test]
-async fn test_establish_primary_phone_session_fails_without_pn() {
+async fn test_primary_phone_session_probe_fails_without_pn() {
     let backend = Arc::new(
         crate::store::SqliteStore::new("file:memdb_no_pn?mode=memory&cache=shared")
             .await
@@ -1063,11 +1063,11 @@ async fn test_establish_primary_phone_session_fails_without_pn() {
     .await;
 
     // No PN set, so this should fail
-    let result = client.establish_primary_phone_session_immediate().await;
+    let result = client.log_primary_phone_session_state().await;
 
     assert!(
         result.is_err(),
-        "establish_primary_phone_session_immediate should fail when no PN is set"
+        "log_primary_phone_session_state should fail when no PN is set"
     );
 
     let err = result.unwrap_err();
@@ -1078,12 +1078,12 @@ async fn test_establish_primary_phone_session_fails_without_pn() {
         err
     );
 
-    info!("✅ test_establish_primary_phone_session_fails_without_pn passed");
+    info!("✅ test_primary_phone_session_probe_fails_without_pn passed");
 }
 
 /// Test that ensure_e2e_sessions waits for offline sync to complete.
 /// This is the CRITICAL difference between ensure_e2e_sessions and
-/// establish_primary_phone_session_immediate.
+/// log_primary_phone_session_state.
 #[tokio::test]
 async fn test_ensure_e2e_sessions_waits_for_offline_sync() {
     use std::sync::atomic::Ordering;
@@ -1197,16 +1197,11 @@ async fn ensure_sessions_warm_cache_short_circuits() {
         .expect("cached session must satisfy ensure without network");
 }
 
-/// Integration test: Verify that the immediate session establishment does NOT
-/// wait for offline sync. This is critical for PDO to work during offline sync.
-///
-/// The flow is:
-/// 1. Login -> establish_primary_phone_session_immediate() is called
-/// 2. This should NOT wait for offline sync (flag is false at this point)
-/// 3. After session is established, offline messages arrive
-/// 4. When decryption fails, PDO can immediately send to device 0
+/// Integration test: the primary-phone probe answers from local state alone —
+/// it never blocks on the offline drain, which is what would make it unsafe to
+/// run at login at all.
 #[tokio::test]
-async fn test_immediate_session_does_not_wait_for_offline_sync() {
+async fn test_primary_phone_session_probe_does_not_wait_for_offline_sync() {
     use std::sync::atomic::Ordering;
     use wacore_binary::Jid;
 
@@ -1221,7 +1216,7 @@ async fn test_immediate_session_does_not_wait_for_offline_sync() {
             .expect("persistence manager should initialize"),
     );
 
-    // Set a PN so establish_primary_phone_session_immediate doesn't fail early
+    // Set a PN so log_primary_phone_session_state doesn't fail early
     pm.modify_device(|device| {
         device.pn = Some(Jid::pn("559999999999"));
     })
@@ -1239,7 +1234,7 @@ async fn test_immediate_session_does_not_wait_for_offline_sync() {
     // Flag is false (offline sync not complete - simulating login state)
     assert!(!client.offline_sync_completed.load(Ordering::Relaxed));
 
-    // Call establish_primary_phone_session_immediate
+    // Call log_primary_phone_session_state
     // It should NOT wait for offline sync - it should proceed immediately
     let start = wacore::time::Instant::now();
 
@@ -1247,7 +1242,7 @@ async fn test_immediate_session_does_not_wait_for_offline_sync() {
     // but the important thing is that it doesn't WAIT for offline sync
     let result = tokio::time::timeout(
         Duration::from_millis(500),
-        client.establish_primary_phone_session_immediate(),
+        client.log_primary_phone_session_state(),
     )
     .await;
 
@@ -1256,36 +1251,34 @@ async fn test_immediate_session_does_not_wait_for_offline_sync() {
     // The call should complete (or fail) quickly, NOT wait for 10 second timeout
     assert!(
         result.is_ok(),
-        "establish_primary_phone_session_immediate should not wait for offline sync, timed out"
+        "log_primary_phone_session_state should not wait for offline sync, timed out"
     );
 
     // It should complete in < 500ms (not 10 second wait)
     assert!(
         elapsed.as_millis() < 500,
-        "establish_primary_phone_session_immediate should not wait, took {:?}",
+        "log_primary_phone_session_state should not wait, took {:?}",
         elapsed
     );
 
     // The actual result might be an error (no network), but that's fine
     // The important thing is it didn't wait for offline sync
     info!(
-        "establish_primary_phone_session_immediate completed in {:?} (result: {:?})",
+        "log_primary_phone_session_state completed in {:?} (result: {:?})",
         elapsed,
         result.unwrap().is_ok()
     );
 
-    info!("✅ test_immediate_session_does_not_wait_for_offline_sync passed");
+    info!("✅ test_primary_phone_session_probe_does_not_wait_for_offline_sync passed");
 }
 
-/// Integration test: Verify that establish_primary_phone_session_immediate
-/// skips establishment when a session already exists.
+/// Integration test: the probe reports an existing session and touches nothing.
 ///
-/// This is the CRITICAL fix for MAC verification failures:
-/// - BUG (before fix): Called process_prekey_bundle() unconditionally,
-///   replacing the existing session with a new one
-/// - RESULT: Remote device still uses old session state, causing MAC failures
+/// It once called `process_prekey_bundle()` unconditionally, replacing a live
+/// session with a fresh one while the remote device kept using the old state —
+/// which is how MAC verification started failing. It must stay read-only.
 #[tokio::test]
-async fn test_establish_session_skips_when_exists() {
+async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
     use wacore::libsignal::protocol::SessionRecord;
     use wacore::libsignal::store::SessionStore;
     use wacore::types::jid::JidExt;
@@ -1340,13 +1333,13 @@ async fn test_establish_session_skips_when_exists() {
     )
     .await;
 
-    // Call establish_primary_phone_session_immediate
+    // Call log_primary_phone_session_state
     // It should return Ok(()) immediately without fetching prekeys
-    let result = client.establish_primary_phone_session_immediate().await;
+    let result = client.log_primary_phone_session_state().await;
 
     assert!(
         result.is_ok(),
-        "establish_primary_phone_session_immediate should succeed when session exists"
+        "log_primary_phone_session_state should succeed when session exists"
     );
 
     // Verify the session was NOT replaced (still has the same record)
@@ -1361,7 +1354,7 @@ async fn test_establish_session_skips_when_exists() {
         assert!(exists, "Session should still exist after the call");
     }
 
-    info!("✅ test_establish_session_skips_when_exists passed");
+    info!("✅ test_primary_phone_session_probe_leaves_an_existing_session_alone passed");
 }
 
 /// Integration test: Verify that the session check prevents MAC failures

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1295,12 +1295,15 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
             .expect("persistence manager should initialize"),
     );
 
-    // Set a PN so the function doesn't fail early
+    // A PN so the probe does not fail early, and a LID so it reaches the
+    // session check at all: without an own LID it returns before probing.
     let own_pn = Jid::pn("559999999999");
     pm.modify_device(|device| {
         device.pn = Some(own_pn.clone());
     })
     .await;
+    pm.process_command(DeviceCommand::SetLid(Some(Jid::lid("100000000000002"))))
+        .await;
 
     // Pre-populate a session for the primary phone JID (device 0)
     let primary_phone_jid = own_pn.with_device(0);
@@ -1308,9 +1311,8 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
 
     // Create a dummy session record
     let dummy_session = SessionRecord::new_fresh();
-    {
-        let device_arc = pm.get_device_arc().await;
-        let device = device_arc.read().await;
+    let record_before = {
+        let device = pm.get_device_snapshot();
         device
             .store_session(&signal_addr, &dummy_session)
             .await
@@ -1322,10 +1324,6 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
             .await
             .expect("Failed to check session");
         assert!(exists, "Session should exist after store");
-    }
-    let record_before = {
-        let device_arc = pm.get_device_arc().await;
-        let device = device_arc.read().await;
         device
             .load_session(&signal_addr)
             .await
@@ -1357,8 +1355,7 @@ async fn test_primary_phone_session_probe_leaves_an_existing_session_alone() {
     // A missing session loads as a fresh record, so existence is still checked
     // separately.
     {
-        let device_arc = pm.get_device_arc().await;
-        let device = device_arc.read().await;
+        let device = pm.get_device_snapshot();
         let exists = device
             .contains_session(&signal_addr)
             .await

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -50,16 +50,20 @@ impl<'a> Presence<'a> {
     }
 
     async fn build_subscription_node(&self, jid: &Jid) -> Node {
-        let mut builder = NodeBuilder::new("presence")
+        // Include tctoken if available (no t attribute, matching WhatsApp Web)
+        let token = self.client.lookup_tc_token_for_jid(jid).await;
+        Self::subscription_node_with_token(jid, token)
+    }
+
+    fn subscription_node_with_token(jid: &Jid, token: Option<Vec<u8>>) -> Node {
+        let builder = NodeBuilder::new("presence")
             .attr("type", "subscribe")
             .attr("to", jid);
 
-        // Include tctoken if available (no t attribute, matching WhatsApp Web)
-        if let Some(token) = self.client.lookup_tc_token_for_jid(jid).await {
-            builder = builder.children([build_tc_token_node(&token)]);
+        match token {
+            Some(token) => builder.children([build_tc_token_node(&token)]).build(),
+            None => builder.build(),
         }
-
-        builder.build()
     }
 
     fn build_unsubscription_node(&self, jid: &Jid) -> Node {
@@ -177,6 +181,13 @@ impl<'a> Presence<'a> {
     }
 }
 
+/// How many presence re-subscriptions a reconnect keeps in flight at once.
+///
+/// Matched to the noise sender's own job channel (`bounded(8)`): the point of
+/// the window is to give that sender several frames to coalesce, and a window
+/// wider than its queue only blocks on it.
+const RESUBSCRIBE_WINDOW: usize = 8;
+
 impl Client {
     fn lock_presence_subscriptions(
         &self,
@@ -202,6 +213,21 @@ impl Client {
         self.lock_presence_subscriptions().iter().cloned().collect()
     }
 
+    /// Re-subscribe to every tracked contact's presence, a window at a time.
+    ///
+    /// Two things make the window the right unit rather than the JID. The
+    /// tcToken lookup is one store read per contact, and the whole window's
+    /// worth collapses into a single backend call. And awaiting each
+    /// `send_node` in turn guarantees the noise sender never has more than one
+    /// job queued, so every stanza became its own transport write — one TLS
+    /// record, one WebSocket frame and one syscall per contact; issuing a
+    /// window at once is what lets the sender coalesce them, exactly as the
+    /// transport-ack worker does.
+    ///
+    /// The window is what bounds it: a client tracking hundreds of contacts
+    /// still has at most [`RESUBSCRIBE_WINDOW`] stanzas in flight, and the
+    /// generation / connection checks run per window, so a reconnect landing
+    /// mid-walk still stops it within one window rather than after the lot.
     pub(crate) async fn resubscribe_presence_subscriptions(&self, expected_generation: u64) {
         let subscribed_jids = self.tracked_presence_subscriptions();
         if subscribed_jids.is_empty() {
@@ -213,7 +239,7 @@ impl Client {
             subscribed_jids.len()
         );
 
-        for jid in subscribed_jids {
+        for window in subscribed_jids.chunks(RESUBSCRIBE_WINDOW) {
             if self
                 .connection_generation
                 .load(std::sync::atomic::Ordering::SeqCst)
@@ -228,9 +254,34 @@ impl Client {
                 return;
             }
 
-            if let Err(err) = self.presence().re_subscribe_when_active(&jid).await {
-                warn!("Failed to re-subscribe to presence for {jid}: {err:?}");
+            // An `unsubscribe` may land at any point in the walk, so the
+            // tracking set is re-read here and again after the lookup — never
+            // taken from the snapshot above, which would let this undo it.
+            let pending: Vec<Jid> = window
+                .iter()
+                .filter(|jid| self.is_presence_subscription_tracked(jid))
+                .cloned()
+                .collect();
+            if pending.is_empty() {
+                continue;
             }
+
+            let tokens = self.lookup_tc_tokens_for_jids(&pending).await;
+            let sends = pending.iter().zip(tokens).filter_map(|(jid, token)| {
+                // Re-read after the lookup, which awaited. An `unsubscribe`
+                // landing in that window has already sent its own stanza, so
+                // subscribing now would leave the peer subscribed while we no
+                // longer track it.
+                self.is_presence_subscription_tracked(jid).then(|| {
+                    let node = Presence::subscription_node_with_token(jid, token);
+                    async move {
+                        if let Err(err) = self.send_node(node).await {
+                            warn!("Failed to re-subscribe to presence for {jid}: {err:?}");
+                        }
+                    }
+                })
+            });
+            futures::future::join_all(sends).await;
         }
     }
 
@@ -481,28 +532,60 @@ mod tests {
         );
     }
 
-    /// The resubscribe loop snapshots the tracked set, then re-checks each JID
-    /// before sending. This gates the send so an `unsubscribe` lands after the
-    /// snapshot was taken but before the loop reaches that JID.
+    /// Awaiting each subscribe in turn left the noise sender with one job
+    /// queued at a time, so every stanza became its own transport write. A
+    /// window's worth in flight is what gives the sender something to coalesce.
     #[tokio::test]
-    async fn resubscribe_skips_a_jid_unsubscribed_mid_loop() {
-        use crate::client::NodeFilter;
+    async fn resubscribe_batches_its_stanzas_into_fewer_transport_writes() {
+        use std::sync::atomic::Ordering;
+
+        const TRACKED: usize = 24;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        for i in 0..TRACKED {
+            let jid: Jid = format!("1904555{i:04}@s.whatsapp.net")
+                .parse()
+                .expect("valid jid");
+            client.track_presence_subscription(jid);
+        }
+
+        let generation = client.connection_generation.load(Ordering::SeqCst);
+        client.resubscribe_presence_subscriptions(generation).await;
+
+        assert_eq!(
+            transport.sent_count(),
+            TRACKED,
+            "every tracked contact is still re-subscribed exactly once"
+        );
+        assert!(
+            transport.write_count() < TRACKED,
+            "{TRACKED} frames reached the transport in {} writes; the point of \
+             the window is that the sender coalesces them",
+            transport.write_count(),
+        );
+    }
+
+    /// The resubscribe walk snapshots the tracked set, then re-checks each JID
+    /// before building and sending its stanza. This gates the first window's
+    /// first write so an `unsubscribe` lands after the snapshot was taken but
+    /// before the walk reaches the window that JID is in.
+    #[tokio::test]
+    async fn resubscribe_skips_a_jid_unsubscribed_before_its_window() {
         use bytes::Bytes;
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::sync::atomic::{AtomicBool, Ordering};
 
         struct GatedTransport {
+            inner: Arc<crate::transport::mock::CapturingMockTransport>,
             started: async_channel::Sender<()>,
             release: async_channel::Receiver<()>,
             gate_next_send: AtomicBool,
-            sends: Arc<AtomicUsize>,
         }
 
         #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
         #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
         impl crate::transport::Transport for GatedTransport {
-            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
-                self.sends.fetch_add(1, Ordering::AcqRel);
+            async fn send(&self, data: Bytes) -> Result<(), anyhow::Error> {
                 if self.gate_next_send.swap(false, Ordering::AcqRel) {
                     self.started
                         .send(())
@@ -513,7 +596,7 @@ mod tests {
                         .await
                         .map_err(|_| anyhow::anyhow!("gate closed"))?;
                 }
-                Ok(())
+                self.inner.send(data).await
             }
 
             async fn disconnect(&self) {}
@@ -523,58 +606,71 @@ mod tests {
 
         let (started_tx, started_rx) = async_channel::bounded(1);
         let (release_tx, release_rx) = async_channel::bounded(1);
-        let sends = Arc::new(AtomicUsize::new(0));
+        let captured = Arc::new(crate::transport::mock::CapturingMockTransport::new());
         let gated = crate::socket::NoiseSocket::new(
             Arc::new(TokioRuntime),
             Arc::new(GatedTransport {
+                inner: captured.clone(),
                 started: started_tx,
                 release: release_rx,
                 gate_next_send: AtomicBool::new(true),
-                sends: sends.clone(),
             }),
             wacore::handshake::NoiseCipher::new(&[0u8; 32]).expect("valid key"),
             wacore::handshake::NoiseCipher::new(&[0u8; 32]).expect("valid key"),
         );
         *client.noise_socket.lock().unwrap() = Some(Arc::new(gated));
 
-        let first: Jid = "12025550111@s.whatsapp.net".parse().expect("valid jid");
-        let second: Jid = "12025550122@s.whatsapp.net".parse().expect("valid jid");
-        client.track_presence_subscription(first.clone());
-        client.track_presence_subscription(second.clone());
+        // One full window plus one, so there is a JID the walk has not reached
+        // when the first window's first write blocks.
+        for i in 0..=RESUBSCRIBE_WINDOW {
+            let jid: Jid = format!("1202555{i:04}@s.whatsapp.net")
+                .parse()
+                .expect("valid jid");
+            client.track_presence_subscription(jid);
+        }
+        // The set is not modified between this read and the walk's own, and a
+        // `HashSet` iterates one state in one order, so this is the order the
+        // walk will use — which is what makes "in the second window" true.
+        let walk_order = client.tracked_presence_subscriptions();
+        let unsubscribed = walk_order[RESUBSCRIBE_WINDOW].clone();
 
-        // Which JID the set yields first is not fixed, so learn it from the
-        // stanza rather than assuming an iteration order.
-        let sent = client.wait_for_sent_node(NodeFilter::tag("presence"));
         let generation = client.connection_generation.load(Ordering::SeqCst);
         let resubscribe = {
             let client = client.clone();
             tokio::spawn(async move { client.resubscribe_presence_subscriptions(generation).await })
         };
 
-        let node = sent.await.expect("the loop sends the first subscribe");
-        let sent_to = node
-            .attrs
-            .get("to")
-            .cloned()
-            .expect("subscribe carries a target");
-        started_rx.recv().await.expect("the first send is gated");
-
-        let unsubscribed = if sent_to == first.to_string() {
-            second
-        } else {
-            first
-        };
+        started_rx.recv().await.expect("the first write is gated");
         client.untrack_presence_subscription(&unsubscribed);
-
         release_tx.send(()).await.expect("gate released");
         resubscribe
             .await
             .expect("resubscribe task should not panic");
 
+        let targets: Vec<String> =
+            crate::test_utils::decrypt_wire_frames(&captured.sent(), &[0u8; 32])
+                .iter()
+                .map(|plaintext| {
+                    let unpacked =
+                        wacore_binary::util::unpack(plaintext).expect("a sent frame unpacks");
+                    let node = wacore_binary::OwnedNodeRef::new(unpacked.into_owned())
+                        .expect("a sent frame decodes");
+                    node.get()
+                        .get_attr("to")
+                        .map(|to| to.to_string())
+                        .unwrap_or_default()
+                })
+                .collect();
+
         assert_eq!(
-            sends.load(Ordering::Acquire),
-            1,
-            "only the JID still tracked when the loop reached it may be re-subscribed"
+            targets.len(),
+            RESUBSCRIBE_WINDOW,
+            "the window that was in flight is re-subscribed; the next one is not, \
+             because the JID it held was untracked first"
+        );
+        assert!(
+            !targets.contains(&unsubscribed.to_string()),
+            "a JID unsubscribed before its window is reached must not be re-subscribed"
         );
         assert!(
             !client

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -135,13 +135,19 @@ impl Client {
         // would let a racing reset_connection_shutdown swap the underlying
         // notifier mid-loop and strand this task on the next connection's signal.
         let shutdown_signal = self.connection_shutdown_signal();
+        // Seeded once, not per tick: a fresh `StdRng` costs OS entropy and a
+        // 320-byte state to draw one number, and this loop wakes every 15-30 s
+        // on every connected client (measured 14.8 us vs 808 ns for the draw
+        // alone, debug). The interval only needs to be unpredictable enough that
+        // clients do not synchronise their pings.
+        let mut interval_rng = rand::make_rng::<rand::rngs::StdRng>();
 
         loop {
             // Fresh listener each iteration (event_listener is edge-triggered);
             // the Weak underneath stays pinned to this connection's notifier.
             let shutdown = wacore::runtime::wait_for_shutdown(&shutdown_signal);
 
-            let interval_ms = rand::make_rng::<rand::rngs::StdRng>().random_range(
+            let interval_ms = interval_rng.random_range(
                 KEEP_ALIVE_INTERVAL_MIN.as_millis()..=KEEP_ALIVE_INTERVAL_MAX.as_millis(),
             );
             let interval = Duration::from_millis(interval_ms as u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub(crate) mod test_alloc {
         }
     }
 
-    /// Smallest (live bytes, allocations) delta observed while running `op`,
-    /// retrying until it reaches `expected`.
+    /// The quietest (live bytes, allocations) delta observed while running `op`,
+    /// retrying until one sample is within `expected` on both counts.
     ///
     /// Same contract and the same reason as [`min_allocs`]: both counters are
     /// process-wide, so a sibling test thread allocating inside the window
@@ -72,9 +72,15 @@ pub(crate) mod test_alloc {
             );
             // Dropped outside the window: what it frees is not this window's.
             drop(held);
-            best = (best.0.min(bytes), best.1.min(allocs));
-            if best <= expected {
-                break;
+            let sample = (bytes, allocs);
+            if sample.0 <= expected.0 && sample.1 <= expected.1 {
+                return sample;
+            }
+            // Always one real window, never minima stitched from two: ambient
+            // traffic inflates both counters together, so the sample with the
+            // fewest allocations is the quietest one this window saw.
+            if (sample.1, sample.0) < (best.1, best.0) {
+                best = sample;
             }
         }
         best

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,21 +14,70 @@
 #[allow(clippy::disallowed_types)]
 pub(crate) mod test_alloc {
     use std::alloc::{GlobalAlloc, Layout, System};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
     pub(crate) static ALLOCS: AtomicU64 = AtomicU64::new(0);
+    /// Bytes currently live, as a wrapping signed counter: allocation adds, free
+    /// subtracts, so a *delta* over a window is what that window still holds even
+    /// though the absolute value is meaningless (the process was already running
+    /// when counting started). Wrapping arithmetic keeps a window that frees more
+    /// than it allocates from being a panic in debug.
+    pub(crate) static LIVE_BYTES: AtomicI64 = AtomicI64::new(0);
 
     struct CountingAlloc;
 
     unsafe impl GlobalAlloc for CountingAlloc {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             ALLOCS.fetch_add(1, Ordering::Relaxed);
+            LIVE_BYTES.fetch_add(layout.size() as i64, Ordering::Relaxed);
             unsafe { System.alloc(layout) }
         }
 
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            LIVE_BYTES.fetch_sub(layout.size() as i64, Ordering::Relaxed);
             unsafe { System.dealloc(ptr, layout) }
         }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            LIVE_BYTES.fetch_add(new_size as i64 - layout.size() as i64, Ordering::Relaxed);
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
+
+    /// Smallest (live bytes, allocations) delta observed while running `op`,
+    /// retrying until it reaches `expected`.
+    ///
+    /// Same contract and the same reason as [`min_allocs`]: both counters are
+    /// process-wide, so a sibling test thread allocating inside the window
+    /// inflates that window. Retrying until the window lands quiet makes ambient
+    /// traffic cost iterations instead of a false failure, and a real regression
+    /// never reaches `expected`, so the caller's assertion still fires with what
+    /// was actually observed.
+    pub(crate) fn min_live<T>(expected: (i64, u64), mut op: impl FnMut() -> T) -> (i64, u64) {
+        const BUDGET: u32 = 10_000;
+
+        let mut best = (i64::MAX, u64::MAX);
+        for _ in 0..BUDGET {
+            let (bytes_before, allocs_before) = (
+                LIVE_BYTES.load(Ordering::Relaxed),
+                ALLOCS.load(Ordering::Relaxed),
+            );
+            let held = std::hint::black_box(op());
+            let (bytes, allocs) = (
+                LIVE_BYTES
+                    .load(Ordering::Relaxed)
+                    .wrapping_sub(bytes_before),
+                ALLOCS.load(Ordering::Relaxed) - allocs_before,
+            );
+            // Dropped outside the window: what it frees is not this window's.
+            drop(held);
+            best = (best.0.min(bytes), best.1.min(allocs));
+            if best <= expected {
+                break;
+            }
+        }
+        best
     }
 
     #[global_allocator]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -13,7 +13,7 @@ use hashbrown::HashTable;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{BuildHasher, Hash, RandomState};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use wacore::runtime::BoxFuture;
 use wacore::sync_marker::MaybeSend;
@@ -76,8 +76,13 @@ pub(crate) struct CapacityStats {
 /// expired-but-not-yet-evicted entries.
 pub struct PortableCache<K, V> {
     inner: Arc<RwLock<CacheInner<K, V>>>,
-    /// Shared single-flight init-lock registry (see `InitLocks`).
-    init_locks: Arc<InitLocks>,
+    /// Shared single-flight init-lock registry (see `InitLocks`), built on the
+    /// first [`get_with`](Self::get_with) rather than at construction: a client
+    /// builds ~20 of these caches and most of them are only ever `get`/`insert`ed,
+    /// so an eager registry was 20 allocations of pure structure per client for a
+    /// single-flight path they never take. [`Clone`] forces it, so clones of one
+    /// cache still share one registry — which is what makes the flight single.
+    init_locks: OnceLock<Arc<InitLocks>>,
     max_capacity: Option<u64>,
     ttl: Option<Duration>,
     tti: Option<Duration>,
@@ -445,7 +450,7 @@ where
             inner: Arc::new(RwLock::new(CacheInner::new(
                 self.max_capacity.is_some_and(|cap| cap != u64::MAX),
             ))),
-            init_locks: Arc::new(InitLocks::new()),
+            init_locks: OnceLock::new(),
             max_capacity: self.max_capacity,
             ttl: self.ttl,
             tti: self.tti,
@@ -457,6 +462,14 @@ where
 }
 
 // -- PortableCache impl --
+
+impl<K, V> PortableCache<K, V> {
+    /// The single-flight registry, built on first use. Unbounded impl block so
+    /// [`Clone`] can force it too, keeping every clone on one registry.
+    fn init_locks(&self) -> &Arc<InitLocks> {
+        self.init_locks.get_or_init(|| Arc::new(InitLocks::new()))
+    }
+}
 
 impl<K, V> PortableCache<K, V>
 where
@@ -806,13 +819,14 @@ where
     /// per-key lock, with a double-checked `get` so a collided or racing key
     /// still resolves to the first inserted value.
     async fn get_with_slow(&self, key: K, init: BoxFuture<'_, V>) -> V {
-        let hash = self.init_locks.hash_of(&key);
+        let registry = self.init_locks();
+        let hash = registry.hash_of(&key);
         // The cleanup guard holds the sole long-lived Arc so its Drop sees an
         // exact strong count if this future is cancelled at any await below.
         let mut cleanup = InitLockCleanup {
-            registry: &self.init_locks,
+            registry,
             hash,
-            lock: Some(self.init_locks.acquire(hash).await),
+            lock: Some(registry.acquire(hash).await),
         };
 
         let value = {
@@ -833,7 +847,7 @@ where
 
         let init_mutex = cleanup.disarm();
         drop(cleanup);
-        self.init_locks.reclaim(hash, &init_mutex).await;
+        registry.reclaim(hash, &init_mutex).await;
         value
     }
 
@@ -852,8 +866,12 @@ where
 
         drop(guard);
 
-        // Clean up init locks not actively held.
-        self.init_locks.retain_active().await;
+        // Clean up init locks not actively held. `get()`, not `init_locks()`: a
+        // cache that never single-flighted has no registry to sweep, and building
+        // one here would undo the lazy construction.
+        if let Some(registry) = self.init_locks.get() {
+            registry.retain_active().await;
+        }
     }
 }
 
@@ -861,7 +879,7 @@ impl<K, V> Clone for PortableCache<K, V> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
-            init_locks: Arc::clone(&self.init_locks),
+            init_locks: OnceLock::from(Arc::clone(self.init_locks())),
             max_capacity: self.max_capacity,
             ttl: self.ttl,
             tti: self.tti,
@@ -1870,7 +1888,7 @@ mod tests {
         let _ = cache.get_with("key1".to_string(), async { 1 }).await;
         let _ = cache.get_with_by_ref("key2", async { 2 }).await;
 
-        let locks = cache.init_locks.map.lock().await;
+        let locks = cache.init_locks().map.lock().await;
         assert!(
             locks.is_empty(),
             "init locks must be reclaimed after get_with"
@@ -1894,7 +1912,7 @@ mod tests {
         // Poll (bounded) until the in-flight init registers its lock.
         let mut registered = false;
         for _ in 0..400 {
-            if !cache.init_locks.map.lock().await.is_empty() {
+            if !cache.init_locks().map.lock().await.is_empty() {
                 registered = true;
                 break;
             }
@@ -1909,7 +1927,7 @@ mod tests {
         // any run_pending_tasks call.
         let mut reclaimed = false;
         for _ in 0..400 {
-            if cache.init_locks.map.lock().await.is_empty() {
+            if cache.init_locks().map.lock().await.is_empty() {
                 reclaimed = true;
                 break;
             }
@@ -1963,8 +1981,8 @@ mod tests {
             PortableCache::builder().max_capacity(16).build();
         let (a, b) = (CollidingKey("a"), CollidingKey("b"));
         assert_eq!(
-            cache.init_locks.hash_of(&a),
-            cache.init_locks.hash_of(&b),
+            cache.init_locks().hash_of(&a),
+            cache.init_locks().hash_of(&b),
             "test premise: both keys must share one init-lock slot"
         );
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -3506,6 +3506,53 @@ mod tests {
         }
     }
 
+    /// `agent_docs/observability.md` makes reporting every retained collection
+    /// the rule, and this is the drain's largest transient after the commit
+    /// batch itself. Empty must read as zero, not as absent.
+    #[tokio::test]
+    async fn memory_report_accounts_for_the_offline_receipt_buffer() {
+        // Built like `offline_receipt_buffer_protocol`'s client, not through the
+        // test helper: a fresh client is in drain mode, which is what makes an
+        // offline message buffer instead of acking 1:1.
+        let pm = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager should initialize"),
+        );
+        let (client, _rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm,
+            Arc::new(crate::transport::mock::MockTransportFactory::new()),
+            Arc::new(MockHttpClient),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            client.memory_report().await.offline_receipt_buffer.entries,
+            0
+        );
+
+        let peer = "19045550180@s.whatsapp.net";
+        for id in ["OFFR1", "OFFR2", "OFFR3"] {
+            client.ack_received_message(&offline_info(id, peer, peer, false));
+        }
+
+        let reported = client.memory_report().await.offline_receipt_buffer;
+        assert_eq!(reported.entries, 3);
+        assert!(
+            reported.bytes >= 3 * size_of::<MessageInfo>() as u64,
+            "each buffered MessageInfo must be charged, got {} B",
+            reported.bytes,
+        );
+
+        client.clear_offline_receipt_buffer();
+        assert_eq!(
+            client.memory_report().await.offline_receipt_buffer.entries,
+            0
+        );
+    }
+
     #[tokio::test]
     async fn offline_receipt_buffer_protocol() {
         let backend = crate::test_utils::create_test_backend().await;

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -350,6 +350,49 @@ impl Client {
         }
     }
 
+    /// The live tcTokens for several JIDs at once, in the order asked.
+    ///
+    /// One backend call and one AB-props read for the whole set, where
+    /// [`lookup_tc_token_for_jid`](Self::lookup_tc_token_for_jid) does both per
+    /// JID. The reconnect presence re-subscribe walks the entire tracked
+    /// contact set, so per-JID is a query per contact against one store.
+    pub(crate) async fn lookup_tc_tokens_for_jids(&self, jids: &[Jid]) -> Vec<Option<Vec<u8>>> {
+        use wacore::iq::tctoken::is_tc_token_expired_with;
+
+        if jids.is_empty() {
+            return Vec::new();
+        }
+
+        let mut token_keys = Vec::with_capacity(jids.len());
+        for jid in jids {
+            token_keys.push(self.resolve_tc_token_key(jid).await);
+        }
+        let tc_config = self.tc_token_config().await;
+        let entries = match self
+            .persistence_manager
+            .backend()
+            .get_tc_tokens(&token_keys)
+            .await
+        {
+            Ok(entries) => entries,
+            Err(e) => {
+                log::warn!(target: "Client/TcToken", "Failed to get {} tc_tokens: {e}", token_keys.len());
+                return vec![None; jids.len()];
+            }
+        };
+
+        entries
+            .into_iter()
+            .map(|entry| {
+                entry.filter(|entry| {
+                    !entry.token.is_empty()
+                        && !is_tc_token_expired_with(entry.token_timestamp, &tc_config)
+                })
+            })
+            .map(|entry| entry.map(|entry| entry.token))
+            .collect()
+    }
+
     /// Build tctoken timing config from AB props, falling back to defaults.
     pub(crate) async fn tc_token_config(&self) -> wacore::iq::tctoken::TcTokenConfig {
         use wacore::iq::abprops::web;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3397,6 +3397,52 @@ impl ProtocolStore for SqliteStore {
         .await
     }
 
+    async fn get_tc_tokens(&self, jids: &[String]) -> Result<Vec<Option<TcTokenEntry>>> {
+        if jids.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Same write-queue ordering as the single-JID read above, for the same
+        // reason: one `IN (...)` instead of one query per JID, still behind the
+        // permit that orders it against a concurrent touch.
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let wanted = jids.to_vec();
+        self.with_semaphore(move || -> Result<Vec<Option<TcTokenEntry>>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let mut found: std::collections::HashMap<String, TcTokenEntry> =
+                std::collections::HashMap::with_capacity(wanted.len());
+            // Chunked so a large tracked set cannot exceed SQLite's bound-
+            // parameter limit (999 by default, and `device_id` takes one).
+            for chunk in wanted.chunks(500) {
+                let rows: Vec<(String, Vec<u8>, i64, Option<i64>)> = tc_tokens::table
+                    .select((
+                        tc_tokens::jid,
+                        tc_tokens::token,
+                        tc_tokens::token_timestamp,
+                        tc_tokens::sender_timestamp,
+                    ))
+                    .filter(tc_tokens::jid.eq_any(chunk))
+                    .filter(tc_tokens::device_id.eq(device_id))
+                    .load(&mut *conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                for (jid, token, token_timestamp, sender_timestamp) in rows {
+                    found.insert(
+                        jid,
+                        TcTokenEntry {
+                            token,
+                            token_timestamp,
+                            sender_timestamp,
+                        },
+                    );
+                }
+            }
+            Ok(wanted.iter().map(|jid| found.get(jid).cloned()).collect())
+        })
+        .await
+    }
+
     async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
         let pool = self.pool.clone();
         let device_id = self.device_id;
@@ -5080,6 +5126,50 @@ mod tests {
         assert_eq!(loaded.token, vec![1, 2, 3, 4, 5]);
         assert_eq!(loaded.token_timestamp, 1707000000);
         assert_eq!(loaded.sender_timestamp, Some(1707000100));
+    }
+
+    /// The batched read answers positionally, so a caller can zip it against the
+    /// JIDs it asked for — including the ones the store holds nothing for.
+    #[tokio::test]
+    async fn test_tc_tokens_batched_get_answers_in_the_order_asked() {
+        let store = create_test_store().await;
+
+        for (jid, byte) in [("a@lid", 1u8), ("c@lid", 3u8)] {
+            store
+                .put_tc_token(
+                    jid,
+                    &TcTokenEntry {
+                        token: vec![byte],
+                        token_timestamp: 1000 + i64::from(byte),
+                        sender_timestamp: None,
+                    },
+                )
+                .await
+                .expect("put failed");
+        }
+
+        let asked: Vec<String> = ["c@lid", "b@lid", "a@lid", "c@lid"]
+            .iter()
+            .map(|jid| (*jid).to_string())
+            .collect();
+        let got = store
+            .get_tc_tokens(&asked)
+            .await
+            .expect("batched get failed");
+
+        assert_eq!(
+            got.iter()
+                .map(|entry| entry.as_ref().map(|entry| entry.token.clone()))
+                .collect::<Vec<_>>(),
+            vec![Some(vec![3]), None, Some(vec![1]), Some(vec![3])],
+        );
+        assert!(
+            store
+                .get_tc_tokens(&[])
+                .await
+                .expect("an empty batch is not an error")
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -6997,6 +7087,11 @@ mod read_routing_tests {
             "get_tc_token",
             "prepare_privacy_token schedules off this timestamp, so a stale read \
              issues a duplicate token and bypasses the configured interval",
+        ),
+        (
+            "get_tc_tokens",
+            "the batched form of get_tc_token, and it answers the same callers, so \
+             it has to order against a concurrent touch the same way",
         ),
         (
             "has_signal_state_for_user",

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -231,11 +231,6 @@ impl KeyCache {
     fn len(&self) -> usize {
         self.keys.len()
     }
-
-    /// The map the blocking snapshot/patch closures look keys up in.
-    fn snapshot(&self) -> HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>> {
-        self.keys.clone()
-    }
 }
 
 impl AppStateProcessor {
@@ -706,14 +701,27 @@ impl AppStateProcessor {
         self.key_cache.lock().await.len()
     }
 
-    /// Pre-fetch and cache all keys needed for a patch list.
-    async fn prefetch_keys(&self, pl: &PatchList) -> Result<()> {
+    /// Every key a patch list references, expanded, as the one map its blocking
+    /// snapshot and patch closures look keys up in.
+    ///
+    /// Returned rather than read back out of `key_cache`: that cache is bounded,
+    /// so a list referencing more keys than it holds would have evicted its first
+    /// keys by the time its last was fetched, and the closures would then report
+    /// a key the backend has as missing. Each key still passes through the cache
+    /// on its way here, so the next list reuses whatever fits.
+    ///
+    /// A key the backend does not have is left out rather than failing the list:
+    /// the closure that needs it reports it missing, and the caller asks the
+    /// primary for it from that.
+    async fn prefetch_keys(&self, pl: &PatchList) -> HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>> {
         let key_ids = collect_key_id_refs_from_patch_list(pl.snapshot.as_ref(), &pl.patches);
+        let mut keys = HashMap::with_capacity(key_ids.len());
         for key_id in key_ids {
-            // This will fetch and cache if not already cached
-            let _ = self.get_app_state_key(key_id).await;
+            if let Ok(expanded) = self.get_app_state_key(key_id).await {
+                keys.insert(key_id.to_vec(), expanded);
+            }
         }
-        Ok(())
+        keys
     }
 
     /// Process an already-parsed single PatchList: download external blobs via
@@ -800,8 +808,8 @@ impl AppStateProcessor {
         mut pl: PatchList,
         validate_macs: bool,
     ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
-        // Pre-fetch all keys we'll need
-        self.prefetch_keys(&pl).await?;
+        // Arc so each blocking closure's handoff is a refcount bump, not a map copy.
+        let keys_map = Arc::new(self.prefetch_keys(&pl).await);
 
         let stored = self.backend.get_version(pl.name.as_str()).await?;
         let had_baseline = stored.as_ref().is_some_and(|s| s.has_baseline());
@@ -828,7 +836,7 @@ impl AppStateProcessor {
             true
         });
         if snapshot_fresh && let Some(snapshot) = pl.snapshot.take() {
-            let keys_map = self.key_cache.lock().await.snapshot();
+            let keys_map = Arc::clone(&keys_map);
             let collection_name_owned = collection_name.to_string();
 
             // Offload CPU-intensive snapshot processing to a blocking thread. The
@@ -925,9 +933,6 @@ impl AppStateProcessor {
             self.backend.clear_mutation_macs(collection_name).await?;
         }
 
-        // Snapshot the key cache once for all patches (prefetch_keys already populated
-        // it); Arc so the per-patch closure handoff is a refcount bump, not a map copy.
-        let keys_map = Arc::new(self.key_cache.lock().await.snapshot());
         let collection_name_owned = collection_name.to_string();
 
         // Each patch moves into its blocking closure and comes back via the return

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -692,7 +692,7 @@ impl AppStateProcessor {
 
     /// Drop every cached key, so the next access re-expands from the backend.
     ///
-    /// Not part of the reconnect path: [`KeyCache`] bounds itself, and an
+    /// Not part of the reconnect path: the cache bounds itself, and an
     /// expanded key is a pure function of a key id that never changes, so
     /// emptying it across reconnects only bought DB reads and HKDF expansions.
     /// Kept for a caller that genuinely wants the memory back now.
@@ -701,7 +701,7 @@ impl AppStateProcessor {
     }
 
     /// Expanded app-state keys held in memory, for `Client::memory_report()`.
-    /// Bounded by [`KeyCache::CAPACITY`].
+    /// Bounded by `KeyCache::CAPACITY`.
     pub async fn cached_key_count(&self) -> usize {
         self.key_cache.lock().await.len()
     }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
@@ -176,9 +176,10 @@ pub enum RecoveryOutcome {
 pub struct AppStateProcessor {
     pub backend: Arc<dyn Backend>,
     pub runtime: Arc<dyn crate::runtime::Runtime>,
-    /// Keyed by the raw key id: the lookup runs once per mutation, and a
-    /// base64 key meant encoding (and allocating) the id for every one of them.
-    key_cache: Arc<Mutex<HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>>>>,
+    /// Expanded app-state keys, keyed by the raw key id: the lookup runs once
+    /// per mutation, and a base64 key meant encoding (and allocating) the id for
+    /// every one of them.
+    key_cache: Arc<Mutex<KeyCache>>,
     /// Collections a recovery has been asked of the primary for.
     ///
     /// Held here rather than beside the connection because it has to outlive the
@@ -188,12 +189,61 @@ pub struct AppStateProcessor {
     recovery_requested: Arc<Mutex<HashMap<String, RecoveryRequest>>>,
 }
 
+/// Expanded app-state keys, bounded and keyed by raw key id.
+///
+/// An expanded key is a pure function of its key id — HKDF over bytes the
+/// backend stores and never rewrites — so a cached entry can never go stale and
+/// the only reason to drop one is memory. That makes a small capacity the whole
+/// bound this needs: entries survive reconnects (a reconnect used to empty the
+/// map, paying a backend read plus an HKDF expansion again for keys that had not
+/// changed), and an account that references many distinct key ids over a long
+/// connection still cannot grow it without limit.
+///
+/// [`CAPACITY`](Self::CAPACITY) is well above what a sync touches — WA Web sends
+/// a handful of key ids per collection — so eviction is the pathological case,
+/// not the steady state, and oldest-first is enough: an evicted key costs one
+/// backend read to come back.
+#[derive(Default)]
+struct KeyCache {
+    keys: HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>>,
+    /// Insertion order, oldest first. Only ids currently in `keys`.
+    order: VecDeque<Vec<u8>>,
+}
+
+impl KeyCache {
+    const CAPACITY: usize = 32;
+
+    fn get(&self, key_id: &[u8]) -> Option<Arc<ExpandedAppStateKeys>> {
+        self.keys.get(key_id).cloned()
+    }
+
+    fn insert(&mut self, key_id: Vec<u8>, expanded: Arc<ExpandedAppStateKeys>) {
+        if self.keys.insert(key_id.clone(), expanded).is_none() {
+            self.order.push_back(key_id);
+            while self.order.len() > Self::CAPACITY
+                && let Some(oldest) = self.order.pop_front()
+            {
+                self.keys.remove(&oldest);
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// The map the blocking snapshot/patch closures look keys up in.
+    fn snapshot(&self) -> HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>> {
+        self.keys.clone()
+    }
+}
+
 impl AppStateProcessor {
     pub fn new(backend: Arc<dyn Backend>, runtime: Arc<dyn crate::runtime::Runtime>) -> Self {
         Self {
             runtime,
             backend,
-            key_cache: Arc::new(Mutex::new(HashMap::new())),
+            key_cache: Arc::new(Mutex::new(KeyCache::default())),
             recovery_requested: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -351,7 +401,7 @@ impl AppStateProcessor {
     ) -> std::result::Result<Arc<ExpandedAppStateKeys>, AppStateSyncError> {
         use base64::Engine;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
-        if let Some(cached) = self.key_cache.lock().await.get(key_id).cloned() {
+        if let Some(cached) = self.key_cache.lock().await.get(key_id) {
             return Ok(cached);
         }
         let key_opt = self.backend.get_sync_key(key_id).await?;
@@ -640,20 +690,18 @@ impl AppStateProcessor {
         Ok(RecoveryOutcome::Applied(mutations))
     }
 
-    /// Clear the in-memory key cache (e.g. on reconnect).
-    /// Keys will be re-fetched from the database backend on next access.
+    /// Drop every cached key, so the next access re-expands from the backend.
+    ///
+    /// Not part of the reconnect path: [`KeyCache`] bounds itself, and an
+    /// expanded key is a pure function of a key id that never changes, so
+    /// emptying it across reconnects only bought DB reads and HKDF expansions.
+    /// Kept for a caller that genuinely wants the memory back now.
     pub async fn clear_key_cache(&self) {
-        *self.key_cache.lock().await = HashMap::new();
+        *self.key_cache.lock().await = KeyCache::default();
     }
 
     /// Expanded app-state keys held in memory, for `Client::memory_report()`.
-    ///
-    /// The cache has neither a capacity cap nor a TTL: it gains an entry per
-    /// distinct key id the server's patches reference and is emptied only by
-    /// [`Self::clear_key_cache`] on reconnect, so a long-lived connection is its
-    /// only bound. That is why the count is worth reporting — the backend stays
-    /// authoritative, so a cap would be safe here, but nothing has measured how
-    /// many distinct keys a real account accumulates.
+    /// Bounded by [`KeyCache::CAPACITY`].
     pub async fn cached_key_count(&self) -> usize {
         self.key_cache.lock().await.len()
     }
@@ -780,7 +828,7 @@ impl AppStateProcessor {
             true
         });
         if snapshot_fresh && let Some(snapshot) = pl.snapshot.take() {
-            let keys_map = self.key_cache.lock().await.clone();
+            let keys_map = self.key_cache.lock().await.snapshot();
             let collection_name_owned = collection_name.to_string();
 
             // Offload CPU-intensive snapshot processing to a blocking thread. The
@@ -879,7 +927,7 @@ impl AppStateProcessor {
 
         // Snapshot the key cache once for all patches (prefetch_keys already populated
         // it); Arc so the per-patch closure handoff is a refcount bump, not a map copy.
-        let keys_map = Arc::new(self.key_cache.lock().await.clone());
+        let keys_map = Arc::new(self.key_cache.lock().await.snapshot());
         let collection_name_owned = collection_name.to_string();
 
         // Each patch moves into its blocking closure and comes back via the return
@@ -1299,5 +1347,51 @@ mod dedup_tests {
                 *b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod key_cache_tests {
+    use super::*;
+
+    fn expanded(byte: u8) -> Arc<ExpandedAppStateKeys> {
+        Arc::new(expand_app_state_keys(&[byte; 32]))
+    }
+
+    /// The cap is the whole bound: entries are never invalidated, only crowded
+    /// out, and the oldest is the one that goes.
+    #[test]
+    fn the_key_cache_keeps_the_newest_entries_up_to_its_capacity() {
+        let mut cache = KeyCache::default();
+        for i in 0..(KeyCache::CAPACITY + 4) {
+            cache.insert(vec![i as u8], expanded(i as u8));
+        }
+
+        assert_eq!(cache.len(), KeyCache::CAPACITY);
+        for evicted in 0..4u8 {
+            assert!(
+                cache.get(&[evicted]).is_none(),
+                "key {evicted} is one of the four oldest and must have been evicted"
+            );
+        }
+        for kept in 4..(KeyCache::CAPACITY + 4) {
+            assert!(
+                cache.get(&[kept as u8]).is_some(),
+                "key {kept} must be kept"
+            );
+        }
+    }
+
+    /// Re-expanding a key already held must not consume a second slot: the same
+    /// key id can be looked up any number of times.
+    #[test]
+    fn re_inserting_a_key_id_does_not_grow_the_cache() {
+        let mut cache = KeyCache::default();
+        for _ in 0..(KeyCache::CAPACITY * 2) {
+            cache.insert(vec![7], expanded(7));
+        }
+
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get(&[7]).is_some());
     }
 }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -712,16 +712,25 @@ impl AppStateProcessor {
     ///
     /// A key the backend does not have is left out rather than failing the list:
     /// the closure that needs it reports it missing, and the caller asks the
-    /// primary for it from that.
-    async fn prefetch_keys(&self, pl: &PatchList) -> HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>> {
+    /// primary for it from that. Any other failure is the backend's, and is
+    /// returned as such: swallowed, it would surface as that same missing-key
+    /// report and ask the primary for a key this side already holds.
+    async fn prefetch_keys(
+        &self,
+        pl: &PatchList,
+    ) -> Result<HashMap<Vec<u8>, Arc<ExpandedAppStateKeys>>> {
         let key_ids = collect_key_id_refs_from_patch_list(pl.snapshot.as_ref(), &pl.patches);
         let mut keys = HashMap::with_capacity(key_ids.len());
         for key_id in key_ids {
-            if let Ok(expanded) = self.get_app_state_key(key_id).await {
-                keys.insert(key_id.to_vec(), expanded);
+            match self.get_app_state_key(key_id).await {
+                Ok(expanded) => {
+                    keys.insert(key_id.to_vec(), expanded);
+                }
+                Err(AppStateSyncError::KeyNotFound(_)) => {}
+                Err(error) => return Err(error.into()),
             }
         }
-        keys
+        Ok(keys)
     }
 
     /// Process an already-parsed single PatchList: download external blobs via
@@ -809,7 +818,7 @@ impl AppStateProcessor {
         validate_macs: bool,
     ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
         // Arc so each blocking closure's handoff is a refcount bump, not a map copy.
-        let keys_map = Arc::new(self.prefetch_keys(&pl).await);
+        let keys_map = Arc::new(self.prefetch_keys(&pl).await?);
 
         let stored = self.backend.get_version(pl.name.as_str()).await?;
         let had_baseline = stored.as_ref().is_some_and(|s| s.has_baseline());

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -48,6 +48,18 @@ pub struct VerifiedName {
     pub certificate: Option<Vec<u8>>,
 }
 
+impl crate::stats::HeapSize for VerifiedName {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+        [&self.name, &self.serial, &self.issuer]
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .map(HeapSize::heap_bytes)
+            .sum::<usize>()
+            + self.certificate.as_ref().map_or(0, HeapSize::heap_bytes)
+    }
+}
+
 impl VerifiedName {
     pub fn try_from_node(node: &NodeRef<'_>) -> Result<Self> {
         use wacore_binary::NodeContentRef;

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -918,6 +918,21 @@ pub trait ProtocolStore: Send + Sync {
     /// Get a trusted contact token for a JID (stored under LID).
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>>;
 
+    /// Get the trusted contact tokens for several JIDs at once, in the order
+    /// asked, `None` where the backend holds no row.
+    ///
+    /// The reconnect presence re-subscribe looks one of these up per tracked
+    /// contact, which is a query per contact against one store — the shape this
+    /// exists to collapse. The default is a loop for third-party backends; the
+    /// built-in stores override it with a single query.
+    async fn get_tc_tokens(&self, jids: &[String]) -> Result<Vec<Option<TcTokenEntry>>> {
+        let mut entries = Vec::with_capacity(jids.len());
+        for jid in jids {
+            entries.push(self.get_tc_token(jid).await?);
+        }
+        Ok(entries)
+    }
+
     /// Store or update a trusted contact token for a JID.
     async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()>;
 

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -474,6 +474,68 @@ pub struct MessageInfo {
     pub bcl_participants: Vec<Jid>,
 }
 
+impl crate::stats::HeapSize for MessageSource {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+        self.chat.heap_bytes()
+            + self.sender.heap_bytes()
+            + [
+                &self.sender_alt,
+                &self.recipient_alt,
+                &self.broadcast_list_owner,
+                &self.recipient,
+            ]
+            .iter()
+            .filter_map(|jid| jid.as_ref())
+            .map(HeapSize::heap_bytes)
+            .sum::<usize>()
+    }
+}
+
+/// A floor, deliberately: the boxed sub-structs are charged their own
+/// `size_of` but not walked. All four are absent on the overwhelming majority
+/// of messages, and what they point at is small next to the box itself, so
+/// descending would add code to the report for digits it would not change.
+impl crate::stats::HeapSize for MessageInfo {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+        self.source.heap_bytes()
+            + self.id.heap_bytes()
+            + self.push_name.heap_bytes()
+            + self
+                .bot_info
+                .as_ref()
+                .map_or(0, |_| size_of::<MsgBotInfo>())
+            + self
+                .meta_info
+                .as_ref()
+                .map_or(0, |_| size_of::<MsgMetaInfo>())
+            + self
+                .verified_name
+                .as_ref()
+                .map_or(0, |_| size_of::<crate::stanza::business::VerifiedName>())
+            + self
+                .device_sent_meta
+                .as_ref()
+                .map_or(0, |_| size_of::<DeviceSentMeta>())
+            + self
+                .unavailable_request_id
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + self.verified_level.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self
+                .peer_recipient_pn
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + self.bcl_participants.capacity() * size_of::<Jid>()
+            + self
+                .bcl_participants
+                .iter()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
+    }
+}
+
 /// What [`MessageInfo::meta`] hands out for a stanza that carried no `<meta>`
 /// or `<reporting>` child: every field `None`, shared by every such message.
 static EMPTY_META: std::sync::LazyLock<MsgMetaInfo> =

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -492,32 +492,80 @@ impl crate::stats::HeapSize for MessageSource {
     }
 }
 
-/// A floor, deliberately: the boxed sub-structs are charged their own
-/// `size_of` but not walked. All four are absent on the overwhelming majority
-/// of messages, and what they point at is small next to the box itself, so
-/// descending would add code to the report for digits it would not change.
+impl crate::stats::HeapSize for MsgBotInfo {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+        self.edit_target_id.as_ref().map_or(0, HeapSize::heap_bytes)
+    }
+}
+
+impl crate::stats::HeapSize for MsgMetaInfo {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+        let spilled = |bytes: &Option<ReportingBytes>| {
+            bytes
+                .as_ref()
+                .filter(|b| b.spilled())
+                .map_or(0, |b| b.capacity())
+        };
+        [
+            &self.target_id,
+            &self.thread_message_id,
+            &self.content_type,
+            &self.appdata,
+        ]
+        .iter()
+        .filter_map(|s| s.as_ref())
+        .map(HeapSize::heap_bytes)
+        .sum::<usize>()
+            + [
+                &self.target_sender,
+                &self.target_chat,
+                &self.thread_message_sender_jid,
+            ]
+            .iter()
+            .filter_map(|jid| jid.as_ref())
+            .map(HeapSize::heap_bytes)
+            .sum::<usize>()
+            + spilled(&self.reporting_tag)
+            + spilled(&self.reporting_token)
+    }
+}
+
+impl crate::stats::HeapSize for DeviceSentMeta {
+    fn heap_bytes(&self) -> usize {
+        self.destination_jid.heap_bytes() + self.phash.heap_bytes()
+    }
+}
+
+/// Every allocation the message owns, the boxed sub-structs and the fallback
+/// enum payloads included. All of them are absent on the overwhelming majority
+/// of messages, but a buffer that retains whole messages
+/// (`offline_receipt_buffer`) is exactly where a report that skipped them would
+/// read quietest while it grows.
 impl crate::stats::HeapSize for MessageInfo {
     fn heap_bytes(&self) -> usize {
         use crate::stats::HeapSize;
+        fn boxed<T: HeapSize>(value: &Option<Box<T>>) -> usize {
+            value
+                .as_ref()
+                .map_or(0, |v| size_of::<T>() + v.heap_bytes())
+        }
         self.source.heap_bytes()
             + self.id.heap_bytes()
             + self.push_name.heap_bytes()
-            + self
-                .bot_info
-                .as_ref()
-                .map_or(0, |_| size_of::<MsgBotInfo>())
-            + self
-                .meta_info
-                .as_ref()
-                .map_or(0, |_| size_of::<MsgMetaInfo>())
-            + self
-                .verified_name
-                .as_ref()
-                .map_or(0, |_| size_of::<crate::stanza::business::VerifiedName>())
-            + self
-                .device_sent_meta
-                .as_ref()
-                .map_or(0, |_| size_of::<DeviceSentMeta>())
+            + match &self.category {
+                MessageCategory::Other(value) => value.heap_bytes(),
+                _ => 0,
+            }
+            + match &self.edit {
+                EditAttribute::Unknown(value) => value.heap_bytes(),
+                _ => 0,
+            }
+            + boxed(&self.bot_info)
+            + boxed(&self.meta_info)
+            + boxed(&self.verified_name)
+            + boxed(&self.device_sent_meta)
             + self
                 .unavailable_request_id
                 .as_ref()
@@ -583,6 +631,55 @@ mod tests {
             EditAttribute::from("99"),
             EditAttribute::Unknown("99".to_owned())
         );
+    }
+
+    /// The fallback enum payloads and the boxed sub-structs are the only places
+    /// a `MessageInfo` can hold an allocation the report would otherwise miss.
+    #[test]
+    fn message_info_heap_bytes_counts_the_fallback_strings_and_boxed_metadata() {
+        use crate::stanza::business::VerifiedName;
+        use crate::stats::HeapSize;
+
+        let baseline = MessageInfo::default().heap_bytes();
+
+        let category = "some-category";
+        let edit = "99";
+        let business = "Fictitious Business";
+        let certificate = vec![0u8; 64];
+        let target_id = "a-target-id-longer-than-twenty-four-bytes";
+        let destination = "19045550180@s.whatsapp.net";
+
+        let mut info = MessageInfo {
+            category: MessageCategory::Other(category.to_owned()),
+            edit: EditAttribute::Unknown(edit.to_owned()),
+            ..Default::default()
+        };
+        info.verified_name = Some(Box::new(VerifiedName {
+            name: Some(business.to_owned()),
+            serial: None,
+            issuer: None,
+            certificate: Some(certificate.clone()),
+        }));
+        info.meta_info = Some(Box::new(MsgMetaInfo {
+            target_id: Some(target_id.into()),
+            ..Default::default()
+        }));
+        info.device_sent_meta = Some(Box::new(DeviceSentMeta {
+            destination_jid: destination.to_owned(),
+            phash: String::new(),
+        }));
+
+        let expected = baseline
+            + category.len()
+            + edit.len()
+            + size_of::<VerifiedName>()
+            + business.len()
+            + certificate.capacity()
+            + size_of::<MsgMetaInfo>()
+            + target_id.len()
+            + size_of::<DeviceSentMeta>()
+            + destination.len();
+        assert_eq!(info.heap_bytes(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

What a client costs to build, to log in, and to sit idle, from the connect/idle exploration pass. Seven commits, each measured in-tree.

- **Post-login task.** The `needs_initial_sync` arm of the `<success>` handler is now its own function, `Box::pin`ned at the call site, so the future handed to `spawn_detached` on every login no longer carries the fresh-pairing arm's locals. Future size 8,264 B → 1,192 B (−86%). A test pins it under 2 KiB through a sizing runtime wrapper.
- **Fixed per-client footprint.** `PortableCache`'s single-flight init-lock registry is built on the first `get_with` instead of at construction (a client builds ~20 caches, most never single-flight; `Clone` forces it so clones share one registry). The `MajorSyncTask` channel is `bounded(8)` instead of 32. 21 `Arc<AtomicX>` / `Arc<Event>` fields on `Client` with no `Arc::clone` site are inlined; `enable_auto_reconnect`, `id_counter`, `connection_generation` and `initial_keys_synced_notifier` are untouched, so the public surface is unchanged. Per client: 19,056 B / 153 allocations → 15,184 B / 112 (−20%, −41 allocations), measured with the counting test allocator as a min-delta over 16 `Client::assemble` calls; a test pins 17,000 B / 160 allocations (the count leaves room for the 20-allocation spread observed between machines).
- **Login critical path.** `establish_primary_phone_session_immediate` established nothing and only logged; renamed to `log_primary_phone_session_state` and moved off the pre-`set_passive(false)` path onto the detached pre-key task. About 180 µs and two DB queries per reconnect, per the exploration report.
- **App-state key cache** is a 32-entry `KeyCache` (oldest evicted first) instead of being emptied on every reconnect. `clear_key_cache` stays public but is off the reconnect path. The keys a patch list needs are collected into an operation-local map, so a list referencing more keys than the cache holds still applies in full (regression test with 40 keys).
- **Keepalive RNG** is seeded once per connection instead of once per tick.
- **`memory_report()`** now reports the offline receipt buffer (`offline_receipt_buffer`, a `CollectionStats` under "Transient retention"), with `HeapSize` impls for `MessageInfo`, `MessageSource` and their boxed sub-structs. `MemoryReport` is `#[non_exhaustive]`, so this is additive.
- **Presence re-subscribe on reconnect** walks the tracked set in windows of 8 (the noise sender's own queue depth): one batched tcToken read per window through a new provided `ProtocolStore::get_tc_tokens` (loop default; chunked `IN (...)` override in the SQLite store), and the window's stanzas issued together so the sender coalesces them. The unsubscribe re-check now runs per window rather than per JID, which the old code's comment already described as a narrowed rather than closed race; the existing test was rewritten as `resubscribe_skips_a_jid_unsubscribed_before_its_window` to assert the guarantee that actually holds.

## Measured

Same machine, main vs this branch, each number from the test or bench named in the row.

| What | main | this PR | How measured |
|---|---:|---:|---|
| Post-login task future (boxed on every login) | 8,264 B | 1,192 B (−86%) | `the_post_login_task_does_not_carry_the_fresh_pairing_arm` |
| Fixed structure per `Client::assemble` | 19,056 B / 153 allocations | 15,184 B / 112 (−20% / −41) | `one_client_costs_a_bounded_amount_of_fixed_structure`, counting test allocator, min over 16 builds |
| Login critical path, before `set_passive(false)` | primary-phone probe: ~180 µs, 2 DB queries | 0 (on the detached pre-key task) | exploration profile |
| App-state keys after a reconnect | cache emptied: 1 DB read + HKDF per key on the next sync | kept, bounded at 32 entries | `key_cache_tests` |
| Keepalive interval RNG | seeded per tick | seeded once per connection | code |
| Presence re-subscribe, 24 tracked contacts | 24 tcToken DB reads, 24 transport writes | 3 DB reads, 3 transport writes | `resubscribe_batches_its_stanzas_into_fewer_transport_writes` |
| `memory_report()` coverage | offline receipt buffer unreported | `offline_receipt_buffer` reported, `HeapSize` for `MessageInfo` | additive `MemoryReport` field; `message_info_heap_bytes_counts_the_fallback_strings_and_boxed_metadata` |

CodSpeed on this branch: `bench_chat_lane_create` reads +96 B, which is the single-flight registry now built on the first `get_with` (inside the measured region of that bench) instead of at construction; one allocation per cache for the whole run, per-insert cost unchanged at 1 allocation. Embedding the registry inline instead would cost 80 B in every cache, +1.4 KB per client, so the lazy `Arc` stays. The store benches listed after the merge with main (`registry_put_each[1]`, `read_query_read_under_write`) are not touched by this diff and show the same numbers on #1400.

## Left out

The prekey digest memo (skipping the reconnect digest when nothing changed locally): there is no existing signal that covers every local prekey mutation (the cache's `remove_prekey` and its deferred batch flush, the adapter's `remove_prekey`, and the direct `store_prekey`/`store_prekeys_batch` calls that bypass the cache), and a check that misses one path becomes a silent no-op for the exact case it exists to catch.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p wacore -p whatsapp-rust -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`; `cargo check -p whatsapp-rust --all-targets --features plugins,client-lifecycle,passkey,tracing,metrics`
- [x] `cargo test -p whatsapp-rust --lib` (1874 passed), `-p wacore --lib` (1571), `-p whatsapp-rust-sqlite-storage --lib` (83), `cargo test --doc`
- [x] CI green on the merged head (all required checks; `Semver Checks` is informational and red on `main` as well: `ProtocolStore` gains a defaulted method and `MemoryReport` a field behind `#[non_exhaustive]`, both additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN