### PR TITLE
fix(conn): bound every teardown and retire what a connection leaves behind

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2172,6 +2172,23 @@ pub(crate) fn should_reset_backoff(
         })
 }
 
+/// Ceiling on the consecutive-failure count that drives the reconnect backoff.
+///
+/// The delay is already pinned at the 900 s cap from attempt 17 on, so every
+/// value past that names the same wait — what would keep growing is only the
+/// number itself, which `stats().reconnect_errors` reports and which a 429 adds
+/// five to at a time. A link that flaps for weeks would run it up without
+/// bound, so it saturates here instead: far enough beyond the cap that the
+/// schedule is untouched, close enough that the counter stays a number a
+/// consumer can read.
+pub(crate) const MAX_BACKOFF_ATTEMPTS: u32 = 64;
+
+/// The consecutive-failure count that follows `previous`, saturating at
+/// [`MAX_BACKOFF_ATTEMPTS`].
+pub(crate) fn next_backoff_attempt(previous: u32) -> u32 {
+    previous.saturating_add(1).min(MAX_BACKOFF_ATTEMPTS)
+}
+
 /// Computes a reconnect delay matching WhatsApp Web's Fibonacci backoff:
 /// `{ algo: { type: "fibonacci", first: 1000, second: 1000 }, jitter: 0.1, max: 9e5 }`
 ///
@@ -2183,6 +2200,13 @@ fn fibonacci_backoff(attempt: u32) -> Duration {
     let mut a: u64 = 1000;
     let mut b: u64 = 1000;
     for _ in 0..attempt {
+        // Every step past the cap yields the cap again, so the loop stops at
+        // the first one instead of counting out an attempt number nothing else
+        // bounds. Same clamp `prekeys.rs` applies to its own retry exponent,
+        // and the same reason.
+        if a >= MAX_MS {
+            break;
+        }
         let next = a.saturating_add(b).min(MAX_MS);
         a = b;
         b = next;
@@ -2192,8 +2216,11 @@ fn fibonacci_backoff(attempt: u32) -> Duration {
     // ±10% jitter (WA Web: jitter: 0.1)
     let jitter_range = base / 10;
     let jitter = if jitter_range > 0 {
-        rand::make_rng::<rand::rngs::StdRng>().random_range(0..=(jitter_range * 2)) as i64
-            - jitter_range as i64
+        // The thread-local generator, not a fresh `StdRng`: seeding one runs a
+        // full ChaCha key schedule off OS entropy to draw a single number
+        // (measured at 14.8 us against 808 ns for the draw, which is why
+        // `keepalive_loop` hoists its own out of the loop).
+        rand::rng().random_range(0..=(jitter_range * 2)) as i64 - jitter_range as i64
     } else {
         0
     };

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1378,7 +1378,15 @@ impl Client {
     /// snapshot silently never happens.
     fn schedule_app_state_task_retry(self: &Arc<Self>, name: WAPatchName, full_sync: bool) {
         let mut scope = self.sync_scope(None);
-        let client = self.clone();
+        // Weak across the sleep: the backoff doubles to an hour, and holding a
+        // strong reference through it keeps the entire client graph — caches,
+        // stores, subsystems — alive for that long after the application has
+        // dropped its handle, and defers the `Drop` that signals shutdown. The
+        // runtime handle is kept separately so the sleep needs nothing from the
+        // client, and the loop re-acquires a strong reference for the round it
+        // is about to run and releases it again at the end of the iteration.
+        let weak_client = Arc::downgrade(self);
+        let runtime = self.runtime.clone();
         self.runtime.spawn_detached(Box::pin(async move {
             // Attempts and rounds are counted separately: a wait that ran out
             // never reached the server, so spending an attempt on it would let a
@@ -1389,7 +1397,11 @@ impl Client {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                client.runtime.sleep(app_state_retry_backoff(attempts)).await;
+                runtime.sleep(app_state_retry_backoff(attempts)).await;
+                let Some(client) = weak_client.upgrade() else {
+                    debug!(target: "Client/AppState", "App state task retry cancelled: client is gone");
+                    return;
+                };
                 if client.is_terminal() {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
                     return;
@@ -1495,7 +1507,11 @@ impl Client {
         if collections.is_empty() {
             return;
         }
-        let client = self.clone();
+        // Weak across the sleep, for the same reason as
+        // `schedule_app_state_task_retry`: an hour-long backoff must not keep
+        // the client graph alive after the application lets go of it.
+        let weak_client = Arc::downgrade(self);
+        let runtime = self.runtime.clone();
         self.runtime.spawn_detached(Box::pin(async move {
             let mut scope = scope;
             let mut settles = settles;
@@ -1517,7 +1533,11 @@ impl Client {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                client.runtime.sleep(app_state_retry_backoff(attempts)).await;
+                runtime.sleep(app_state_retry_backoff(attempts)).await;
+                let Some(client) = weak_client.upgrade() else {
+                    debug!(target: "Client/AppState", "App state retry cancelled: client is gone");
+                    return;
+                };
                 // Waited for, not charged for. Without this the loop spends an
                 // attempt on every offline round, and the whole budget is gone
                 // long before a reconnect that backs off in minutes returns —
@@ -1607,6 +1627,12 @@ impl Client {
             // producing any — would otherwise finish in silence, with the
             // collections still stale. `retryable` is exactly what these are:
             // not synced, and a later trigger can still fix them.
+            //
+            // Nobody to report to if the client is gone; the strong reference
+            // the rounds held was released with the last of them.
+            let Some(client) = weak_client.upgrade() else {
+                return;
+            };
             if client.admits(scope).is_ok() {
                 let exhausted = BatchedSyncOutcome {
                     retryable: pending,
@@ -3695,6 +3721,46 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Neither retry scheduler may keep the client alive while it sleeps.
+    ///
+    /// The backoff doubles to an hour, so a strong reference held across it
+    /// pins the whole graph — caches, stores, the persistence manager — and
+    /// defers the `Drop` that signals shutdown, for as long after the
+    /// application let go of the client. Both loops re-acquire a strong
+    /// reference for the round they are about to run and release it again.
+    #[tokio::test]
+    async fn a_sleeping_app_state_retry_does_not_hold_the_client() {
+        let client = crate::test_utils::create_test_client_with_name("appstate_retry_weak").await;
+        let scope = client.sync_scope(None);
+        // Let construction settle before the count is taken: a startup task
+        // still holding its own clone would otherwise release it during the
+        // yields below and read as this scheduler letting one go.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        let before = Arc::strong_count(&client);
+
+        client.schedule_app_state_task_retry(WAPatchName::RegularLow, false);
+        client.schedule_app_state_retry(
+            vec![WAPatchName::RegularHigh],
+            scope,
+            SyncSettles::JustTheCollections,
+            false,
+        );
+
+        // Time is not advanced here on purpose: both tasks are parked in their
+        // first backoff sleep, which is exactly the state being asserted about.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            Arc::strong_count(&client),
+            before,
+            "a retry parked in its backoff must hold the client weakly"
+        );
+    }
 
     #[tokio::test]
     async fn key_arrival_finishes_before_a_slow_fanout() {

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -3749,17 +3749,19 @@ mod tests {
             false,
         );
 
-        // Time is not advanced here on purpose: both tasks are parked in their
-        // first backoff sleep, which is exactly the state being asserted about.
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
-
-        assert_eq!(
-            Arc::strong_count(&client),
-            before,
-            "a retry parked in its backoff must hold the client weakly"
-        );
+        // Time is not advanced here on purpose: both tasks park in their first
+        // backoff sleep, which is exactly the state being asserted about. Polled
+        // rather than counted in yields, because under a loaded test host the
+        // spawned tasks may not have reached their sleep after any fixed number
+        // of yields; a task that held the client across its backoff would keep
+        // the count above `before` for the whole (minutes-long) sleep, which the
+        // poll's deadline turns into a failure. `<=` tolerates a startup task
+        // releasing its own clone in the meantime.
+        crate::test_utils::poll_until(
+            "both retry schedulers to park in their backoff holding the client weakly",
+            || Arc::strong_count(&client) <= before,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -21,6 +21,41 @@ impl Client {
     /// long is the reconnect backoff counter reset to its base.
     pub(crate) const STABLE_CONNECTION_RESET: Duration = Duration::from_secs(30);
 
+    /// How long a teardown waits for the socket to close before walking away
+    /// from it.
+    ///
+    /// A close is a network write that shares the transport's sink with every
+    /// send, so it queues behind whatever is already in flight there; on a
+    /// black-holed connection that write is not refused, it is retried by the
+    /// kernel until `tcp_retries2` runs out (~15 minutes on Linux). Every
+    /// teardown path here runs on the caller's thread of control — the run loop
+    /// for a reconnect, the application's for `disconnect()` — so an untimed
+    /// close parks the whole client behind a socket the OS has not finished
+    /// failing. Two seconds is far past what a live socket needs (the close
+    /// frame is one small write) and far short of what a dead one costs.
+    ///
+    /// Walking away is safe: the transport is dropped with the connection
+    /// state, and the close is best-effort anyway — the server drops a session
+    /// whose socket stops answering.
+    pub(crate) const TRANSPORT_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+
+    /// Close `transport`, bounded by [`Self::TRANSPORT_CLOSE_TIMEOUT`].
+    async fn close_transport_bounded(&self, transport: &Arc<dyn crate::transport::Transport>) {
+        if rt_timeout(
+            &*self.runtime,
+            Self::TRANSPORT_CLOSE_TIMEOUT,
+            transport.disconnect(),
+        )
+        .await
+        .is_err()
+        {
+            warn!(
+                "Transport close did not finish in {:?}; abandoning the socket",
+                Self::TRANSPORT_CLOSE_TIMEOUT
+            );
+        }
+    }
+
     /// Create a runtime-validated low-level client builder.
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
@@ -801,7 +836,17 @@ impl Client {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
             }
 
-            let error_count = self.auto_reconnect_errors.fetch_add(1, Ordering::SeqCst);
+            // Saturating, not a bare increment: this counter is only ever reset
+            // by a connection that stayed up 30 s, so a link that flaps for a
+            // month climbs it forever. See `MAX_BACKOFF_ATTEMPTS` — the delay
+            // stopped changing long before the ceiling, so nothing about the
+            // schedule moves.
+            let error_count = self
+                .auto_reconnect_errors
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |previous| {
+                    Some(next_backoff_attempt(previous))
+                })
+                .unwrap_or_else(|previous| previous);
             // WA Web: Fibonacci backoff with 10% jitter, max 900s.
             // algo: { type: "fibonacci", first: 1000, second: 1000 }
             // jitter: 0.1, max: 9e5
@@ -948,8 +993,18 @@ impl Client {
         // as NotConnected, which the loop classifies as fatal and exits on,
         // leaving the connection with no idle ping and no dead-socket watchdog.
         let keepalive = self.clone();
+        // Both captured here, in the caller, not inside the task: the spawn only
+        // promises the loop will run, not when its first poll happens, and by
+        // then a teardown may already have reset the notifier and bumped the
+        // generation for the next connection. See `keepalive_loop`.
+        let keepalive_shutdown = self.connection_shutdown_signal();
+        let keepalive_generation = self.connection_generation.load(Ordering::Acquire);
         self.runtime
-            .spawn(Box::pin(async move { keepalive.keepalive_loop().await }))
+            .spawn(Box::pin(async move {
+                keepalive
+                    .keepalive_loop(keepalive_shutdown, keepalive_generation)
+                    .await
+            }))
             .detach();
 
         let loop_result = self.read_messages_loop().await;
@@ -1327,7 +1382,7 @@ impl Client {
         // socket write) would park `connect_internal`, which installs through this mutex.
         let transport = self.transport.lock().await.clone();
         if let Some(transport) = transport {
-            transport.disconnect().await;
+            self.close_transport_bounded(&transport).await;
         }
         self.cleanup_connection_state().await;
 
@@ -1401,7 +1456,7 @@ impl Client {
 
         let transport = self.transport.lock().await.clone();
         if let Some(transport) = transport {
-            transport.disconnect().await;
+            self.close_transport_bounded(&transport).await;
         }
     }
 
@@ -1437,7 +1492,7 @@ impl Client {
 
         let transport = self.transport.lock().await.clone();
         if let Some(transport) = transport {
-            transport.disconnect().await;
+            self.close_transport_bounded(&transport).await;
         }
     }
 
@@ -1580,7 +1635,7 @@ impl Client {
         }
 
         if let Some(transport) = &torn_down {
-            transport.disconnect().await;
+            self.close_transport_bounded(transport).await;
         }
 
         // A connection nobody is reading has no `drive_connection` to run the
@@ -1791,9 +1846,23 @@ impl Client {
         // afterwards would strip the replacement connection instead of the one being torn down.
         let transport = self.transport.lock().await.take();
         *self.transport_events.lock().await = None;
-        *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = None;
+        let noise_socket = self
+            .noise_socket
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take();
+        // Stop the noise sender explicitly rather than leaving it to the last
+        // `Arc` clone. Its callers hold the socket across their awaits, so a
+        // send parked on a dead transport keeps the task — and the transport's
+        // sink — alive well past this teardown, and the close below would then
+        // queue behind a write the kernel is still retrying. Done before the
+        // close for that reason, and after the caller's bounded outbound flush,
+        // so nothing that was still allowed to go out is cancelled here.
+        if let Some(noise_socket) = noise_socket {
+            noise_socket.abort_sender();
+        }
         if let Some(transport) = transport {
-            transport.disconnect().await;
+            self.close_transport_bounded(&transport).await;
         }
         // Authoritative point for the gauge: every disconnect (intentional or a
         // run-loop drop/reconnect) funnels through here, so disconnect()'s early
@@ -2327,6 +2396,88 @@ impl Drop for Connection<'_> {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    /// Install a socket over `transport` on `client` as a published connection,
+    /// the way `connect_internal` would.
+    async fn publish_transport_for_test(
+        client: &Arc<Client>,
+        transport: Arc<crate::transport::mock::StallingMockTransport>,
+    ) -> Arc<NoiseSocket> {
+        use wacore::handshake::NoiseCipher;
+
+        let noise_socket = Arc::new(NoiseSocket::new(
+            client.runtime.clone(),
+            transport.clone() as Arc<dyn crate::transport::Transport>,
+            NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+            NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+        ));
+        *client.transport.lock().await = Some(transport as Arc<dyn crate::transport::Transport>);
+        *client
+            .noise_socket
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(&noise_socket));
+        client.set_connected_for_test(true);
+        noise_socket
+    }
+
+    /// A teardown may not park on a socket that never closes.
+    ///
+    /// This is the shape a long-lived session hits: the peer disappears without
+    /// a FIN, the write the noise sender is parked in is retried by the kernel
+    /// for another quarter of an hour, and the close queues behind it because
+    /// both share the transport's sink. Untimed, `disconnect()` — and every
+    /// reconnect, which tears down the same way — inherits that wait, so the
+    /// run loop stops driving anything for as long as the OS takes to give up.
+    #[tokio::test(start_paused = true)]
+    async fn teardown_is_bounded_when_the_socket_never_closes() {
+        let client = crate::test_utils::create_test_client().await;
+        let transport = Arc::new(crate::transport::mock::StallingMockTransport::new());
+        let noise_socket = publish_transport_for_test(&client, Arc::clone(&transport)).await;
+
+        // A send parked inside the transport, holding the sink the close needs.
+        // Spawned with its own clone of the socket, which is what makes the
+        // refcount alone unable to stop the sender task.
+        let parked_send = tokio::spawn({
+            let noise_socket = Arc::clone(&noise_socket);
+            async move {
+                noise_socket
+                    .encrypt_and_send(bytes::Bytes::from_static(b"parked"))
+                    .await
+            }
+        });
+        crate::test_utils::poll_until("the noise sender to park in the transport", || {
+            transport.sends_started() >= 1
+        })
+        .await;
+
+        let started = tokio::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(600), client.disconnect())
+            .await
+            .expect("disconnect() must not wait on a socket that never closes");
+        assert!(
+            transport.disconnects_started() >= 1,
+            "the teardown must still have asked the transport to close"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(60),
+            "teardown took {:?}; it is supposed to be bounded by a handful of \
+             {:?} windows",
+            started.elapsed(),
+            Client::TRANSPORT_CLOSE_TIMEOUT,
+        );
+
+        // The other half: the sender task is stopped outright, so the caller
+        // parked on it is failed rather than left waiting on a socket nobody
+        // will ever read again.
+        let sent = tokio::time::timeout(Duration::from_secs(30), parked_send)
+            .await
+            .expect("the parked send must be released by the teardown")
+            .expect("the sending task must not panic");
+        assert!(
+            sent.is_err(),
+            "a send the teardown cancelled must report failure, not success"
+        );
+    }
 
     /// What one `Client` costs before it has connected, cached or received
     /// anything: pure structure, shared `PersistenceManager` and backend

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -6,8 +6,8 @@ use wacore::net::DisconnectReason;
 use wacore::stanza::wire_tags::StanzaTag;
 
 /// Non-error exits of [`Client::read_messages_loop`] — `ServerRecycle` keeps the
-/// routine reconnect path out of `Err`, so severity consumers (logs, the span's
-/// `err(...)` capture, error trackers) only fire for genuine failures.
+/// routine reconnect path out of `Err`, so severity consumers (logs, error
+/// trackers) only fire for genuine failures.
 pub(crate) enum ReadLoopExit {
     /// Shutdown signal or an expected disconnect.
     Expected,
@@ -161,28 +161,37 @@ impl Client {
         }
     }
 
-    // err(...) stays at the default ERROR on purpose: with the routine server
-    // recycle moved to Ok(ServerRecycle), an Err from this loop now always means
-    // something genuinely wrong — so the automatic capture only ever reports
-    // real failures, not WhatsApp's periodic stream recycling.
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(
-            name = "wa.conn.read_loop",
-            level = "debug",
-            skip_all,
-            fields(lid = tracing::field::Empty, pn = tracing::field::Empty),
-            err(Debug)
-        )
-    )]
+    /// Read until the connection ends, reporting how it ended.
+    ///
+    /// Deliberately NOT instrumented, on the same grounds as `keepalive_loop`
+    /// and `run`: a span opened here lives for the whole connection — days on a
+    /// long-lived session — so nothing exports until the disconnect, every
+    /// per-frame span hangs off a parent that never closes, and any duration
+    /// histogram over it measures uptime rather than work. The loop's entry and
+    /// exit are events instead, and the per-frame spans (`wa.conn.node`,
+    /// `wa.conn.decrypt_frame`) keep their own timing.
     pub(crate) async fn read_messages_loop(
         self: &Arc<Self>,
     ) -> Result<ReadLoopExit, ReadLoopError> {
-        #[cfg(feature = "tracing")]
-        self.record_identity_on_span(&tracing::Span::current());
-
         debug!("Starting message processing loop...");
+        let outcome = self.read_messages_loop_inner().await;
+        // The exit reason at the same level as the entry: with the span gone,
+        // this is what pairs a loop that started with the connection that ended
+        // it. Severity stays with the callers — `drive_connection` decides
+        // which of these is worth an event and which is routine.
+        match &outcome {
+            Ok(ReadLoopExit::Expected) => {
+                debug!("Message processing loop exited: expected disconnect.")
+            }
+            Ok(ReadLoopExit::ServerRecycle(reason)) => {
+                debug!("Message processing loop exited: stream recycled ({reason:?}).")
+            }
+            Err(e) => debug!("Message processing loop exited with an error: {e}"),
+        }
+        outcome
+    }
 
+    async fn read_messages_loop_inner(self: &Arc<Self>) -> Result<ReadLoopExit, ReadLoopError> {
         let mut rx_guard = self.transport_events.lock().await;
         let transport_events = rx_guard
             .take()

--- a/src/client/offline_resume.rs
+++ b/src/client/offline_resume.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use futures::FutureExt;
 use log::{debug, warn};
 use wacore_binary::Node;
 use wacore_binary::builder::NodeBuilder;
@@ -163,11 +164,25 @@ pub(crate) async fn send_first_batch(client: Arc<Client>, total: usize) {
 /// connection is reported as interrupted instead.
 pub(crate) fn spawn_inactivity_watchdog(client: Arc<Client>, generation: u64, timeout: Duration) {
     let runtime = client.runtime.clone();
+    // Subscribed at the spawn, for the connection whose generation this
+    // watchdog was armed with — subscribing inside the task would pick up
+    // whatever notifier a teardown had already installed.
+    let shutdown = client.connection_shutdown_signal();
     runtime
         .spawn(Box::pin(async move {
             let mut seen = client.offline_batch.stanza_activity();
             loop {
-                client.runtime.sleep(timeout).await;
+                // Raced rather than merely re-checked after waking: the window
+                // is a minute long, so on a teardown this task otherwise stays
+                // scheduled — holding the whole client graph alive through its
+                // `Arc` — for up to that long after the connection it belongs
+                // to is gone, once per connection. The checks below are
+                // unchanged and still decide everything; this only stops the
+                // waiting early.
+                futures::select! {
+                    _ = client.runtime.sleep(timeout).fuse() => {}
+                    _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => return,
+                }
                 if !client.offline_batch.is_armed_for(generation)
                     || client.connection_generation.load(Ordering::Acquire) != generation
                     || client.offline_sync_completed.load(Ordering::Acquire)

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -1,6 +1,7 @@
 //! E2E Session management for Client.
 
 use anyhow::Result;
+use futures::FutureExt;
 use rand::rngs::StdRng;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -556,78 +557,118 @@ impl Client {
     }
 
     pub(crate) async fn wait_for_offline_delivery_end_with_timeout(&self, timeout: Duration) {
+        /// Why the wait ended, when it did not run out of time.
+        enum Wake {
+            /// The offline sync signalled completion.
+            Sync,
+            /// The connection this wait belongs to ended under it.
+            ConnectionEnded,
+        }
+
         let wait_generation = self.connection_generation.load(Ordering::Acquire);
+        // Subscribed before the completion check, so a teardown landing in the
+        // window between the two still wakes this wait.
+        let shutdown = self.connection_shutdown_signal();
         let offline_fut = self.offline_sync_notifier.listen();
         if self.offline_sync_completed.load(Ordering::Relaxed) {
             return;
         }
 
-        if wacore::runtime::timeout(&*self.runtime, timeout, offline_fut)
-            .await
-            .is_err()
-        {
-            // Guard: don't complete sync for a stale connection generation.
-            // A reconnect may have happened while we were waiting, making this
-            // timeout belong to the old connection.
-            if self.connection_generation.load(Ordering::Acquire) != wait_generation
-                || self.expected_disconnect.load(Ordering::Relaxed)
-            {
+        // Raced against the per-connection shutdown, because every caller of
+        // this helper is doing something for *this* connection — the post-login
+        // task, the prekey-low top-up, the dirty-bits handler, the send path's
+        // session pre-flight — and a teardown makes all of it moot. Without the
+        // arm they parked here for the whole timeout after the socket was gone,
+        // which on a reconnect-heavy month is a task per reconnect sitting on a
+        // connection that no longer exists.
+        //
+        // The shutdown arm deliberately does NOT complete the sync: completion
+        // is a claim about a live connection's backlog, and the timeout path
+        // below is the only place entitled to make it (behind the same
+        // generation guard it always had).
+        let waited = wacore::runtime::timeout(&*self.runtime, timeout, async {
+            futures::select! {
+                _ = offline_fut.fuse() => Wake::Sync,
+                _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => Wake::ConnectionEnded,
+            }
+        })
+        .await;
+
+        match waited {
+            Ok(Wake::Sync) => return,
+            Ok(Wake::ConnectionEnded) => {
                 log::debug!(
                     target: "Client/OfflineSync",
-                    "Offline sync timeout ignored: connection generation changed or disconnected",
+                    "Offline sync wait ended with its connection (generation {} -> {}); leaving the sync uncompleted",
+                    wait_generation,
+                    self.connection_generation.load(Ordering::Acquire),
                 );
                 return;
             }
+            Err(_) => {}
+        }
 
-            let processed = self
-                .offline_sync_metrics
-                .processed_messages
-                .load(Ordering::Acquire);
-            let expected = self
-                .offline_sync_metrics
-                .total_messages
-                .load(Ordering::Acquire);
-            log::warn!(
+        // Guard: don't complete sync for a stale connection generation.
+        // A reconnect may have happened while we were waiting, making this
+        // timeout belong to the old connection.
+        if self.connection_generation.load(Ordering::Acquire) != wait_generation
+            || self.expected_disconnect.load(Ordering::Relaxed)
+        {
+            log::debug!(
                 target: "Client/OfflineSync",
-                "Offline sync timed out after {:?} (processed {} of {} items); marking sync complete",
-                timeout,
-                processed,
-                expected,
+                "Offline sync timeout ignored: connection generation changed or disconnected",
             );
-            self.complete_offline_sync_for_generation(
-                i32::try_from(processed).unwrap_or(i32::MAX),
-                wait_generation,
-            )
-            .await;
-            // The finisher runs as a spawned task; keep this helper's contract
-            // that live state is in place when it returns (callers start
-            // session/send work right after). Ticked so a reconnect or
-            // shutdown mid-commit cannot strand this waiter, and bounded by a
-            // second `timeout` window: when the marker-triggered finisher was
-            // ALREADY running and its tail commit/hook is stuck, the
-            // complete_offline_sync above started nothing, and an unbounded
-            // wait here would defeat this helper's whole point — callers
-            // proceed and the finisher keeps running in the background.
-            let deadline = wacore::time::Instant::now() + timeout;
-            loop {
-                let listener = self.offline_sync_notifier.listen();
-                if self.offline_sync_completed.load(Ordering::Acquire)
-                    || self.connection_generation.load(Ordering::Acquire) != wait_generation
-                    || self.expected_disconnect.load(Ordering::Relaxed)
-                {
-                    return;
-                }
-                if wacore::time::Instant::now() >= deadline {
-                    log::warn!(
-                        target: "Client/OfflineSync",
-                        "Drain finisher still running {:?} after the offline sync timeout; proceeding without it",
-                        timeout,
-                    );
-                    return;
-                }
-                let _ = wacore::runtime::timeout(&*self.runtime, Duration::from_secs(1), listener)
-                    .await;
+            return;
+        }
+
+        let processed = self
+            .offline_sync_metrics
+            .processed_messages
+            .load(Ordering::Acquire);
+        let expected = self
+            .offline_sync_metrics
+            .total_messages
+            .load(Ordering::Acquire);
+        log::warn!(
+            target: "Client/OfflineSync",
+            "Offline sync timed out after {:?} (processed {} of {} items); marking sync complete",
+            timeout,
+            processed,
+            expected,
+        );
+        self.complete_offline_sync_for_generation(
+            i32::try_from(processed).unwrap_or(i32::MAX),
+            wait_generation,
+        )
+        .await;
+        // The finisher runs as a spawned task; keep this helper's contract
+        // that live state is in place when it returns (callers start
+        // session/send work right after). Ticked so a reconnect or
+        // shutdown mid-commit cannot strand this waiter, and bounded by a
+        // second `timeout` window: when the marker-triggered finisher was
+        // ALREADY running and its tail commit/hook is stuck, the
+        // complete_offline_sync above started nothing, and an unbounded
+        // wait here would defeat this helper's whole point — callers
+        // proceed and the finisher keeps running in the background.
+        let deadline = wacore::time::Instant::now() + timeout;
+        loop {
+            let listener = self.offline_sync_notifier.listen();
+            if self.offline_sync_completed.load(Ordering::Acquire)
+                || self.connection_generation.load(Ordering::Acquire) != wait_generation
+                || self.expected_disconnect.load(Ordering::Relaxed)
+            {
+                return;
             }
+            if wacore::time::Instant::now() >= deadline {
+                log::warn!(
+                    target: "Client/OfflineSync",
+                    "Drain finisher still running {:?} after the offline sync timeout; proceeding without it",
+                    timeout,
+                );
+                return;
+            }
+            let _ =
+                wacore::runtime::timeout(&*self.runtime, Duration::from_secs(1), listener).await;
         }
     }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3205,6 +3205,50 @@ fn test_fibonacci_backoff_max_900s() {
     );
 }
 
+/// The sequence stops changing at the cap, so the work of computing it must
+/// stop there too. The counter feeding this is only reset by a connection that
+/// stays up 30 s, so on a link that flaps for weeks it is the one input here
+/// with no natural bound.
+#[test]
+fn fibonacci_backoff_stops_at_the_cap_instead_of_counting_out_the_attempt() {
+    let capped = fibonacci_backoff(20);
+    let far_past_the_cap = fibonacci_backoff(u32::MAX);
+    for (label, delay) in [
+        ("attempt 20", capped),
+        ("attempt u32::MAX", far_past_the_cap),
+    ] {
+        let ms = delay.as_millis() as u64;
+        assert!(
+            (810_000..=990_000).contains(&ms),
+            "{label} should be the 900s cap (±10% jitter), got {ms}ms"
+        );
+    }
+}
+
+/// The counter itself saturates, so a month of flapping cannot run it up (or,
+/// with the 429 handler adding five at a time, wrap it). The delay is pinned at
+/// the cap long before the ceiling, so nothing about the schedule moves.
+#[test]
+fn reconnect_attempts_saturate_at_the_ceiling() {
+    assert_eq!(next_backoff_attempt(0), 1);
+    assert_eq!(
+        next_backoff_attempt(MAX_BACKOFF_ATTEMPTS - 1),
+        MAX_BACKOFF_ATTEMPTS
+    );
+    assert_eq!(
+        next_backoff_attempt(MAX_BACKOFF_ATTEMPTS),
+        MAX_BACKOFF_ATTEMPTS
+    );
+    assert_eq!(next_backoff_attempt(u32::MAX), MAX_BACKOFF_ATTEMPTS);
+    const {
+        assert!(
+            MAX_BACKOFF_ATTEMPTS > 17,
+            "the ceiling must sit past the attempt at which the delay reaches \
+             its cap, so saturating never changes a wait"
+        )
+    };
+}
+
 #[test]
 fn test_fibonacci_backoff_first_attempt_is_1s() {
     let delay = fibonacci_backoff(0);
@@ -7300,6 +7344,18 @@ async fn arm_offline_drain(client: &Arc<Client>, total: usize, delivered: usize)
     offline_resume::send_first_batch(Arc::clone(client), total).await;
 }
 
+/// Stand in for the next connection opening, after a fixture has torn the
+/// previous one down by hand.
+///
+/// `connect_internal` resets the per-connection shutdown notifier before it
+/// publishes a socket, and that notifier is sticky: without this step the
+/// teardown's fired signal still stands on the "new" connection, and everything
+/// that watches it — the offline-delivery wait, the inactivity watchdog —
+/// correctly stands down on sight.
+fn open_next_connection_for_test(client: &Arc<Client>) {
+    client.reset_connection_shutdown();
+}
+
 fn drain_offline_sync_events(
     rx: &async_channel::Receiver<Arc<Event>>,
 ) -> (Vec<(i32, i32)>, Vec<i32>) {
@@ -7468,6 +7524,7 @@ async fn a_later_drain_still_reports_its_own_outcome() {
 
     arm_offline_drain(&client, 711, 700).await;
     client.cleanup_connection_state().await;
+    open_next_connection_for_test(&client);
 
     // The real path: an `<ib><offline_preview count>` on the next connection,
     // processed inline like any other stanza.
@@ -7512,6 +7569,7 @@ async fn a_finisher_left_behind_by_two_connections_reports_nothing() {
     client.cleanup_connection_state().await;
 
     // A whole new connection and a new drain, which reports its own outcome.
+    open_next_connection_for_test(&client);
     let live_generation = client.connection_generation.load(Ordering::Acquire);
     arm_offline_drain(&client, 25, 25).await;
     client
@@ -7554,6 +7612,7 @@ async fn a_stale_completion_does_not_consume_the_next_connection_finisher() {
         .await;
 
     // The next connection's drain still gets its own finisher and its own event.
+    open_next_connection_for_test(&client);
     let live_generation = client.connection_generation.load(Ordering::Acquire);
     arm_offline_drain(&client, 25, 25).await;
     client
@@ -7564,6 +7623,73 @@ async fn a_stale_completion_does_not_consume_the_next_connection_finisher() {
     let (interrupted, completed) = drain_offline_sync_events(&rx);
     assert_eq!(interrupted.len(), 1, "the first drain's interruption");
     assert_eq!(completed, vec![25], "the second drain still completes");
+}
+
+/// The wait belongs to a connection, so it must end when that connection does
+/// — and it must not mark the sync complete on the way out.
+///
+/// Every caller of this helper (the post-login task, the prekey-low top-up, the
+/// dirty-bits handler, the send path's session pre-flight) was otherwise parked
+/// here for the full timeout after the socket was already gone. Over a month of
+/// reconnects that is one such task per reconnect, each holding the client and
+/// each waiting on a connection that no longer exists.
+#[tokio::test(start_paused = true)]
+async fn wait_for_offline_delivery_end_returns_when_its_connection_ends() {
+    let client = offline_resume_test_client().await;
+    arm_offline_drain(&client, 711, 5).await;
+
+    let started = tokio::time::Instant::now();
+    let waiter = {
+        let client = client.clone();
+        tokio::spawn(async move {
+            client
+                .wait_for_offline_delivery_end_with_timeout(Duration::from_secs(60))
+                .await;
+        })
+    };
+
+    // Sticky, so this cannot lose the race against the waiter's subscription:
+    // a signal fired first is still observed by a later subscriber.
+    client.notify_connection_shutdown();
+
+    tokio::time::timeout(Duration::from_secs(600), waiter)
+        .await
+        .expect("the wait must end with its connection")
+        .expect("the waiting task must not panic");
+
+    assert!(
+        started.elapsed() < Duration::from_secs(60),
+        "the wait ran for {:?}; a teardown must release it rather than let it \
+         serve out the timeout",
+        started.elapsed()
+    );
+    assert!(
+        !client.offline_sync_completed.load(Ordering::Relaxed),
+        "a sync belonging to a connection that ended must not be marked complete"
+    );
+}
+
+/// The inactivity watchdog waits a minute at a time, and its whole job is to
+/// complete a drain the *server* stopped feeding. A drain the *connection*
+/// stopped feeding is the other case — the backlog was never acked and the
+/// server redelivers it — so a teardown has to stop the watchdog rather than
+/// let it wake a minute later and declare the resume finished.
+#[tokio::test(start_paused = true)]
+async fn the_inactivity_watchdog_stops_with_its_connection() {
+    let client = offline_resume_test_client().await;
+    // Arms the coordinator and spawns the production watchdog.
+    arm_offline_drain(&client, 711, 5).await;
+
+    client.notify_connection_shutdown();
+
+    // Well past the window the watchdog would otherwise have completed in.
+    tokio::time::sleep(Duration::from_secs(600)).await;
+
+    assert!(
+        !client.offline_sync_completed.load(Ordering::Acquire),
+        "a resume whose connection ended is reported as interrupted, not \
+         completed by a watchdog that outlived it"
+    );
 }
 
 /// The startup waiter reports a teardown as soon as it happens.

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -46,6 +46,31 @@ fn classify_keepalive_error(e: &IqError) -> KeepaliveResult {
     }
 }
 
+/// Consecutive unanswered pings after which the connection is torn down rather
+/// than pinged again.
+///
+/// Three, because a ping is only sent when the link has been *idle* for at
+/// least `KEEP_ALIVE_INTERVAL_MIN` (the recent-activity early return skips it
+/// otherwise), so three of them in a row is roughly a minute in which nothing
+/// arrived AND nothing we sent was answered. A busy connection cannot reach
+/// this count: every inbound frame resets it on the activity path, and most
+/// ticks on such a connection never ping at all.
+///
+/// The hole this closes is the half-open socket the dead-socket watchdog is
+/// blind to by design: `is_dead_socket_at` is cancelled by any receive, so a
+/// link that still delivers inbound frames while our writes go nowhere looks
+/// alive to it forever — and every send, ack and receipt is silently lost for
+/// the rest of the session. Reconnect-looping against a merely slow server is
+/// bounded by the two resets (`Ok` and recent activity) and by
+/// `should_reset_backoff`, which keeps escalating the Fibonacci delay until a
+/// connection stays up 30 s.
+fn keepalive_failures_are_terminal(error_count: u32) -> bool {
+    error_count >= KEEPALIVE_MAX_CONSECUTIVE_FAILURES
+}
+
+/// See [`keepalive_failures_are_terminal`].
+const KEEPALIVE_MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
 /// Whether a keepalive ping error is just collateral of a teardown already
 /// being handled elsewhere (the connection is gone, so the ping had nowhere to
 /// go) rather than a genuine failure the keepalive surfaced first.
@@ -127,14 +152,23 @@ impl Client {
     // connection (tens of minutes), polluting duration/throughput metrics and
     // only reporting at disconnect. Per-ping visibility comes from
     // `wa.conn.keepalive.ping` on send_keepalive.
-    pub(crate) async fn keepalive_loop(self: Arc<Self>) {
+    ///
+    /// `shutdown_signal` and `generation` are taken from the caller rather than
+    /// read here, and both for the same reason: this task's first poll can be
+    /// arbitrarily late. Subscribing inside it let a `reset_connection_shutdown`
+    /// that already ran hand it the *next* connection's notifier, and reading
+    /// the generation here would pin it to the same wrong connection — either
+    /// way the previous connection's keepalive never exits and two of them ping
+    /// the same socket. Captured at the spawn, they name the connection this
+    /// loop was started for, whenever it happens to start.
+    pub(crate) async fn keepalive_loop(
+        self: Arc<Self>,
+        shutdown_signal: wacore::runtime::ShutdownSignal,
+        generation: u64,
+    ) {
         let mut error_count = 0u32;
         let mut cleanup_counter = 0u32;
         let sent_msg_ttl = self.cache_config.sent_message_ttl_secs;
-        // Capture the per-connection signal once — re-subscribing each iteration
-        // would let a racing reset_connection_shutdown swap the underlying
-        // notifier mid-loop and strand this task on the next connection's signal.
-        let shutdown_signal = self.connection_shutdown_signal();
         // Seeded once, not per tick: a fresh `StdRng` costs OS entropy and a
         // 320-byte state to draw one number, and this loop wakes every 15-30 s
         // on every connected client (measured 14.8 us vs 808 ns for the draw
@@ -156,6 +190,21 @@ impl Client {
                 _ = self.runtime.sleep(interval).fuse() => {
                     if !self.is_connected() {
                         debug!(target: "Client/Keepalive", "Not connected, exiting keepalive loop.");
+                        return;
+                    }
+                    // The connected flag alone cannot tell "still my connection"
+                    // from "someone else's": a reconnect that completes before
+                    // this task is first polled leaves it true again, and the
+                    // loop would go on pinging a socket it was never started
+                    // for, alongside that connection's own keepalive.
+                    let current = self.connection_generation.load(
+                        std::sync::atomic::Ordering::Acquire,
+                    );
+                    if current != generation {
+                        debug!(
+                            target: "Client/Keepalive",
+                            "Connection generation moved on ({generation} -> {current}), exiting keepalive loop.",
+                        );
                         return;
                     }
 
@@ -213,6 +262,14 @@ impl Client {
                         KeepaliveResult::TransientFailure => {
                             error_count += 1;
                             warn!(target: "Client/Keepalive", "Keepalive timeout, error count: {error_count}");
+                            if keepalive_failures_are_terminal(error_count) {
+                                warn!(
+                                    target: "Client/Keepalive",
+                                    "{error_count} consecutive unanswered pings, forcing reconnect.",
+                                );
+                                self.reconnect_immediately().await;
+                                return;
+                            }
                         }
                     }
 
@@ -311,6 +368,73 @@ mod tests {
     use super::*;
     use crate::socket::error::{EncryptSendError, SocketError};
     use wacore_binary::builder::NodeBuilder;
+
+    /// Three, and the two below it are not. The counter was already being
+    /// computed and logged; this is the decision that makes it load-bearing.
+    #[test]
+    fn three_consecutive_unanswered_pings_are_terminal() {
+        assert!(!keepalive_failures_are_terminal(0));
+        assert!(!keepalive_failures_are_terminal(1));
+        assert!(
+            !keepalive_failures_are_terminal(2),
+            "two unanswered pings is a slow server, not a broken one"
+        );
+        assert!(keepalive_failures_are_terminal(3));
+        assert!(keepalive_failures_are_terminal(4));
+    }
+
+    /// A keepalive belongs to the connection it was started for. Its first poll
+    /// can land after that connection is gone — the spawn only promises the
+    /// task will run — and `is_connected()` is true again by then if a
+    /// reconnect has completed, so without the generation check the old loop
+    /// would go on pinging the new connection's socket alongside its own
+    /// keepalive: two pingers on one socket, and one more with every reconnect.
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_exits_when_its_connection_generation_is_retired() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let stale_generation = client
+            .connection_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        // The connection this loop was started for is retired, and (as after a
+        // reconnect) the client is connected again on a newer one.
+        client
+            .connection_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        tokio::time::timeout(
+            Duration::from_secs(600),
+            client
+                .clone()
+                .keepalive_loop(client.connection_shutdown_signal(), stale_generation),
+        )
+        .await
+        .expect("a keepalive on a retired generation must exit at its first tick");
+        assert_eq!(
+            transport.sent_count(),
+            0,
+            "a retired keepalive must not ping the connection that replaced it"
+        );
+
+        // The control, and the reason the assertion above is about the
+        // generation rather than about a fixture that could not have sent
+        // anything: the same loop on the live generation does ping (and then
+        // ends itself, because nothing answers it).
+        let live_generation = client
+            .connection_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        tokio::time::timeout(
+            Duration::from_secs(600),
+            client
+                .clone()
+                .keepalive_loop(client.connection_shutdown_signal(), live_generation),
+        )
+        .await
+        .expect("an unanswered ping ends the loop through the dead-socket check");
+        assert!(
+            transport.sent_count() >= 1,
+            "the fixture must be able to send a ping at all"
+        );
+    }
 
     #[test]
     fn test_classify_timeout_is_transient() {

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -204,8 +204,10 @@ pub struct NoiseSocket {
     /// await the result without holding a lock.
     send_job_tx: async_channel::Sender<SendJob>,
     /// Handle to the sender task. Aborted on drop to prevent resource leaks
-    /// if the task is stuck on a slow/hanging network operation.
-    _sender_task_handle: AbortHandle,
+    /// if the task is stuck on a slow/hanging network operation, and
+    /// explicitly by [`NoiseSocket::abort_sender`] when teardown cannot wait
+    /// for the last `Arc` to go.
+    sender_task_handle: AbortHandle,
 }
 
 impl NoiseSocket {
@@ -258,7 +260,7 @@ impl NoiseSocket {
             read_key,
             read_counter: Arc::new(AtomicU32::new(0)),
             send_job_tx,
-            _sender_task_handle: sender_task_handle,
+            sender_task_handle,
         }
     }
 
@@ -629,6 +631,26 @@ impl NoiseSocket {
         Self::await_send(receiver).await
     }
 
+    /// Stop the sender task now, without waiting for the last `Arc` to drop.
+    ///
+    /// Drop alone is not enough on a teardown path. The socket is handed out as
+    /// an `Arc`, and a send held across an await (`send_raw_bytes`) keeps a
+    /// clone alive for as long as that send is parked — which, on a black-holed
+    /// TCP connection, is however long the kernel takes to give up on the write
+    /// (`tcp_retries2`, ~15 minutes on Linux). Until then the task stays parked
+    /// inside `transport.send`, holding the transport's sink, so the close that
+    /// teardown is waiting on cannot even start. Cancelling the task drops that
+    /// send, releases the sink, and hands every queued and in-flight caller a
+    /// closed channel instead of a wait with no deadline.
+    ///
+    /// Closing the job channel first is what makes the failure prompt rather
+    /// than merely eventual: an enqueue racing the abort fails immediately
+    /// instead of landing in a queue nothing will drain.
+    pub(crate) fn abort_sender(&self) {
+        self.send_job_tx.close();
+        self.sender_task_handle.abort();
+    }
+
     pub fn decrypt_frame(&self, mut ciphertext: BytesMut) -> Result<BytesMut> {
         // Checked increment: error instead of wrapping the read counter (AES-GCM
         // nonce reuse). fetch_update returns the pre-increment counter to use, or
@@ -646,6 +668,8 @@ impl NoiseSocket {
 
 // AbortHandle aborts the sender task on drop automatically, so no manual
 // Drop impl is needed — the `sender_task_handle` field's own Drop does the work.
+// `abort_sender` is the same stop, taken early by a teardown that cannot wait
+// for the last `Arc` clone to be released.
 
 #[cfg(test)]
 mod tests {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -47,6 +47,62 @@ pub mod mock {
         }
     }
 
+    /// A transport that accepts calls and never answers them.
+    ///
+    /// Stands in for the socket a teardown cannot rely on: a connection whose
+    /// peer has gone away without a FIN is not refused, it is retried by the
+    /// kernel until `tcp_retries2` gives up (~15 minutes on Linux), and both
+    /// `send` and the close queue behind that. Anything that awaits either of
+    /// them unbounded is parked for the same quarter of an hour.
+    pub struct StallingMockTransport {
+        sends_started: std::sync::atomic::AtomicUsize,
+        disconnects_started: std::sync::atomic::AtomicUsize,
+    }
+
+    impl StallingMockTransport {
+        pub fn new() -> Self {
+            Self {
+                sends_started: std::sync::atomic::AtomicUsize::new(0),
+                disconnects_started: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        /// Sends that entered the transport and never came back out.
+        pub fn sends_started(&self) -> usize {
+            self.sends_started
+                .load(std::sync::atomic::Ordering::Acquire)
+        }
+
+        /// Closes that entered the transport and never came back out.
+        pub fn disconnects_started(&self) -> usize {
+            self.disconnects_started
+                .load(std::sync::atomic::Ordering::Acquire)
+        }
+    }
+
+    impl Default for StallingMockTransport {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl Transport for StallingMockTransport {
+        async fn send(&self, _data: bytes::Bytes) -> Result<(), anyhow::Error> {
+            self.sends_started
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            std::future::pending::<()>().await;
+            unreachable!("a stalled send never resolves")
+        }
+
+        async fn disconnect(&self) {
+            self.disconnects_started
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            std::future::pending::<()>().await;
+        }
+    }
+
     /// Splits one transport write into the length-prefixed frames it carries,
     /// each returned with its 3-byte prefix intact so callers keep seeing what
     /// a single-frame write used to look like. A trailing partial frame (which


### PR DESCRIPTION
Third round of the long-running-session work, connection lifecycle: a session that stays up for weeks and reconnects hundreds of times must not accumulate tasks, waits or spans that belong to connections that are gone, and no teardown may park the run loop.

## What changes

| # | What | Why it matters over weeks of uptime | Test |
| --- | --- | --- | --- |
| 1 | **Bounded teardown.** Every `transport.disconnect().await` on a teardown path (`disconnect`, `reconnect`, `reconnect_immediately`, `pause`, `cleanup_connection_state_inner`) goes through `Client::close_transport_bounded`, an `rt_timeout` of `TRANSPORT_CLOSE_TIMEOUT` (2 s). `NoiseSocket::abort_sender()` (closes the job channel, aborts the sender task) runs from `cleanup_connection_state_inner` where the socket slot is cleared, before that bounded close. | A close is a network write sharing the transport's sink with every send. On a black-holed socket the kernel retries until `tcp_retries2` (~15 min on Linux), and the noise sender parks in `transport.send` holding the sink, kept alive by the `Arc` clone `send_raw_bytes` holds across its await. Untimed, one such socket parked the run loop (and the application's `disconnect()`) for a quarter of an hour. | `client::lifecycle::tests::teardown_is_bounded_when_the_socket_never_closes` (new `transport::mock::StallingMockTransport`; asserts bounded virtual time, that the close was attempted, and that the parked send fails rather than hangs, which is what proves `abort_sender` ran) |
| 2 | **`wait_for_offline_delivery_end` races the per-connection shutdown.** The notifier wait is a `select!` against `connection_shutdown_signal()`; the shutdown arm returns *without* completing the sync, and the stale-generation guard on the timeout path is untouched. | Its callers (post-login task, prekey-low top-up, dirty-bits handler, `ensure_e2e_sessions` on the send path) otherwise sat here for the full 60 s after their connection was gone, once per reconnect, each holding the client. | `client::tests::wait_for_offline_delivery_end_returns_when_its_connection_ends`; three existing finisher tests now call `open_next_connection_for_test`, which does what `connect_internal` does first (reset the sticky per-connection notifier) |
| 3 | **Keepalive pinned to its connection, and its error counter load-bearing.** `keepalive_loop` takes the shutdown signal and connection generation from the spawn in `drive_connection`, and exits when the generation no longer matches. Three consecutive `TransientFailure`s force `reconnect_immediately()` (`keepalive_failures_are_terminal`). | A first poll landing after a reconnect subscribed to the *next* connection's notifier and read `is_connected()` as true, so the old loop never exited: one extra pinger per late reconnect. And `error_count` was computed, logged and never read, so a half-open socket that still delivers inbound frames (which cancels `is_dead_socket_at` by design) black-holed every send, ack and receipt with nothing to end it. | `keepalive::tests::keepalive_exits_when_its_connection_generation_is_retired` (with the live-generation loop as the control), `keepalive::tests::three_consecutive_unanswered_pings_are_terminal` |
| 4 | **Sleepers stop with their connection.** The offline-resume inactivity watchdog's 60 s wait is a `select!` against the shutdown signal captured at the spawn. Both app-state retry schedulers hold a `Weak<Client>` across their backoff. | The watchdog held a strong `Arc` and only checked liveness after waking: a minute of retained client graph per reconnect. The app-state backoff doubles to an hour; a strong reference across it pins caches, stores and the persistence manager, and defers the `Drop` that signals shutdown. | `client::tests::the_inactivity_watchdog_stops_with_its_connection`, `client::app_state::tests::a_sleeping_app_state_retry_does_not_hold_the_client` |
| 5 | **Reconnect backoff arithmetic.** `fibonacci_backoff` stops at the 900 s cap instead of iterating `attempt` times and draws jitter from `rand::rng()` instead of seeding a `StdRng` per call. `auto_reconnect_errors` saturates at `MAX_BACKOFF_ATTEMPTS` (64) via `next_backoff_attempt`. | The counter is only reset by a connection that stays up 30 s, so a flapping link grew it without bound (a 429 adds five at a time). 64 sits far past the attempt (~17) at which the delay reaches its cap, so no wait changes. | `client::tests::fibonacci_backoff_stops_at_the_cap_instead_of_counting_out_the_attempt`, `client::tests::reconnect_attempts_saturate_at_the_ceiling` |
| 6 | **`wa.conn.read_loop` is no longer a span.** Replaced by `debug!` events at entry and exit (body moved to `read_messages_loop_inner`); per-frame spans untouched. | The span lived for the whole connection, days on a long session: nothing exported until the disconnect, every per-frame span hung off a parent that never closed, and a duration histogram over it measured uptime. `keepalive_loop` and `run` already refuse this in comments. | Not unit-testable; the two sibling loops are the precedent |

## Behaviour changes worth a look

- `abort_sender()` cancels sends in flight at teardown: callers get `EncryptSendError::channel_closed()` instead of an unbounded wait. Anything mid-send during a teardown was going to fail anyway (the socket closes one line later) and the keepalive already classifies that error as benign teardown.
- `disconnect()` closes the transport itself and `cleanup_connection_state` closes it again (idempotent), so a dead socket costs up to 2 × 2 s.
- The keepalive can now force a reconnect against a merely slow server: three unanswered idle pings in a row. Bounded by "consecutive", the two existing resets, and `should_reset_backoff` escalating the Fibonacci delay until a connection stays up 30 s.
- `stats().reconnect_errors` saturates at 64.
- The read-loop span's automatic `err(Debug)` ERROR event is gone; read-loop failures are still logged and still dispatch `Disconnected`.

## Not done

- Live-task counter and the delivery-receipt worker queue (both from the audit): left for their own PRs. `MemoryReport` is being edited by [#1408](https://github.com/oxidezap/whatsapp-rust/pull/1408).
- A mock that never answers `<ping>` for the 3-strike rule: on a fixture that receives nothing, the dead-socket watchdog fires after the first unanswered ping, which is correct and exactly why the counter only bites when inbound traffic keeps cancelling that watchdog. The decision function is unit-tested instead.

## Validation

`cargo fmt --all`, `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings`, `cargo check -p e2e-tests --tests`, `cargo test -p whatsapp-rust --lib` (1890 tests; the eight new ones pass in every run, including the paused-time ones re-run for flakiness). A rotating subset of `pair_code::tests` (0–4 per run) failed on a loaded 4-core box with and without this diff: they assert on a mock frame within a 5 s real-time budget and are unrelated to this change.

## CI note

Semver Checks is informational and red on `main` independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN

---
_Generated by [Claude Code](https://claude.ai/code/session_0172fpxasGTrouFyYH5UGmjN)_