### PR TITLE
feat(send)!: SendResult carries the message the send encoded; edit, revoke and pin return one

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -212,11 +212,13 @@ impl MessageContext {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.bot.edit_message", level = "debug", skip_all, fields(chat = %self.info.source.chat.observe()), err(Debug)))]
+    /// Edit a message of ours in this chat; see [`Client::edit_message`] for
+    /// what the returned result describes.
     pub async fn edit_message(
         &self,
         original_message_id: impl Into<String>,
         new_message: wa::Message,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         self.client
             .edit_message(&self.info.source.chat, original_message_id, new_message)
             .await
@@ -228,7 +230,7 @@ impl MessageContext {
         &self,
         message_id: impl Into<String>,
         revoke_type: crate::send::RevokeType,
-    ) -> Result<(), crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         self.client
             .revoke_message(&self.info.source.chat, message_id, revoke_type)
             .await

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -159,12 +159,20 @@ impl Client {
         }
     }
 
+    /// Edit a message you own (`original_id`), replacing its content with
+    /// `new_content`.
+    ///
+    /// The returned [`SendResult`](crate::send::SendResult) describes the edit
+    /// itself: `message_id` is the edit stanza's own fresh id (never
+    /// `original_id`, which the server would deduplicate against the original
+    /// and drop), and `message` the protocol message this crate built around
+    /// `new_content`, keyed by `original_id`.
     pub async fn edit_message(
         &self,
         to: impl Into<Jid>,
         original_id: impl Into<String>,
         new_content: wa::Message,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         self.edit_message_inner(to.into(), original_id.into(), new_content, None)
             .await
     }
@@ -180,14 +188,15 @@ impl Client {
     /// id (the edit skips outbound-secret and retry-cache persistence, leaving
     /// the original message's state intact), and whether the collision is
     /// honored is server/client dependent — treat it as best-effort. See
-    /// [`crate::send::EditOptions::stanza_id`].
+    /// [`crate::send::EditOptions::stanza_id`]. The result's `message_id` is
+    /// then the borrowed id.
     pub async fn edit_message_with_options(
         &self,
         to: impl Into<Jid>,
         original_id: impl Into<String>,
         new_content: wa::Message,
         options: crate::send::EditOptions,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         self.edit_message_inner(
             to.into(),
             original_id.into(),
@@ -208,7 +217,7 @@ impl Client {
         original_id: String,
         new_content: wa::Message,
         request_id: Option<String>,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         // WhatsApp Web uses getMeUserLidOrJidForChat(chat, EditMessage) which
         // returns LID for LID-addressing groups and PN otherwise.
         let participant = if to.is_group() {
@@ -228,7 +237,7 @@ impl Client {
 
         let edit_container_message = crate::send::build_edit_message(
             &to,
-            original_id.clone(),
+            original_id,
             participant,
             new_content,
             wacore::time::now_millis(),
@@ -242,21 +251,13 @@ impl Client {
         // want to pin the outer stanza id pass it via `request_id`; that id is
         // borrowed from another message, so id-keyed state (retry cache, outbound
         // secret) must not be bound to it.
-        let borrowed_message_id = request_id.is_some();
-        self.send_message_impl(
+        self.send_built_message(
             to,
-            &edit_container_message,
-            crate::send::SendPipelineOptions {
-                edit: Some(crate::types::message::EditAttribute::MessageEdit),
-                request_id: request_id.as_deref(),
-                borrowed_message_id,
-                ..Default::default()
-            },
+            edit_container_message,
+            crate::types::message::EditAttribute::MessageEdit,
+            request_id,
         )
         .await
-        .map_err(crate::send::SendError::from_anyhow)?;
-
-        Ok(original_id)
     }
 
     /// Edit a message via the message-secret encrypted path (`secret_encrypted_message`
@@ -267,13 +268,17 @@ impl Client {
     /// `message_secret` is the *original* message's 32-byte secret (you generated it when
     /// you sent that message). You can only edit your own messages, so the original
     /// sender and the editor are both you.
+    ///
+    /// Returns the edit's own [`SendResult`](crate::send::SendResult), like
+    /// [`Client::edit_message`]; here `message` is the `secretEncryptedMessage`
+    /// envelope, so `new_content` is not readable from it.
     pub async fn edit_message_encrypted(
         &self,
         to: impl Into<Jid>,
         original_id: impl Into<String>,
         message_secret: &[u8],
         new_content: wa::Message,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         self.edit_message_encrypted_inner(
             to.into(),
             original_id.into(),
@@ -290,7 +295,7 @@ impl Client {
         original_id: String,
         message_secret: &[u8],
         new_content: wa::Message,
-    ) -> Result<String, crate::send::SendError> {
+    ) -> Result<crate::send::SendResult, crate::send::SendError> {
         use crate::send::SendError;
         // Newsletters/channels are plaintext (no message-secret addon crypto) and the
         // E2E send path rejects them, so an encrypted edit can't apply there; fail with
@@ -331,18 +336,13 @@ impl Client {
             new_content,
         )?;
 
-        self.send_message_impl(
+        self.send_built_message(
             to,
-            &envelope,
-            crate::send::SendPipelineOptions {
-                edit: Some(crate::types::message::EditAttribute::MessageEdit),
-                ..Default::default()
-            },
+            envelope,
+            crate::types::message::EditAttribute::MessageEdit,
+            None,
         )
         .await
-        .map_err(SendError::from_anyhow)?;
-
-        Ok(original_id)
     }
 
     /// Send a server-side reaction (used by both newsletter and status reactions).

--- a/src/send/actions.rs
+++ b/src/send/actions.rs
@@ -11,12 +11,16 @@ impl Client {
     /// * `message_id` - The ID of the message to delete
     /// * `revoke_type` - Use `RevokeType::Sender` to delete your own message,
     ///   or `RevokeType::Admin { original_sender }` to delete another user's message as group admin
+    ///
+    /// The returned [`SendResult`] describes the revoke itself: `message_id`
+    /// is the revoke stanza's own fresh id, and `message` the protocol message
+    /// it carried, keyed by the message being deleted.
     pub async fn revoke_message(
         &self,
         to: impl Into<Jid>,
         message_id: impl Into<String>,
         revoke_type: RevokeType,
-    ) -> Result<(), SendError> {
+    ) -> Result<SendResult, SendError> {
         self.revoke_message_inner(to.into(), message_id.into(), revoke_type)
             .await
     }
@@ -27,7 +31,7 @@ impl Client {
         to: Jid,
         message_id: String,
         revoke_type: RevokeType,
-    ) -> Result<(), SendError> {
+    ) -> Result<SendResult, SendError> {
         self.require_pn().map_err(SendError::from_anyhow)?;
 
         let (from_me, participant, edit_attr) = match &revoke_type {
@@ -62,17 +66,8 @@ impl Client {
         //
         // A revoke is an ordinary group message: the sender key goes only to devices
         // that do not have it yet, like every other send.
-        self.send_message_impl(
-            to,
-            &revoke_message,
-            SendPipelineOptions {
-                edit: Some(edit_attr),
-                ..Default::default()
-            },
-        )
-        .await
-        .map_err(SendError::from_anyhow)?;
-        Ok(())
+        self.send_built_message(to, revoke_message, edit_attr, None)
+            .await
     }
 
     /// Keep (or un-keep) a message in a disappearing chat for everyone.
@@ -98,12 +93,15 @@ impl Client {
     }
 
     /// Pin a message in a chat for all participants.
+    ///
+    /// The returned [`SendResult`] describes the pin itself: its own fresh
+    /// `message_id`, and in `message` the `pinInChatMessage` that was sent.
     pub async fn pin_message(
         &self,
         chat: impl Into<Jid>,
         key: wa::MessageKey,
         duration: PinDuration,
-    ) -> Result<(), SendError> {
+    ) -> Result<SendResult, SendError> {
         self.send_pin(
             chat.into(),
             key,
@@ -113,12 +111,13 @@ impl Client {
         .await
     }
 
-    /// Unpin a previously pinned message.
+    /// Unpin a previously pinned message. Returns the unpin's own
+    /// [`SendResult`], like [`Client::pin_message`].
     pub async fn unpin_message(
         &self,
         chat: impl Into<Jid>,
         key: wa::MessageKey,
-    ) -> Result<(), SendError> {
+    ) -> Result<SendResult, SendError> {
         self.send_pin(
             chat.into(),
             key,
@@ -135,7 +134,7 @@ impl Client {
         key: wa::MessageKey,
         pin_type: wa::message::pin_in_chat_message::Type,
         duration_secs: u32,
-    ) -> Result<(), SendError> {
+    ) -> Result<SendResult, SendError> {
         let message = wa::Message {
             pin_in_chat_message: buffa::MessageField::some(wa::message::PinInChatMessage {
                 key: buffa::MessageField::some(key),
@@ -149,16 +148,7 @@ impl Client {
             ..Default::default()
         };
 
-        self.send_message_impl(
-            chat,
-            &message,
-            SendPipelineOptions {
-                edit: Some(EditAttribute::PinInChat),
-                ..Default::default()
-            },
-        )
-        .await
-        .map_err(SendError::from_anyhow)?;
-        Ok(())
+        self.send_built_message(chat, message, EditAttribute::PinInChat, None)
+            .await
     }
 }

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -532,11 +532,31 @@ pub(crate) struct DmDeltaResend<'a> {
 }
 
 /// Result of a successfully sent message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct SendResult {
     pub message_id: String,
     pub to: Jid,
+    /// The message this send encoded, exactly as the pipeline handed it to
+    /// the encoder: after every change the send applied on the caller's
+    /// behalf ([`SendOptions::ephemeral_expiration`], forward preparation) and
+    /// including the whole of what this crate built for an edit, a revoke, a
+    /// pin, a poll or a status.
+    ///
+    /// Not a copy of the wire bytes: when the message carries no
+    /// `message_context_info` of its own, the plaintext the recipient decrypts
+    /// additionally carries the reporting-token context (a `message_secret`
+    /// and its version) the pipeline splices onto the encoding, and the copy
+    /// for our own devices is wrapped in a `DeviceSentMessage`. Both are
+    /// delivery metadata rather than content; reporting them here would cost a
+    /// decode of the plaintext we just encoded, so a caller that needs the
+    /// exact wire form reads it from the echo the account's other devices
+    /// receive.
+    ///
+    /// Shared rather than owned so that a host publishing the send to several
+    /// consumers hands out the pointer, the same shape an inbound
+    /// message arrives in, and so that cloning the result stays cheap.
+    pub message: std::sync::Arc<wa::Message>,
     /// For a DM, what the recipient half of the fan-out actually encrypted for.
     /// `None` for every other send shape: a group, a status, a peer sync and a
     /// newsletter plaintext each answer a different question about who was
@@ -999,10 +1019,12 @@ impl Client {
         to: impl Into<Jid>,
         message: wa::Message,
     ) -> impl Future<Output = Result<SendResult, SendError>> + '_ {
-        // Sync-prologue box: a plain async fn would hold the ~1 KB message
-        // by value in every embedder's frame.
+        // Sync-prologue allocation: a plain async fn would hold the ~1 KB
+        // message by value in every embedder's frame. An `Arc` rather than a
+        // `Box` because the same allocation is what `SendResult::message`
+        // hands back, so the send never copies the message again.
         let to = to.into();
-        let message = Box::new(message);
+        let message = std::sync::Arc::new(message);
         async move {
             // Box::pin: the inner future carries ~1 KB of pre-encrypt locals.
             Box::pin(self.send_message_with_options_inner(to, message, SendOptions::default()))
@@ -1018,7 +1040,7 @@ impl Client {
     ) -> impl Future<Output = Result<SendResult, SendError>> + '_ {
         use wacore::proto_helpers::MessageBuilderExt;
         let to = to.into();
-        let message = Box::new(wa::Message::text(text));
+        let message = std::sync::Arc::new(wa::Message::text(text));
         async move {
             Box::pin(self.send_message_with_options_inner(to, message, SendOptions::default()))
                 .await
@@ -1042,7 +1064,9 @@ impl Client {
     ) -> impl Future<Output = Result<SendResult, SendError>> + '_ {
         use wacore::proto_helpers::MessageExt;
         let to = to.into();
-        let body = message.get_base_message().prepare_for_forward();
+        // Same sync-prologue `Arc` as `send_message`: the prepared copy is
+        // built straight into the allocation the result hands back.
+        let body = std::sync::Arc::new(message.get_base_message().prepare_for_forward());
         async move {
             Box::pin(self.send_message_with_options_inner(to, body, SendOptions::default())).await
         }
@@ -1057,9 +1081,9 @@ impl Client {
     ) -> impl Future<Output = Result<SendResult, SendError>> + '_ {
         // Thin generic shim: the large async body below stays monomorphic so
         // each `Into<Jid>` instantiation does not duplicate the state machine.
-        // Sync-prologue box + Box::pin as in send_message.
+        // Sync-prologue `Arc` + Box::pin as in send_message.
         let to = to.into();
-        let message = Box::new(message);
+        let message = std::sync::Arc::new(message);
         async move { Box::pin(self.send_message_with_options_inner(to, message, options)).await }
     }
 
@@ -1080,7 +1104,7 @@ impl Client {
     async fn send_message_with_options_inner(
         &self,
         to: Jid,
-        mut message: Box<wa::Message>,
+        mut message: std::sync::Arc<wa::Message>,
         options: SendOptions,
     ) -> Result<SendResult, SendError> {
         #[cfg(feature = "tracing")]
@@ -1105,7 +1129,9 @@ impl Client {
             && exp > 0
         {
             use wacore::proto_helpers::MessageExt;
-            if !message.set_ephemeral_expiration(exp) {
+            // The shim above created this `Arc` and nothing else holds it, so
+            // `make_mut` edits in place and never clones.
+            if !std::sync::Arc::make_mut(&mut message).set_ephemeral_expiration(exp) {
                 // Bare `conversation` messages have no contextInfo field.
                 log::warn!("Could not set contextInfo.expiration on this message type");
             }
@@ -1153,6 +1179,7 @@ impl Client {
                 message_id: request_id,
                 to: result_to,
                 recipient_fanout: None,
+                message,
             });
         }
 
@@ -1186,6 +1213,7 @@ impl Client {
             message_id: request_id,
             to: result_to,
             recipient_fanout,
+            message,
         })
     }
 
@@ -1462,6 +1490,7 @@ impl Client {
             message_id: request_id,
             to,
             recipient_fanout: None,
+            message: std::sync::Arc::new(message),
         })
     }
 
@@ -2013,6 +2042,52 @@ impl Client {
         group_info: &wacore::client::context::GroupInfo,
     ) -> Result<Node, anyhow::Error> {
         Ok(wacore::send::ensure_status_participants(stanza, group_info))
+    }
+
+    /// Send a message this crate built on the caller's behalf (an edit, a
+    /// revoke, a pin) under an explicit stanza `edit` attribute, and hand back
+    /// the same [`SendResult`] a caller-built send gets, message included: the
+    /// only way a caller can see what those sends put in the chat.
+    ///
+    /// `borrowed_stanza_id` names the outer stanza after another message (see
+    /// [`EditOptions::stanza_id`]), so the pipeline binds no id-keyed state to
+    /// it. `None` names the send with a fresh id, like every other send.
+    pub(crate) async fn send_built_message(
+        &self,
+        to: Jid,
+        message: wa::Message,
+        edit: EditAttribute,
+        borrowed_stanza_id: Option<String>,
+    ) -> Result<SendResult, SendError> {
+        // Sampled here and lent down, the way `send_message_with_options_inner`
+        // does it, so the send still names its message and stamps its instant
+        // exactly once.
+        let sent_at = SendInstant::now();
+        let borrowed_message_id = borrowed_stanza_id.is_some();
+        let request_id = borrowed_stanza_id
+            .unwrap_or_else(|| self.generate_message_id_at(sent_at.unix_secs_u64()));
+        let message = std::sync::Arc::new(message);
+        let result_to = to.clone();
+        let recipient_fanout = self
+            .send_message_impl(
+                to,
+                &message,
+                SendPipelineOptions {
+                    sent_at: Some(sent_at),
+                    request_id: Some(&request_id),
+                    edit: Some(edit),
+                    borrowed_message_id,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(SendError::from_anyhow)?;
+        Ok(SendResult {
+            message_id: request_id,
+            to: result_to,
+            recipient_fanout,
+            message,
+        })
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.impl", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
@@ -3638,11 +3713,11 @@ mod tests {
                 .await;
         }
 
-        async fn revoke(&self, message_id: &str, revoke_type: RevokeType) {
+        async fn revoke(&self, message_id: &str, revoke_type: RevokeType) -> SendResult {
             self.client
                 .revoke_message(self.group.clone(), message_id, revoke_type)
                 .await
-                .expect("revoke should reach the wire");
+                .expect("revoke should reach the wire")
         }
 
         fn admin_revoke(&self) -> RevokeType {
@@ -3706,6 +3781,43 @@ mod tests {
         assert!(
             fixture.frame_len(1) < fixture.frame_len(0),
             "a revoke that distributes nothing must be smaller than the cold send"
+        );
+    }
+
+    /// A group revoke's result is named by the stanza it went out under and
+    /// carries the key the admin revoke was built with: the original sender
+    /// exactly as given, since the receiving side matches it against the
+    /// target's own key.
+    #[tokio::test]
+    async fn a_group_revoke_result_names_the_stanza_it_sent() {
+        let fixture = GroupSendFixture::new().await;
+        fixture.send_text("first message warms the group").await;
+
+        let result = fixture
+            .revoke("3EB0FAKEREVOKED02", fixture.admin_revoke())
+            .await;
+        let revoke = fixture.stanza(1).await;
+        assert_eq!(
+            attr_value(&revoke, "id").as_deref(),
+            Some(result.message_id.as_str()),
+            "the result is named by the stanza the revoke went out under"
+        );
+        assert_eq!(result.to, fixture.group);
+        assert!(
+            result.recipient_fanout.is_none(),
+            "a group send does not describe itself in a DM's terms"
+        );
+        let key = result
+            .message
+            .protocol_message
+            .as_option()
+            .and_then(|pm| pm.key.as_option())
+            .expect("the revoke is keyed by the target");
+        assert_eq!(key.id.as_deref(), Some("3EB0FAKEREVOKED02"));
+        assert_eq!(key.from_me, Some(false));
+        assert_eq!(
+            key.participant.as_deref(),
+            Some(fixture.member.to_non_ad_string().as_str())
         );
     }
 
@@ -7696,6 +7808,223 @@ mod tests {
         assert!(
             result.recipient_fanout.is_none(),
             "a status send must not describe itself in a DM's terms"
+        );
+    }
+
+    /// `SendResult::message` is the message as the pipeline encoded it: the
+    /// caller's content plus what the send applied on the caller's behalf
+    /// (here the expiration from `SendOptions`), and without the
+    /// reporting-token context the wire plaintext gains, which the outbound
+    /// secret buffer holds instead. A host that shares one client between
+    /// several consumers reads this to show the others what one of them sent,
+    /// because WhatsApp echoes a send to every device except the sending one.
+    #[tokio::test]
+    async fn a_result_carries_the_message_as_the_send_encoded_it() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+
+        let result = client
+            .send_message_with_options(
+                peer_pn.clone(),
+                wa::Message {
+                    extended_text_message: buffa::MessageField::some(
+                        wa::message::ExtendedTextMessage {
+                            text: Some("hi".into()),
+                            ..Default::default()
+                        },
+                    ),
+                    ..Default::default()
+                },
+                SendOptions::default().with_ephemeral_expiration(86_400),
+            )
+            .await
+            .expect("connected test client should complete the send");
+
+        let sent = result
+            .message
+            .extended_text_message
+            .as_option()
+            .expect("the content the caller passed");
+        assert_eq!(sent.text.as_deref(), Some("hi"));
+        assert_eq!(
+            sent.context_info.as_option().and_then(|c| c.expiration),
+            Some(86_400),
+            "what the send applied on the caller's behalf is part of what it reports"
+        );
+        assert!(
+            result.message.message_context_info.is_unset(),
+            "the reporting-token context is spliced onto the wire plaintext, \
+             not onto the reported message"
+        );
+        assert!(
+            client
+                .msg_secret_buffer
+                .lookup(
+                    &peer_pn.to_non_ad_string(),
+                    &client.pn().expect("own pn").to_non_ad_string(),
+                    &result.message_id,
+                )
+                .is_some(),
+            "the secret the wire copy carries is still held for the message's add-ons"
+        );
+    }
+
+    /// An edit's result describes the edit: the stanza it went out under and
+    /// the protocol message this crate wrapped the caller's content in. The
+    /// stanza id is the edit's own (the original's would be deduplicated away
+    /// by the server) unless the caller borrowed one through `EditOptions`.
+    #[tokio::test]
+    async fn an_edit_reports_its_own_stanza_and_the_container_it_built() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+        let waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("message")
+                .attr("edit", EditAttribute::MessageEdit.to_string_val()),
+        );
+
+        let result = client
+            .edit_message(peer_pn.clone(), "ORIGINAL", wa::Message::text("new"))
+            .await
+            .expect("connected test client should complete the edit");
+
+        let stanza = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("the edit reaches the wire")
+            .expect("sent node waiter resolves");
+        assert_eq!(
+            stanza.attrs().optional_string("id").as_deref(),
+            Some(result.message_id.as_str()),
+            "the result is named by the stanza the edit went out under"
+        );
+        assert_ne!(
+            result.message_id, "ORIGINAL",
+            "an edit is named by its own id, or the server drops it as a duplicate"
+        );
+        assert_eq!(result.to, peer_pn);
+        let container = result
+            .message
+            .protocol_message
+            .as_option()
+            .expect("the edit is a protocol message");
+        assert_eq!(
+            container.r#type,
+            Some(wa::message::protocol_message::Type::MessageEdit)
+        );
+        assert_eq!(
+            container.key.as_option().and_then(|k| k.id.as_deref()),
+            Some("ORIGINAL"),
+            "keyed by the message being edited"
+        );
+        assert_eq!(
+            container
+                .edited_message
+                .as_option()
+                .and_then(|m| m.conversation.as_deref()),
+            Some("new"),
+            "carrying the caller's replacement content"
+        );
+
+        let borrowed = client
+            .edit_message_with_options(
+                peer_pn.clone(),
+                "ORIGINAL",
+                wa::Message::text("newer"),
+                EditOptions {
+                    stanza_id: Some("BORROWED".into()),
+                },
+            )
+            .await
+            .expect("connected test client should complete the edit");
+        assert_eq!(
+            borrowed.message_id, "BORROWED",
+            "a borrowed stanza id is what the edit was named with"
+        );
+    }
+
+    /// The sends that build their whole message inside this crate (a revoke,
+    /// a pin, a poll) report it the same way, so a caller sees what each put in
+    /// the chat without re-implementing the builder that made it.
+    #[tokio::test]
+    async fn a_revoke_a_pin_and_a_poll_report_the_message_this_crate_built() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let (peer_pn, _peer_lid) = seed_dm_wire_namespace_state(&client).await;
+
+        let revoke = client
+            .revoke_message(peer_pn.clone(), "TARGET", RevokeType::Sender)
+            .await
+            .expect("connected test client should complete the revoke");
+        assert_ne!(
+            revoke.message_id, "TARGET",
+            "a revoke is named by its own id, not the target's"
+        );
+        assert_eq!(revoke.to, peer_pn);
+        let container = revoke
+            .message
+            .protocol_message
+            .as_option()
+            .expect("the revoke is a protocol message");
+        assert_eq!(
+            container.r#type,
+            Some(wa::message::protocol_message::Type::Revoke)
+        );
+        let key = container.key.as_option().expect("keyed by the target");
+        assert_eq!(key.id.as_deref(), Some("TARGET"));
+        assert_eq!(key.from_me, Some(true));
+        assert_eq!(
+            key.remote_jid.as_deref(),
+            Some(peer_pn.to_string().as_str())
+        );
+
+        let target = wa::MessageKey {
+            remote_jid: Some(peer_pn.to_string()),
+            from_me: Some(true),
+            id: Some("TARGET".into()),
+            participant: None,
+        };
+        let pin = client
+            .pin_message(peer_pn.clone(), target.clone(), PinDuration::Days30)
+            .await
+            .expect("connected test client should complete the pin");
+        let pinned = pin
+            .message
+            .pin_in_chat_message
+            .as_option()
+            .expect("the pin is a pinInChatMessage");
+        assert_eq!(
+            pinned.r#type,
+            Some(wa::message::pin_in_chat_message::Type::PinForAll)
+        );
+        assert_eq!(pinned.key.as_option(), Some(&target));
+        assert_eq!(
+            pin.message
+                .message_context_info
+                .as_option()
+                .and_then(|c| c.message_add_on_duration_in_secs),
+            Some(PinDuration::Days30.as_secs()),
+            "the duration the pin was sent with"
+        );
+
+        let options = ["yes".to_string(), "no".to_string()];
+        let (poll, secret) = client
+            .polls()
+            .create(peer_pn.clone(), "lunch?", &options, 1)
+            .await
+            .expect("connected test client should complete the poll");
+        let creation = poll
+            .message
+            .poll_creation_message_v3
+            .as_option()
+            .expect("a single-select poll is the v3 shape");
+        assert_eq!(creation.name.as_deref(), Some("lunch?"));
+        assert_eq!(creation.options.len(), 2);
+        assert_eq!(
+            poll.message
+                .message_context_info
+                .as_option()
+                .and_then(|c| c.message_secret.as_deref()),
+            Some(secret.as_slice()),
+            "a poll's own secret is part of the message it built, so the wire \
+             copy and the reported one agree on it"
         );
     }
 

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -167,7 +167,11 @@ pub trait MessageExt {
     ///
     /// Forwards the message body as-is, so existing media is relayed from the same
     /// CDN blob (mediaKey/url are carried over) rather than re-uploaded.
-    fn prepare_for_forward(&self) -> Box<wa::Message>;
+    ///
+    /// Returned by value, unlike [`prepare_for_quote`](Self::prepare_for_quote),
+    /// so the send path can place the copy straight into the allocation it
+    /// hands back as `SendResult::message` instead of re-homing a `Box`.
+    fn prepare_for_forward(&self) -> wa::Message;
 
     /// Sets context_info on the first supported message field.
     ///
@@ -369,7 +373,7 @@ impl MessageExt for wa::Message {
         Box::new(msg)
     }
 
-    fn prepare_for_forward(&self) -> Box<wa::Message> {
+    fn prepare_for_forward(&self) -> wa::Message {
         // WA Web's `FREQUENTLY_FORWARDED_SENTINEL` (Constants/Deprecated): the
         // score saturates by jumping here at the >= 5 threshold, not at 5.
         const FREQUENTLY_FORWARDED_SENTINEL: u32 = 127;
@@ -396,7 +400,7 @@ impl MessageExt for wa::Message {
                             n
                         });
                         ctx.is_forwarded = Some(true);
-                        return Box::new(msg);
+                        return msg;
                     }
                 )+
             };
@@ -417,7 +421,7 @@ impl MessageExt for wa::Message {
                     ..Default::default()
                 });
         }
-        Box::new(msg)
+        msg
     }
 
     fn set_context_info(&mut self, context: wa::ContextInfo) -> bool {


### PR DESCRIPTION
Closes #1404.

## Summary

A host that shares one `Client` between several consumers owes them its own echo of every send: WhatsApp echoes a send to every device on the account except the one that sent it, and all of those consumers are that one device. For a send whose message the caller built that is a `clone()` before the call. For the sends whose message **this crate** builds (an edit, a revoke, a pin, a poll, a status) the caller had nothing to echo: each assembled a `wa::Message`, sent it and dropped it, handing back at most an id. Rebuilding it downstream would be a copy of our builders that drifts the day one of them changes (`build_poll_creation_message` alone picks v3 vs v1 on `selectable_count`, sets the poll type and hex-encodes a quiz's option hash because WA Web does).

This is shape (1) from the issue, done without the clone it was priced at:

- **`SendResult::message: Arc<wa::Message>`** — the message exactly as the pipeline handed it to the encoder. Reaches every send at once, including the ones that already returned a `SendResult`.
- **`edit_message`, `edit_message_with_options`, `edit_message_encrypted`** return `SendResult` instead of the `String` the caller passed in; **`revoke_message`, `pin_message`, `unpin_message`** return `SendResult` instead of `()`. `MessageContext::edit_message` / `revoke_message` follow. For these, `message_id` is the stanza the operation went out under (an edit's own fresh id, or the borrowed one from `EditOptions::stanza_id`) and `message` the protocol message this crate built, keyed by the target.
- `Polls::create` / `create_quiz` / `Events::create` keep their `(SendResult, Vec<u8>)`; the secret is also inside `message.message_context_info`, the tuple stays because it is the ergonomic form for the vote/RSVP that follows.

## No clone anywhere

The public shims (`send_message`, `send_text`, `forward_message`, `send_message_with_options`) already boxed the message in their sync prologue so the caller's future stays pointer-sized. That `Box` is now the `Arc` the result hands back: same single allocation, and the message is never copied again. `Arc::make_mut` on the ephemeral-expiration path is a refcount check, not a clone, because nothing else holds it yet. `prepare_for_forward` returns its copy by value instead of a `Box` for the same reason, so a forward builds the body straight into that allocation rather than re-homing it (that is the one `wacore` change; `prepare_for_quote` is untouched and the doc says why the two differ). The status path moves its message into the result.

The five sends that ran `send_message_impl` directly go through one new `send_built_message`, which names the send before the pipeline the way `send_message_with_options_inner` does (one wall-clock read, one id, both lent down) and builds the same `SendResult`. Those pay one small `Arc` allocation each for the message they used to keep on the stack; an edit gives back the `original_id.clone()` it no longer needs, a revoke or a pin does not, and both sit behind a Signal encrypt per device.

`SendResult` loses `Eq` (a `wa::Message` carries floats); it keeps `Clone`, which is now a refcount bump, and `PartialEq`.

`benches/client_dm_send` (release, this box, two alternating rounds of main and this branch):

| median, µs | main r1 | branch r1 | main r2 | branch r2 |
| --- | ---: | ---: | ---: | ---: |
| `warm_dm_send_lid` 1 / 2 / 5 | 52.7 / 61.3 / 94.0 | 50.7 / 67.0 / 91.3 | 47.2 / 70.7 / 96.1 | 48.6 / 65.5 / 94.2 |
| `warm_dm_send_pn_with_known_lid` 1 / 2 / 5 | 59.6 / 67.9 / 109.7 | 51.7 / 63.8 / 95.5 | 54.9 / 63.0 / 95.4 | 51.6 / 72.5 / 98.0 |

Inside run-to-run noise in both directions (the "fastest" columns agree to about 1 µs), which is what a change that adds no allocation to that path should measure; CodSpeed's instruction count on this PR is the precise figure.

## Which message it is

Not the wire bytes, and the field's doc says so. When the message carries no `message_context_info` of its own, the plaintext the recipient decrypts additionally carries the reporting-token context (`message_secret` + version) the DM and group branches splice onto the encoding, and the own-device copy is wrapped in a `DeviceSentMessage`. Both are delivery metadata rather than content; producing them here would cost a decode of the plaintext we just encoded, so the issue's guess (pre-hoist is cheaper and what the use case needs) is the contract, with the secret still held by the outbound secret buffer for the add-ons that need it. The test below pins that boundary.

## Not done

- Public builders (shape 3). With the message in the result nobody needs to rebuild one, and the builders take decisions a free function cannot (an edit resolves our own JID for the group's addressing mode, a revoke needs the account's PN); exposing them would be surface to keep stable for a two-step flow that `SendResult::message` makes unnecessary.
- Newsletter `edit_message` / `revoke_message` still return `()`: the plaintext path sends a node under the *target's* id with the caller's own body, so there is neither a fresh id nor a built message to report.

## Testing

- `a_result_carries_the_message_as_the_send_encoded_it`: the reported message carries the expiration `SendOptions` applied and not the reporting-token context, while the outbound secret buffer holds that secret under the same id.
- `an_edit_reports_its_own_stanza_and_the_container_it_built`: the result's id is the `edit="1"` stanza's id and not the original's; the container is `MESSAGE_EDIT` keyed by the original with the new content inside; a borrowed `EditOptions::stanza_id` is what the result is named with.
- `a_revoke_a_pin_and_a_poll_report_the_message_this_crate_built`: the revoke's key, the pin's type/key/duration, the poll's v3 shape and its secret.
- `a_group_revoke_result_names_the_stanza_it_sent`: on the group fixture, the admin revoke's result matches the captured stanza's id and carries the original sender as given.
- Locally: `cargo fmt --all`, `cargo clippy -p wacore -p whatsapp-rust --all-targets --features bench-harness -- -D warnings`, `cargo check --workspace --all-targets` (minus `voip-cli`, no libopus here), `cargo test -p whatsapp-rust --lib` (1875 passed, incl. `send_futures_stay_small` and the clock-budget tests), `cargo test -p wacore --lib proto_helpers`, `RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust -p wacore --no-deps`.

CI note: `Semver Checks (informational)` is red on `main` as well; this PR is intentionally breaking (`!`) on the return types above and on `MessageExt::prepare_for_forward`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDRuxyAHB6nNz7q3aA6LKV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDRuxyAHB6nNz7q3aA6LKV)_