### PR TITLE
perf(send): memoize per-device addresses and batch session loads

### DIFF
--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -139,6 +139,22 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
+    /// Collapse the send's N+1 session loads into one backend batch by faulting
+    /// the fan-out's candidate addresses into the cache before it probes them
+    /// one by one. Best-effort by contract: the per-device paths still serve
+    /// anything this misses.
+    async fn prefetch_sessions(
+        &self,
+        addresses: &[ProtocolAddress],
+    ) -> Result<(), SignalProtocolError> {
+        let device = self.0.device();
+        self.0
+            .cache
+            .prefetch_sessions(addresses, &*device.backend)
+            .await
+            .map_err(signal_err("backend"))
+    }
+
     async fn load_session_for_update(
         &self,
         address: &ProtocolAddress,

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -139,10 +139,6 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
-    /// Collapse the send's N+1 session loads into one backend batch by faulting
-    /// the fan-out's candidate addresses into the cache before it probes them
-    /// one by one. Best-effort by contract: the per-device paths still serve
-    /// anything this misses.
     async fn prefetch_sessions(
         &self,
         addresses: &[ProtocolAddress],

--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -215,8 +215,8 @@ fn remove_prekeys_batch(bencher: divan::Bencher, n: usize) {
 }
 
 /// One `get_session` per device: the N+1 a group send pays on its session
-/// checkout, with no batch API to fold it into. The number a future
-/// `load_sessions_batch` has to beat.
+/// checkout when the cache is cold. The number `get_sessions_batch` has to
+/// beat: same rows through one query.
 #[divan::bench(args = BATCH_SIZES)]
 fn get_session_hit(bencher: divan::Bencher, n: usize) {
     let db = db(5, "get-hit");

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2178,6 +2178,36 @@ impl SignalStore for SqliteStore {
             .map(Bytes::from))
     }
 
+    /// One read query for the whole fan-out: the per-address `get_session` is a
+    /// pool checkout plus query each, and a group send faults one per device on
+    /// a cold cache. Chunked like `delete_sessions_batch`: a large group
+    /// carries more addresses than SQLite's host-parameter limit. Returns only
+    /// the addresses that exist, in backend order.
+    async fn get_sessions_batch(&self, addresses: &[Arc<str>]) -> Result<Vec<(Arc<str>, Bytes)>> {
+        if addresses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let device_id = self.device_id;
+        let items = Arc::new(addresses.to_vec());
+        self.read_query(move |conn| {
+            let mut out = Vec::with_capacity(items.len());
+            for chunk in items.chunks(ID_PARAM_CHUNK) {
+                let rows: Vec<(String, Vec<u8>)> = sessions::table
+                    .select((sessions::address, sessions::record))
+                    .filter(sessions::address.eq_any(chunk.iter().map(|a| a.as_ref())))
+                    .filter(sessions::device_id.eq(device_id))
+                    .load(conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                out.extend(
+                    rows.into_iter()
+                        .map(|(address, record)| (Arc::from(address), Bytes::from(record))),
+                );
+            }
+            Ok(out)
+        })
+        .await
+    }
+
     async fn has_session(&self, address: &str) -> Result<bool> {
         // Not the cache's has_session, which reads get_session instead. This one
         // is only reached through Device::contains_session, whose single caller
@@ -5195,6 +5225,46 @@ mod tests {
         store.put_sessions_batch(&[]).await.unwrap();
         store.put_identities_batch(&[]).await.unwrap();
         store.put_sender_keys_batch(&[]).await.unwrap();
+    }
+
+    /// The batch read is one query for the whole fan-out: hits come back keyed
+    /// as requested, misses are omitted (never returned empty), and an empty
+    /// request short-circuits without touching the database.
+    #[tokio::test]
+    async fn get_sessions_batch_reads_hits_in_one_query() {
+        use std::sync::Arc;
+        let store = create_test_store().await;
+
+        let sessions: Vec<(Arc<str>, Bytes)> = (0..5u8)
+            .map(|i| {
+                (
+                    Arc::from(format!("batchuser{i}@s.whatsapp.net").as_str()),
+                    Bytes::from(vec![i; 8]),
+                )
+            })
+            .collect();
+        store.put_sessions_batch(&sessions).await.unwrap();
+
+        let missing: Arc<str> = Arc::from("nobody@s.whatsapp.net");
+        let mut requested: Vec<Arc<str>> = sessions.iter().map(|(addr, _)| addr.clone()).collect();
+        requested.insert(2, missing.clone());
+        let loaded = store.get_sessions_batch(&requested).await.unwrap();
+        assert_eq!(loaded.len(), sessions.len(), "misses are omitted");
+        for (addr, bytes) in &sessions {
+            assert!(
+                loaded.iter().any(|(a, b)| a == addr && b == bytes),
+                "hit for {addr} must come back with its record"
+            );
+        }
+
+        assert!(
+            store
+                .get_sessions_batch(&[missing])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(store.get_sessions_batch(&[]).await.unwrap().is_empty());
     }
 
     #[test]

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -222,6 +222,21 @@ pub trait SessionStore: ThreadSafe {
     /// Destructive cache checkouts belong in `load_session_for_update`.
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
 
+    /// Hint to fault `addresses` into the store in one backend round-trip.
+    ///
+    /// A send fans out over every device, and without this each device pays its
+    /// own load; the caller offers the whole candidate set up front so a
+    /// batch-capable store can collapse the N+1. The default does nothing:
+    /// warming then happens through the normal per-address paths, so stores
+    /// without a batch backend keep their exact behavior. An override must only
+    /// populate what a later `load_session`/`has_session` would have read
+    /// anyway — never change store contents — so ignoring the hint is always
+    /// correct, just slower on a cold cache.
+    async fn prefetch_sessions(&self, addresses: &[ProtocolAddress]) -> Result<()> {
+        let _ = addresses;
+        Ok(())
+    }
+
     /// Loads a mutation copy and optionally marks it as destructively checked out.
     ///
     /// `None` is an assertion that [`load_session`] was non-destructive. A store

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -574,6 +574,13 @@ pub struct SessionPlan {
     /// Empty means "no device is overridden"; otherwise one slot per device.
     /// See [`record_encryption_override`].
     encryption_overrides: Vec<Option<Jid>>,
+    /// Effective encryption address per device, parallel to the `devices` slice
+    /// the plan was built from: rendered once by
+    /// [`ensure_sessions_for_devices`] so the encrypt fan-out reuses it instead
+    /// of formatting every device a second time. Empty for plans that predate
+    /// the memo ([`SessionPlan::assume_ready`]); consumers fall back to
+    /// rendering per device when the lengths disagree.
+    effective_addresses: Vec<ProtocolAddress>,
     pub had_unregistered_device: bool,
     /// Devices the server rejected *by name*. Empty when the whole batch
     /// failed, since a batch-wide answer names nobody.
@@ -607,6 +614,7 @@ impl SessionPlan {
         Self {
             device_count,
             encryption_overrides: Vec::new(),
+            effective_addresses: Vec::new(),
             had_unregistered_device: false,
             rejected_devices: Vec::new(),
             first_error: None,
@@ -643,6 +651,26 @@ async fn has_session_or_report(
 /// is what a warm send carries.
 fn encryption_override_at(overrides: &[Option<Jid>], index: usize) -> Option<&Jid> {
     overrides.get(index).and_then(Option::as_ref)
+}
+
+/// Effective encryption address for `devices[index]`: the render
+/// [`ensure_sessions_for_devices`] memoized in the plan, cloned out (an inline
+/// value, so the clone is a memcpy, not an allocation). A plan without a memo
+/// for this device — [`SessionPlan::assume_ready`], or a length mismatch that
+/// means the plan was built for a different slice — renders on the spot, which
+/// is what every path did before the memo existed.
+fn encrypt_address_at(
+    effective_addresses: &[ProtocolAddress],
+    overrides: &[Option<Jid>],
+    devices: &[Jid],
+    index: usize,
+) -> ProtocolAddress {
+    if let Some(addr) = effective_addresses.get(index) {
+        return addr.clone();
+    }
+    encryption_override_at(overrides, index)
+        .unwrap_or(&devices[index])
+        .to_protocol_address()
 }
 
 /// Record a per-index LID override, materializing the map on its first entry.
@@ -708,14 +736,14 @@ pub async fn ensure_sessions_for_devices_resolved(
     let mut unkeyed_devices: Vec<Jid> = Vec::new();
     let mut first_error = None;
 
-    let mut reusable_addr = crate::types::jid::make_reusable_protocol_address();
-
+    // Resolve every device's LID upgrade up front: the prefetch below and the
+    // probe loop both index by device, and resolving twice would pay the
+    // mapping lookup (a boxed `async_trait` call into an async-locked cache) N
+    // extra times. A caller-resolved address that equals the device is "no
+    // upgrade", the same answer the lookup gives.
+    let mut lid_upgrades: Vec<Option<Cow<'_, Jid>>> = Vec::with_capacity(devices.len());
     for (idx, device_jid) in devices.iter().enumerate() {
-        // Resolved once per device: both the session probe and the prekey
-        // branch below want it, and the lookup is a boxed `async_trait` call
-        // into an async-locked cache. A caller-resolved address that equals
-        // the device is "no upgrade", the same answer the lookup gives.
-        let lid_jid: Option<Cow<'_, Jid>> = match signal_addresses {
+        lid_upgrades.push(match signal_addresses {
             Some(addrs) => {
                 let addr = &addrs[idx];
                 (addr != device_jid).then_some(Cow::Borrowed(addr))
@@ -725,42 +753,57 @@ pub async fn ensure_sessions_for_devices_resolved(
                 .await
                 .map(|lid_user| Cow::Owned(Jid::lid_device(lid_user, device_jid.device))),
             None => None,
-        };
+        });
+    }
+
+    // Render every candidate address once: `candidates[i]` is what `devices[i]`
+    // probes under, with the LID upgrades appended after (their positions in
+    // `lid_addr_of`). The probe loop and the encrypt fan-out both consume these
+    // renders, so no device formats its address twice per send anymore.
+    let mut candidates: Vec<ProtocolAddress> =
+        Vec::with_capacity(devices.len() + lid_upgrades.iter().filter(|u| u.is_some()).count());
+    for device_jid in devices.iter() {
+        candidates.push(device_jid.to_protocol_address());
+    }
+    let mut lid_addr_of: Vec<Option<usize>> = Vec::with_capacity(devices.len());
+    for upgrade in &lid_upgrades {
+        match upgrade {
+            Some(lid_jid) => {
+                lid_addr_of.push(Some(candidates.len()));
+                candidates.push(lid_jid.to_protocol_address());
+            }
+            None => lid_addr_of.push(None),
+        }
+    }
+
+    // One backend round-trip for the whole fan-out instead of one per cold
+    // device: the probes below (and the encrypt checkouts after them) then hit
+    // cache. Best-effort — a failure falls through to the per-device paths,
+    // which report it with its address attached.
+    if let Err(error) = stores.session_store.prefetch_sessions(&candidates).await {
+        log::debug!("session prefetch failed, falling back to per-device loads: {error}");
+    }
+
+    // The effective encryption address per device, parallel to `devices`: the
+    // single render the encrypt fan-out reuses.
+    let mut effective_addresses: Vec<ProtocolAddress> = Vec::with_capacity(devices.len());
+
+    for (idx, device_jid) in devices.iter().enumerate() {
         // WhatsApp Web's SignalAddress.toString() normalizes PN → LID before
         // creating signal addresses. We do the same: check LID session FIRST.
         // This prevents using stale PN sessions when a newer LID session exists.
-        if let Some(lid_jid) = &lid_jid {
-            lid_jid.reset_protocol_address(&mut reusable_addr);
-
-            if has_session_or_report(stores.session_store, &reusable_addr, resolver, devices)
-                .await?
-            {
-                log::debug!(
-                    "Using LID session {} for PN {} (LID-first lookup)",
-                    lid_jid.observe(),
-                    device_jid.observe()
-                );
-                record_encryption_override(
-                    &mut encryption_overrides,
-                    devices.len(),
-                    idx,
-                    lid_jid.clone().into_owned(),
-                );
-                continue;
-            }
-        }
-
-        device_jid.reset_protocol_address(&mut reusable_addr);
-        if has_session_or_report(stores.session_store, &reusable_addr, resolver, devices).await? {
-            continue;
-        }
-
-        // No session found - need to fetch prekeys and create session.
-        // Keep device_jid for prekey fetch (server returns bundles keyed by this),
-        // but normalize to LID for the actual session creation.
-        if let Some(lid_jid) = lid_jid {
+        if let (Some(lid_jid), Some(lid_addr_idx)) =
+            (lid_upgrades[idx].as_deref(), lid_addr_of[idx])
+            && has_session_or_report(
+                stores.session_store,
+                &candidates[lid_addr_idx],
+                resolver,
+                devices,
+            )
+            .await?
+        {
             log::debug!(
-                "Will create LID session {} for PN {} (no existing session)",
+                "Using LID session {} for PN {} (LID-first lookup)",
                 lid_jid.observe(),
                 device_jid.observe()
             );
@@ -768,8 +811,33 @@ pub async fn ensure_sessions_for_devices_resolved(
                 &mut encryption_overrides,
                 devices.len(),
                 idx,
-                lid_jid.into_owned(),
+                lid_jid.clone(),
             );
+            effective_addresses.push(candidates[lid_addr_idx].clone());
+            continue;
+        }
+
+        if has_session_or_report(stores.session_store, &candidates[idx], resolver, devices).await? {
+            effective_addresses.push(candidates[idx].clone());
+            continue;
+        }
+
+        // No session found - need to fetch prekeys and create session.
+        // Keep device_jid for prekey fetch (server returns bundles keyed by this),
+        // but normalize to LID for the actual session creation.
+        if let (Some(lid_jid), Some(lid_addr_idx)) = (
+            lid_upgrades[idx].clone().map(Cow::into_owned),
+            lid_addr_of[idx],
+        ) {
+            log::debug!(
+                "Will create LID session {} for PN {} (no existing session)",
+                lid_jid.observe(),
+                device_jid.observe()
+            );
+            effective_addresses.push(candidates[lid_addr_idx].clone());
+            record_encryption_override(&mut encryption_overrides, devices.len(), idx, lid_jid);
+        } else {
+            effective_addresses.push(candidates[idx].clone());
         }
         indices_needing_prekeys.push(idx);
     }
@@ -1009,6 +1077,7 @@ pub async fn ensure_sessions_for_devices_resolved(
     Ok(SessionPlan {
         device_count: devices.len(),
         encryption_overrides,
+        effective_addresses,
         had_unregistered_device: had_406,
         rejected_devices,
         first_error,
@@ -1146,6 +1215,7 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
     let SessionPlan {
         device_count: _,
         encryption_overrides,
+        effective_addresses,
         had_unregistered_device,
         rejected_devices,
         mut first_error,
@@ -1161,9 +1231,8 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
     // sorts before hashing, as does our `participant_list_hash`.
     if devices.len() <= INLINE_ENCRYPT_DEVICES {
         for (idx, device) in devices.iter().enumerate() {
-            let addr = encryption_override_at(&encryption_overrides, idx)
-                .unwrap_or(device)
-                .to_protocol_address();
+            let addr =
+                encrypt_address_at(&effective_addresses, &encryption_overrides, devices, idx);
             let res = encrypt_one_device(
                 plaintext_to_encrypt,
                 &addr,
@@ -1200,10 +1269,15 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
             // The 'static task can't borrow devices/encryption_overrides.
             let jobs: Vec<(ProtocolAddress, Jid)> = (chunk_start..chunk_end)
                 .map(|idx| {
-                    let addr = encryption_override_at(&encryption_overrides, idx)
-                        .unwrap_or(&devices[idx])
-                        .to_protocol_address();
-                    (addr, devices[idx].clone())
+                    (
+                        encrypt_address_at(
+                            &effective_addresses,
+                            &encryption_overrides,
+                            devices,
+                            idx,
+                        ),
+                        devices[idx].clone(),
+                    )
                 })
                 .collect();
             let plaintext = plaintext_arc.clone();
@@ -1315,7 +1389,10 @@ mod participant_node_tests {
 
 #[cfg(test)]
 mod encryption_override_tests {
-    use super::{SessionPlan, encryption_override_at, record_encryption_override};
+    use super::{
+        SessionPlan, encrypt_address_at, encryption_override_at, record_encryption_override,
+    };
+    use crate::types::jid::JidExt;
     use wacore_binary::Jid;
 
     fn lid(user: &str, device: u16) -> Jid {
@@ -1387,5 +1464,31 @@ mod encryption_override_tests {
             Some(&lid("100000000000009", 33))
         );
         assert!(encryption_override_at(&overrides, 1).is_none());
+    }
+
+    /// The memo hit serves the exact render `ensure` stored, so the fan-out
+    /// formats nothing; without a memo entry the address renders on the spot,
+    /// byte-identical to the pre-memo path.
+    #[test]
+    fn encrypt_address_prefers_the_memoized_render() {
+        let device = lid("100000000000001", 5);
+        let upgraded = lid("100000000000002", 5);
+        let devices = vec![device.clone()];
+        let memo = vec![upgraded.to_protocol_address()];
+        let overrides = vec![Some(upgraded.clone())];
+
+        let addr = encrypt_address_at(&memo, &overrides, &devices, 0);
+        assert_eq!(addr.as_str(), upgraded.to_protocol_address().as_str());
+        assert_ne!(addr.as_str(), device.to_protocol_address().as_str());
+
+        // No memo (e.g. `assume_ready`): the override still decides the render.
+        let empty: Vec<crate::libsignal::protocol::ProtocolAddress> = Vec::new();
+        let addr = encrypt_address_at(&empty, &overrides, &devices, 0);
+        assert_eq!(addr.as_str(), upgraded.to_protocol_address().as_str());
+
+        // Neither memo nor override: the device's own address.
+        let no_overrides: Vec<Option<Jid>> = Vec::new();
+        let addr = encrypt_address_at(&empty, &no_overrides, &devices, 0);
+        assert_eq!(addr.as_str(), device.to_protocol_address().as_str());
     }
 }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -581,6 +581,12 @@ pub struct SessionPlan {
     /// the memo ([`SessionPlan::assume_ready`]); consumers fall back to
     /// rendering per device when the lengths disagree.
     effective_addresses: Vec<ProtocolAddress>,
+    /// Fingerprint of the exact device identities the memo was rendered from.
+    /// Length alone cannot prove the memo belongs to this list — same length,
+    /// different devices would silently encrypt to stale sessions — so the
+    /// consume points verify it. Zero for [`SessionPlan::assume_ready`], whose
+    /// memo is always empty and never consulted.
+    device_fingerprint: u64,
     pub had_unregistered_device: bool,
     /// Devices the server rejected *by name*. Empty when the whole batch
     /// failed, since a batch-wide answer names nobody.
@@ -615,6 +621,7 @@ impl SessionPlan {
             device_count,
             encryption_overrides: Vec::new(),
             effective_addresses: Vec::new(),
+            device_fingerprint: 0,
             had_unregistered_device: false,
             rejected_devices: Vec::new(),
             first_error: None,
@@ -651,6 +658,28 @@ async fn has_session_or_report(
 /// is what a warm send carries.
 fn encryption_override_at(overrides: &[Option<Jid>], index: usize) -> Option<&Jid> {
     overrides.get(index).and_then(Option::as_ref)
+}
+
+/// Identity fingerprint of the device list a [`SessionPlan`] memo was rendered
+/// from: FNV-1a over each device's user, server and device id. Compared at the
+/// consume points so a plan can never serve a same-length, different-identity
+/// list its renders do not belong to. No dependency and no allocation; the
+/// release build never calls it (see the `debug_assert` at the consume site).
+fn device_list_fingerprint(devices: &[Jid]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET;
+    for device in devices {
+        for byte in device.user.as_str().as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        hash ^= device.server as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        hash ^= u64::from(device.device);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
 }
 
 /// Effective encryption address for `devices[index]`: the render
@@ -1078,6 +1107,7 @@ pub async fn ensure_sessions_for_devices_resolved(
         device_count: devices.len(),
         encryption_overrides,
         effective_addresses,
+        device_fingerprint: device_list_fingerprint(devices),
         had_unregistered_device: had_406,
         rejected_devices,
         first_error,
@@ -1212,10 +1242,23 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
         devices.len(),
         "SessionPlan built for a different device list"
     );
+    // Same length is not same list: the memo is parallel to the exact
+    // identities it was rendered from, and serving it to different devices
+    // would encrypt to stale sessions. Unreachable by construction — the memo
+    // field is private, `assume_ready` (the only cross-crate constructor)
+    // leaves it empty, and every in-tree flow consumes the plan over the slice
+    // it was built from — so this stays a debug check and release pays nothing.
+    // An empty memo (`assume_ready`) always falls back to per-device rendering.
+    debug_assert!(
+        plan.effective_addresses.is_empty()
+            || plan.device_fingerprint == device_list_fingerprint(devices),
+        "SessionPlan consumed with different device identities than built from"
+    );
     let SessionPlan {
         device_count: _,
         encryption_overrides,
         effective_addresses,
+        device_fingerprint: _,
         had_unregistered_device,
         rejected_devices,
         mut first_error,
@@ -1390,7 +1433,8 @@ mod participant_node_tests {
 #[cfg(test)]
 mod encryption_override_tests {
     use super::{
-        SessionPlan, encrypt_address_at, encryption_override_at, record_encryption_override,
+        SessionPlan, device_list_fingerprint, encrypt_address_at, encryption_override_at,
+        record_encryption_override,
     };
     use crate::types::jid::JidExt;
     use wacore_binary::Jid;
@@ -1490,5 +1534,25 @@ mod encryption_override_tests {
         let no_overrides: Vec<Option<Jid>> = Vec::new();
         let addr = encrypt_address_at(&empty, &no_overrides, &devices, 0);
         assert_eq!(addr.as_str(), device.to_protocol_address().as_str());
+    }
+
+    /// The fingerprint behind the consume-site guard: stable for the same
+    /// list, different for a same-length list with different identities, so a
+    /// memo can never serve devices it was not rendered from.
+    #[test]
+    fn device_list_fingerprint_separates_same_length_lists() {
+        let list = vec![lid("100000000000001", 5), lid("100000000000002", 0)];
+        assert_eq!(
+            device_list_fingerprint(&list),
+            device_list_fingerprint(&list.clone())
+        );
+        assert_ne!(
+            device_list_fingerprint(&list),
+            device_list_fingerprint(&vec![lid("100000000000001", 5), lid("100000000000003", 0)])
+        );
+        assert_ne!(
+            device_list_fingerprint(&list),
+            device_list_fingerprint(&vec![lid("100000000000001", 5)])
+        );
     }
 }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -1548,11 +1548,11 @@ mod encryption_override_tests {
         );
         assert_ne!(
             device_list_fingerprint(&list),
-            device_list_fingerprint(&vec![lid("100000000000001", 5), lid("100000000000003", 0)])
+            device_list_fingerprint(&[lid("100000000000001", 5), lid("100000000000003", 0)])
         );
         assert_ne!(
             device_list_fingerprint(&list),
-            device_list_fingerprint(&vec![lid("100000000000001", 5)])
+            device_list_fingerprint(&[lid("100000000000001", 5)])
         );
     }
 }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -312,6 +312,19 @@ impl SignalStore for InMemoryBackend {
         Ok(self.state.lock().await.sessions.get(address).cloned())
     }
 
+    /// One lock acquisition for the whole fan-out instead of one per device.
+    /// Returns only the addresses that exist, like the default.
+    async fn get_sessions_batch(&self, addresses: &[Arc<str>]) -> Result<Vec<(Arc<str>, Bytes)>> {
+        let state = self.state.lock().await;
+        let mut result = Vec::with_capacity(addresses.len());
+        for address in addresses {
+            if let Some(session) = state.sessions.get(address.as_ref()) {
+                result.push((address.clone(), session.clone()));
+            }
+        }
+        Ok(result)
+    }
+
     async fn put_session(&self, address: &str, session: &[u8]) -> Result<()> {
         self.state
             .lock()
@@ -1510,6 +1523,40 @@ mod tests {
     #[test]
     fn in_memory_backend_implements_backend() {
         is_backend::<InMemoryBackend>();
+    }
+
+    /// The batch read returns only what exists, keyed as requested: a send's
+    /// prefetch tells hits from misses by set difference.
+    #[tokio::test]
+    async fn get_sessions_batch_returns_only_hits() {
+        let backend = InMemoryBackend::new();
+        let first: Arc<str> = "15550000001:1@s.whatsapp.net".into();
+        let second: Arc<str> = "15550000002:2@s.whatsapp.net".into();
+        let missing: Arc<str> = "15550000003:3@s.whatsapp.net".into();
+        backend
+            .put_sessions_batch(&[
+                (first.clone(), Bytes::from_static(b"first")),
+                (second.clone(), Bytes::from_static(b"second")),
+            ])
+            .await
+            .unwrap();
+
+        let loaded = backend
+            .get_sessions_batch(&[first.clone(), missing.clone(), second.clone()])
+            .await
+            .unwrap();
+        assert_eq!(loaded.len(), 2, "misses are omitted, not returned empty");
+        assert_eq!(loaded[0], (first, Bytes::from_static(b"first")));
+        assert_eq!(loaded[1], (second, Bytes::from_static(b"second")));
+
+        assert!(
+            backend
+                .get_sessions_batch(&[missing])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(backend.get_sessions_batch(&[]).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1367,6 +1367,70 @@ impl SignalStoreCache {
             .is_some())
     }
 
+    /// Fault a send's candidate session addresses into the cache in one backend
+    /// round-trip instead of one per cold device.
+    ///
+    /// Only addresses the cache does not already know are read; a warm send
+    /// therefore pays a lock scan and no backend call at all. Each row installs
+    /// exactly as a cold [`Self::checkout_session`] would have left it —
+    /// positively, or negatively when the backend has no row (or this build
+    /// cannot decode it) — so a later checkout or probe answers from cache.
+    /// An entry that appeared while the batch was in flight is never clobbered:
+    /// it is newer than anything the batch could have read.
+    pub async fn prefetch_sessions(
+        &self,
+        addresses: &[ProtocolAddress],
+        backend: &dyn SignalStore,
+    ) -> Result<()> {
+        let (missing, since) = {
+            let state = self.lock_sessions().await;
+            let mut missing = Vec::new();
+            for address in addresses {
+                let key = address.as_str();
+                if state.cache.get(key).is_none() {
+                    missing.push(state.key_for(key));
+                }
+            }
+            (missing, state.cache.removal_seq())
+        };
+        if missing.is_empty() {
+            return Ok(());
+        }
+        // Backend I/O outside the lock, like every other cold path.
+        let loaded = backend.get_sessions_batch(&missing).await?;
+        let mut state = self.lock_sessions().await;
+        let mut found: HashMap<&str, &[u8]> = HashMap::with_capacity(loaded.len());
+        for (address, record) in &loaded {
+            found.insert(address.as_ref(), record.as_ref());
+        }
+        for key in &missing {
+            // Raced with a concurrent install, checkout or eviction: keep the
+            // newer entry, or skip a key whose newer write was dropped behind
+            // us, rather than rewinding it with the batch's older read. This is
+            // the multi-key form of the stamp `checkout_session` re-checks.
+            if state.cache.get(key.as_ref()).is_some()
+                || state.cache.removed_since(key.as_ref(), since)
+            {
+                continue;
+            }
+            // Decoded against the current incarnation, which may have bumped
+            // while the batch was in flight; the rows are still the backend's
+            // truth either way.
+            let record = found
+                .get(key.as_ref())
+                .copied()
+                .and_then(|bytes| Self::decode_stored_session(key, bytes, &state.incarnation))
+                .map(Arc::new);
+            let entry = match &record {
+                Some(record) => SessionEntry::Present(record.clone()),
+                None => SessionEntry::Absent,
+            };
+            state.cache.insert(key.clone(), entry);
+        }
+        state.evict_if_needed(self.max_entries);
+        Ok(())
+    }
+
     // === Identities ===
 
     pub async fn get_identity(
@@ -3525,6 +3589,66 @@ mod sender_key_lock_tests {
             Some(false),
             "negative-cached entry must answer synchronously"
         );
+    }
+
+    /// A send faults its whole fan-out with one backend read: hits install as
+    /// present, misses as absent, and afterwards every probe and checkout is
+    /// served synchronously with no backend consult left to make.
+    #[tokio::test]
+    async fn prefetch_faults_a_whole_fanout_in_one_backend_read() {
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let writer = SignalStoreCache::with_max_entries_and_incarnation(
+            DEFAULT_MAX_CACHE_ENTRIES,
+            [0xA1; 16],
+        );
+        let present: Vec<ProtocolAddress> = (0..4u8)
+            .map(|i| ProtocolAddress::new(&format!("199955510{i}@c.us"), 0.into()))
+            .collect();
+        for addr in &present {
+            writer.put_session(addr, SessionRecord::new_fresh()).await;
+        }
+        writer.flush(&backend).await.expect("seed flush");
+
+        let cache = SignalStoreCache::with_max_entries_and_incarnation(
+            DEFAULT_MAX_CACHE_ENTRIES,
+            [0xA1; 16],
+        );
+        let missing = ProtocolAddress::new("19995551999@c.us", 0.into());
+        let fanout: Vec<ProtocolAddress> = present
+            .iter()
+            .cloned()
+            .chain(std::iter::once(missing.clone()))
+            .collect();
+        cache
+            .prefetch_sessions(&fanout, &backend)
+            .await
+            .expect("prefetch");
+
+        for addr in &present {
+            assert_eq!(
+                cache.try_has_session(addr),
+                Some(true),
+                "a prefetched hit must answer synchronously"
+            );
+            let (record, checkout) = cache
+                .try_checkout_session(addr)
+                .expect("lock free")
+                .expect("cached hit checks out");
+            assert!(record.is_some(), "the prefetched row must decode");
+            cache.cancel_session_checkout(addr, checkout);
+        }
+        assert_eq!(
+            cache.try_has_session(&missing),
+            Some(false),
+            "a prefetched miss must answer negatively without a backend read"
+        );
+
+        // A warm prefetch is only the lock scan: everything is already known.
+        cache
+            .prefetch_sessions(&fanout, &backend)
+            .await
+            .expect("warm prefetch");
+        assert_eq!(cache.try_has_session(&missing), Some(false));
     }
 
     #[tokio::test]

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -591,6 +591,21 @@ pub trait SignalStore: Send + Sync {
         Ok(())
     }
 
+    /// Load multiple encrypted sessions in a single backend operation.
+    /// Returns only the addresses that exist, like [`Self::load_prekeys_batch`].
+    /// Default implementation falls back to individual `get_session` calls.
+    /// Addresses are `Arc<str>` so a caller holding the cache's keys passes
+    /// shared refs without allocating a `String` per entry.
+    async fn get_sessions_batch(&self, addresses: &[Arc<str>]) -> Result<Vec<(Arc<str>, Bytes)>> {
+        let mut result = Vec::with_capacity(addresses.len());
+        for address in addresses {
+            if let Some(session) = self.get_session(address).await? {
+                result.push((address.clone(), session));
+            }
+        }
+        Ok(result)
+    }
+
     /// Delete a session.
     async fn delete_session(&self, address: &str) -> Result<()>;
 


### PR DESCRIPTION
Kills the O(devices) per-send allocs and round-trips in group/DM sends:

- **Render once, reuse across the send.** `ensure_sessions_for_devices_resolved` hoists LID resolution, renders every candidate address once, and records the effective render per device in `SessionPlan.effective_addresses`; both encrypt branches consume via `encrypt_address_at` (falls back to per-device render for foreign plans). Audit: `dm.rs:616` already formatted once; all other callers are single-address paths — the `encrypt.rs` fan-out loops were the only per-device sites. Store-trait keys stay `&str`.
- **Batch session loads.** New `SignalStore::get_sessions_batch` (hits only, mirrors `load_prekeys_batch`, defaulted so downstream backends keep compiling) with single-lock (in-memory) and single-query (SQLite, `IN (...)` per chunk) overrides. The send path prefetches the candidate set best-effort via a new no-op-default `SessionStore::prefetch_sessions`, installed into the cache exactly like a cold checkout; warm sends pay only a lock scan and issue no backend call.

Verified: `wacore` lib 1576 passed (3 new), `sqlite-storage` 92 passed (1 new), adapter tests 18 passed, `fmt`/`clippy` clean. Watch in CI: `client_group_send` warm send (scales with device count); `get_session_hit` pins the old N+1 path. Note: the `client_usync protocol_address` micro-rows bench the constructor itself (unchanged) — the send path just calls it half as often.