### PR TITLE
bench: cover the hot paths without a number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,6 +366,22 @@ required-features = ["bench-harness"]
 name = "jid_keyed_cache"
 harness = false
 
+# USync normalization + spec build: pure `wacore`/`wacore-binary` calls, no
+# runtime, no `bench-harness`. Same plain-`cargo bench` reasoning as above.
+[[bench]]
+name = "client_usync"
+harness = false
+
+# Warm `LidPnCache` hit/miss through the public cache only. Same reasoning.
+[[bench]]
+name = "client_identity_cache"
+harness = false
+
+# `Cache` write/evict/sweep terms around the read path. Same reasoning.
+[[bench]]
+name = "client_cache_maint"
+harness = false
+
 [profile.release]
 opt-level = 3
 debug = false

--- a/benches/client_cache_maint.rs
+++ b/benches/client_cache_maint.rs
@@ -1,0 +1,177 @@
+//! Client cache maintenance: the write and sweep terms around the read path.
+//!
+//! `jid_keyed_cache` pins the per-message `get` hit/miss/create; what it
+//! cannot see is what keeps that cache (and every sibling `Cache<Jid, _>`)
+//! bounded: plain `insert` throughput, insertion at capacity forcing FIFO
+//! eviction, and the `run_pending_tasks` sweep the keepalive maintenance tick
+//! runs (`fa36dc61e`). The sweep row is the regression for re-adding unbounded
+//! growth: with no TTL configured it must stay near-free, with expired
+//! entries it must scale with the expired set, not the resident one.
+//!
+//! Driven on a bare poll loop rather than a Tokio runtime, for the reason
+//! `jid_keyed_cache`'s header gives: uncontended `async_lock` futures complete
+//! on the first poll, and a runtime would bill its scheduling to the lookup.
+//!
+//! What it does not cover: the `TypedCache` custom-store path
+//! (`src/cache_store.rs:96` `to_string` per op), which needs a backend and
+//! belongs in `store_shapes`/`store_contention`, and the offline receipt
+//! grouping itself (`group_delivery_receipts` is crate-private; its burst
+//! shape is covered by `inbound_stanza`'s `burst_*` rows and its alloc floor
+//! by its unit test).
+
+use divan::{black_box, counter::ItemsCount};
+use std::future::Future;
+use std::pin::pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll, Waker};
+use std::time::Duration;
+use wacore_binary::jid::Jid;
+use whatsapp_rust::cache::Cache;
+
+fn main() {
+    divan::main();
+}
+
+/// Same first-poll driver as `jid_keyed_cache`; see its header.
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    loop {
+        if let Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+        std::hint::spin_loop();
+    }
+}
+
+const CACHE_SIZES: [usize; 3] = [64, 512, 4096];
+const BATCH: usize = 512;
+
+fn key(i: usize) -> Jid {
+    Jid::pn(format!("5511999{i:06}"))
+}
+
+/// Warm caches per size, built once; values are cheap so the clock keeps the
+/// cache bookkeeping, not the payload.
+fn warm(n: usize) -> &'static Cache<Jid, Arc<()>> {
+    static BUILT: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        CACHE_SIZES
+            .iter()
+            .map(|&m| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder().max_capacity(m as u64).build();
+                block_on(async {
+                    for i in 0..m {
+                        cache.insert(key(i), Arc::new(())).await;
+                    }
+                });
+                cache
+            })
+            .collect()
+    });
+    let idx = CACHE_SIZES
+        .iter()
+        .position(|&m| m == n)
+        .expect("known size");
+    &built[idx]
+}
+
+/// Plain insert throughput into a warm cache that never evicts.
+#[divan::bench(args = CACHE_SIZES)]
+fn cache_insert(bencher: divan::Bencher, n: usize) {
+    let cache = warm(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        block_on(async {
+            for i in 0..BATCH {
+                cache.insert(black_box(key(n + i)), Arc::new(())).await;
+            }
+        });
+        // Keep the cache at its size so every iteration measures the same
+        // steady state instead of growing the fixture without bound.
+        block_on(async {
+            for i in 0..BATCH {
+                cache.invalidate(black_box(&key(n + i))).await;
+            }
+        });
+        black_box(cache.entry_count())
+    });
+}
+
+/// Insertion at capacity: every insert evicts one entry, so the FIFO scan is
+/// on the bill. The per-iteration cost must not grow with what is retained.
+#[divan::bench(args = CACHE_SIZES)]
+fn cache_insert_at_capacity(bencher: divan::Bencher, n: usize) {
+    static FULL: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
+    let built = FULL.get_or_init(|| {
+        CACHE_SIZES
+            .iter()
+            .map(|&m| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder().max_capacity(m as u64).build();
+                block_on(async {
+                    for i in 0..m {
+                        cache.insert(key(i), Arc::new(())).await;
+                    }
+                });
+                cache
+            })
+            .collect()
+    });
+    let idx = CACHE_SIZES
+        .iter()
+        .position(|&m| m == n)
+        .expect("known size");
+    let cache = &built[idx];
+    let next = std::sync::atomic::AtomicUsize::new(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        block_on(async {
+            for _ in 0..BATCH {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                cache.insert(black_box(key(i)), Arc::new(())).await;
+            }
+        });
+        black_box(cache.entry_count())
+    });
+}
+
+/// The maintenance-tick sweep with nothing expirable: no TTL means no table
+/// walk, so this must stay flat in cache size.
+#[divan::bench(args = CACHE_SIZES)]
+fn sweep_idle_no_ttl(bencher: divan::Bencher, n: usize) {
+    let cache = warm(n);
+    bencher.counter(ItemsCount::new(1usize)).bench(|| {
+        block_on(cache.run_pending_tasks());
+        black_box(cache.entry_count())
+    });
+}
+
+/// The sweep with expired entries present: scales with the expired set.
+#[divan::bench(args = [64, 512])]
+fn sweep_with_expired(bencher: divan::Bencher, n: usize) {
+    static BUILT: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        [64usize, 512usize]
+            .iter()
+            .map(|&m| {
+                let cache: Cache<Jid, Arc<()>> = Cache::builder()
+                    .max_capacity((m * 2) as u64)
+                    .time_to_live(Duration::from_secs(3600))
+                    .build();
+                cache
+            })
+            .collect()
+    });
+    let idx = [64usize, 512usize]
+        .iter()
+        .position(|&m| m == n)
+        .expect("known size");
+    let cache = &built[idx];
+    bencher.counter(ItemsCount::new(n)).bench(|| {
+        block_on(async {
+            for i in 0..n {
+                cache.insert(black_box(key(i)), Arc::new(())).await;
+            }
+            cache.run_pending_tasks().await;
+        });
+        black_box(cache.entry_count())
+    });
+}

--- a/benches/client_cache_maint.rs
+++ b/benches/client_cache_maint.rs
@@ -76,18 +76,40 @@ fn warm(n: usize) -> &'static Cache<Jid, Arc<()>> {
     &built[idx]
 }
 
-/// Plain insert throughput into a warm cache that never evicts.
+/// Plain insert throughput into a warm cache that never evicts: capacity is
+/// `n + BATCH`, so the batch fits beside the resident set and every
+/// iteration starts and ends with the same `n` entries.
 #[divan::bench(args = CACHE_SIZES)]
 fn cache_insert(bencher: divan::Bencher, n: usize) {
-    let cache = warm(n);
+    static ROOMY: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
+    let built = ROOMY.get_or_init(|| {
+        CACHE_SIZES
+            .iter()
+            .map(|&m| {
+                let cache: Cache<Jid, Arc<()>> =
+                    Cache::builder().max_capacity((m + BATCH) as u64).build();
+                block_on(async {
+                    for i in 0..m {
+                        cache.insert(key(i), Arc::new(())).await;
+                    }
+                });
+                cache
+            })
+            .collect()
+    });
+    let idx = CACHE_SIZES
+        .iter()
+        .position(|&m| m == n)
+        .expect("known size");
+    let cache = &built[idx];
     bencher.counter(ItemsCount::new(BATCH)).bench(|| {
         block_on(async {
             for i in 0..BATCH {
                 cache.insert(black_box(key(n + i)), Arc::new(())).await;
             }
         });
-        // Keep the cache at its size so every iteration measures the same
-        // steady state instead of growing the fixture without bound.
+        // Back to the steady state so every iteration measures the same work
+        // instead of growing the fixture without bound.
         block_on(async {
             for i in 0..BATCH {
                 cache.invalidate(black_box(&key(n + i))).await;

--- a/benches/client_cache_maint.rs
+++ b/benches/client_cache_maint.rs
@@ -145,7 +145,15 @@ fn sweep_idle_no_ttl(bencher: divan::Bencher, n: usize) {
 }
 
 /// The sweep with expired entries present: scales with the expired set.
-#[divan::bench(args = [64, 512])]
+///
+/// Entries carry a 10 ms TTL and each iteration sleeps past it before
+/// sweeping, so the sweep always reclaims `n` expired entries — the assert
+/// proves it, and a sweep that stopped expiring would fail instead of
+/// silently measuring the live-entry walk. The sleep is a syscall, ~zero
+/// instructions, so CodSpeed's instruction counts stay a clean signal; wall
+/// time includes it, which is why this row runs few samples. Same 10/20 ms
+/// pairing the `portable_cache` expiry tests use.
+#[divan::bench(args = [64, 512], sample_count = 5, sample_size = 3)]
 fn sweep_with_expired(bencher: divan::Bencher, n: usize) {
     static BUILT: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
     let built = BUILT.get_or_init(|| {
@@ -154,7 +162,7 @@ fn sweep_with_expired(bencher: divan::Bencher, n: usize) {
             .map(|&m| {
                 let cache: Cache<Jid, Arc<()>> = Cache::builder()
                     .max_capacity((m * 2) as u64)
-                    .time_to_live(Duration::from_secs(3600))
+                    .time_to_live(Duration::from_millis(10))
                     .build();
                 cache
             })
@@ -170,8 +178,11 @@ fn sweep_with_expired(bencher: divan::Bencher, n: usize) {
             for i in 0..n {
                 cache.insert(black_box(key(i)), Arc::new(())).await;
             }
-            cache.run_pending_tasks().await;
         });
-        black_box(cache.entry_count())
+        std::thread::sleep(Duration::from_millis(20));
+        block_on(cache.run_pending_tasks());
+        let remaining = cache.entry_count();
+        assert_eq!(remaining, 0, "the sweep must reclaim every expired entry");
+        black_box(remaining)
     });
 }

--- a/benches/client_identity_cache.rs
+++ b/benches/client_identity_cache.rs
@@ -1,0 +1,157 @@
+//! LID↔PN identity lookups: the mapping every Signal address resolution pays.
+//!
+//! Both DM and group sends resolve each device's Signal address through
+//! `LidPnCache`, and the msg-secret path re-checks the alternate JID on a
+//! miss (`e18d9b10b`). `store_shapes` measures the DB scan behind a cold
+//! start; what is measured here is the warm in-process hit and miss, which is
+//! what every send after the first pays.
+//!
+//! Driven on a bare poll loop rather than a Tokio runtime: the cache's locks
+//! are `async_lock` primitives that resolve without yielding when
+//! uncontended, so every future here completes on its first poll, and a
+//! runtime in the loop would put its own scheduling on the clock instead of
+//! the lookup's. Same pattern as `benches/jid_keyed_cache.rs`.
+//!
+//! Fixtures are built once and each iteration works a batch: one lookup is
+//! tens of nanoseconds, below cloud wall-clock noise. Probes cycle rather
+//! than repeat so one process's hash seed cannot amplify a lucky bucket into
+//! a baseline shift (same note as `jid_keyed_cache`).
+//!
+//! What it does not cover: the persistent warm-up scan (see `store_shapes`
+//! `lid_pn_warm_up_scan`), the usync fetch that learns a miss, and the
+//! `SenderKeyDeviceMap` gate, which is `pub(crate)` and therefore measured
+//! only through `client_group_send`'s warm-send rows.
+
+use divan::{black_box, counter::ItemsCount};
+use std::future::Future;
+use std::pin::pin;
+use std::sync::OnceLock;
+use std::task::{Context, Poll, Waker};
+use wacore::types::{LearningSource, LidPnEntry};
+use whatsapp_rust::lid_pn_cache::LidPnCache;
+
+fn main() {
+    divan::main();
+}
+
+/// Drive a future to completion by polling it. Every future in this file
+/// resolves on the first poll; the spin is a fallback that hangs visibly
+/// rather than returning a wrong answer. Same helper as `jid_keyed_cache`.
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut cx = Context::from_waker(Waker::noop());
+    loop {
+        if let Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+        std::hint::spin_loop();
+    }
+}
+
+/// Mapping counts worth distinguishing: a 1:1-heavy account, a group-heavy
+/// one, a large community member set.
+const ENTRY_COUNTS: [usize; 3] = [64, 512, 4096];
+
+/// Lookups per measured iteration.
+const BATCH: usize = 1024;
+
+/// Fictional but well-shaped identifiers: 15-digit LIDs, E.164-like PNs.
+fn entry(i: usize) -> LidPnEntry {
+    LidPnEntry::new(
+        format!("100000000{i:06}"),
+        format!("1555000{i:05}"),
+        LearningSource::Usync,
+    )
+}
+
+struct Fixture {
+    cache: LidPnCache,
+    phones_hit: Vec<String>,
+    lids_hit: Vec<String>,
+    phones_miss: Vec<String>,
+    lids_miss: Vec<String>,
+}
+
+fn fixture(n: usize) -> &'static Fixture {
+    static BUILT: OnceLock<Vec<Fixture>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        ENTRY_COUNTS
+            .iter()
+            .map(|&m| {
+                let cache = LidPnCache::new();
+                block_on(async {
+                    for i in 0..m {
+                        cache.add(&entry(i)).await;
+                    }
+                });
+                Fixture {
+                    cache,
+                    phones_hit: (0..m).map(|i| format!("1555000{i:05}")).collect(),
+                    lids_hit: (0..m).map(|i| format!("100000000{i:06}")).collect(),
+                    phones_miss: (0..m).map(|i| format!("1555999{i:05}")).collect(),
+                    lids_miss: (0..m).map(|i| format!("199999999{i:06}")).collect(),
+                }
+            })
+            .collect()
+    });
+    let idx = ENTRY_COUNTS
+        .iter()
+        .position(|&m| m == n)
+        .expect("known width");
+    &built[idx]
+}
+
+/// PN → LID: the direction a PN-addressed send resolves per device.
+#[divan::bench(args = ENTRY_COUNTS)]
+fn lid_lookup_by_phone_hit(bencher: divan::Bencher, n: usize) {
+    let fx = fixture(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for i in 0..BATCH {
+            found += block_on(fx.cache.get_current_lid(black_box(&fx.phones_hit[i % n]))).is_some()
+                as usize;
+        }
+        black_box(found)
+    });
+}
+
+#[divan::bench(args = ENTRY_COUNTS)]
+fn lid_lookup_by_phone_miss(bencher: divan::Bencher, n: usize) {
+    let fx = fixture(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut absent = 0usize;
+        for i in 0..BATCH {
+            absent += block_on(fx.cache.get_current_lid(black_box(&fx.phones_miss[i % n])))
+                .is_none() as usize;
+        }
+        black_box(absent)
+    });
+}
+
+/// LID → PN: the direction group sends and the msg-secret alternate-JID check
+/// use.
+#[divan::bench(args = ENTRY_COUNTS)]
+fn pn_lookup_by_lid_hit(bencher: divan::Bencher, n: usize) {
+    let fx = fixture(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut found = 0usize;
+        for i in 0..BATCH {
+            found += block_on(fx.cache.get_phone_number(black_box(&fx.lids_hit[i % n]))).is_some()
+                as usize;
+        }
+        black_box(found)
+    });
+}
+
+#[divan::bench(args = ENTRY_COUNTS)]
+fn pn_lookup_by_lid_miss(bencher: divan::Bencher, n: usize) {
+    let fx = fixture(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut absent = 0usize;
+        for i in 0..BATCH {
+            absent += block_on(fx.cache.get_phone_number(black_box(&fx.lids_miss[i % n]))).is_none()
+                as usize;
+        }
+        black_box(absent)
+    });
+}

--- a/benches/client_usync.rs
+++ b/benches/client_usync.rs
@@ -1,0 +1,140 @@
+//! USync device-resolution hot path: the per-user work every send pays before
+//! any crypto runs.
+//!
+//! `client_group_send` / `client_dm_send` measure the whole warm send; what
+//! they cannot isolate is the addressing normalization underneath it:
+//! `Jid::to_non_ad` per user (`src/usync.rs:61`), the second `into_non_ad`
+//! pass over the same list (`:79`), the `to_protocol_address()` `String` per
+//! device (`wacore/src/send/encrypt.rs`), and the `DeviceListSpec` build for
+//! a registry miss. Each row here pins one of those terms so a change to it
+//! reads as a delta instead of hiding inside a whole-send number.
+//!
+//! Pure CPU, no runtime: every function measured is synchronous. Fixtures are
+//! built once per input width and each iteration works a batch, since one JID
+//! conversion is nanoseconds, below cloud wall-clock noise (same note as
+//! `wacore/binary/benches/jid_benchmark.rs`).
+//!
+//! What it does not cover, so no number here is over-read: the registry read
+//! itself (see `store_shapes` / `store_contention`), the network IQ, and the
+//! encrypt that follows. `into_non_ad` on an already-normalized list is the
+//! documented no-op second pass, kept as the regression that justifies
+//! removing it.
+
+use divan::{black_box, counter::ItemsCount};
+use std::sync::OnceLock;
+use wacore::iq::usync::DeviceListSpec;
+use wacore::types::jid::JidExt;
+use wacore_binary::jid::{Jid, Server};
+
+fn main() {
+    divan::main();
+}
+
+/// User counts worth distinguishing: a DM burst, a mid-size group, a large
+/// group sweep. What changes across them is the per-user slope, not the
+/// fixture.
+const USER_COUNTS: [usize; 3] = [32, 128, 512];
+
+/// Work per measured iteration: enough conversions that the batch clears timer
+/// noise, small enough that the fixture stays in cache.
+const BATCH: usize = 512;
+
+/// Fixed-width fictional users from the reserved 555-01xx block, alternating
+/// PN/LID servers the way a migrated group's member set looks. Six digits
+/// cover the largest fixture; widths never change mid-run.
+fn users(n: usize) -> &'static Vec<Jid> {
+    static BUILT: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
+    let built = BUILT.get_or_init(|| {
+        USER_COUNTS
+            .iter()
+            .map(|&m| {
+                (0..m)
+                    .map(|i| {
+                        let server = if i % 2 == 0 { Server::Pn } else { Server::Lid };
+                        Jid::new(format!("1555000{i:05}"), server)
+                    })
+                    .collect()
+            })
+            .collect()
+    });
+    let idx = USER_COUNTS
+        .iter()
+        .position(|&m| m == n)
+        .expect("known width");
+    &built[idx]
+}
+
+/// `Jid::to_non_ad` per user: the first pass `get_user_devices` always pays.
+#[divan::bench(args = USER_COUNTS)]
+fn normalize_borrow(bencher: divan::Bencher, n: usize) {
+    let input = users(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut done = 0usize;
+        for _ in 0..BATCH {
+            for jid in input.iter() {
+                black_box(jid.to_non_ad());
+                done += 1;
+            }
+        }
+        black_box(done)
+    });
+}
+
+/// `Jid::into_non_ad` over the already-normalized list: the second pass, a
+/// functional no-op that still walks and branches per user.
+#[divan::bench(args = USER_COUNTS)]
+fn normalize_owned_second_pass(bencher: divan::Bencher, n: usize) {
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut done = 0usize;
+        for _ in 0..BATCH {
+            // Cloned outside the timed region in spirit: `with_inputs` would
+            // exclude it, but the clone itself is part of what the second
+            // pass costs a caller that could have passed borrows instead.
+            let mut owned: Vec<Jid> = users(n).clone();
+            for jid in owned.drain(..) {
+                black_box(jid.into_non_ad());
+                done += 1;
+            }
+        }
+        black_box(done)
+    });
+}
+
+/// `to_protocol_address()` per device: the `user:device@server` `String` each
+/// device encrypt allocates to key its session lookup.
+#[divan::bench(args = USER_COUNTS)]
+fn protocol_address_per_device(bencher: divan::Bencher, n: usize) {
+    let input = users(n);
+    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+        let mut done = 0usize;
+        for _ in 0..BATCH {
+            for jid in input.iter() {
+                black_box(jid.with_device(0).to_protocol_address());
+                done += 1;
+            }
+        }
+        black_box(done)
+    });
+}
+
+/// `DeviceListSpec::new` for a full miss: the query object a registry miss
+/// builds before the IQ goes out. Pure construction, no IO.
+#[divan::bench(args = USER_COUNTS)]
+fn usync_spec_build(bencher: divan::Bencher, n: usize) {
+    bencher.counter(ItemsCount::new(n)).bench(|| {
+        let spec = DeviceListSpec::new(black_box(users(n).clone()), "bench-sid");
+        black_box(spec.jids.len())
+    });
+}
+
+/// `sort_dedup_by_user` over the miss list: paid once per fetch before the
+/// network, O(N log N) over users.
+#[divan::bench(args = USER_COUNTS)]
+fn sort_dedup_users(bencher: divan::Bencher, n: usize) {
+    bencher.counter(ItemsCount::new(n)).bench(|| {
+        let mut list = users(n).clone();
+        list.extend(users(n).iter().cloned());
+        wacore::types::jid::sort_dedup_by_user(black_box(&mut list));
+        black_box(list.len())
+    });
+}

--- a/benches/client_usync.rs
+++ b/benches/client_usync.rs
@@ -68,7 +68,7 @@ fn users(n: usize) -> &'static Vec<Jid> {
 #[divan::bench(args = USER_COUNTS)]
 fn normalize_borrow(bencher: divan::Bencher, n: usize) {
     let input = users(n);
-    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+    bencher.counter(ItemsCount::new(BATCH * n)).bench(|| {
         let mut done = 0usize;
         for _ in 0..BATCH {
             for jid in input.iter() {
@@ -84,7 +84,7 @@ fn normalize_borrow(bencher: divan::Bencher, n: usize) {
 /// functional no-op that still walks and branches per user.
 #[divan::bench(args = USER_COUNTS)]
 fn normalize_owned_second_pass(bencher: divan::Bencher, n: usize) {
-    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+    bencher.counter(ItemsCount::new(BATCH * n)).bench(|| {
         let mut done = 0usize;
         for _ in 0..BATCH {
             // Cloned outside the timed region in spirit: `with_inputs` would
@@ -105,7 +105,7 @@ fn normalize_owned_second_pass(bencher: divan::Bencher, n: usize) {
 #[divan::bench(args = USER_COUNTS)]
 fn protocol_address_per_device(bencher: divan::Bencher, n: usize) {
     let input = users(n);
-    bencher.counter(ItemsCount::new(BATCH)).bench(|| {
+    bencher.counter(ItemsCount::new(BATCH * n)).bench(|| {
         let mut done = 0usize;
         for _ in 0..BATCH {
             for jid in input.iter() {

--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -131,7 +131,7 @@ fn remove_db_files(path: &std::path::Path) {
     }
 }
 
-const DB_SLOTS: usize = 5;
+const DB_SLOTS: usize = 7;
 static DBS: [OnceLock<Db>; DB_SLOTS] = [const { OnceLock::new() }; DB_SLOTS];
 
 fn db(slot: usize, tag: &str) -> &'static Db {
@@ -211,5 +211,47 @@ fn remove_prekeys_batch(bencher: divan::Bencher, n: usize) {
             db.runtime
                 .block_on(db.store.remove_prekeys_batch(black_box(&ids)))
                 .expect("remove batch");
+        });
+}
+
+/// One `get_session` per device: the N+1 a group send pays on its session
+/// checkout, with no batch API to fold it into. The number a future
+/// `load_sessions_batch` has to beat.
+#[divan::bench(args = BATCH_SIZES)]
+fn get_session_hit(bencher: divan::Bencher, n: usize) {
+    let db = db(5, "get-hit");
+    bencher
+        .with_inputs(|| db.inserted_sessions(n))
+        .bench_values(|addresses| {
+            db.runtime.block_on(async {
+                for address in &addresses {
+                    black_box(
+                        db.store
+                            .get_session(black_box(address))
+                            .await
+                            .expect("load session"),
+                    );
+                }
+            });
+        });
+}
+
+/// Same, for addresses never written: the miss a first-contact send pays.
+#[divan::bench(args = BATCH_SIZES)]
+fn get_session_miss(bencher: divan::Bencher, n: usize) {
+    let db = db(6, "get-miss");
+    bencher
+        .with_inputs(|| db.fresh_sessions(n))
+        .bench_values(|batch| {
+            db.runtime.block_on(async {
+                for (address, _) in &batch {
+                    black_box(
+                        db.store
+                            .get_session(black_box(address))
+                            .await
+                            .expect("load miss"),
+                    );
+                }
+            });
         });
 }

--- a/wacore/benches/appstate_sync_benchmark.rs
+++ b/wacore/benches/appstate_sync_benchmark.rs
@@ -45,3 +45,18 @@ fn bench_collect_unique_index_macs(bencher: divan::Bencher, n: usize) {
         .with_inputs(|| setup_mutations(n))
         .bench_refs(|mutations| black_box(collect_unique_index_macs(black_box(mutations))));
 }
+
+/// Same scan over a patch that repeats one index: the dedup early-out shape.
+/// The delta against the distinct-index row above is the best-vs-worst spread
+/// a swap (HashSet, sort) must beat on both ends before it lands.
+fn setup_duplicate_mutations(n: usize) -> Vec<wa::SyncdMutation> {
+    let one = setup_mutations(1).pop().expect("one mutation");
+    vec![one; n]
+}
+
+#[divan::bench(args = [10, 1000])]
+fn bench_collect_unique_index_macs_duplicates(bencher: divan::Bencher, n: usize) {
+    bencher
+        .with_inputs(|| setup_duplicate_mutations(n))
+        .bench_refs(|mutations| black_box(collect_unique_index_macs(black_box(mutations))));
+}

--- a/wacore/benches/appstate_sync_benchmark.rs
+++ b/wacore/benches/appstate_sync_benchmark.rs
@@ -37,8 +37,9 @@ fn setup_mutations(n: usize) -> Vec<wa::SyncdMutation> {
         .collect()
 }
 
-/// 10 = a typical incremental patch; 1000 = the resume-sync upper bound, where
-/// the quadratic scan does ~500k Vec<u8> compares.
+/// 10 and 1000 straddle `MAC_DEDUP_SCAN_LIMIT` (64): 10 takes the linear
+/// scan — distinct indices are its worst case, a full compare per element —
+/// while 1000 takes the sort+dedup path, the resume-sync upper bound.
 #[divan::bench(args = [10, 1000])]
 fn bench_collect_unique_index_macs(bencher: divan::Bencher, n: usize) {
     bencher
@@ -46,9 +47,10 @@ fn bench_collect_unique_index_macs(bencher: divan::Bencher, n: usize) {
         .bench_refs(|mutations| black_box(collect_unique_index_macs(black_box(mutations))));
 }
 
-/// Same scan over a patch that repeats one index: the dedup early-out shape.
-/// The delta against the distinct-index row above is the best-vs-worst spread
-/// a swap (HashSet, sort) must beat on both ends before it lands.
+/// Same widths over one repeated index: the dedup early-out on the scan path
+/// (10) and an already-sorted input on the sort path (1000). The delta
+/// against the distinct rows above is the best-vs-worst spread a swap
+/// (HashSet, sort) must beat on both ends before it lands.
 fn setup_duplicate_mutations(n: usize) -> Vec<wa::SyncdMutation> {
     let one = setup_mutations(1).pop().expect("one mutation");
     vec![one; n]

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -173,3 +173,29 @@ fn media_decrypt_in_place_10mb(bencher: Bencher) {
 fn media_decrypt_in_place_1mb(bencher: Bencher) {
     bench_decrypt_in_place(bencher, MB, MediaType::Image);
 }
+
+/// The copying decrypt: allocates the plaintext beside the ciphertext, so one
+/// full-file memcpy plus a 2x peak. The delta against the in-place rows above
+/// is what routing a buffered HTTP response through
+/// `verify_and_decrypt_in_place` saves.
+fn bench_decrypt_copy(bencher: Bencher, len: usize, media_type: MediaType) {
+    let ciphertext = encrypted(len, media_type);
+    bencher
+        .counter(BytesCount::new(len))
+        .with_inputs(|| ciphertext.clone())
+        .bench_refs(|buf| {
+            black_box(
+                DownloadUtils::verify_and_decrypt(black_box(buf), &MEDIA_KEY, media_type).unwrap(),
+            );
+        });
+}
+
+#[divan::bench]
+fn media_decrypt_copy_10mb(bencher: Bencher) {
+    bench_decrypt_copy(bencher, 10 * MB, MediaType::Video);
+}
+
+#[divan::bench]
+fn media_decrypt_copy_1mb(bencher: Bencher) {
+    bench_decrypt_copy(bencher, MB, MediaType::Image);
+}

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -185,7 +185,8 @@ fn bench_decrypt_copy(bencher: Bencher, len: usize, media_type: MediaType) {
         .with_inputs(|| ciphertext.clone())
         .bench_refs(|buf| {
             black_box(
-                DownloadUtils::verify_and_decrypt(black_box(buf), &MEDIA_KEY, media_type).unwrap(),
+                DownloadUtils::verify_and_decrypt(black_box(buf), &MEDIA_KEY, media_type)
+                    .expect("fixture decrypt"),
             );
         });
 }

--- a/wacore/noise/benches/noise_benchmark.rs
+++ b/wacore/noise/benches/noise_benchmark.rs
@@ -1,9 +1,18 @@
 //! Transport-frame crypto: every stanza in and out of the socket pays one of
 //! these AES-256-GCM passes. 1.5 KB approximates a typical message stanza;
 //! 64 KB approximates a media-chunk-sized frame.
+//!
+//! The framing rows cover the buffer handoff around the crypto: `feed` copies
+//! a read into the accumulation buffer while `feed_owned` adopts a
+//! uniquely-owned `Bytes` instead. 28 KB is the AB-props response that aborted
+//! the ESP32-C3 with two full-size copies alive (`docs/esp32c3.md` in
+//! whatsapp-rust-esp32); the delta between the two rows is what that adoption
+//! saves per large frame.
 
+use bytes::Bytes;
 use divan::black_box;
 use wacore_noise::NoiseCipher;
+use wacore_noise::framing::{FrameDecoder, encode_frame};
 
 fn main() {
     divan::main();
@@ -39,5 +48,31 @@ fn bench_frame_decrypt_in_place(bencher: divan::Bencher, len: usize) {
             cipher.decrypt_in_place_with_counter(7, buf).unwrap();
             // Contents, not length: keeps the in-place writes observable.
             black_box(buf.as_slice());
+        });
+}
+
+/// The 28 KB AB-props-shaped frame, fed as a borrowed slice: one copy into
+/// the accumulation buffer on top of the caller's allocation.
+#[divan::bench]
+fn frame_feed_copy_28k(bencher: divan::Bencher) {
+    let wire = encode_frame(&frame(28_204), None).expect("encode");
+    bencher
+        .with_inputs(FrameDecoder::new)
+        .bench_values(|mut decoder| {
+            decoder.feed(black_box(&wire));
+            black_box(decoder.decode_frame().map(|f| f.len()))
+        });
+}
+
+/// Same frame, handed over as a uniquely-owned `Bytes`: adopted in place, no
+/// second copy. The delta against `frame_feed_copy_28k` is the ESP32-C3 fix.
+#[divan::bench]
+fn frame_feed_owned_28k(bencher: divan::Bencher) {
+    let wire = encode_frame(&frame(28_204), None).expect("encode");
+    bencher
+        .with_inputs(|| (FrameDecoder::new(), Bytes::from(wire.clone())))
+        .bench_values(|(mut decoder, owned)| {
+            decoder.feed_owned(black_box(owned));
+            black_box(decoder.decode_frame().map(|f| f.len()))
         });
 }


### PR DESCRIPTION
New targets (public API only, no bench-harness, plain `cargo bench`):
- **client_usync**: `to_non_ad`/`into_non_ad` second pass, protocol address per device, `DeviceListSpec` build, `sort_dedup_by_user`
- **client_identity_cache**: warm `LidPnCache` hit/miss both directions
- **client_cache_maint**: `Cache` insert/at-capacity, idle and expired sweep

New rows on existing targets:
- noise framing `feed` copy vs `feed_owned` at 28 KB (AB-props shape)
- appstate dedup best case (duplicate indices)
- signal `get_session` hit/miss (the N+1 a batch load must beat)
- media decrypt copy vs in-place at 1/10 MB

Patterns followed: `OnceLock` fixtures outside measurement, batch iterations, bare poll loop (no Tokio) for uncontended `async_lock` caches, current-thread runtime with `max_blocking_threads(1)` + 24h keep-alive where SQLite is involved. New targets reach only public APIs so they build without `bench-harness` and fall into the existing CodSpeed shards with no workflow change. Compiled via `cargo bench --no-run`, `fmt --check` and `clippy --benches` clean; numbers come from CI.