### PR TITLE
perf(memory): sweep expired cache entries on the maintenance tick, release online device-sync dedup, report LID/PN side maps and chat-lane backlog

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -744,12 +744,13 @@ Against that, the two preallocated bounded queues a session owns:
 
 | queue | capacity | payload | retained |
 | --- | ---: | ---: | ---: |
-| `major_sync_task_sender` (`Client::new`) | 32 | 56 B | 2 816 B |
+| `major_sync_task_sender` (`Client::new`) | 8 | 56 B | ~0.5 KiB |
 | transport events (`EVENT_CHANNEL_CAPACITY`, per connection) | 64 | 40 B | 3 840 B |
 
-So the sync queue is ~11% of a constructed client — but a connected session's
-marginal cost is ~530 KiB (see the table further up), against which both queues
-together are ~1.2%. **Neither is worth making lazy.** The sync queue's receiver
+(The sync queue was measured at 2 816 B when its capacity was 32; the 8-slot
+figure is computed, not re-measured.) So the sync queue is ~2% of a constructed
+client — and a connected session's marginal cost is ~530 KiB (see the table
+further up), against which both queues together are under 1%. **Neither is worth making lazy.** The sync queue's receiver
 is handed to `Bot::build` to spawn its worker, so deferring the allocation means
 an `Option` plus a builder handoff that no longer has a receiver to give; the
 transport queue is created by the transport at connect, and every connected
@@ -788,7 +789,7 @@ message can overshoot substantially on its own.
 | collection | bound | what eviction costs |
 | --- | --- | --- |
 | `group_cache` | 1h TTL, 250 | re-query on miss |
-| `device_registry_cache` | 1h TTL, 5 000 | store stays authoritative |
+| `device_registry_cache` | 1h TTL, 20 000 | store stays authoritative |
 | `recent_messages` | 5m TTL, 0 (disabled) | DB is authoritative |
 | `message_retry_counts` | 1h TTL, 500, FIFO | a forgiven `MAX_DECRYPT_RETRIES` — see below |
 | `undecryptable_dispatched` | 5m TTL, 1 000 | a duplicate event |
@@ -802,11 +803,21 @@ message can overshoot substantially on its own.
 | `SignalStoreCache::sender_key_locks` | 2 000, idle-only | nothing: only locks held solely by the map are dropped |
 | `inbound_commit_batch` | 400 messages / 4 MiB, checked after insert | commits early, no loss; overshoots by one message |
 | `msg_secret_buffer` | 4 096, except on cancellation | nothing: a producer that would exceed it parks on `capacity_available`, and a cancelled one force-buffers past the mark rather than losing captures |
-| device-topology changed-users log | 256 | a memo recompute; overflow can never serve stale data |
+| device-topology changed-users log | 4 096 | a memo recompute; overflow can never serve stale data |
 | `AbPropsCache` | the compile-time `WATCHED` interest set | server props outside it are discarded at parse |
 | `CallRegistry` pre-offer controls / ringing group calls / event queues | 64 entries or 1 MiB each | fail-closed admission |
 | `PendingCallLinkJoins` transitions | 32 | fail-closed |
-| `major_sync_task_sender` / transport events / noise send jobs | 32 / 64 / 8 | backpressure, no loss |
+| `major_sync_task_sender` / transport events / noise send jobs | 8 / 64 / 8 | backpressure, no loss |
+
+**A TTL is a bound only if something sweeps.** `PortableCache` expires lazily:
+an entry leaves on the access that finds it stale or under capacity pressure
+from a new insert, and a quiet connection does neither. So the keepalive's
+~5-minute maintenance tick also runs `Client::run_cache_maintenance`, which
+sweeps every TTL/TTI cache above (store-backed ones expire on their own and
+no-op). Between sweeps `memory_report()` counts include expired entries, which
+is why a count can exceed what a lookup would find; a report taken right after
+a sweep is the exact one. Capacity-only caches are not swept — they have nothing
+to expire.
 
 ### What is unbounded, and why it stays that way
 
@@ -824,14 +835,25 @@ the bound is a drain or a lifecycle, so the count is the only warning available.
   already requested or loses the dedup that keeps a stuck sender from re-asking
   every few seconds. Growth is self-limiting anyway: each new key id costs a peer
   message on the wire.
-- **`pending_device_sync`** — one entry per distinct user seen with an unknown
-  device. Offline entries are drained by `doPendingDeviceSync` at the end of the
-  backlog; entries the *online* path adds are removed only by that same drain or
-  by teardown, so a connection that never drains keeps them for its lifetime,
-  which also suppresses a second immediate refresh for those users. A cap would
-  skip a device refresh and leave the next send to that user addressed to a stale
-  device list, so the fix if this ever matters is a removal on the online path,
-  not a ceiling.
+- **`pending_device_sync`** — one entry per user with a device refresh pending
+  or in flight. Offline entries are drained by `doPendingDeviceSync` at the end
+  of the backlog; an entry the *online* path adds is released by a `scopeguard`
+  when its refresh finishes, so outside a drain the set holds only what is in
+  flight. (It used to hold online entries for the connection's lifetime, which
+  also meant a user who added a second new device weeks later never got another
+  refresh.) A cap would skip a device refresh and leave the next send to that
+  user addressed to a stale device list, so the bound stays the drain.
+- **Chat-lane queues** (`chat_lane_backlog`) — the lanes are capped, their
+  `async_channel::unbounded` queues are not, and each queued message retains
+  its whole inbound frame. The bound is the worker draining it; a backlog that
+  grows is a worker that is stuck (a slow durability hook, a hung decrypt), and
+  the count is the signal. Capping the queue would drop or redeliver messages
+  the server already considers delivered.
+- **`lid_pn_cache` side maps** (`lid_pn_contact_hash_entries`,
+  `lid_pn_persisted_entries`) — unbounded with the cache they index, one entry
+  per identifier and one per persisted pair. Their payload is the entry's own
+  strings, so the report charges them table structure only; that structure is
+  what grows with the contact list, ~10% on top of the entries themselves.
 - **`AppStateProcessor::key_cache`** — expanded app-state keys, one entry per
   distinct key id the server's patches reference, with no cap and no TTL;
   emptied only by `clear_key_cache` on reconnect. The backend stays

--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -241,6 +241,17 @@ where
         }
     }
 
+    /// Entry count plus table bytes only (see
+    /// [`PortableCache::structural_stats`]). Custom stores report zero.
+    ///
+    /// [`PortableCache::structural_stats`]: crate::portable_cache::PortableCache::structural_stats
+    pub async fn structural_stats(&self) -> wacore::stats::CollectionStats {
+        match &self.inner {
+            Inner::Local(cache) => cache.structural_stats().await,
+            Inner::Custom { .. } => wacore::stats::CollectionStats::default(),
+        }
+    }
+
     /// Approximate entry count (sync). Returns `0` for custom backends.
     ///
     /// For diagnostics that need custom backend counts, use

--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -253,9 +253,11 @@ where
     }
 
     /// Approximate entry count, delegating to the custom backend if available.
+    /// The in-process count is awaited, so unlike
+    /// [`entry_count`](Self::entry_count) it never reads `0` under write load.
     pub async fn entry_count_async(&self) -> u64 {
         match &self.inner {
-            Inner::Local(cache) => cache.entry_count(),
+            Inner::Local(cache) => cache.entry_count_async().await,
             Inner::Custom {
                 store, namespace, ..
             } => store.entry_count(namespace).await.unwrap_or(0),

--- a/src/client.rs
+++ b/src/client.rs
@@ -778,7 +778,6 @@ impl std::fmt::Display for MemoryReport {
             self.group_metadata_inflight
         )?;
         writeln!(f, "  chat_lanes:             {}", self.chat_lanes)?;
-        writeln!(f, "  chat_lane_backlog:      {}", self.chat_lane_backlog)?;
         writeln!(
             f,
             "  group_dist_locks:       {} (evicted: {}, blocked: {})",
@@ -798,6 +797,7 @@ impl std::fmt::Display for MemoryReport {
         )?;
         writeln!(f, "  skdm_warm_memo:         {}", self.skdm_warm_memo)?;
         writeln!(f, "--- Unbounded collections ---")?;
+        writeln!(f, "  chat_lane_backlog:      {}", self.chat_lane_backlog)?;
         writeln!(f, "  transport_ack_queue:    {}", self.transport_ack_queue)?;
         writeln!(
             f,

--- a/src/client.rs
+++ b/src/client.rs
@@ -634,14 +634,14 @@ impl MemoryReport {
         [
             ("group_cache:", &self.group_cache),
             ("device_registry_cache:", &self.device_registry_cache),
-            ("lid_pn (lid):", &self.lid_pn_lid_entries),
-            ("lid_pn (pn):", &self.lid_pn_pn_entries),
-            ("lid_pn (hash):", &self.lid_pn_contact_hash_entries),
-            ("lid_pn (persisted):", &self.lid_pn_persisted_entries),
             ("recent_messages:", &self.recent_messages),
             ("sk_device_cache:", &self.sender_key_device_cache),
             ("group_devices_memo:", &self.group_devices_memo),
             ("dm_devices_memo:", &self.dm_devices_memo),
+            ("lid_pn (lid):", &self.lid_pn_lid_entries),
+            ("lid_pn (pn):", &self.lid_pn_pn_entries),
+            ("lid_pn (hash):", &self.lid_pn_contact_hash_entries),
+            ("lid_pn (persisted):", &self.lid_pn_persisted_entries),
             ("signal_sessions:", &self.signal_sessions),
             ("signal_identities:", &self.signal_identities),
             ("signal_sender_keys:", &self.signal_sender_keys),
@@ -736,13 +736,18 @@ impl std::fmt::Display for MemoryReport {
             writeln!(f, "  {name:<22} {:>7} entries {:>10} B", c.entries, c.bytes)
         }
         // First TTL_BOUNDED entries of collections() are the TTL-bounded
-        // caches; the next SIGNAL_CACHES are Signal store caches. The rest are
-        // transient retention: history sync, the inbound commit batch, then the
-        // offline receipt buffer. Adding a cache to collections() means moving
-        // this boundary, or the sections shift.
-        const TTL_BOUNDED: usize = 10;
+        // caches; the next LID_PN_MAPS are the LID/PN maps, which have no
+        // TTL and are bounded by the contact list, so they get their own
+        // heading rather than passing as bounded-cache activity; the next
+        // SIGNAL_CACHES are Signal store caches. The rest are transient
+        // retention: history sync, the inbound commit batch, then the offline
+        // receipt buffer. Adding a cache to collections() means moving this
+        // boundary, or the sections shift.
+        const TTL_BOUNDED: usize = 6;
+        const LID_PN_MAPS: usize = 4;
+        const LID_PN_END: usize = TTL_BOUNDED + LID_PN_MAPS;
         const SIGNAL_CACHES: usize = 3;
-        const HISTORY_SYNC: usize = TTL_BOUNDED + SIGNAL_CACHES;
+        const HISTORY_SYNC: usize = LID_PN_END + SIGNAL_CACHES;
         const COMMIT_BATCH: usize = HISTORY_SYNC + 1;
         const OFFLINE_RECEIPTS: usize = COMMIT_BATCH + 1;
         let collections = self.collections();
@@ -760,6 +765,10 @@ impl std::fmt::Display for MemoryReport {
         writeln!(f, "  dispatched_messages:    {}", self.dispatched_messages)?;
         writeln!(f, "  pdo_pending_requests:   {}", self.pdo_pending_requests)?;
         writeln!(f, "  pdo_requested:          {}", self.pdo_requested)?;
+        writeln!(f, "--- LID/PN maps (bounded by the contact list) ---")?;
+        for (name, c) in &collections[TTL_BOUNDED..LID_PN_END] {
+            line(f, name, c)?;
+        }
         writeln!(f, "--- Capacity-only caches ---")?;
         writeln!(f, "  session_locks:          {}", self.session_locks)?;
         writeln!(f, "  ensure_inflight:        {}", self.ensure_inflight)?;
@@ -822,7 +831,7 @@ impl std::fmt::Display for MemoryReport {
         )?;
         writeln!(f, "  app_state_syncing:      {}", self.app_state_syncing)?;
         writeln!(f, "--- Signal store caches ---")?;
-        for (name, c) in &collections[TTL_BOUNDED..TTL_BOUNDED + SIGNAL_CACHES] {
+        for (name, c) in &collections[LID_PN_END..LID_PN_END + SIGNAL_CACHES] {
             line(f, name, c)?;
         }
         if !self.subsystems.is_empty() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -434,6 +434,16 @@ pub struct MemoryReport {
     /// [`Self::lid_pn_lid_entries`]; bytes here cover only entries the LID
     /// map no longer holds (normally 0), so the total counts each once.
     pub lid_pn_pn_entries: CollectionStats,
+    /// Contact-hash → LID index of the LID/PN cache, one entry per identifier
+    /// (both sides of every pair). Bytes are the table alone: the LID it
+    /// points at is the entry's, already counted above. Unbounded with the
+    /// cache it indexes, and rebuilt from warm-up each process.
+    pub lid_pn_contact_hash_entries: CollectionStats,
+    /// PN → LID pairs this process has durably persisted, the dedup that lets
+    /// the learn path skip a re-persist. Bytes are the table alone (both
+    /// strings are the entry's). One entry per persisted contact for the
+    /// process lifetime.
+    pub lid_pn_persisted_entries: CollectionStats,
     pub recent_messages: CollectionStats,
     pub sender_key_device_cache: CollectionStats,
     pub group_devices_memo: CollectionStats,
@@ -485,9 +495,9 @@ pub struct MemoryReport {
     /// second refresh for the same user while one is outstanding.
     ///
     /// Offline entries are drained by `doPendingDeviceSync` at the end of the
-    /// backlog. Entries added by the *online* path are removed only by that
-    /// same drain or by teardown, so on a connection with no offline drain this
-    /// grows with the distinct users seen with an unknown device.
+    /// backlog; an entry the *online* path adds leaves when its refresh
+    /// finishes. A value that stays high outside a drain means refreshes are
+    /// not completing, not that many users were seen.
     pub pending_device_sync: usize,
     // -- Capacity-only caches (coordination, counts only) --
     pub session_locks: u64,
@@ -496,6 +506,12 @@ pub struct MemoryReport {
     /// Groups with a metadata query in flight; normally zero.
     pub group_metadata_inflight: u64,
     pub chat_lanes: u64,
+    /// Inbound messages queued behind their chat's lane worker, summed over
+    /// every lane. The lanes are capacity-bounded; their queues are not, and
+    /// each queued message retains its whole frame, so a worker that is stuck
+    /// (a slow durability hook, a hung decrypt) shows up here as a backlog
+    /// that grows with the chat's inbound rate.
+    pub chat_lane_backlog: u64,
     pub group_distribution_locks: u64,
     /// Cumulative capacity evictions; poll successive reports to derive a rate.
     pub group_distribution_lock_evictions: u64,
@@ -614,12 +630,14 @@ pub struct SubsystemMemory {
 impl MemoryReport {
     /// Common byte-carrying collections used by both totals and `Display`.
     /// Feature-specific collections stay beside their gated report section.
-    fn collections(&self) -> [(&'static str, &CollectionStats); 14] {
+    fn collections(&self) -> [(&'static str, &CollectionStats); 16] {
         [
             ("group_cache:", &self.group_cache),
             ("device_registry_cache:", &self.device_registry_cache),
             ("lid_pn (lid):", &self.lid_pn_lid_entries),
             ("lid_pn (pn):", &self.lid_pn_pn_entries),
+            ("lid_pn (hash):", &self.lid_pn_contact_hash_entries),
+            ("lid_pn (persisted):", &self.lid_pn_persisted_entries),
             ("recent_messages:", &self.recent_messages),
             ("sk_device_cache:", &self.sender_key_device_cache),
             ("group_devices_memo:", &self.group_devices_memo),
@@ -654,6 +672,58 @@ impl MemoryReport {
         let total = total.saturating_add(self.plugin_event_queue.bytes);
         total
     }
+
+    /// The collections whose only bound is a drain or a lifecycle, by name
+    /// and entry count — the set a long-running soak compares between
+    /// snapshots. Kept here, beside the fields, so a collection added to the
+    /// report is added to the growth check in the same place, rather than to
+    /// a hand-copied list in a test that nothing keeps in step.
+    ///
+    /// Capacity-bounded caches are left out: they can only ever read their
+    /// cap. `lid_pn_*` maps are in, since their bound is the contact list.
+    pub fn unbounded_counts(&self) -> Vec<(&'static str, u64)> {
+        let n = |v: usize| u64::try_from(v).unwrap_or(u64::MAX);
+        vec![
+            ("lid_pn_lid_entries", self.lid_pn_lid_entries.entries),
+            ("lid_pn_pn_entries", self.lid_pn_pn_entries.entries),
+            (
+                "lid_pn_contact_hash_entries",
+                self.lid_pn_contact_hash_entries.entries,
+            ),
+            (
+                "lid_pn_persisted_entries",
+                self.lid_pn_persisted_entries.entries,
+            ),
+            ("history_sync_tasks", self.history_sync_tasks.entries),
+            ("inbound_commit_batch", self.inbound_commit_batch.entries),
+            ("msg_secret_buffer", n(self.msg_secret_buffer)),
+            ("pending_device_sync", n(self.pending_device_sync)),
+            ("ensure_inflight", self.ensure_inflight),
+            ("group_metadata_inflight", self.group_metadata_inflight),
+            ("chat_lane_backlog", self.chat_lane_backlog),
+            ("transport_ack_queue", n(self.transport_ack_queue)),
+            ("delivery_receipt_queue", n(self.delivery_receipt_queue)),
+            ("response_waiters", n(self.response_waiters)),
+            ("node_waiters", n(self.node_waiters)),
+            ("sent_node_waiters", n(self.sent_node_waiters)),
+            ("pending_retries", n(self.pending_retries)),
+            ("pending_lid_refreshes", n(self.pending_lid_refreshes)),
+            ("presence_subscriptions", n(self.presence_subscriptions)),
+            ("app_state_key_requests", n(self.app_state_key_requests)),
+            ("app_state_key_cache", n(self.app_state_key_cache)),
+            (
+                "app_state_recovery_requests",
+                n(self.app_state_recovery_requests),
+            ),
+            ("app_state_syncing", n(self.app_state_syncing)),
+            ("signal_sessions", self.signal_sessions.entries),
+            ("signal_identities", self.signal_identities.entries),
+            ("signal_sender_keys", self.signal_sender_keys.entries),
+            ("chatstate_handlers", n(self.chatstate_handlers)),
+            ("custom_enc_handlers", n(self.custom_enc_handlers)),
+            ("stanza_interceptors", n(self.stanza_interceptors)),
+        ]
+    }
 }
 
 impl std::fmt::Display for MemoryReport {
@@ -670,7 +740,7 @@ impl std::fmt::Display for MemoryReport {
         // transient retention: history sync, the inbound commit batch, then the
         // offline receipt buffer. Adding a cache to collections() means moving
         // this boundary, or the sections shift.
-        const TTL_BOUNDED: usize = 8;
+        const TTL_BOUNDED: usize = 10;
         const SIGNAL_CACHES: usize = 3;
         const HISTORY_SYNC: usize = TTL_BOUNDED + SIGNAL_CACHES;
         const COMMIT_BATCH: usize = HISTORY_SYNC + 1;
@@ -699,6 +769,7 @@ impl std::fmt::Display for MemoryReport {
             self.group_metadata_inflight
         )?;
         writeln!(f, "  chat_lanes:             {}", self.chat_lanes)?;
+        writeln!(f, "  chat_lane_backlog:      {}", self.chat_lane_backlog)?;
         writeln!(
             f,
             "  group_dist_locks:       {} (evicted: {}, blocked: {})",

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -318,15 +318,16 @@ impl Client {
     /// byte figures.
     ///
     /// On-demand only: walks the in-process caches under their locks when
-    /// called, costs nothing otherwise. Counts are approximate (caches may
-    /// have pending evictions); call `run_pending_tasks()` on individual
-    /// caches first if you need exact counts.
+    /// called, costs nothing otherwise. Counts include entries that have
+    /// expired but not yet been swept; the sweep runs with the keepalive's
+    /// periodic maintenance ([`Self::run_cache_maintenance`]), so between
+    /// sweeps a count can exceed what a fresh lookup would find.
     pub async fn memory_report(&self) -> MemoryReport {
         use wacore::stats::{CollectionStats, HeapSize};
 
         let (signal_sessions, signal_identities, signal_sender_keys) =
             self.signal_cache.memory_stats().await;
-        let (lid_pn_lid_entries, lid_pn_pn_entries) = self.lid_pn_cache.memory_stats().await;
+        let lid_pn = self.lid_pn_cache.memory_stats().await;
         let pending_retries_count = self
             .pending_retries
             .lock()
@@ -364,6 +365,17 @@ impl Client {
             .memory_stats(|k, v| k.heap_bytes() + v.heap_bytes())
             .await;
         let group_distribution_locks = self.group_distribution_locks.capacity_stats().await;
+        // One awaited walk: a lane's queue length is a channel counter, so this
+        // reads each lane once and allocates nothing.
+        let (chat_lanes, chat_lane_backlog) = self
+            .chat_lanes
+            .fold_entries((0u64, 0u64), |(lanes, backlog), _, lane| {
+                (
+                    lanes + 1,
+                    backlog.saturating_add(u64::try_from(lane.queue_tx.len()).unwrap_or(u64::MAX)),
+                )
+            })
+            .await;
 
         // Each count read into a local so no two guards are ever held at once.
         let response_waiters = self.response_waiters_guard().len();
@@ -456,17 +468,19 @@ impl Client {
         MemoryReport {
             group_cache,
             device_registry_cache: self.device_registry_cache.memory_stats().await,
-            lid_pn_lid_entries,
-            lid_pn_pn_entries,
+            lid_pn_lid_entries: lid_pn.lid,
+            lid_pn_pn_entries: lid_pn.pn,
+            lid_pn_contact_hash_entries: lid_pn.contact_hash,
+            lid_pn_persisted_entries: lid_pn.persisted,
             recent_messages,
             sender_key_device_cache: self.sender_key_device_cache.memory_stats().await,
             group_devices_memo,
             dm_devices_memo,
-            message_retry_counts: self.message_retry_counts.entry_count(),
-            undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
-            dispatched_messages: self.dispatched_messages.entry_count(),
-            pdo_pending_requests: self.pdo_pending_requests.entry_count(),
-            pdo_requested: self.pdo_requested.entry_count(),
+            message_retry_counts: self.message_retry_counts.entry_count_async().await,
+            undecryptable_dispatched: self.undecryptable_dispatched.entry_count_async().await,
+            dispatched_messages: self.dispatched_messages.entry_count_async().await,
+            pdo_pending_requests: self.pdo_pending_requests.entry_count_async().await,
+            pdo_requested: self.pdo_requested.entry_count_async().await,
             history_sync_tasks,
             history_sync_tasks_peak: history_sync_activity.tasks_peak as u64,
             history_sync_payload_bytes_peak: history_sync_activity.payload_bytes_peak as u64,
@@ -474,16 +488,17 @@ impl Client {
             offline_receipt_buffer,
             msg_secret_buffer,
             pending_device_sync,
-            session_locks: self.session_locks.entry_count(),
+            session_locks: self.session_locks.entry_count_async().await,
             ensure_inflight: self.ensure_inflight.len() as u64,
             group_metadata_inflight: self.group_metadata_inflight.len() as u64,
-            chat_lanes: self.chat_lanes.entry_count(),
+            chat_lanes,
+            chat_lane_backlog,
             group_distribution_locks: group_distribution_locks.entries,
             group_distribution_lock_evictions: group_distribution_locks.evictions,
             group_distribution_lock_eviction_blocks: group_distribution_locks.eviction_blocks,
-            resend_rate_limiter_chats: self.resend_rate_limiter.entry_count(),
-            session_recreate_history: self.session_recreate_history.entry_count(),
-            skdm_warm_memo: self.skdm_warm_memo.entry_count(),
+            resend_rate_limiter_chats: self.resend_rate_limiter.entry_count_async().await,
+            session_recreate_history: self.session_recreate_history.entry_count_async().await,
+            skdm_warm_memo: self.skdm_warm_memo.entry_count_async().await,
             transport_ack_queue: self.transport_ack_queue.get().map_or(0, |tx| tx.len()),
             delivery_receipt_queue: self.delivery_receipt_queue.get().map_or(0, |tx| tx.len()),
             response_waiters,

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -243,8 +243,10 @@ impl DeviceRegistryCache {
         self.cache.memory_stats(|_k, v| v.heap_bytes()).await
     }
 
-    /// Test-only passthrough for cache maintenance flushes.
-    #[cfg(test)]
+    /// Sweep expired records (in-process backend only; a custom store expires
+    /// its own). Driven by [`Client::run_cache_maintenance`].
+    ///
+    /// [`Client::run_cache_maintenance`]: crate::client::Client::run_cache_maintenance
     pub(crate) async fn run_pending_tasks(&self) {
         self.cache.run_pending_tasks().await;
     }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4966,6 +4966,23 @@ async fn memory_report_display_sections_stay_aligned() {
         );
     }
 
+    // The lanes are capped; their queues are not, so the backlog belongs with
+    // the drain-bounded collections, not beside the lane count.
+    let capacity_start = rendered
+        .find("--- Capacity-only caches ---")
+        .expect("capacity section");
+    let unbounded_start = rendered
+        .find("--- Unbounded collections ---")
+        .expect("unbounded section");
+    assert!(
+        !rendered[capacity_start..unbounded_start].contains("chat_lane_backlog:"),
+        "chat_lane_backlog must not render as capacity-bounded, got:\n{rendered}"
+    );
+    assert!(
+        rendered[unbounded_start..signal_start].contains("chat_lane_backlog:"),
+        "chat_lane_backlog must render under the unbounded heading, got:\n{rendered}"
+    );
+
     // The last two `collections()` entries are transient retention, one section
     // each. Their order is what the two boundary constants encode, so a cache
     // appended to `collections()` without moving them lands here.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4927,6 +4927,8 @@ async fn memory_report_display_sections_stay_aligned() {
     for name in [
         "group_cache:",
         "device_registry_cache:",
+        "lid_pn (hash):",
+        "lid_pn (persisted):",
         "recent_messages:",
         "group_devices_memo:",
         "dm_devices_memo:",
@@ -5002,6 +5004,150 @@ async fn memory_report_counts_the_offline_device_sync_queue() {
 
     client.pending_device_sync.take_all();
     assert_eq!(client.memory_report().await.pending_device_sync, 0);
+}
+
+/// The LID/PN cache's side maps grow with the contact list for the process
+/// lifetime, one entry per identifier and one per persisted pair, and were
+/// invisible to the report; the counts must surface and the bytes must be the
+/// table alone, since both maps hold the entry's own strings.
+#[tokio::test]
+async fn memory_report_counts_lid_pn_side_maps() {
+    let client = crate::test_utils::create_test_client_with_name("lid_pn_side_maps").await;
+    let before = client.memory_report().await;
+    assert_eq!(before.lid_pn_contact_hash_entries.entries, 0);
+    assert_eq!(before.lid_pn_persisted_entries.entries, 0);
+
+    let entry = crate::lid_pn_cache::LidPnEntry::new(
+        "100000000000002".to_string(),
+        "19045550180".to_string(),
+        LearningSource::Usync,
+    );
+    client.lid_pn_cache.add(&entry).await;
+    client
+        .lid_pn_cache
+        .mark_persisted(&entry.phone_number, &entry.lid)
+        .await;
+
+    let report = client.memory_report().await;
+    assert_eq!(
+        report.lid_pn_contact_hash_entries.entries, 2,
+        "both sides of a pair are hash-indexed"
+    );
+    assert_eq!(report.lid_pn_persisted_entries.entries, 1);
+    assert!(
+        report.lid_pn_contact_hash_entries.bytes > 0 && report.lid_pn_persisted_entries.bytes > 0,
+        "table structure is charged even though the strings are the entry's"
+    );
+    assert!(
+        report.lid_pn_contact_hash_entries.bytes < report.lid_pn_lid_entries.bytes,
+        "a side map must not re-charge the payload the entry map already counts"
+    );
+    let names: Vec<&str> = report
+        .unbounded_counts()
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert!(names.contains(&"lid_pn_contact_hash_entries"));
+    assert!(names.contains(&"lid_pn_persisted_entries"));
+}
+
+/// A lane's queue is unbounded and each queued message retains its frame, so
+/// a stuck worker is a backlog the report has to show; the lane count alone
+/// reads the same whether the queues are empty or a million deep.
+#[tokio::test]
+async fn memory_report_sums_chat_lane_backlog() {
+    let client = crate::test_utils::create_test_client_with_name("chat_lane_backlog").await;
+    assert_eq!(client.memory_report().await.chat_lane_backlog, 0);
+
+    // A lane with no worker: nothing drains what is enqueued.
+    let chat: Jid = "120363000000000042@g.us".parse().unwrap();
+    let (queue_tx, _queue_rx) = async_channel::unbounded();
+    let lane = ChatLane {
+        enqueue_lock: Arc::new(Mutex::new(())),
+        queue_tx,
+        worker_running: Arc::new(Mutex::new(())),
+    };
+    client.chat_lanes.insert(chat.clone(), lane.clone()).await;
+    for id in ["A", "B", "C"] {
+        let node = NodeBuilder::new("message")
+            .attr("from", chat.clone())
+            .attr("id", id)
+            .build();
+        lane.try_enqueue(node_to_owned_ref(node))
+            .expect("an unbounded lane queue accepts every message");
+    }
+
+    let report = client.memory_report().await;
+    assert_eq!(report.chat_lanes, 1);
+    assert_eq!(report.chat_lane_backlog, 3);
+    assert!(
+        report
+            .unbounded_counts()
+            .contains(&("chat_lane_backlog", 3)),
+        "the backlog is a drain-bounded collection, so the soak compares it"
+    );
+}
+
+/// An online device refresh releases its dedup entry when it finishes. Left
+/// in place, the entry outlived the refresh by the whole connection: the user
+/// was retained until teardown, and a later unknown device from them never
+/// triggered another refresh.
+#[tokio::test]
+async fn online_device_sync_releases_its_dedup_entry() {
+    let client = crate::test_utils::create_test_client_with_name("online_device_sync").await;
+    let jid: Jid = "19045550180@s.whatsapp.net".parse().unwrap();
+
+    // Not connected, so the refresh fails; the release must not depend on it
+    // succeeding.
+    client
+        .schedule_unknown_device_sync(jid.clone(), false)
+        .await;
+    for _ in 0..1_000 {
+        if client.pending_device_sync.len() == 0 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        client.pending_device_sync.len(),
+        0,
+        "the dedup entry must leave with the refresh that took it"
+    );
+    assert!(
+        client.pending_device_sync.add(&jid),
+        "a later unknown device from the same user triggers a refresh again"
+    );
+}
+
+/// Expired entries leave a quiet cache only when something sweeps: nothing
+/// accesses them and nothing inserts, so without the maintenance tick the
+/// dedup gates hold five-minute-old keys for weeks.
+#[tokio::test]
+async fn cache_maintenance_sweeps_expired_entries() {
+    let mut cache_config = CacheConfig::default();
+    cache_config.dispatched_messages =
+        crate::cache_config::CacheEntryConfig::new(Some(Duration::from_millis(20)), 64);
+    let client = crate::test_utils::create_test_client_with_config(
+        "cache_maintenance",
+        Arc::new(MockHttpClient),
+        cache_config,
+    )
+    .await;
+
+    let chat: Jid = "19045550180@s.whatsapp.net".parse().unwrap();
+    let key =
+        wacore::types::message::SenderMessageId::new(chat.clone(), "3EB0EXPIRING".into(), chat);
+    client.dispatched_messages.insert(key, ()).await;
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(
+        client.dispatched_messages.entry_count_async().await,
+        1,
+        "a quiet cache keeps its expired entry until swept"
+    );
+
+    client.run_cache_maintenance().await;
+    assert_eq!(client.dispatched_messages.entry_count_async().await, 0);
+    assert_eq!(client.memory_report().await.dispatched_messages, 0);
 }
 
 #[tokio::test]

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4921,14 +4921,14 @@ async fn memory_report_display_sections_stay_aligned() {
     let ttl_start = rendered
         .find("--- TTL-bounded caches ---")
         .expect("ttl section");
+    let lid_pn_start = rendered.find("--- LID/PN maps").expect("lid/pn section");
     let signal_start = rendered.find("--- Signal store").expect("signal section");
-    let ttl_block = &rendered[ttl_start..signal_start];
+    let ttl_block = &rendered[ttl_start..lid_pn_start];
+    let lid_pn_block = &rendered[lid_pn_start..signal_start];
 
     for name in [
         "group_cache:",
         "device_registry_cache:",
-        "lid_pn (hash):",
-        "lid_pn (persisted):",
         "recent_messages:",
         "group_devices_memo:",
         "dm_devices_memo:",
@@ -4936,6 +4936,23 @@ async fn memory_report_display_sections_stay_aligned() {
         assert!(
             ttl_block.contains(name),
             "{name} must render under the TTL-bounded heading, got:\n{rendered}"
+        );
+    }
+    // No TTL bounds these; a contact-list-sized map rendered as a TTL-bounded
+    // cache would make sustained growth read as normal cache activity.
+    for name in [
+        "lid_pn (lid):",
+        "lid_pn (pn):",
+        "lid_pn (hash):",
+        "lid_pn (persisted):",
+    ] {
+        assert!(
+            lid_pn_block.contains(name),
+            "{name} must render under the LID/PN heading, got:\n{rendered}"
+        );
+        assert!(
+            !ttl_block.contains(name),
+            "{name} must not render as a TTL-bounded cache, got:\n{rendered}"
         );
     }
     for name in [
@@ -5117,6 +5134,38 @@ async fn online_device_sync_releases_its_dedup_entry() {
         client.pending_device_sync.add(&jid),
         "a later unknown device from the same user triggers a refresh again"
     );
+}
+
+/// A runtime may drop a spawned future before its first poll. The release
+/// guard is built before the spawn and moved into the task, so even then the
+/// dedup entry leaves with the work it was deduplicating.
+#[tokio::test]
+async fn online_device_sync_releases_its_dedup_entry_when_never_polled() {
+    let pm = Arc::new(
+        PersistenceManager::new(crate::test_utils::create_test_backend().await)
+            .await
+            .expect("persistence manager should initialize"),
+    );
+    let (client, _rx) = Client::new_with_cache_config(
+        Arc::new(DropSpawnRuntime),
+        pm,
+        Arc::new(crate::transport::mock::MockTransportFactory::new()),
+        Arc::new(MockHttpClient),
+        None,
+        CacheConfig::default(),
+    )
+    .await;
+    let jid: Jid = "19045550180@s.whatsapp.net".parse().unwrap();
+
+    client
+        .schedule_unknown_device_sync(jid.clone(), false)
+        .await;
+    assert_eq!(
+        client.pending_device_sync.len(),
+        0,
+        "a task dropped before its first poll must still release its entry"
+    );
+    assert!(client.pending_device_sync.add(&jid));
 }
 
 /// Expired entries leave a quiet cache only when something sweeps: nothing

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -166,6 +166,7 @@ impl Client {
                     if cleanup_counter >= 12 {
                         cleanup_counter = 0;
                         self.spawn_retention_cleanup(sent_msg_ttl);
+                        self.spawn_cache_maintenance();
                     }
 
                     // Same reason as the retention sweep above: driven by the
@@ -243,6 +244,47 @@ impl Client {
                 }
             }
         }
+    }
+
+    /// Sweep expired entries out of the in-process caches.
+    ///
+    /// The caches expire lazily: an entry is dropped on the access that finds
+    /// it stale, or on capacity pressure from a new insert. Neither happens on
+    /// a quiet connection, so without a timer a client that fanned out to a
+    /// large group set once kept every one of those records — up to the
+    /// 20 000-entry device registry — for as long as it stayed connected.
+    /// This is that timer. Store-backed caches expire on their own and the
+    /// wrappers no-op for them; capacity-only caches have nothing to expire
+    /// and are left alone.
+    ///
+    /// Runs on the keepalive's ~5-minute maintenance tick, not every tick and
+    /// never on the receive path: each sweep takes its cache's write lock for
+    /// a full walk of the table.
+    pub async fn run_cache_maintenance(&self) {
+        self.recent_messages.run_pending_tasks().await;
+        self.message_retry_counts.run_pending_tasks().await;
+        self.session_recreate_history.run_pending_tasks().await;
+        self.undecryptable_dispatched.run_pending_tasks().await;
+        self.dispatched_messages.run_pending_tasks().await;
+        self.pdo_pending_requests.run_pending_tasks().await;
+        self.pdo_requested.run_pending_tasks().await;
+        self.device_registry_cache.run_pending_tasks().await;
+        self.sender_key_device_cache.run_pending_tasks().await;
+        self.lid_pn_cache.run_pending_tasks().await;
+        // `get()`, not `get_group_cache()`: maintenance must not be what
+        // builds a cache the client never used.
+        if let Some(group_cache) = self.group_cache.get() {
+            group_cache.run_pending_tasks().await;
+        }
+    }
+
+    fn spawn_cache_maintenance(self: &Arc<Self>) {
+        let client = Arc::clone(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                client.run_cache_maintenance().await;
+            }))
+            .detach();
     }
 
     /// Fire-and-forget DB retention sweeps. Each TTL gates its own delete so

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -84,6 +84,19 @@ pub struct LidPnCache {
     persisted: TypedCache<Arc<str>, Arc<str>>,
 }
 
+/// What [`LidPnCache::memory_stats`] reports: one figure per internal map.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LidPnMemory {
+    /// LID → entry, charged with the entry payloads.
+    pub lid: wacore::stats::CollectionStats,
+    /// PN → entry; bytes cover only entries the LID map no longer shares.
+    pub pn: wacore::stats::CollectionStats,
+    /// Contact hash → LID, structural bytes only (the LID is the entry's).
+    pub contact_hash: wacore::stats::CollectionStats,
+    /// PN → persisted LID, structural bytes only (both strings are the entry's).
+    pub persisted: wacore::stats::CollectionStats,
+}
+
 /// Proof that LID/PN mapping mutations are serialized.
 pub(crate) struct LidPnMutationGuard<'a> {
     _guard: async_lock::MutexGuard<'a, ()>,
@@ -158,12 +171,7 @@ impl LidPnCache {
     /// the LID map no longer holds (transient eviction asymmetry), keeping
     /// every entry counted exactly once. `Arc<T>`'s `HeapSize` already
     /// includes `size_of::<LidPnEntry>()`.
-    pub async fn memory_stats(
-        &self,
-    ) -> (
-        wacore::stats::CollectionStats,
-        wacore::stats::CollectionStats,
-    ) {
+    pub async fn memory_stats(&self) -> LidPnMemory {
         use wacore::stats::HeapSize;
         // Dedup by heap address as `usize`, not `*const LidPnEntry`: a raw-pointer
         // set is `!Send`, and held across the two `.await`s below it would make
@@ -187,7 +195,32 @@ impl LidPnCache {
                 }
             })
             .await;
-        (lid, pn)
+        // Both side maps hold only `Arc<str>`s the entries above already own
+        // (`contact_hash_to_lid` clones the entry's LID; `persisted` takes the
+        // entry's own pair), so their payload is charged once, at the entry.
+        // What they add is table structure, which `memory_stats` charges
+        // itself — and that is the part that grows with the contact count for
+        // the whole process lifetime, which is why they are reported at all.
+        let contact_hash = self.contact_hash_to_lid.memory_stats(|_, _| 0).await;
+        let persisted = self.persisted.memory_stats(|_, _| 0).await;
+        LidPnMemory {
+            lid,
+            pn,
+            contact_hash,
+            persisted,
+        }
+    }
+
+    /// Sweep entries past the configured idle timeout (a no-op for the
+    /// default, unbounded configuration, and for store-backed maps). Driven by
+    /// [`Client::run_cache_maintenance`].
+    ///
+    /// [`Client::run_cache_maintenance`]: crate::client::Client::run_cache_maintenance
+    pub async fn run_pending_tasks(&self) {
+        self.lid_to_entry.run_pending_tasks().await;
+        self.pn_to_entry.run_pending_tasks().await;
+        self.contact_hash_to_lid.run_pending_tasks().await;
+        self.persisted.run_pending_tasks().await;
     }
 
     /// Get the current LID for a phone number.

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -201,8 +201,8 @@ impl LidPnCache {
         // What they add is table structure, which `memory_stats` charges
         // itself — and that is the part that grows with the contact count for
         // the whole process lifetime, which is why they are reported at all.
-        let contact_hash = self.contact_hash_to_lid.memory_stats(|_, _| 0).await;
-        let persisted = self.persisted.memory_stats(|_, _| 0).await;
+        let contact_hash = self.contact_hash_to_lid.structural_stats().await;
+        let persisted = self.persisted.structural_stats().await;
         LidPnMemory {
             lid,
             pn,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1716,6 +1716,12 @@ impl Client {
     /// pending/in-flight), then offline → batch for `doPendingDeviceSync`, online
     /// → invalidate + usync immediately. WA Web: online `syncDeviceListJob`,
     /// offline `OfflinePendingDeviceCache`.
+    ///
+    /// The online path releases its dedup entry when the refresh finishes.
+    /// Left in place, the entry outlived the refresh by the whole connection:
+    /// a user who added a second new device weeks later never got another
+    /// refresh, and every such user was retained until teardown. WA Web's
+    /// `syncDeviceListJob` is likewise keyed only while the job runs.
     pub(crate) async fn schedule_unknown_device_sync(
         self: &Arc<Self>,
         user_jid: Jid,
@@ -1739,6 +1745,14 @@ impl Client {
             let client = Arc::clone(self);
             self.runtime
                 .spawn(Box::pin(async move {
+                    // A guard, not a trailing call: the refresh can fail or be
+                    // cancelled with the runtime, and either way the dedup must
+                    // not outlive the work it was deduplicating.
+                    let released = Arc::clone(&client);
+                    let release_jid = user_jid.clone();
+                    let _release = scopeguard::guard((), move |()| {
+                        released.pending_device_sync.remove(&release_jid);
+                    });
                     client.invalidate_device_cache(&user_jid.user).await;
                     if let Err(e) = client.get_user_devices(&[user_jid]).await {
                         log::warn!("Immediate device sync failed: {e:?}");

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1743,16 +1743,18 @@ impl Client {
                 user_jid.observe()
             );
             let client = Arc::clone(self);
+            // A guard, not a trailing call, and built before the spawn rather
+            // than inside the task: the refresh can fail, be cancelled with the
+            // runtime, or be dropped before its first poll, and in every case
+            // the dedup must not outlive the work it was deduplicating.
+            let released = Arc::clone(self);
+            let release_jid = user_jid.clone();
+            let release = scopeguard::guard((), move |()| {
+                released.pending_device_sync.remove(&release_jid);
+            });
             self.runtime
                 .spawn(Box::pin(async move {
-                    // A guard, not a trailing call: the refresh can fail or be
-                    // cancelled with the runtime, and either way the dedup must
-                    // not outlive the work it was deduplicating.
-                    let released = Arc::clone(&client);
-                    let release_jid = user_jid.clone();
-                    let _release = scopeguard::guard((), move |()| {
-                        released.pending_device_sync.remove(&release_jid);
-                    });
+                    let _release = release;
                     client.invalidate_device_cache(&user_jid.user).await;
                     if let Err(e) = client.get_user_devices(&[user_jid]).await {
                         log::warn!("Immediate device sync failed: {e:?}");

--- a/src/pending_device_sync.rs
+++ b/src/pending_device_sync.rs
@@ -41,10 +41,21 @@ impl PendingDeviceSync {
         std::mem::take(&mut *self.lock()).into_iter().collect()
     }
 
-    /// Users queued for the next `doPendingDeviceSync`, plus the users an
-    /// online refresh already covered — [`Self::add`] is the dedup for both, and
-    /// only [`Self::take_all`] and [`Self::clear`] remove anything, so an entry
-    /// added by the online path stays until the next drain or teardown.
+    /// Release a user whose online refresh has finished, so the next unknown
+    /// device from them triggers a refresh again instead of hitting the dedup
+    /// for the rest of the connection. A no-op for an entry an offline drain
+    /// already took.
+    pub(crate) fn remove(&self, jid: &Jid) {
+        let mut pending = self.lock();
+        pending.remove(jid);
+        crate::client::release_after_burst(&mut pending);
+    }
+
+    /// Users queued for the next `doPendingDeviceSync`, plus the users with an
+    /// online refresh in flight — [`Self::add`] is the dedup for both. Offline
+    /// entries leave with [`Self::take_all`]; an online entry leaves when its
+    /// refresh finishes ([`Self::remove`]), so outside a drain this holds only
+    /// what is in flight.
     ///
     /// The set has no capacity cap, and a cap would be the wrong fix: dropping a
     /// user silently skips a device refresh and leaves the next send to them

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -1002,12 +1002,15 @@ where
     }
 
     pub async fn run_pending_tasks(&self) {
-        let now = self.entry_time();
-        let mut guard = self.inner.write().await;
-
-        guard.retain_unexpired(|entry| self.is_expired(entry, now));
-
-        drop(guard);
+        // Nothing can be expired without a TTL or TTI, so a cache configured
+        // with neither (the coordination caches, the default LID/PN maps)
+        // skips the write lock and the table walk; only the init-lock sweep
+        // below applies to it.
+        if self.ttl.is_some() || self.tti.is_some() {
+            let now = self.entry_time();
+            let mut guard = self.inner.write().await;
+            guard.retain_unexpired(|entry| self.is_expired(entry, now));
+        }
 
         // Clean up init locks not actively held. `get()`, not `init_locks()`: a
         // cache that never single-flighted has no registry to sweep, and building

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -135,6 +135,10 @@ enum ClockWalk {
 /// compiled once, and each `<K, V>` cache contributes only the probe, which
 /// is the `find` its eviction hook already carries. A `retain` over the
 /// table and the order map would be a second full walk per instantiation.
+/// `inline(never)`: under fat LTO the optimizer would otherwise inline this
+/// into every instantiation of the caller, which is the duplication it exists
+/// to avoid.
+#[inline(never)]
 fn expiry_walk(
     order: &BTreeMap<u64, u64>,
     probe: &mut dyn FnMut(u64, u64) -> bool,

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -130,6 +130,24 @@ enum ClockWalk {
     Blocked,
 }
 
+/// The `(seq, hash)` pairs in `order` whose entry `probe` reports expired.
+/// Same shape as [`clock_walk`], and for the same reason: the walk is
+/// compiled once, and each `<K, V>` cache contributes only the probe, which
+/// is the `find` its eviction hook already carries. A `retain` over the
+/// table and the order map would be a second full walk per instantiation.
+fn expiry_walk(
+    order: &BTreeMap<u64, u64>,
+    probe: &mut dyn FnMut(u64, u64) -> bool,
+) -> Vec<(u64, u64)> {
+    let mut expired = Vec::new();
+    for (&seq, &hash) in order.iter() {
+        if probe(seq, hash) {
+            expired.push((seq, hash));
+        }
+    }
+    expired
+}
+
 /// One pass of the second-chance walk over `order`, oldest first: the first
 /// unreferenced, unheld entry is the victim; entries hit since the last pass
 /// have their bit cleared (by `probe`) and re-queue behind everything
@@ -182,10 +200,11 @@ struct CacheInner<K, V> {
     /// stored `seq`. The hash plus the seq find the slot in `table`, so no key
     /// is stored here.
     ///
-    /// Left empty for a cache that has no capacity bound: nothing could ever
-    /// pop it, so maintaining it would spend a `BTreeMap` node per entry on a
-    /// structure that is never read. The unbounded LID↔PN caches hold tens
-    /// of thousands of entries for the life of the process.
+    /// Left empty for a cache that has neither a capacity bound nor a time
+    /// bound: nothing could ever pop or expire an entry, so maintaining it
+    /// would spend a `BTreeMap` node per entry on a structure that is never
+    /// read. The unbounded LID↔PN caches hold tens of thousands of entries
+    /// for the life of the process.
     order: BTreeMap<u64, u64>,
     track_order: bool,
     /// Next FIFO sequence to assign.
@@ -392,12 +411,24 @@ where
         );
     }
 
-    /// Drop expired entries and the FIFO records that named them.
+    /// Drop expired entries and the FIFO records that named them. Driven by
+    /// `order`, which every cache that expires by time maintains (see
+    /// `PortableCacheBuilder::build`), so the walk itself is [`expiry_walk`].
     fn retain_unexpired(&mut self, mut is_expired: impl FnMut(&CacheEntry<V>) -> bool) {
-        let table = &mut self.table;
-        let order = &mut self.order;
-        table.retain(|slot| !is_expired(&slot.entry));
-        order.retain(|seq, hash| table.find(*hash, |slot| slot.entry.seq == *seq).is_some());
+        debug_assert!(
+            self.track_order,
+            "a cache that expires by time tracks order; the sweep walks it"
+        );
+        let table = &self.table;
+        let expired = expiry_walk(&self.order, &mut |seq, hash| {
+            table
+                .find(hash, |slot| slot.entry.seq == seq)
+                .is_some_and(|slot| is_expired(&slot.entry))
+        });
+        for (seq, hash) in expired {
+            self.order.remove(&seq);
+            self.remove_by_seq(hash, seq);
+        }
     }
 }
 
@@ -557,10 +588,15 @@ where
             "a cache with an evict_guard holds live coordination objects and must not expire by time"
         );
 
+        // Order is what eviction pops and what the expiry sweep walks, so a
+        // cache with either a capacity bound or a time bound keeps it. A cache
+        // with neither (the default LID/PN maps) is never swept and skips the
+        // BTreeMap node per entry.
+        let track_order = self.max_capacity.is_some_and(|cap| cap != u64::MAX)
+            || self.ttl.is_some()
+            || self.tti.is_some();
         PortableCache {
-            inner: Arc::new(RwLock::new(CacheInner::new(
-                self.max_capacity.is_some_and(|cap| cap != u64::MAX),
-            ))),
+            inner: Arc::new(RwLock::new(CacheInner::new(track_order))),
             init_locks: OnceLock::new(),
             max_capacity: self.max_capacity,
             ttl: self.ttl,
@@ -864,6 +900,14 @@ where
     pub async fn fold_entries<A>(&self, init: A, mut f: impl FnMut(A, &K, &V) -> A) -> A {
         let guard = self.inner.read().await;
         guard.iter().fold(init, |acc, (k, e)| f(acc, k, &e.value))
+    }
+
+    /// Entry count plus the bytes of the table and eviction order alone, for
+    /// a cache whose payload is already charged elsewhere. No per-entry walk,
+    /// so nothing is instantiated per `<K, V>` beyond the size arithmetic.
+    pub async fn structural_stats(&self) -> wacore::stats::CollectionStats {
+        let guard = self.inner.read().await;
+        wacore::stats::CollectionStats::new(guard.len() as u64, guard.structural_bytes() as u64)
     }
 
     /// Entry count plus estimated retained bytes: the table and eviction

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -825,8 +825,18 @@ where
         self.max_capacity
     }
 
+    /// Best-effort entry count: a `try_read` that answers `0` while a writer
+    /// holds the lock. Fine on a hot path that only needs a hint; a report
+    /// wants [`entry_count_async`](Self::entry_count_async), which cannot
+    /// under-read a cache that is being written to.
     pub fn entry_count(&self) -> u64 {
         self.inner.try_read().map(|g| g.len() as u64).unwrap_or(0)
+    }
+
+    /// Entry count under an awaited read guard. Includes expired entries not
+    /// yet swept, like [`entry_count`](Self::entry_count).
+    pub async fn entry_count_async(&self) -> u64 {
+        self.inner.read().await.len() as u64
     }
 
     pub(crate) async fn capacity_stats(&self) -> CapacityStats {

--- a/src/resend_rate_limiter.rs
+++ b/src/resend_rate_limiter.rs
@@ -131,9 +131,10 @@ impl ResendRateLimiter {
         self.throttled_total.load(Ordering::Relaxed)
     }
 
-    /// Number of chats holding a live bucket (diagnostics).
-    pub(crate) fn entry_count(&self) -> u64 {
-        self.buckets.entry_count()
+    /// Number of chats holding a live bucket (diagnostics). Awaited, so a
+    /// report taken during a resend burst does not read `0`.
+    pub(crate) async fn entry_count_async(&self) -> u64 {
+        self.buckets.entry_count_async().await
     }
 }
 
@@ -207,7 +208,7 @@ mod tests {
             assert!(limiter.try_acquire(&c).await);
         }
         assert_eq!(
-            limiter.entry_count(),
+            limiter.entry_count_async().await,
             0,
             "disabled limiter creates no buckets"
         );

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -300,6 +300,14 @@ impl SenderKeyDeviceCache {
             .memory_stats(|k, v| k.capacity() + v.retained_bytes())
             .await
     }
+
+    /// Sweep maps idle past their TTI. Driven by
+    /// [`Client::run_cache_maintenance`].
+    ///
+    /// [`Client::run_cache_maintenance`]: crate::client::Client::run_cache_maintenance
+    pub(crate) async fn run_pending_tasks(&self) {
+        self.inner.run_pending_tasks().await;
+    }
 }
 
 #[cfg(test)]

--- a/tests/e2e/tests/memory_soak.rs
+++ b/tests/e2e/tests/memory_soak.rs
@@ -94,64 +94,23 @@ fn analyze_growth(label: &str, snapshots: &[Snapshot]) {
         first.round, last.round
     );
 
-    // Unbounded collections: must not grow beyond a small constant
-    let checks: Vec<(&str, usize, usize)> = vec![
-        (
-            "response_waiters",
-            first.diag.response_waiters,
-            last.diag.response_waiters,
-        ),
-        (
-            "node_waiters",
-            first.diag.node_waiters,
-            last.diag.node_waiters,
-        ),
-        (
-            "pending_retries",
-            first.diag.pending_retries,
-            last.diag.pending_retries,
-        ),
-        (
-            "presence_subscriptions",
-            first.diag.presence_subscriptions,
-            last.diag.presence_subscriptions,
-        ),
-        (
-            "app_state_key_requests",
-            first.diag.app_state_key_requests,
-            last.diag.app_state_key_requests,
-        ),
-        (
-            "app_state_syncing",
-            first.diag.app_state_syncing,
-            last.diag.app_state_syncing,
-        ),
-        (
-            "signal_sessions",
-            first.diag.signal_sessions.entries as usize,
-            last.diag.signal_sessions.entries as usize,
-        ),
-        (
-            "signal_identities",
-            first.diag.signal_identities.entries as usize,
-            last.diag.signal_identities.entries as usize,
-        ),
-        (
-            "signal_sender_keys",
-            first.diag.signal_sender_keys.entries as usize,
-            last.diag.signal_sender_keys.entries as usize,
-        ),
-        (
-            "chatstate_handlers",
-            first.diag.chatstate_handlers,
-            last.diag.chatstate_handlers,
-        ),
-        (
-            "custom_enc_handlers",
-            first.diag.custom_enc_handlers,
-            last.diag.custom_enc_handlers,
-        ),
-    ];
+    // Unbounded collections: must not grow beyond a small constant. The list
+    // comes from the report itself, so a collection added there is checked
+    // here without anyone editing this test.
+    let last_counts = last.diag.unbounded_counts();
+    let checks: Vec<(&str, usize, usize)> = first
+        .diag
+        .unbounded_counts()
+        .into_iter()
+        .zip(last_counts)
+        .map(|((name, first_val), (last_name, last_val))| {
+            assert_eq!(
+                name, last_name,
+                "unbounded_counts() must be stable in order"
+            );
+            (name, first_val as usize, last_val as usize)
+        })
+        .collect();
 
     let mut warnings = Vec::new();
     for (name, first_val, last_val) in &checks {


### PR DESCRIPTION
Third round of the long-running-session work: an idle client should not retain what it no longer needs, and everything whose only bound is a drain has to be visible in `memory_report()` so a soak can compare it between snapshots.

## What changes

| Change | Why it matters over weeks of uptime | Test |
| --- | --- | --- |
| **Cache maintenance sweep** (`Client::run_cache_maintenance`, spawned from the keepalive's existing ~5-minute maintenance tick) | `PortableCache` expires lazily: an entry leaves on the access that finds it stale or on capacity pressure from a new insert. A quiet connection does neither, and `run_pending_tasks` had no production caller, so a client that fanned out to a large group set once kept every one of those records — up to the 20 000-entry device registry — until it disconnected. The sweep covers every TTL/TTI cache (`recent_messages`, `message_retry_counts`, `session_recreate_history`, `undecryptable_dispatched`, `dispatched_messages`, `pdo_*`, `device_registry_cache`, `sender_key_device_cache`, `lid_pn_cache`, `group_cache` when built); store-backed caches no-op, capacity-only caches are left alone. | `cache_maintenance_sweeps_expired_entries` |
| **Online device refresh releases its dedup entry** (`schedule_unknown_device_sync`) | The online path added the user to `pending_device_sync` and nothing removed it until the next offline drain or teardown. On a connection that never drained, every user seen with an unknown device was retained for the connection's lifetime — and worse, a user who added a second new device weeks later never got another refresh, because the dedup still matched. A `scopeguard` now releases the entry when the refresh finishes, whatever the outcome (this is what WA Web's `syncDeviceListJob` keying does). | `online_device_sync_releases_its_dedup_entry` |
| **LID/PN side maps reported** (`lid_pn_contact_hash_entries`, `lid_pn_persisted_entries`) | The contact-hash index and the persisted-pair map are unbounded with the cache they index, one entry per identifier and one per persisted pair, and were invisible. Both hold the entry's own `Arc<str>`s, so the report charges table structure only — the part that grows with the contact list. | `memory_report_counts_lid_pn_side_maps` |
| **Chat-lane backlog reported** (`chat_lane_backlog`) | The lanes are capped; their `async_channel::unbounded` queues are not, and each queued message retains its whole inbound frame. The lane count reads the same whether the queues are empty or a million deep. One awaited fold over the lanes sums the channel counters. | `memory_report_sums_chat_lane_backlog` |
| **Awaited entry counts in the report** (`PortableCache::entry_count_async`, used for the ten count-only fields) | `entry_count()` is a `try_read` that answers `0` while a writer holds the lock, so a report taken under load silently under-read exactly the caches that were busy. | covered by the report tests above (`resend_rate_limiter` test moved to the awaited count) |
| **`MemoryReport::unbounded_counts()`** and the e2e memory soak driven off it | `memory_soak.rs::analyze_growth` compared a hand-copied list of eleven fields; a collection added to the report was not added to the soak. The list now lives beside the fields. | `cargo check -p e2e-tests --tests`; the soak stays `#[ignore]`d as before |
| **Docs** (`agent_docs/observability.md`) | `device_registry_cache` said 5 000 (it is 20 000), the topology log said 256 (4 096), the sync queue said 32 (8), and the `pending_device_sync` paragraph described the behaviour this PR removes. Adds the "a TTL is a bound only if something sweeps" rule and the two new unbounded entries. | — |

`MemoryReport` is `#[non_exhaustive]`, so the three new fields are additive. `LidPnCache::memory_stats` now returns a `LidPnMemory` struct instead of a 2-tuple (`pub`, but only the report consumed it).

## Measured

Local, `cargo test` debug build, `cache_maintenance_sweeps_expired_entries`: a `dispatched_messages` entry past its TTL stays at `entry_count_async() == 1` indefinitely on a quiet client and reads `0` after one `run_cache_maintenance()`. The sweep takes each cache's write lock for one table walk, which is why it rides the 12-tick maintenance cadence rather than every tick and never the receive path.

Validation: `cargo fmt`, `cargo test -p whatsapp-rust --lib` (1889 passed), `cargo test --test report_coverage`, `cargo check -p e2e-tests --tests`, `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings`.

## CI note

Semver Checks is informational and red on `main` independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_