### PR TITLE
perf(events)!: box LoggedOut and TemporaryBan payloads

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1214,7 +1214,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     {
         self.on_event_for(&[EventKind::LoggedOut], move |event, _client| {
             let fut = match &*event {
-                Event::LoggedOut(info) => Some(handler(info.clone())),
+                Event::LoggedOut(info) => Some(handler(info.as_ref().clone())),
                 _ => None,
             };
             async move {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1310,12 +1310,12 @@ impl Client {
             warn!("Failed to send logout IQ: {e}");
         }
 
-        self.core.event_bus.dispatch(Event::LoggedOut(
+        self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
             crate::types::events::LoggedOut::builder()
                 .on_connect(false)
                 .reason(ConnectFailureReason::LoggedOut)
                 .build(),
-        ));
+        )));
 
         self.disconnect().await;
     }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1957,13 +1957,13 @@ impl Client {
             let event = if conflict_type == "replaced" {
                 Event::StreamReplaced(crate::types::events::StreamReplaced::builder().build())
             } else {
-                Event::LoggedOut(
+                Event::LoggedOut(Box::new(
                     crate::types::events::LoggedOut::builder()
                         .on_connect(false)
                         .reason(ConnectFailureReason::LoggedOut)
                         .raw(node.to_owned())
                         .build(),
-                )
+                ))
             };
             self.core.event_bus.dispatch(event);
             should_disconnect = true;
@@ -1980,26 +1980,26 @@ impl Client {
                     info!("Got 516 stream error (device removed). Logging out.");
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
-                    self.core.event_bus.dispatch(Event::LoggedOut(
+                    self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
                         crate::types::events::LoggedOut::builder()
                             .on_connect(false)
                             .reason(ConnectFailureReason::LoggedOut)
                             .raw(node.to_owned())
                             .build(),
-                    ));
+                    )));
                     should_disconnect = true;
                 }
                 "401" => {
                     info!("Got 401 stream error (unauthorized). Logging out.");
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
-                    self.core.event_bus.dispatch(Event::LoggedOut(
+                    self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
                         crate::types::events::LoggedOut::builder()
                             .on_connect(false)
                             .reason(ConnectFailureReason::LoggedOut)
                             .raw(node.to_owned())
                             .build(),
-                    ));
+                    )));
                     should_disconnect = true;
                 }
                 "409" => {
@@ -2143,14 +2143,14 @@ impl Client {
                 "Got {reason:?} connect failure, logging out: {}",
                 DisplayableNodeRef(node)
             );
-            self.core.event_bus.dispatch(Event::LoggedOut(
+            self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
                 crate::types::events::LoggedOut::builder()
                     .on_connect(true)
                     .reason(reason)
                     .maybe_logout_message(failure.logout_message())
                     .raw(node.to_owned())
                     .build(),
-            ));
+            )));
         } else if let ConnectFailureReason::TempBanned = reason
             && let Some(expire_secs) = failure.expire
             && let Some(ban_code) = failure.code
@@ -2161,7 +2161,7 @@ impl Client {
                 "Temporary ban connect failure: {}",
                 DisplayableNodeRef(node)
             );
-            self.core.event_bus.dispatch(Event::TemporaryBan(
+            self.core.event_bus.dispatch(Event::TemporaryBan(Box::new(
                 crate::types::events::TemporaryBan::builder()
                     .code(crate::types::events::TempBanReason::from(ban_code))
                     .expire(expire_duration)
@@ -2169,7 +2169,7 @@ impl Client {
                     .maybe_url(failure.url.as_deref().map(str::to_owned))
                     .raw(node.to_owned())
                     .build(),
-            ));
+            )));
         } else if let ConnectFailureReason::ClientOutdated = reason {
             error!("Client is outdated and was rejected by server.");
             self.core.event_bus.dispatch(Event::ClientOutdated(

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -901,7 +901,14 @@ pub enum Event {
     Disconnected(Disconnected),
     PairSuccess(PairSuccess),
     PairError(PairError),
-    LoggedOut(LoggedOut),
+    /// The device was logged out: unlinked, locked, or refused at connect.
+    /// Terminal for the session, so it fires at most once per connection.
+    ///
+    /// Boxed for the same reason as [`Event::IncomingCall`]: at 328 bytes it
+    /// was the variant setting the size of every `Event`, and every
+    /// dispatched event is one `Arc` allocation of that size whatever its
+    /// payload. A `<presence>` is not obliged to pay for a logout stanza.
+    LoggedOut(Box<LoggedOut>),
     PairingQrCode(PairingQrCode),
     PairingCode(PairingCode),
     PairingCodeRefresh(PairingCodeRefresh),
@@ -1018,7 +1025,10 @@ pub enum Event {
     BusinessStatusUpdate(BusinessStatusUpdate),
 
     StreamReplaced(StreamReplaced),
-    TemporaryBan(TemporaryBan),
+    /// The server temporarily banned the account. Like [`Event::LoggedOut`]
+    /// it fires at most once per connection, and carries the whole
+    /// `<failure>` stanza, so it is boxed for the same reason.
+    TemporaryBan(Box<TemporaryBan>),
     ConnectFailure(ConnectFailure),
     StreamError(StreamError),
 
@@ -2686,15 +2696,16 @@ mod tests {
     }
 
     /// `size_of::<Event>()` sizes every dispatched event (see the boxed
-    /// variants' docs for why). The ceiling is set by `LoggedOut` (328), with
-    /// `TemporaryBan` (312) behind it.
+    /// variants' docs for why). The ceiling is set by `ConnectFailure` (272);
+    /// `LoggedOut` and `TemporaryBan` used to set it at 328 before their
+    /// payloads were boxed.
     ///
     /// The number is not sacred; the order of magnitude is. Raising it means a
     /// new variant just made every event bigger, and the fix is almost always
     /// to box that variant's payload rather than to edit this line.
     #[test]
     fn event_stays_under_its_size_ceiling() {
-        const CEILING: usize = 328;
+        const CEILING: usize = 272;
         let size = size_of::<Event>();
         assert!(
             size <= CEILING,


### PR DESCRIPTION
Follow-up to #1402, which boxed `IncomingCall` and `GroupUpdate::action` (432 to 328 B). This boxes the two variants left setting the ceiling.

## Measurement

Probed `size_of` for every payload struct in `wacore/src/types/events.rs`:

| Payload | Bytes |
|---|---|
| `LoggedOut` | 328 |
| `TemporaryBan` | 312 |
| `ConnectFailure` | 272 |
| `StreamError` / `Receipt` | 264 |

`size_of::<Event>()`: **328 to 272 B (-56 B, -17%)**, now set by `ConnectFailure`. The discriminant still fits the existing padding, so the enum lands exactly on the third-largest payload.

## Decision: box at the enum level (Option A)

Matches the `IncomingCall(Box<IncomingCall>)` / `HistorySync(Box<LazyHistorySync>)` precedent exactly. Payload structs, builders, field types and variant order are untouched, so construction (`LoggedOut::builder()...build()`) and field reads (`lo.reason`, `ban.raw`) work as before; only the six dispatch sites wrap in `Box::new` and the bot callback clones through the box. Breaking for top-level pattern matching, hence the `!` (accepted pre-1.0). No runtime or wire change: `Box` is serde-transparent and both events fire at most once per connection, so the added indirection is off every hot path.

Option B (boxing `raw: Option<Node>` inside the structs) would have changed builder setters and every `.raw` reader for a smaller saving, and matched no precedent.

## Tests

- `event_stays_under_its_size_ceiling` now pins 272 and names `ConnectFailure` as the setter.
- Disconnect/logout/temp-ban suites green (`client::tests` 199 passed, `types::events` 28 passed, full `wacore` lib 1573 passed).
- Full `whatsapp-rust` lib green on rerun (1910 passed); one unrelated timing flake in `online_device_sync_releases_its_dedup_entry` on the first pass, green in isolation and on rerun.

Local: `cargo fmt --all` clean. Full `--all-targets` matrix and workspace clippy left for CI.