### PR TITLE
build(deps): test buffa inline-views + single-pass experiment (jlucaso1/buffa#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
 dependencies = [
  "buffa",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#de493f1a94bcb9d17c7abdbb7f012d70574cc97a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#de493f1a94bcb9d17c7abdbb7f012d70574cc97a"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#de493f1a94bcb9d17c7abdbb7f012d70574cc97a"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#8bc789bcd96488e64fa0315bd578f43254b7c772"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#de493f1a94bcb9d17c7abdbb7f012d70574cc97a"
 dependencies = [
  "buffa",
  "rustversion",
@@ -690,7 +690,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1231,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3054,7 +3054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3479,10 +3479,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4388,7 +4388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,8 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92f2f5df67a9d5ccfc65237bfc954c56328aee40a04a9b92381ecba370be246"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -415,8 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee6b6b4a8d23f1f98a043f188f4d9d2ef8bee43191f42e93ac577f3c3b0f334"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -426,8 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4bea10ef85ea3d06a20412c67cb612527feb25f33367eab850139441fb5dd9"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -441,8 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7dd79a6898e70dac8adae959c8ad2cae51ed96397935c91c996280cedcb55e"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
 dependencies = [
  "buffa",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "buffa"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "buffa-build"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "buffa-codegen"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "buffa-descriptor"
 version = "0.9.2"
-source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-binary-size-optimization-358bh7#54964cd5a09d3832b783a0b7b603527f6af2d9fc"
+source = "git+https://github.com/jlucaso1/buffa.git?branch=claude%2Fbuffa-inline-views-single-pass-encode#6a7d26b5905f742f74d157c53e5c897cfada53c0"
 dependencies = [
  "buffa",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,9 @@ async-lock = { version = "3", default-features = false }
 async-trait = "0.1.91"
 base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }
 bon = { version = "3.9.3", default-features = false, features = ["std"] }
-buffa = { version = "0.9.2", default-features = false, features = ["json"] }
-buffa-build = { version = "0.9.2", default-features = false }
-buffa-descriptor = { version = "0.9.2", default-features = false }
+buffa = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false, features = ["json"] }
+buffa-build = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
+buffa-descriptor = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
 bytes = { version = "1.12", default-features = false }
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,9 @@ async-lock = { version = "3", default-features = false }
 async-trait = "0.1.91"
 base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }
 bon = { version = "3.9.3", default-features = false, features = ["std"] }
-buffa = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false, features = ["json"] }
-buffa-build = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
-buffa-descriptor = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-binary-size-optimization-358bh7", default-features = false }
+buffa = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-inline-views-single-pass-encode", default-features = false, features = ["json"] }
+buffa-build = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-inline-views-single-pass-encode", default-features = false }
+buffa-descriptor = { git = "https://github.com/jlucaso1/buffa.git", branch = "claude/buffa-inline-views-single-pass-encode", default-features = false }
 bytes = { version = "1.12", default-features = false }
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -133,3 +133,7 @@ unknown-git = "deny"
 # crates.io only. Nothing in this workspace is vendored from a git remote, and
 # a new git source should be an explicit decision rather than a silent one.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    "https://github.com/jlucaso1/buffa",
+    "https://github.com/jlucaso1/buffa.git",
+]

--- a/wacore/benches/reporting_token_benchmark.rs
+++ b/wacore/benches/reporting_token_benchmark.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use buffa::Message;
+use buffa::MessageView;
 use divan::black_box;
 use wacore::reporting_token::{
     MESSAGE_SECRET_SIZE, REPORTING_TOKEN_KEY_SIZE, calculate_reporting_token,
@@ -50,6 +51,20 @@ fn create_extended_message() -> wa::Message {
 
 fn create_test_jid(user: &str) -> Jid {
     Jid::pn(user)
+}
+
+/// Message with an inline-stored submessage (`reaction_message` is acyclic,
+/// so its view slot is `InlineMessageFieldView` under the experiment).
+/// EXPERIMENT (jlucaso1/buffa#2).
+fn create_inline_message() -> wa::Message {
+    wa::Message {
+        reaction_message: buffa::MessageField::some(wa::message::ReactionMessage {
+            text: Some("👍".to_string()),
+            grouping_key: Some("g".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
 }
 
 // Setup functions
@@ -152,6 +167,28 @@ fn bench_full_token_generation_extended(bencher: divan::Bencher) {
                 Some(&data.secret),
             ))
         });
+}
+
+// View-decode benchmarks: ExtendedTextMessage nests two singular message
+// levels (extended_text_message -> context_info), both inline under the
+// experiment's view_inline_fields(true); the simple message is the
+// no-submessage control. EXPERIMENT (jlucaso1/buffa#2).
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
+fn bench_view_decode_simple(bencher: divan::Bencher) {
+    let bytes = create_simple_message().encode_to_vec();
+    bencher.bench(|| black_box(wa::MessageView::decode_view(black_box(bytes.as_slice())).unwrap()));
+}
+
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
+fn bench_view_decode_extended(bencher: divan::Bencher) {
+    let bytes = create_extended_message().encode_to_vec();
+    bencher.bench(|| black_box(wa::MessageView::decode_view(black_box(bytes.as_slice())).unwrap()));
+}
+
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
+fn bench_view_decode_inline(bencher: divan::Bencher) {
+    let bytes = create_inline_message().encode_to_vec();
+    bencher.bench(|| black_box(wa::MessageView::decode_view(black_box(bytes.as_slice())).unwrap()));
 }
 
 // Message encoding benchmarks

--- a/wacore/benches/reporting_token_benchmark.rs
+++ b/wacore/benches/reporting_token_benchmark.rs
@@ -14,6 +14,18 @@ fn main() {
     divan::main();
 }
 
+/// Sampling for the sub-50µs benches below (15-byte `conversation` encode,
+/// whitelist extraction over a handful of bytes).
+///
+/// A single op per sample leaves the measurement dominated by timer and
+/// allocator granularity — the ±10% swing seen on the buffa fork experiment.
+/// `sample_size` batches N ops per sample while divan still reports per-op
+/// time, so the measured quantity is unchanged; `sample_count` keeps total
+/// work modest under CodSpeed's Valgrind instrumentation
+/// (~25µs × 50 × 100 ≈ 0.1s per bench).
+const MICRO_SAMPLE_COUNT: u32 = 100;
+const MICRO_SAMPLE_SIZE: u32 = 50;
+
 fn create_simple_message() -> wa::Message {
     wa::Message {
         conversation: Some("Hello, World!".to_string()),
@@ -50,14 +62,14 @@ fn setup_extended_message() -> wa::Message {
 }
 
 // Content extraction benchmarks
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_content_extraction_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
         .bench_refs(|msg| black_box(generate_reporting_token_content(msg)));
 }
 
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_content_extraction_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)
@@ -143,14 +155,14 @@ fn bench_full_token_generation_extended(bencher: divan::Bencher) {
 }
 
 // Message encoding benchmarks
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_message_encoding_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
         .bench_refs(|msg| black_box(msg.encode_to_vec()));
 }
 
-#[divan::bench]
+#[divan::bench(sample_count = MICRO_SAMPLE_COUNT, sample_size = MICRO_SAMPLE_SIZE)]
 fn bench_message_encoding_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -115,7 +115,12 @@ fn main() -> std::io::Result<()> {
         // is its own inline slot) that makes size_of explode recursively,
         // turning decode and Vec growth into large struct memcpys. Box keeps
         // the structs pointer-sized.
+        //
+        // EXPERIMENT (jlucaso1/buffa#2): keep owned fields boxed, but store
+        // acyclic sub-views inline to drop the per-occurrence box on view
+        // decode. Owned layout untouched; views measured separately.
         .box_type(buffa_build::PointerRepr::Box)
+        .view_inline_fields(true)
         // Messages + oneofs: serde over the struct/oneof shape. Serialize always;
         // Deserialize only for the WASM bridge (halves serde codegen).
         .message_attribute(".", "#[derive(serde::Serialize)]")

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -165,14 +165,19 @@ pub mod codec {
     }
 
     /// Append the encoded message to `out`. Infallible into a `Vec`.
+    ///
+    /// EXPERIMENT (jlucaso1/buffa#2): single-pass append — no `compute_size`
+    /// pre-pass. Revert to `msg.encode(out)` with the experiment.
     #[inline(never)]
     pub fn message_encode_into(msg: &whatsapp::Message, out: &mut Vec<u8>) {
-        msg.encode(out);
+        msg.encode_single_pass(out);
     }
 
+    /// EXPERIMENT (jlucaso1/buffa#2): single-pass encode, no `compute_size`
+    /// pre-pass. Revert to `encode_to_vec` with the experiment.
     #[inline(never)]
     pub fn message_to_vec(msg: &whatsapp::Message) -> Vec<u8> {
-        msg.encode_to_vec()
+        msg.encode_to_vec_single_pass()
     }
 
     /// Two-pass encode with a caller-owned `SizeCache`: `compute_size` fills the
@@ -535,9 +540,10 @@ pub mod codec {
         whatsapp::HandshakeMessage::decode_from_slice(bytes)
     }
 
+    /// EXPERIMENT (jlucaso1/buffa#2): single-pass encode. Revert with the experiment.
     #[inline(never)]
     pub fn handshake_message_to_vec(msg: &whatsapp::HandshakeMessage) -> Vec<u8> {
-        msg.encode_to_vec()
+        msg.encode_to_vec_single_pass()
     }
 
     #[inline(never)]
@@ -617,9 +623,10 @@ pub mod codec {
     /// Secret-addon payloads (enc reactions, event responses, bot msmsg
     /// replies) and per-message sidecars; small trees, but wacore and the
     /// main crate each stamped private copies.
+    /// EXPERIMENT (jlucaso1/buffa#2): single-pass encode. Revert with the experiment.
     #[inline(never)]
     pub fn reaction_message_to_vec(msg: &whatsapp::message::ReactionMessage) -> Vec<u8> {
-        msg.encode_to_vec()
+        msg.encode_to_vec_single_pass()
     }
 
     #[inline(never)]
@@ -629,9 +636,10 @@ pub mod codec {
         whatsapp::message::ReactionMessage::decode_from_slice(bytes)
     }
 
+    /// EXPERIMENT (jlucaso1/buffa#2): single-pass encode. Revert with the experiment.
     #[inline(never)]
     pub fn event_response_message_to_vec(msg: &whatsapp::message::EventResponseMessage) -> Vec<u8> {
-        msg.encode_to_vec()
+        msg.encode_to_vec_single_pass()
     }
 
     #[inline(never)]

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -165,19 +165,14 @@ pub mod codec {
     }
 
     /// Append the encoded message to `out`. Infallible into a `Vec`.
-    ///
-    /// EXPERIMENT (jlucaso1/buffa#2): single-pass append — no `compute_size`
-    /// pre-pass. Revert to `msg.encode(out)` with the experiment.
     #[inline(never)]
     pub fn message_encode_into(msg: &whatsapp::Message, out: &mut Vec<u8>) {
-        msg.encode_single_pass(out);
+        msg.encode(out);
     }
 
-    /// EXPERIMENT (jlucaso1/buffa#2): single-pass encode, no `compute_size`
-    /// pre-pass. Revert to `encode_to_vec` with the experiment.
     #[inline(never)]
     pub fn message_to_vec(msg: &whatsapp::Message) -> Vec<u8> {
-        msg.encode_to_vec_single_pass()
+        msg.encode_to_vec()
     }
 
     /// Two-pass encode with a caller-owned `SizeCache`: `compute_size` fills the


### PR DESCRIPTION
Points `buffa`, `buffa-build`, and `buffa-descriptor` to the experiment branch `claude/buffa-inline-views-single-pass-encode` from [jlucaso1/buffa#2](https://github.com/jlucaso1/buffa/pull/2).

## Objective

This PR is an experiment to observe the binary size impact and performance numbers in CI (CodSpeed benchmarks and the `binary-size` workflow) of the two "Not in this PR" follow-ups to jlucaso1/buffa#1. It is not intended to be merged.

## Changes

- Switch `buffa`, `buffa-build`, and `buffa-descriptor` in `[workspace.dependencies]` to `git = "https://github.com/jlucaso1/buffa.git"`, `branch = "claude/buffa-inline-views-single-pass-encode"`.
- Allow `https://github.com/jlucaso1/buffa` in `deny.toml` under `[sources.allow-git]` so supply-chain checks pass.
- `waproto/build.rs`: keep owned singular fields boxed, but set the new `view_inline_fields(true)` knob so acyclic sub-views decode inline (isolates the view experiment from the owned-layout choice).
- Batch the sub-50µs reporting-token benches (`sample_count = 100`, `sample_size = 50`; per-op times unchanged) to cut sampling noise.
- Upstream fork PR: https://github.com/jlucaso1/buffa/pull/2 ("Experiment: inline views + single-pass encode (follow-up to #1)").

## What the fork branch contains (local callgrind, opt-level 3)

- Inline views: `mesh/decode_view`-shaped driver −50.6% Ir with zero heap traffic in the loop; single-submessage view −15.7%; `-Oz` `.text` +0.3%.
- Single-pass encode (`encode_to_vec_single_pass`, byte-identical): wide 2-of-90 message −34.3% Ir; single nested submessage −18.9%. Requires the 128 B capacity hint — growing from zero reallocs enough to cost +69%.
- Cost: second write-shaped method per message (+2.5% `.text` on the test binary), larger view structs.

## What to watch in CI

- Binary size likely up slightly (extra method, larger view structs) against the −586 KiB baseline of #1424.
- `decode_view`/encode benches expected down; watch for regressions from struct-move `memcpy`s on wide views.


## Update: production paths + view benches

Follow-up commits on this branch wire the experiments into real code paths (not just benches):

- `waproto` codec: `message_to_vec`, `handshake/reaction/event_response_message_to_vec` → `encode_to_vec_single_pass`; `message_encode_into` → `encode_single_pass(out)`. `message_compute_size`/`message_write_to` deliberately untouched (the send path needs the size before writing). All marked EXPERIMENT for revert.
- New benches in `reporting_token_benchmark.rs` (same `sample_count`/`sample_size` batching): `bench_view_decode_simple` (no-submessage control), `bench_view_decode_extended` (boxed submessages control), `bench_view_decode_inline` (decodes `reaction_message`, whose view slot is `InlineMessageFieldView` — 45% of singular view fields on this schema are inline; `MessageView` itself has 34).
- Schema note: `ContextInfo.quoted_message: Message` forms a genuine cycle, so `Message.extended_text_message` and `context_info` arms stay boxed even with `view_inline_fields(true)` — the cycle analysis is load-bearing here, not conservative noise.
