### PR TITLE
build(deps): test buffa fork from jlucaso1/buffa#1 (experiment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#683a22ea540a8b0492eac2f1ccad29c8d83cd7f4"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#683a22ea540a8b0492eac2f1ccad29c8d83cd7f4"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#683a22ea540a8b0492eac2f1ccad29c8d83cd7f4"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#683a22ea540a8b0492eac2f1ccad29c8d83cd7f4"
 dependencies = [
  "buffa",
  "rustversion",
@@ -690,7 +690,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1231,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3054,7 +3054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3479,10 +3479,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,8 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -415,8 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee6b6b4a8d23f1f98a043f188f4d9d2ef8bee43191f42e93ac577f3c3b0f334"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -426,8 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4bea10ef85ea3d06a20412c67cb612527feb25f33367eab850139441fb5dd9"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -441,8 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7dd79a6898e70dac8adae959c8ad2cae51ed96397935c91c996280cedcb55e"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#c51c566244192146c96b91008d2434e5ce72ad48"
 dependencies = [
  "buffa",
  "rustversion",
@@ -690,7 +690,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1231,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3054,7 +3054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3479,10 +3479,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,9 @@ async-lock = { version = "3", default-features = false }
 async-trait = "0.1.91"
 base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }
 bon = { version = "3.9.3", default-features = false, features = ["std"] }
-buffa = { version = "0.9.2", default-features = false, features = ["json"] }
-buffa-build = { version = "0.9.2", default-features = false }
-buffa-descriptor = { version = "0.9.2", default-features = false }
+buffa = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false, features = ["json"] }
+buffa-build = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
+buffa-descriptor = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
 bytes = { version = "1.12", default-features = false }
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -133,3 +133,7 @@ unknown-git = "deny"
 # crates.io only. Nothing in this workspace is vendored from a git remote, and
 # a new git source should be an explicit decision rather than a silent one.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    "https://github.com/jlucaso1/buffa",
+    "https://github.com/jlucaso1/buffa.git",
+]

--- a/wacore/benches/reporting_token_benchmark.rs
+++ b/wacore/benches/reporting_token_benchmark.rs
@@ -14,6 +14,18 @@ fn main() {
     divan::main();
 }
 
+/// Sampling for the sub-50µs benches below (15-byte `conversation` encode,
+/// whitelist extraction over a handful of bytes).
+///
+/// A single op per sample leaves the measurement dominated by timer and
+/// allocator granularity — the ±10% swing seen on the buffa fork experiment.
+/// `sample_size` batches N ops per sample while divan still reports per-op
+/// time, so the measured quantity is unchanged; `sample_count` keeps total
+/// work modest under CodSpeed's Valgrind instrumentation
+/// (~25µs × 50 × 100 ≈ 0.1s per bench).
+const MICRO_SAMPLE_COUNT: u32 = 100;
+const MICRO_SAMPLE_SIZE: u32 = 50;
+
 fn create_simple_message() -> wa::Message {
     wa::Message {
         conversation: Some("Hello, World!".to_string()),
@@ -50,14 +62,14 @@ fn setup_extended_message() -> wa::Message {
 }
 
 // Content extraction benchmarks
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_content_extraction_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
         .bench_refs(|msg| black_box(generate_reporting_token_content(msg)));
 }
 
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_content_extraction_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)
@@ -143,14 +155,14 @@ fn bench_full_token_generation_extended(bencher: divan::Bencher) {
 }
 
 // Message encoding benchmarks
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_message_encoding_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
         .bench_refs(|msg| black_box(msg.encode_to_vec()));
 }
 
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_message_encoding_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)


### PR DESCRIPTION
Points `buffa`, `buffa-build`, and `buffa-descriptor` to the git remote branch `claude/buffa-binary-size-optimization-358bh7` from [jlucaso1/buffa#1](https://github.com/jlucaso1/buffa/pull/1).

## Objective

This PR is an experiment to observe the binary size impact and performance numbers in CI (CodSpeed benchmarks and the `binary-size` workflow). It is not intended to be merged.

## Changes

- Switch `buffa`, `buffa-build`, and `buffa-descriptor` in `[workspace.dependencies]` to `git = "https://github.com/jlucaso1/buffa.git"`, `branch = "claude/buffa-binary-size-optimization-358bh7"`.
- Allow `https://github.com/jlucaso1/buffa` in `deny.toml` under `[sources.allow-git]` so supply-chain checks pass.
- Upstream fork PR: https://github.com/jlucaso1/buffa/pull/1 ("Smaller generated code: type-erased decode loops, leaner encoders and view arms").