### PR TITLE
perf(sqlite): reuse prepared statements for hot Signal upserts

### DIFF
--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -366,17 +366,16 @@ fn update_sessions_first_prepare(bencher: divan::Bencher, n: usize) {
             let alt = true;
             let batch = db.fixed_sessions(n, alt);
             ColdUpdateInput {
-                db,
+                db: Some(db),
                 alt,
                 batch,
                 written: false,
             }
         })
         .bench_local_refs(|input| {
-            input
-                .db
-                .runtime
-                .block_on(input.db.store.put_sessions_batch(black_box(&input.batch)))
+            let db = input.db.as_ref().expect("live cold input");
+            db.runtime
+                .block_on(db.store.put_sessions_batch(black_box(&input.batch)))
                 .expect("cold update batch");
             input.written = true;
         });
@@ -384,7 +383,7 @@ fn update_sessions_first_prepare(bencher: divan::Bencher, n: usize) {
 
 // Input destruction happens outside bench_local_refs' measured region.
 struct ColdUpdateInput {
-    db: Db,
+    db: Option<Db>,
     alt: bool,
     batch: Vec<(Arc<str>, Bytes)>,
     written: bool,
@@ -392,9 +391,12 @@ struct ColdUpdateInput {
 
 impl Drop for ColdUpdateInput {
     fn drop(&mut self) {
+        let Some(db) = self.db.take() else { return };
         if self.written && !std::thread::panicking() {
-            self.db.verify_fixed_sessions(self.batch.len(), self.alt);
+            db.verify_fixed_sessions(self.batch.len(), self.alt);
         }
-        self.db.remove_files();
+        let path = db.path.clone();
+        drop(db);
+        remove_db_files(&path);
     }
 }

--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -14,8 +14,9 @@
 //!   per backend call, each a `spawn_blocking`, a pool checkout and a WAL
 //!   commit; the batched form is one transaction.
 //!
-//! One database per benchmark, opened once for the process and grown by every
-//! iteration: rows are never reused, so an insert is always an insert.
+//! Insert/delete fixtures reuse a database and generate fresh row keys.
+//! Warm updates reuse fixed keys; first-preparation updates use a fresh store
+//! per input with the target rows seeded through a separate connection.
 
 use bytes::Bytes;
 use divan::black_box;
@@ -356,13 +357,14 @@ fn update_sessions_first_prepare(bencher: divan::Bencher, n: usize) {
                         )
                         .bind::<diesel::sql_types::Text, _>(address.as_ref())
                         .bind::<diesel::sql_types::Binary, _>(record.as_ref())
-                        .bind::<diesel::sql_types::Integer, _>(0)
+                        .bind::<diesel::sql_types::Integer, _>(db.store.device_id())
                         .execute(conn)?;
                     }
                     Ok::<_, diesel::result::Error>(())
                 })
                 .expect("seed initial rows");
             }
+            db.verify_fixed_sessions(n, false);
             let alt = true;
             let batch = db.fixed_sessions(n, alt);
             ColdUpdateInput {

--- a/storages/sqlite-storage/benches/signal_flush.rs
+++ b/storages/sqlite-storage/benches/signal_flush.rs
@@ -31,7 +31,7 @@ fn main() {
     }
 }
 
-const BATCH_SIZES: &[usize] = &[1, 8, 64];
+const BATCH_SIZES: &[usize] = &[1, 8, 64, 256];
 
 /// A flushed session record is a few hundred bytes; the size only has to be
 /// realistic enough that the row write is not dominated by the key.
@@ -121,6 +121,58 @@ impl Db {
             .expect("seed prekeys");
         batch.into_iter().map(|(id, _)| id).collect()
     }
+
+    fn ensure_fixed_sessions(&self, n: usize) {
+        let addresses: Vec<(Arc<str>, Bytes)> = (0..n)
+            .map(|i| {
+                (
+                    Arc::from(format!("1000000{i:08}@fixed").as_str()),
+                    Bytes::from(vec![0x11; RECORD_LEN]),
+                )
+            })
+            .collect();
+        self.runtime
+            .block_on(self.store.put_sessions_batch(&addresses))
+            .expect("seed fixed sessions");
+    }
+
+    fn fixed_sessions(&self, n: usize, alt: bool) -> Vec<(Arc<str>, Bytes)> {
+        let byte = if alt { 0xA5 } else { 0x5A };
+        let record = Bytes::from(vec![byte; RECORD_LEN]);
+        (0..n)
+            .map(|i| {
+                (
+                    Arc::from(format!("1000000{i:08}@fixed").as_str()),
+                    record.clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn verify_fixed_sessions(&self, n: usize, alt: bool) {
+        let expected = if alt { 0xA5 } else { 0x5A };
+        self.runtime.block_on(async {
+            for i in 0..n {
+                let addr = format!("1000000{i:08}@fixed");
+                let loaded = self
+                    .store
+                    .get_session(&addr)
+                    .await
+                    .expect("load fixed session")
+                    .expect("session must exist");
+                assert_eq!(
+                    loaded.len(),
+                    RECORD_LEN,
+                    "record length mismatch for {addr}"
+                );
+                assert_eq!(
+                    loaded.as_ref(),
+                    &[expected; RECORD_LEN],
+                    "record payload mismatch for {addr}"
+                );
+            }
+        });
+    }
 }
 
 fn remove_db_files(path: &std::path::Path) {
@@ -131,7 +183,7 @@ fn remove_db_files(path: &std::path::Path) {
     }
 }
 
-const DB_SLOTS: usize = 7;
+const DB_SLOTS: usize = 8;
 static DBS: [OnceLock<Db>; DB_SLOTS] = [const { OnceLock::new() }; DB_SLOTS];
 
 fn db(slot: usize, tag: &str) -> &'static Db {
@@ -254,4 +306,95 @@ fn get_session_miss(bencher: divan::Bencher, n: usize) {
                 }
             });
         });
+}
+
+/// Repeated updates of existing sessions with alternating payloads:
+/// steady-state statement reuse across multiple flushes of fixed conversation keys.
+#[divan::bench(args = BATCH_SIZES)]
+fn update_sessions_warm(bencher: divan::Bencher, n: usize) {
+    let db = db(7, "update-warm");
+    db.ensure_fixed_sessions(n);
+    let toggle = portable_atomic::AtomicBool::new(false);
+    let last_written = portable_atomic::AtomicBool::new(false);
+    bencher
+        .with_inputs(|| {
+            let alt = toggle.fetch_xor(true, portable_atomic::Ordering::Relaxed);
+            last_written.store(alt, portable_atomic::Ordering::Relaxed);
+            db.fixed_sessions(n, alt)
+        })
+        .bench_values(|batch| {
+            db.runtime
+                .block_on(db.store.put_sessions_batch(black_box(&batch)))
+                .expect("warm update batch");
+        });
+    db.verify_fixed_sessions(n, last_written.load(portable_atomic::Ordering::Relaxed));
+}
+
+/// First execution of the upsert on a fresh store/connection:
+/// measures initial statement preparation before any statement reuse.
+#[divan::bench(args = BATCH_SIZES, sample_count = 20, sample_size = 1)]
+fn update_sessions_first_prepare(bencher: divan::Bencher, n: usize) {
+    static COLD_ID: portable_atomic::AtomicU64 = portable_atomic::AtomicU64::new(0);
+    bencher
+        .with_inputs(|| {
+            let id = COLD_ID.fetch_add(1, portable_atomic::Ordering::Relaxed);
+            let db = Db::open(&format!("cold-{n}-{id}"));
+            // Seed directly with an independent connection so db.store's pooled connection
+            // has not yet prepared the upsert statement.
+            {
+                use diesel::Connection;
+                use diesel::RunQueryDsl;
+                let mut conn = diesel::sqlite::SqliteConnection::establish(
+                    db.path.to_str().expect("utf-8 path"),
+                )
+                .expect("open direct seed connection");
+                let batch = db.fixed_sessions(n, false);
+                conn.transaction(|conn| {
+                    for (address, record) in &batch {
+                        diesel::sql_query(
+                            "INSERT INTO sessions (address, record, device_id) VALUES (?, ?, ?)",
+                        )
+                        .bind::<diesel::sql_types::Text, _>(address.as_ref())
+                        .bind::<diesel::sql_types::Binary, _>(record.as_ref())
+                        .bind::<diesel::sql_types::Integer, _>(0)
+                        .execute(conn)?;
+                    }
+                    Ok::<_, diesel::result::Error>(())
+                })
+                .expect("seed initial rows");
+            }
+            let alt = true;
+            let batch = db.fixed_sessions(n, alt);
+            ColdUpdateInput {
+                db,
+                alt,
+                batch,
+                written: false,
+            }
+        })
+        .bench_local_refs(|input| {
+            input
+                .db
+                .runtime
+                .block_on(input.db.store.put_sessions_batch(black_box(&input.batch)))
+                .expect("cold update batch");
+            input.written = true;
+        });
+}
+
+// Input destruction happens outside bench_local_refs' measured region.
+struct ColdUpdateInput {
+    db: Db,
+    alt: bool,
+    batch: Vec<(Arc<str>, Bytes)>,
+    written: bool,
+}
+
+impl Drop for ColdUpdateInput {
+    fn drop(&mut self) {
+        if self.written && !std::thread::panicking() {
+            self.db.verify_fixed_sessions(self.batch.len(), self.alt);
+        }
+        self.db.remove_files();
+    }
 }

--- a/storages/sqlite-storage/src/lib.rs
+++ b/storages/sqlite-storage/src/lib.rs
@@ -7,6 +7,7 @@ mod pool;
 mod schema;
 mod shared;
 mod sqlite_store;
+pub(crate) mod upsert_queries;
 mod wire;
 
 pub use shared::SharedSqlite;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1464,17 +1464,13 @@ impl SqliteStore {
                     let mut conn = pool_clone
                         .get()
                         .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::insert_into(identities::table)
-                        .values((
-                            identities::address.eq(address_clone.as_ref()),
-                            identities::key.eq(&key[..]),
-                            identities::device_id.eq(device_id),
-                        ))
-                        .on_conflict((identities::address, identities::device_id))
-                        .do_update()
-                        .set(identities::key.eq(&key[..]))
-                        .execute(&mut *conn)
-                        .map_err(DieselOrStore::Diesel)?;
+                    crate::upsert_queries::UpsertIdentity {
+                        address: address_clone.as_ref(),
+                        key: &key[..],
+                        device_id,
+                    }
+                    .execute(&mut *conn)
+                    .map_err(DieselOrStore::Diesel)?;
                     Ok(())
                 })
                 .await;
@@ -1599,17 +1595,13 @@ impl SqliteStore {
                     let mut conn = pool_clone
                         .get()
                         .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::insert_into(sessions::table)
-                        .values((
-                            sessions::address.eq(address_clone.as_ref()),
-                            sessions::record.eq(session_clone.as_ref()),
-                            sessions::device_id.eq(device_id),
-                        ))
-                        .on_conflict((sessions::address, sessions::device_id))
-                        .do_update()
-                        .set(sessions::record.eq(session_clone.as_ref()))
-                        .execute(&mut *conn)
-                        .map_err(DieselOrStore::Diesel)?;
+                    crate::upsert_queries::UpsertSession {
+                        address: address_clone.as_ref(),
+                        record: session_clone.as_ref(),
+                        device_id,
+                    }
+                    .execute(&mut *conn)
+                    .map_err(DieselOrStore::Diesel)?;
                     Ok(())
                 })
                 .await;
@@ -1676,17 +1668,13 @@ impl SqliteStore {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            diesel::insert_into(sender_keys::table)
-                .values((
-                    sender_keys::address.eq(address),
-                    sender_keys::record.eq(&record_vec),
-                    sender_keys::device_id.eq(device_id),
-                ))
-                .on_conflict((sender_keys::address, sender_keys::device_id))
-                .do_update()
-                .set(sender_keys::record.eq(&record_vec))
-                .execute(&mut *conn)
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            crate::upsert_queries::UpsertSenderKey {
+                address: &address,
+                record: &record_vec,
+                device_id,
+            }
+            .execute(&mut *conn)
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
@@ -2102,16 +2090,12 @@ impl SignalStore for SqliteStore {
             Box::new(move |conn: &mut SqliteConnection| {
                 conn.transaction(|conn| {
                     for (address, key) in batch.iter() {
-                        diesel::insert_into(identities::table)
-                            .values((
-                                identities::address.eq(address.as_ref()),
-                                identities::key.eq(&key[..]),
-                                identities::device_id.eq(device_id),
-                            ))
-                            .on_conflict((identities::address, identities::device_id))
-                            .do_update()
-                            .set(identities::key.eq(&key[..]))
-                            .execute(conn)?;
+                        crate::upsert_queries::UpsertIdentity {
+                            address: address.as_ref(),
+                            key: &key[..],
+                            device_id,
+                        }
+                        .execute(conn)?;
                     }
                     Ok(())
                 })
@@ -2289,16 +2273,12 @@ impl SignalStore for SqliteStore {
             Box::new(move |conn: &mut SqliteConnection| {
                 conn.transaction(|conn| {
                     for (address, record) in batch.iter() {
-                        diesel::insert_into(sessions::table)
-                            .values((
-                                sessions::address.eq(address.as_ref()),
-                                sessions::record.eq(record.as_ref()),
-                                sessions::device_id.eq(device_id),
-                            ))
-                            .on_conflict((sessions::address, sessions::device_id))
-                            .do_update()
-                            .set(sessions::record.eq(record.as_ref()))
-                            .execute(conn)?;
+                        crate::upsert_queries::UpsertSession {
+                            address: address.as_ref(),
+                            record: record.as_ref(),
+                            device_id,
+                        }
+                        .execute(conn)?;
                     }
                     Ok(())
                 })
@@ -2758,16 +2738,12 @@ impl SignalStore for SqliteStore {
             Box::new(move |conn: &mut SqliteConnection| {
                 conn.transaction(|conn| {
                     for (address, record) in batch.iter() {
-                        diesel::insert_into(sender_keys::table)
-                            .values((
-                                sender_keys::address.eq(address.as_ref()),
-                                sender_keys::record.eq(record.as_ref()),
-                                sender_keys::device_id.eq(device_id),
-                            ))
-                            .on_conflict((sender_keys::address, sender_keys::device_id))
-                            .do_update()
-                            .set(sender_keys::record.eq(record.as_ref()))
-                            .execute(conn)?;
+                        crate::upsert_queries::UpsertSenderKey {
+                            address: address.as_ref(),
+                            record: record.as_ref(),
+                            device_id,
+                        }
+                        .execute(conn)?;
                     }
                     Ok(())
                 })
@@ -3362,27 +3338,17 @@ impl ProtocolStore for SqliteStore {
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let raw_id_i32 = record.raw_id.map(|r| r as i32);
-            diesel::insert_into(device_registry::table)
-                .values((
-                    device_registry::user_id.eq(record.user.as_ref()),
-                    device_registry::devices_json.eq(&devices_json),
-                    device_registry::timestamp.eq(record.timestamp as i32),
-                    device_registry::phash.eq(record.phash.as_deref()),
-                    device_registry::device_id.eq(device_id),
-                    device_registry::updated_at.eq(now),
-                    device_registry::raw_id.eq(raw_id_i32),
-                ))
-                .on_conflict((device_registry::user_id, device_registry::device_id))
-                .do_update()
-                .set((
-                    device_registry::devices_json.eq(&devices_json),
-                    device_registry::timestamp.eq(record.timestamp as i32),
-                    device_registry::phash.eq(record.phash.as_deref()),
-                    device_registry::updated_at.eq(now),
-                    device_registry::raw_id.eq(raw_id_i32),
-                ))
-                .execute(&mut *conn)
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            crate::upsert_queries::UpsertDeviceRegistry {
+                user_id: record.user.as_ref(),
+                devices_json: &devices_json,
+                timestamp: record.timestamp as i32,
+                phash: record.phash.as_deref(),
+                device_id,
+                updated_at: now,
+                raw_id: raw_id_i32,
+            }
+            .execute(&mut *conn)
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
@@ -3429,26 +3395,16 @@ impl ProtocolStore for SqliteStore {
             Box::new(move |conn: &mut SqliteConnection| {
                 conn.transaction::<_, DieselError, _>(|conn| {
                     for row in prepared.iter() {
-                        diesel::insert_into(device_registry::table)
-                            .values((
-                                device_registry::user_id.eq(&row.user),
-                                device_registry::devices_json.eq(&row.devices_json),
-                                device_registry::timestamp.eq(row.timestamp),
-                                device_registry::phash.eq(&row.phash),
-                                device_registry::device_id.eq(device_id),
-                                device_registry::updated_at.eq(now),
-                                device_registry::raw_id.eq(row.raw_id),
-                            ))
-                            .on_conflict((device_registry::user_id, device_registry::device_id))
-                            .do_update()
-                            .set((
-                                device_registry::devices_json.eq(&row.devices_json),
-                                device_registry::timestamp.eq(row.timestamp),
-                                device_registry::phash.eq(&row.phash),
-                                device_registry::updated_at.eq(now),
-                                device_registry::raw_id.eq(row.raw_id),
-                            ))
-                            .execute(conn)?;
+                        crate::upsert_queries::UpsertDeviceRegistry {
+                            user_id: &row.user,
+                            devices_json: &row.devices_json,
+                            timestamp: row.timestamp,
+                            phash: row.phash.as_deref(),
+                            device_id,
+                            updated_at: now,
+                            raw_id: row.raw_id,
+                        }
+                        .execute(conn)?;
                     }
                     Ok(())
                 })
@@ -5344,6 +5300,72 @@ mod tests {
 
         assert_eq!(loaded.devices.len(), 2);
         assert_eq!(loaded.phash.as_deref(), Some("2:new"));
+    }
+
+    #[tokio::test]
+    async fn test_device_registry_batch_update_transitions() {
+        let store = create_test_store().await;
+
+        let batch1 = vec![
+            DeviceListRecord {
+                user: "user_a".into(),
+                devices: [DeviceInfo::new(0, None)].into(),
+                timestamp: 1000,
+                phash: Some("phash_a1".into()),
+                raw_id: Some(10),
+            },
+            DeviceListRecord {
+                user: "user_b".into(),
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(1, Some(2))].into(),
+                timestamp: 1000,
+                phash: None,
+                raw_id: None,
+            },
+        ];
+        store
+            .update_device_lists(batch1)
+            .await
+            .expect("batch1 failed");
+
+        let loaded_a = store.get_devices("user_a").await.unwrap().unwrap();
+        assert_eq!(loaded_a.phash.as_deref(), Some("phash_a1"));
+        assert_eq!(loaded_a.raw_id, Some(10));
+
+        let loaded_b = store.get_devices("user_b").await.unwrap().unwrap();
+        assert_eq!(loaded_b.phash, None);
+        assert_eq!(loaded_b.raw_id, None);
+
+        // Transition: user_a becomes None, user_b becomes Some
+        let batch2 = vec![
+            DeviceListRecord {
+                user: "user_a".into(),
+                devices: [DeviceInfo::new(0, None), DeviceInfo::new(2, None)].into(),
+                timestamp: 2000,
+                phash: None,
+                raw_id: None,
+            },
+            DeviceListRecord {
+                user: "user_b".into(),
+                devices: [DeviceInfo::new(0, None)].into(),
+                timestamp: 2000,
+                phash: Some("phash_b2".into()),
+                raw_id: Some(20),
+            },
+        ];
+        store
+            .update_device_lists(batch2)
+            .await
+            .expect("batch2 failed");
+
+        let loaded_a2 = store.get_devices("user_a").await.unwrap().unwrap();
+        assert_eq!(loaded_a2.phash, None);
+        assert_eq!(loaded_a2.raw_id, None);
+        assert_eq!(loaded_a2.devices.len(), 2);
+
+        let loaded_b2 = store.get_devices("user_b").await.unwrap().unwrap();
+        assert_eq!(loaded_b2.phash.as_deref(), Some("phash_b2"));
+        assert_eq!(loaded_b2.raw_id, Some(20));
+        assert_eq!(loaded_b2.devices.len(), 1);
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/upsert_queries.rs
+++ b/storages/sqlite-storage/src/upsert_queries.rs
@@ -1,0 +1,676 @@
+use diesel::query_builder::{AstPass, QueryFragment, QueryId};
+use diesel::query_dsl::RunQueryDsl;
+use diesel::result::QueryResult;
+use diesel::sql_types::{Binary, Integer, Nullable, Text};
+use diesel::sqlite::Sqlite;
+
+/// Static query identifier for `UpsertSession`.
+#[derive(Debug, Clone, Copy)]
+pub struct UpsertSessionQuery;
+
+impl QueryId for UpsertSessionQuery {
+    type QueryId = Self;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+/// Typed UPSERT statement for the `sessions` table.
+///
+/// Invariant SQL and bind order ensure safe caching in Diesel's per-connection
+/// statement cache. Uses SQLite `excluded.record` to avoid double-binding the
+/// payload blob between `VALUES` and `DO UPDATE SET`.
+#[derive(Debug)]
+pub struct UpsertSession<'a> {
+    pub address: &'a str,
+    pub record: &'a [u8],
+    pub device_id: i32,
+}
+
+impl<'a> QueryId for UpsertSession<'a> {
+    type QueryId = UpsertSessionQuery;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+impl<Conn> RunQueryDsl<Conn> for UpsertSession<'_> {}
+
+impl<'a> QueryFragment<Sqlite> for UpsertSession<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        out.push_sql("INSERT INTO \"sessions\" (\"address\", \"record\", \"device_id\") VALUES (");
+        out.push_bind_param::<Text, _>(&self.address)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Binary, _>(&self.record)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.device_id)?;
+        out.push_sql(
+            ") ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"record\" = excluded.\"record\"",
+        );
+        Ok(())
+    }
+}
+
+/// Static query identifier for `UpsertIdentity`.
+#[derive(Debug, Clone, Copy)]
+pub struct UpsertIdentityQuery;
+
+impl QueryId for UpsertIdentityQuery {
+    type QueryId = Self;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+/// Typed UPSERT statement for the `identities` table.
+#[derive(Debug)]
+pub struct UpsertIdentity<'a> {
+    pub address: &'a str,
+    pub key: &'a [u8],
+    pub device_id: i32,
+}
+
+impl<'a> QueryId for UpsertIdentity<'a> {
+    type QueryId = UpsertIdentityQuery;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+impl<Conn> RunQueryDsl<Conn> for UpsertIdentity<'_> {}
+
+impl<'a> QueryFragment<Sqlite> for UpsertIdentity<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        out.push_sql("INSERT INTO \"identities\" (\"address\", \"key\", \"device_id\") VALUES (");
+        out.push_bind_param::<Text, _>(&self.address)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Binary, _>(&self.key)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.device_id)?;
+        out.push_sql(
+            ") ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"key\" = excluded.\"key\"",
+        );
+        Ok(())
+    }
+}
+
+/// Static query identifier for `UpsertSenderKey`.
+#[derive(Debug, Clone, Copy)]
+pub struct UpsertSenderKeyQuery;
+
+impl QueryId for UpsertSenderKeyQuery {
+    type QueryId = Self;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+/// Typed UPSERT statement for the `sender_keys` table.
+#[derive(Debug)]
+pub struct UpsertSenderKey<'a> {
+    pub address: &'a str,
+    pub record: &'a [u8],
+    pub device_id: i32,
+}
+
+impl<'a> QueryId for UpsertSenderKey<'a> {
+    type QueryId = UpsertSenderKeyQuery;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+impl<Conn> RunQueryDsl<Conn> for UpsertSenderKey<'_> {}
+
+impl<'a> QueryFragment<Sqlite> for UpsertSenderKey<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        out.push_sql(
+            "INSERT INTO \"sender_keys\" (\"address\", \"record\", \"device_id\") VALUES (",
+        );
+        out.push_bind_param::<Text, _>(&self.address)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Binary, _>(&self.record)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.device_id)?;
+        out.push_sql(
+            ") ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"record\" = excluded.\"record\"",
+        );
+        Ok(())
+    }
+}
+
+/// Static query identifier for `UpsertDeviceRegistry`.
+#[derive(Debug, Clone, Copy)]
+pub struct UpsertDeviceRegistryQuery;
+
+impl QueryId for UpsertDeviceRegistryQuery {
+    type QueryId = Self;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+/// Typed UPSERT statement for the `device_registry` table.
+///
+/// Invariant parameter count and types ensure that optional fields (`phash`, `raw_id`)
+/// generate the exact same SQL placeholder sequence whether `Some` or `None`.
+#[derive(Debug)]
+pub struct UpsertDeviceRegistry<'a> {
+    pub user_id: &'a str,
+    pub devices_json: &'a str,
+    pub timestamp: i32,
+    pub phash: Option<&'a str>,
+    pub device_id: i32,
+    pub updated_at: i32,
+    pub raw_id: Option<i32>,
+}
+
+impl<'a> QueryId for UpsertDeviceRegistry<'a> {
+    type QueryId = UpsertDeviceRegistryQuery;
+    const HAS_STATIC_QUERY_ID: bool = true;
+}
+
+impl<Conn> RunQueryDsl<Conn> for UpsertDeviceRegistry<'_> {}
+
+impl<'a> QueryFragment<Sqlite> for UpsertDeviceRegistry<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        out.push_sql(
+            "INSERT INTO \"device_registry\" (\
+             \"user_id\", \"devices_json\", \"timestamp\", \"phash\", \"device_id\", \"updated_at\", \"raw_id\"\
+             ) VALUES (",
+        );
+        out.push_bind_param::<Text, _>(&self.user_id)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Text, _>(&self.devices_json)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.timestamp)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Nullable<Text>, _>(&self.phash)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.device_id)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Integer, _>(&self.updated_at)?;
+        out.push_sql(", ");
+        out.push_bind_param::<Nullable<Integer>, _>(&self.raw_id)?;
+        out.push_sql(
+            ") ON CONFLICT (\"user_id\", \"device_id\") DO UPDATE SET \
+             \"devices_json\" = excluded.\"devices_json\", \
+             \"timestamp\" = excluded.\"timestamp\", \
+             \"phash\" = excluded.\"phash\", \
+             \"updated_at\" = excluded.\"updated_at\", \
+             \"raw_id\" = excluded.\"raw_id\"",
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel::connection::SimpleConnection;
+    use diesel::prelude::*;
+    use diesel::sqlite::SqliteConnection;
+
+    #[test]
+    fn test_upsert_session_sql_invariance() {
+        let q1 = UpsertSession {
+            address: "1234@s.whatsapp.net",
+            record: b"record1",
+            device_id: 0,
+        };
+        let q2 = UpsertSession {
+            address: "5678@s.whatsapp.net",
+            record: b"record2_longer_than_before",
+            device_id: 1,
+        };
+        let s1 = diesel::debug_query::<Sqlite, _>(&q1).to_string();
+        let s2 = diesel::debug_query::<Sqlite, _>(&q2).to_string();
+        let sql1 = s1.split(" -- binds:").next().unwrap();
+        let sql2 = s2.split(" -- binds:").next().unwrap();
+        assert_eq!(sql1, sql2);
+        assert_eq!(
+            sql1,
+            "INSERT INTO \"sessions\" (\"address\", \"record\", \"device_id\") VALUES (?, ?, ?) \
+             ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"record\" = excluded.\"record\""
+        );
+    }
+
+    #[test]
+    fn test_upsert_identity_sql_invariance() {
+        let q1 = UpsertIdentity {
+            address: "user1",
+            key: b"key1",
+            device_id: 0,
+        };
+        let q2 = UpsertIdentity {
+            address: "user2",
+            key: b"key2",
+            device_id: 2,
+        };
+        let s1 = diesel::debug_query::<Sqlite, _>(&q1).to_string();
+        let s2 = diesel::debug_query::<Sqlite, _>(&q2).to_string();
+        let sql1 = s1.split(" -- binds:").next().unwrap();
+        let sql2 = s2.split(" -- binds:").next().unwrap();
+        assert_eq!(sql1, sql2);
+        assert_eq!(
+            sql1,
+            "INSERT INTO \"identities\" (\"address\", \"key\", \"device_id\") VALUES (?, ?, ?) \
+             ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"key\" = excluded.\"key\""
+        );
+    }
+
+    #[test]
+    fn test_upsert_sender_key_sql_invariance() {
+        let q1 = UpsertSenderKey {
+            address: "group1",
+            record: b"sk1",
+            device_id: 0,
+        };
+        let q2 = UpsertSenderKey {
+            address: "group2",
+            record: b"sk2",
+            device_id: 3,
+        };
+        let s1 = diesel::debug_query::<Sqlite, _>(&q1).to_string();
+        let s2 = diesel::debug_query::<Sqlite, _>(&q2).to_string();
+        let sql1 = s1.split(" -- binds:").next().unwrap();
+        let sql2 = s2.split(" -- binds:").next().unwrap();
+        assert_eq!(sql1, sql2);
+        assert_eq!(
+            sql1,
+            "INSERT INTO \"sender_keys\" (\"address\", \"record\", \"device_id\") VALUES (?, ?, ?) \
+             ON CONFLICT (\"address\", \"device_id\") DO UPDATE SET \"record\" = excluded.\"record\""
+        );
+    }
+
+    #[test]
+    fn test_upsert_device_registry_sql_invariance_some_and_none() {
+        let q_some = UpsertDeviceRegistry {
+            user_id: "user1",
+            devices_json: "{}",
+            timestamp: 100,
+            phash: Some("phash1"),
+            device_id: 0,
+            updated_at: 200,
+            raw_id: Some(42),
+        };
+        let q_none = UpsertDeviceRegistry {
+            user_id: "user2",
+            devices_json: "[]",
+            timestamp: 101,
+            phash: None,
+            device_id: 1,
+            updated_at: 201,
+            raw_id: None,
+        };
+
+        let s_some = diesel::debug_query::<Sqlite, _>(&q_some).to_string();
+        let s_none = diesel::debug_query::<Sqlite, _>(&q_none).to_string();
+        let sql_template_some = s_some.split(" -- binds:").next().unwrap();
+        let sql_template_none = s_none.split(" -- binds:").next().unwrap();
+        assert_eq!(sql_template_some, sql_template_none);
+        assert_eq!(
+            sql_template_some,
+            "INSERT INTO \"device_registry\" (\
+             \"user_id\", \"devices_json\", \"timestamp\", \"phash\", \"device_id\", \"updated_at\", \"raw_id\"\
+             ) VALUES (?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT (\"user_id\", \"device_id\") DO UPDATE SET \
+             \"devices_json\" = excluded.\"devices_json\", \
+             \"timestamp\" = excluded.\"timestamp\", \
+             \"phash\" = excluded.\"phash\", \
+             \"updated_at\" = excluded.\"updated_at\", \
+             \"raw_id\" = excluded.\"raw_id\""
+        );
+    }
+
+    #[test]
+    fn test_static_query_ids_unique() {
+        use std::any::TypeId;
+        let id_session = TypeId::of::<<UpsertSession as QueryId>::QueryId>();
+        let id_identity = TypeId::of::<<UpsertIdentity as QueryId>::QueryId>();
+        let id_sender_key = TypeId::of::<<UpsertSenderKey as QueryId>::QueryId>();
+        let id_registry = TypeId::of::<<UpsertDeviceRegistry as QueryId>::QueryId>();
+
+        assert_ne!(id_session, id_identity);
+        assert_ne!(id_session, id_sender_key);
+        assert_ne!(id_session, id_registry);
+        assert_ne!(id_identity, id_sender_key);
+        assert_ne!(id_identity, id_registry);
+        assert_ne!(id_sender_key, id_registry);
+
+        const { assert!(<UpsertSession as QueryId>::HAS_STATIC_QUERY_ID) };
+        const { assert!(<UpsertIdentity as QueryId>::HAS_STATIC_QUERY_ID) };
+        const { assert!(<UpsertSenderKey as QueryId>::HAS_STATIC_QUERY_ID) };
+        const { assert!(<UpsertDeviceRegistry as QueryId>::HAS_STATIC_QUERY_ID) };
+    }
+
+    #[test]
+    fn test_diesel_upsert_execution_and_cache_reuse() {
+        let mut conn = SqliteConnection::establish(":memory:").expect("in-memory db");
+        conn.batch_execute(
+            "CREATE TABLE sessions (
+                address TEXT NOT NULL,
+                record BLOB NOT NULL,
+                device_id INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (address, device_id)
+            );",
+        )
+        .expect("create table");
+
+        // First execution - prepares and caches
+        let rows1 = UpsertSession {
+            address: "user@s.whatsapp.net",
+            record: b"initial_session",
+            device_id: 0,
+        }
+        .execute(&mut conn)
+        .expect("execute 1");
+        assert_eq!(rows1, 1);
+
+        // Second execution - reuses cached prepared statement, updates row
+        let rows2 = UpsertSession {
+            address: "user@s.whatsapp.net",
+            record: b"updated_session",
+            device_id: 0,
+        }
+        .execute(&mut conn)
+        .expect("execute 2");
+        assert_eq!(rows2, 1);
+
+        // Third execution - different device_id, inserts new row
+        let rows3 = UpsertSession {
+            address: "user@s.whatsapp.net",
+            record: b"device_1_session",
+            device_id: 1,
+        }
+        .execute(&mut conn)
+        .expect("execute 3");
+        assert_eq!(rows3, 1);
+
+        // Verify data
+        use diesel::dsl::sql;
+        let count: i64 = diesel::select(sql::<diesel::sql_types::BigInt>("count(*) FROM sessions"))
+            .get_result(&mut conn)
+            .expect("count");
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_device_registry_null_transitions() {
+        let mut conn = SqliteConnection::establish(":memory:").expect("in-memory db");
+        conn.batch_execute(
+            "CREATE TABLE device_registry (
+                user_id TEXT NOT NULL,
+                devices_json TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                phash TEXT,
+                device_id INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                raw_id INTEGER,
+                PRIMARY KEY (user_id, device_id)
+            );",
+        )
+        .expect("create table");
+
+        // 1. Insert with Some(phash) and Some(raw_id)
+        UpsertDeviceRegistry {
+            user_id: "user1",
+            devices_json: "[1,2]",
+            timestamp: 100,
+            phash: Some("phash_v1"),
+            device_id: 0,
+            updated_at: 1000,
+            raw_id: Some(777),
+        }
+        .execute(&mut conn)
+        .expect("insert");
+
+        #[derive(QueryableByName, Debug, PartialEq)]
+        struct RegistryRow {
+            #[diesel(sql_type = Text)]
+            devices_json: String,
+            #[diesel(sql_type = Nullable<Text>)]
+            phash: Option<String>,
+            #[diesel(sql_type = Nullable<Integer>)]
+            raw_id: Option<i32>,
+        }
+
+        let row: RegistryRow = diesel::sql_query(
+            "SELECT devices_json, phash, raw_id FROM device_registry WHERE user_id = 'user1'",
+        )
+        .get_result(&mut conn)
+        .expect("read 1");
+        assert_eq!(row.phash.as_deref(), Some("phash_v1"));
+        assert_eq!(row.raw_id, Some(777));
+
+        // 2. Update with None for both phash and raw_id - verify excluded.* writes NULL
+        UpsertDeviceRegistry {
+            user_id: "user1",
+            devices_json: "[1,2,3]",
+            timestamp: 200,
+            phash: None,
+            device_id: 0,
+            updated_at: 2000,
+            raw_id: None,
+        }
+        .execute(&mut conn)
+        .expect("update to None");
+
+        let row2: RegistryRow = diesel::sql_query(
+            "SELECT devices_json, phash, raw_id FROM device_registry WHERE user_id = 'user1'",
+        )
+        .get_result(&mut conn)
+        .expect("read 2");
+        assert_eq!(row2.devices_json, "[1,2,3]");
+        assert_eq!(row2.phash, None);
+        assert_eq!(row2.raw_id, None);
+
+        // 3. Update back to Some(phash) and None raw_id
+        UpsertDeviceRegistry {
+            user_id: "user1",
+            devices_json: "[1]",
+            timestamp: 300,
+            phash: Some("phash_v2"),
+            device_id: 0,
+            updated_at: 3000,
+            raw_id: None,
+        }
+        .execute(&mut conn)
+        .expect("update to Some/None");
+
+        let row3: RegistryRow = diesel::sql_query(
+            "SELECT devices_json, phash, raw_id FROM device_registry WHERE user_id = 'user1'",
+        )
+        .get_result(&mut conn)
+        .expect("read 3");
+        assert_eq!(row3.phash.as_deref(), Some("phash_v2"));
+        assert_eq!(row3.raw_id, None);
+    }
+
+    #[test]
+    fn test_batch_rollback_leaves_connection_clean_for_reuse() {
+        let mut conn = SqliteConnection::establish(":memory:").expect("in-memory db");
+        conn.batch_execute(
+            "CREATE TABLE sessions (
+                address TEXT NOT NULL,
+                record BLOB NOT NULL,
+                device_id INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (address, device_id)
+            );",
+        )
+        .expect("create table");
+
+        // Seed 1 row
+        UpsertSession {
+            address: "user1",
+            record: b"initial",
+            device_id: 0,
+        }
+        .execute(&mut conn)
+        .expect("initial seed");
+
+        // Execute a transaction that aborts
+        let result: Result<(), diesel::result::Error> = conn.transaction(|conn| {
+            UpsertSession {
+                address: "user2",
+                record: b"rec2",
+                device_id: 0,
+            }
+            .execute(conn)?;
+
+            // Simulating mid-batch abort
+            Err(diesel::result::Error::RollbackTransaction)
+        });
+        assert!(result.is_err());
+
+        // Verify user2 was NOT committed
+        let count: i64 = diesel::select(diesel::dsl::sql::<diesel::sql_types::BigInt>(
+            "count(*) FROM sessions",
+        ))
+        .get_result(&mut conn)
+        .expect("count");
+        assert_eq!(count, 1);
+
+        // Connection statement cache is still healthy and prepared statement can be reused immediately
+        UpsertSession {
+            address: "user1",
+            record: b"updated_after_rollback",
+            device_id: 0,
+        }
+        .execute(&mut conn)
+        .expect("reuse after rollback");
+
+        #[derive(QueryableByName)]
+        struct RecordRow {
+            #[diesel(sql_type = Binary)]
+            record: Vec<u8>,
+        }
+        let row: RecordRow =
+            diesel::sql_query("SELECT record FROM sessions WHERE address = 'user1'")
+                .get_result(&mut conn)
+                .expect("query");
+        assert_eq!(row.record, b"updated_after_rollback");
+    }
+
+    #[test]
+    fn every_upsert_is_cached_once_per_connection_and_survives_statement_error() {
+        use diesel::connection::InstrumentationEvent;
+        use std::sync::{Arc, Mutex};
+
+        for _ in 0..2 {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            conn.batch_execute(
+                "CREATE TABLE sessions (address TEXT, record BLOB CHECK(length(record) > 0), device_id INTEGER, PRIMARY KEY(address, device_id));
+                 CREATE TABLE identities (address TEXT, key BLOB, device_id INTEGER, PRIMARY KEY(address, device_id));
+                 CREATE TABLE sender_keys (address TEXT, record BLOB, device_id INTEGER, PRIMARY KEY(address, device_id));
+                 CREATE TABLE device_registry (user_id TEXT, devices_json TEXT, timestamp INTEGER, phash TEXT, device_id INTEGER, updated_at INTEGER, raw_id INTEGER, PRIMARY KEY(user_id, device_id));"
+            ).unwrap();
+            let cached = Arc::new(Mutex::new(Vec::<String>::new()));
+            let events = Arc::clone(&cached);
+            conn.set_instrumentation(move |event: InstrumentationEvent<'_>| {
+                if let InstrumentationEvent::CacheQuery { sql, .. } = event {
+                    events.lock().unwrap().push(sql.to_owned());
+                }
+            });
+
+            for turn in 0..4 {
+                for device_id in 0..2 {
+                    UpsertSession {
+                        address: "fictional",
+                        record: &[turn + 1],
+                        device_id,
+                    }
+                    .execute(&mut conn)
+                    .unwrap();
+                    UpsertIdentity {
+                        address: "fictional",
+                        key: &[turn + 2; 32],
+                        device_id,
+                    }
+                    .execute(&mut conn)
+                    .unwrap();
+                    UpsertSenderKey {
+                        address: "fictional",
+                        record: &[turn + 3],
+                        device_id,
+                    }
+                    .execute(&mut conn)
+                    .unwrap();
+                    UpsertDeviceRegistry {
+                        user_id: "fictional",
+                        devices_json: "[]",
+                        timestamp: i32::from(turn),
+                        phash: (turn % 2 == 0).then_some("hash"),
+                        device_id,
+                        updated_at: i32::from(turn),
+                        raw_id: (turn % 2 != 0).then_some(7),
+                    }
+                    .execute(&mut conn)
+                    .unwrap();
+                }
+            }
+            let queries = cached.lock().unwrap().clone();
+            assert_eq!(
+                queries.len(),
+                4,
+                "exactly one cache insertion per query shape"
+            );
+            for table in ["sessions", "identities", "sender_keys", "device_registry"] {
+                assert_eq!(
+                    queries
+                        .iter()
+                        .filter(|sql| sql.starts_with(&format!("INSERT INTO \"{table}\"")))
+                        .count(),
+                    1
+                );
+            }
+
+            let failed: QueryResult<()> = conn.transaction(|conn| {
+                UpsertSession {
+                    address: "rolled-back",
+                    record: b"valid",
+                    device_id: 0,
+                }
+                .execute(conn)?;
+                UpsertSession {
+                    address: "invalid",
+                    record: b"",
+                    device_id: 0,
+                }
+                .execute(conn)?;
+                Ok(())
+            });
+            assert!(matches!(
+                failed,
+                Err(diesel::result::Error::DatabaseError(..))
+            ));
+            UpsertSession {
+                address: "fictional",
+                record: b"after-error",
+                device_id: 0,
+            }
+            .execute(&mut conn)
+            .unwrap();
+            assert_eq!(
+                cached.lock().unwrap().len(),
+                4,
+                "failed execution must not evict/reprepare the statement"
+            );
+
+            #[derive(QueryableByName)]
+            struct Row {
+                #[diesel(sql_type = Text)]
+                address: String,
+                #[diesel(sql_type = Binary)]
+                record: Vec<u8>,
+                #[diesel(sql_type = Integer)]
+                device_id: i32,
+            }
+            let rows = diesel::sql_query(
+                "SELECT address, record, device_id FROM sessions ORDER BY device_id",
+            )
+            .load::<Row>(&mut conn)
+            .unwrap();
+            assert_eq!(
+                rows.len(),
+                2,
+                "the failed transaction must leave no partial rows"
+            );
+            assert!(rows.iter().all(|r| r.address == "fictional"));
+            assert_eq!(
+                (rows[0].device_id, rows[0].record.as_slice()),
+                (0, b"after-error".as_slice())
+            );
+            assert_eq!(
+                (rows[1].device_id, rows[1].record.as_slice()),
+                (1, [4].as_slice())
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Persisting a batch of Signal records currently recompiles the same SQLite UPSERT for every row because Diesel's `DoUpdate` disables statement caching. Use four fixed, typed SQL query shapes with distinct query IDs and bound parameters, allowing each connection to reuse its prepared statements. The update clauses read from `excluded`, avoiding duplicate blob binds.

Sessions, identities, sender keys and device registry writes keep their existing conflict keys, transactions and retry paths. Tests observe Diesel cache-insertion events across repeated executions and two connections, cover nullable registry fields and device isolation, and verify rollback and statement reuse after a real SQL constraint failure.

## Performance

Native median-of-medians from three alternating runs per arm, 40 samples × 10 iterations, pinned to CPUs 2,3 on an Intel Core Ultra 9 275HX. Both arms used the same benchmark sources and storage manifests, with independently verified executable hashes.

| Workload | Baseline | Change |
| --- | ---: | ---: |
| Insert 256 sessions | 1.170 ms | 0.461 ms |
| Update 256 existing sessions | 1.070 ms | 0.404 ms |
| Update device registry, 256 users | 1.972 ms | 0.550 ms |

The unchanged session-read controls at 8/64/256 entries moved by -1.3%/-1.2%/-4.1%. Some workloads have substantial run-to-run spread, so these numbers describe this native storage workload rather than a message-throughput guarantee.

Add warm-update and first-preparation benchmarks. Verification and input cleanup stay outside the first-preparation measurement; its sample size bounds the number of live database/runtime fixtures.

### Memory tradeoff

The completed CodSpeed comparison also reports higher first-operation peaks: `insert_sessions_batch[1]` goes from about 1 KB to 4.7 KB, and `registry_put_batch[1]` from 4 KB to 9.4 KB. The cache holds a fixed set of query shapes per connection; these peaks must not be presented as per-message retained memory. The new warm-update case at size 1 measures 888 B of peak memory after setup. This is a CPU/memory tradeoff, not a claim that every memory metric improves.

## Validation

- 103 SQLite library tests passed.
- 3,602 library tests passed across wacore, whatsapp-rust and SQLite with `bench-harness` on the combined validation tree; two tests were skipped.
- The 128-seed × 256-step Signal durability matrix and SQLite SIGKILL/restart test passed.
- Workspace clippy with all targets and `bench-harness`, formatting and benchmark execution smokes passed.
- This branch contains only the storage changes and their tests/benchmarks; CI validates the isolated branch.

