### PR TITLE
perf(signal): pre-size flush batches to their exact upper bound

### DIFF
--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1705,7 +1705,9 @@ impl SignalStoreCache {
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
             let deleted_keys: Vec<_> = state.deleted.iter().cloned().collect();
 
-            let mut batch: Vec<(Arc<str>, bytes::Bytes)> = Vec::new();
+            // At most one push per dirty key, so this is the exact upper
+            // bound: one allocation instead of the 0-4-8-16-32 growth chain.
+            let mut batch: Vec<(Arc<str>, bytes::Bytes)> = Vec::with_capacity(dirty_keys.len());
             for address in &dirty_keys {
                 // A dirty key is Present (promoted) or CheckedOut (taken by a
                 // concurrent reader). Only the Present ones can be persisted now;
@@ -1764,7 +1766,7 @@ impl SignalStoreCache {
             {
                 let mut removed = self.removed_prekeys.lock().await;
                 if !removed.is_empty() {
-                    let mut deletable: Vec<u32> = Vec::new();
+                    let mut deletable: Vec<u32> = Vec::with_capacity(removed.len());
                     for (id, addr) in removed.iter() {
                         // Resolve to an owned decision before any await so no cache
                         // borrow is held across the backend roundtrip.
@@ -1816,7 +1818,7 @@ impl SignalStoreCache {
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
             let deleted_keys: Vec<_> = state.deleted.iter().cloned().collect();
 
-            let mut batch: Vec<(Arc<str>, [u8; 32])> = Vec::new();
+            let mut batch: Vec<(Arc<str>, [u8; 32])> = Vec::with_capacity(dirty_keys.len());
             for address in &dirty_keys {
                 if let Some(Some(data)) = state.cache.get(address.as_ref()) {
                     let key: [u8; 32] = data.as_ref().try_into().map_err(|_| {
@@ -1850,8 +1852,8 @@ impl SignalStoreCache {
             let incarnation = state.incarnation;
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
 
-            let mut batch: Vec<(Arc<str>, bytes::Bytes)> = Vec::new();
-            let mut deleted: Vec<Arc<str>> = Vec::new();
+            let mut batch: Vec<(Arc<str>, bytes::Bytes)> = Vec::with_capacity(dirty_keys.len());
+            let mut deleted: Vec<Arc<str>> = Vec::with_capacity(dirty_keys.len());
             for name in &dirty_keys {
                 match state.cache.get(name.as_ref()) {
                     Some(Some(record)) => {


### PR DESCRIPTION
Eliminates the batch-Vec growth chain in `SignalStoreCache::flush`. Each loop pushes at most one entry per dirty key, so the capacity is the exact upper bound, not a guess.

## Measurement (throwaway counting allocator over flush, min-of-9, InMemoryBackend)

Allocations per flush by dirty-session count, before / after:

| N | before | after |
|---|---|---|
| 1 | 11 | 11 |
| 10 | 40 | 38 |
| 25 | 86 | 83 |
| 50 | 162 | 158 |

The saving is the batch growth chain (0-4-8-16-32 caps); per-session serialization already reserves exactly once, confirmed by identical retained live bytes (19,602 B at N=50 both ways).

## Deliberately not done: scratch-buffer reuse

Measured the prompt's option 2 (one cleared scratch buffer + `Bytes::copy_from_slice`): allocation count identical to this change, retained bytes identical, plus one memcpy per session. More CPU for zero gain, so the per-session `Vec` + zero-copy `Bytes::from` stays. The probe was removed; only the five `with_capacity` sites ship.

Checked the prompt's item 3: identities batch, sender-keys batch + deleted list, and the prekey `deletable` list all had the same pattern and are covered. The `dirty_keys`/`deleted_keys` collects already pre-size via `ExactSizeIterator`, so they are untouched.

## Validation

- `cargo test -p wacore --lib store::signal_cache`: 83 passed.
- `cargo test --test signal_durability_sqlite -- --ignored`: 2 passed.
- Full `wacore` lib: 1573 passed. `cargo clippy -p wacore --all-targets`: clean. `cargo fmt --all`: clean.
- Durability semantics untouched: capacity only bounds allocation, never the pushed contents.

No permanent alloc guard: the saving (~4 allocs at N=50 against ~160 of backend/table noise) cannot carry a bound with headroom, so a guard would be flaky by construction. Correctness follows from the loop structure (at most one push per key).