### PR TITLE
bench(signal): cover flush contention and durable cache batches

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -49,6 +49,9 @@ jobs:
           tool: protoc@${{ env.PROTOC_VERSION }},cargo-binstall
 
       - name: Install cargo-bloat and cargo-llvm-lines
+        env:
+          # binstall can fall back to compilation before sccache is installed.
+          RUSTC_WRAPPER: ""
         run: >
           cargo binstall --no-confirm
           cargo-bloat@${{ env.CARGO_BLOAT_VERSION }}
@@ -187,6 +190,9 @@ jobs:
           tool: protoc@${{ env.PROTOC_VERSION }},cargo-binstall
 
       - name: Install cargo-bloat and cargo-llvm-lines
+        env:
+          # binstall can fall back to compilation before sccache is installed.
+          RUSTC_WRAPPER: ""
         run: >
           cargo binstall --no-confirm
           cargo-bloat@${{ env.CARGO_BLOAT_VERSION }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4297,6 +4297,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "portable-atomic",
+ "rand 0.10.2",
  "scheduled-thread-pool",
  "serde_json",
  "sha2",

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -39,6 +39,8 @@ sha2 = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 portable-atomic = { workspace = true }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "signal_flush"
@@ -50,6 +52,10 @@ harness = false
 
 [[bench]]
 name = "store_contention"
+harness = false
+
+[[bench]]
+name = "signal_cache_contention"
 harness = false
 
 [lints]

--- a/storages/sqlite-storage/benches/signal_cache_contention.rs
+++ b/storages/sqlite-storage/benches/signal_cache_contention.rs
@@ -1,0 +1,279 @@
+//! Cache checkout, chain advance, restore and persistence cost, not message throughput.
+//! The native report overlaps a finite flush with independent warm cache operations.
+//! Divan measures a sequential fixed batch; simulated CPU is not a lock-wait metric.
+
+use divan::black_box;
+use rand::SeedableRng;
+use std::future::poll_fn;
+use std::path::{Path, PathBuf};
+use std::pin::pin;
+use std::sync::Arc;
+use std::task::Poll;
+use std::time::Duration;
+use wacore::libsignal::protocol::{
+    ChainKey, IdentityKey, KeyPair, ProtocolAddress, RootKey, SessionCheckoutStoreResult,
+    SessionRecord, SessionState,
+};
+use wacore::store::signal_cache::SignalStoreCache;
+use wacore::time::Instant;
+use whatsapp_rust_sqlite_storage::SqliteStore;
+
+const FIXTURE_SEED: u64 = 0x51A6_5A17_EC4A_5E01;
+const DEADLINE: Duration = Duration::from_secs(30);
+
+fn remove_db_files(path: &Path) {
+    for suffix in ["", "-wal", "-shm", "-journal"] {
+        let mut name = path.as_os_str().to_owned();
+        name.push(suffix);
+        let _ = std::fs::remove_file(name);
+    }
+}
+
+fn create_session(rng: &mut rand::rngs::StdRng) -> SessionRecord {
+    let local = IdentityKey::new(KeyPair::generate(rng).public_key);
+    let remote = IdentityKey::new(KeyPair::generate(rng).public_key);
+    let base_key = KeyPair::generate(rng).public_key;
+    let mut state = SessionState::new(3, &local, &remote, &RootKey::new([7; 32]), &base_key);
+    state.set_sender_chain(&KeyPair::generate(rng), &ChainKey::new([11; 32], 0));
+    SessionRecord::new(state)
+}
+
+fn chain_index(record: &SessionRecord) -> u32 {
+    record
+        .session_state()
+        .expect("state")
+        .get_sender_chain_key()
+        .expect("chain")
+        .index()
+}
+
+fn spend_session(record: &mut SessionRecord) {
+    let chain = record
+        .session_state()
+        .expect("state")
+        .get_sender_chain_key()
+        .expect("chain");
+    black_box(chain.message_keys().generate_keys());
+    let next = chain.next_chain_key().expect("next chain key");
+    record
+        .session_state_mut()
+        .expect("state")
+        .set_sender_chain_key(&next)
+        .expect("advance");
+    if chain.index() >= record.reserved_sender_chain_index() {
+        record.reserve_sender_chain_counters(chain.index());
+    }
+}
+
+async fn cycle(
+    cache: &SignalStoreCache,
+    store: &SqliteStore,
+    addr: &ProtocolAddress,
+) -> (Duration, Duration) {
+    let start = Instant::now();
+    let (record, token) = cache.checkout_session(addr, store).await.expect("checkout");
+    let checkout = start.elapsed();
+    let mut record = record.expect("warm session");
+    spend_session(&mut record);
+    let start = Instant::now();
+    // Match SessionCheckout::commit, including the queued restore on contention.
+    match cache.restore_session_from_checkout(addr, record, token, true) {
+        SessionCheckoutStoreResult::Stored => {}
+        SessionCheckoutStoreResult::Pending(done) => {
+            cache.complete_session_checkout().await;
+            assert!(done.load(portable_atomic::Ordering::Acquire));
+        }
+        _ => panic!("restore rejected or unhandled"),
+    }
+    (checkout, start.elapsed())
+}
+
+struct Harness {
+    runtime: tokio::runtime::Runtime,
+    store: SqliteStore,
+    cache: Arc<SignalStoreCache>,
+    addresses: Vec<ProtocolAddress>,
+    path: PathBuf,
+}
+
+impl Harness {
+    fn new(chats: usize) -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .max_blocking_threads(1)
+            .thread_keep_alive(Duration::from_secs(86400))
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let path =
+            std::env::temp_dir().join(format!("wa-signal-cache-{}-{chats}.db", std::process::id()));
+        remove_db_files(&path);
+        let store = runtime
+            .block_on(SqliteStore::new(path.to_str().expect("path")))
+            .expect("store");
+        let cache = Arc::new(SignalStoreCache::new());
+        let mut rng = rand::rngs::StdRng::seed_from_u64(FIXTURE_SEED);
+        let addresses: Vec<_> = (0..chats)
+            .map(|i| ProtocolAddress::new(&format!("1555000{i:05}"), 1.into()))
+            .collect();
+        runtime.block_on(async {
+            for addr in &addresses {
+                cache.put_session(addr, create_session(&mut rng)).await;
+            }
+            cache.flush(&store).await.expect("warmup flush");
+            // Prime one dirty advance, so even the first measured flush writes rows.
+            for addr in &addresses {
+                cycle(&cache, &store, addr).await;
+            }
+        });
+        Self {
+            runtime,
+            store,
+            cache,
+            addresses,
+            path,
+        }
+    }
+
+    fn verify_persisted(&self, expected: u32) {
+        self.runtime.block_on(async {
+            assert!(!self.cache.needs_pre_wire_flush().await);
+            // Exact reload in the same incarnation verifies the final flush, not cache hits.
+            self.cache.clear_after_flush().await;
+            for addr in &self.addresses {
+                let (record, token) = self
+                    .cache
+                    .checkout_session(addr, &self.store)
+                    .await
+                    .expect("reload");
+                assert_eq!(chain_index(&record.expect("persisted session")), expected);
+                self.cache.cancel_session_checkout(addr, token);
+            }
+        });
+    }
+
+    fn close(self) {
+        let Self {
+            runtime,
+            store,
+            cache,
+            addresses: _,
+            path,
+        } = self;
+        drop(cache);
+        drop(store);
+        drop(runtime);
+        remove_db_files(&path);
+    }
+}
+
+fn percentile(samples: &mut [Duration], percent: usize) -> f64 {
+    assert!(!samples.is_empty());
+    samples.sort_unstable();
+    let index = (samples.len() * percent).div_ceil(100).saturating_sub(1);
+    samples[index].as_secs_f64() * 1_000_000.0
+}
+
+#[allow(clippy::print_stdout)]
+fn report() {
+    println!(
+        "Cache operations only; timings include scheduling. Flush duration is not mutex hold time."
+    );
+    println!(
+        "The no-overlap control persists once at the end; the overlap case persists each round plus final drain."
+    );
+    println!(
+        "| Round | Chats | Overlap | Cache cycles/s | Checkout p50 us | Checkout p99 us | Restore p99 us | Flush-call p99 us |"
+    );
+    println!("|---|---|---|---|---|---|---|---|");
+    for repetition in 0..3 {
+        for chats in [1, 8, 32] {
+            for overlap in [false, true] {
+                let h = Harness::new(chats);
+                let rounds = 100;
+                let mut checkouts = Vec::with_capacity(chats * rounds);
+                let mut restores = Vec::with_capacity(chats * rounds);
+                let mut flushes = Vec::with_capacity(rounds + 1);
+                let start = Instant::now();
+                h.runtime.block_on(async {
+                    tokio::time::timeout(DEADLINE, async {
+                        for _ in 0..rounds {
+                            let mut flush = pin!(h.cache.flush(&h.store));
+                            let flush_start = Instant::now();
+                            if overlap {
+                                // The first poll acquires the cache lock and submits the SQLite job.
+                                // Hold that future pending until the sibling operations are issued.
+                                assert!(
+                                    poll_fn(|cx| Poll::Ready(flush.as_mut().poll(cx).is_pending()))
+                                        .await
+                                );
+                            }
+                            let tasks: Vec<_> = h
+                                .addresses
+                                .iter()
+                                .map(|addr| {
+                                    let addr = addr.clone();
+                                    let cache = Arc::clone(&h.cache);
+                                    let store = h.store.clone();
+                                    tokio::spawn(async move { cycle(&cache, &store, &addr).await })
+                                })
+                                .collect();
+                            if overlap {
+                                flush.await.expect("round flush");
+                                flushes.push(flush_start.elapsed());
+                            }
+                            for task in tasks {
+                                let (checkout, restore) = task.await.expect("task");
+                                checkouts.push(checkout);
+                                restores.push(restore);
+                            }
+                        }
+                        let final_start = Instant::now();
+                        h.cache.flush(&h.store).await.expect("final drain");
+                        flushes.push(final_start.elapsed());
+                    })
+                    .await
+                    .expect("workload timeout");
+                });
+                let elapsed = start.elapsed();
+                h.verify_persisted(u32::try_from(rounds + 1).expect("counter"));
+                println!(
+                    "| {} | {chats} | {overlap} | {:.0} | {:.2} | {:.2} | {:.2} | {:.2} |",
+                    repetition + 1,
+                    (chats * rounds) as f64 / elapsed.as_secs_f64(),
+                    percentile(&mut checkouts, 50),
+                    percentile(&mut checkouts, 99),
+                    percentile(&mut restores, 99),
+                    percentile(&mut flushes, 99)
+                );
+                h.close();
+            }
+        }
+    }
+}
+
+/// Sequential cache cycles followed by a fixed flush; no concurrency claim.
+#[divan::bench(args = [1, 8, 32])]
+fn signal_cache_batch_flush(bencher: divan::Bencher, chats: usize) {
+    let h = Harness::new(chats);
+    let mut advances = 1u32;
+    bencher.bench_local(|| {
+        h.runtime.block_on(async {
+            for addr in &h.addresses {
+                cycle(&h.cache, &h.store, black_box(addr)).await;
+            }
+            h.cache.flush(&h.store).await.expect("flush");
+        });
+        advances += 1;
+    });
+    h.verify_persisted(advances);
+    h.close();
+}
+
+fn main() {
+    if std::env::args().any(|arg| arg == "--report") {
+        report();
+    } else {
+        divan::main();
+    }
+}

--- a/storages/sqlite-storage/benches/signal_cache_contention.rs
+++ b/storages/sqlite-storage/benches/signal_cache_contention.rs
@@ -183,9 +183,12 @@ fn report() {
         "The no-overlap control persists once at the end; the overlap case persists each round plus final drain."
     );
     println!(
-        "| Round | Chats | Overlap | Cache cycles/s | Checkout p50 us | Checkout p99 us | Restore p99 us | Flush-call p99 us |"
+        "Early flushes completed before sibling operations were issued and did not overlap them."
     );
-    println!("|---|---|---|---|---|---|---|---|");
+    println!(
+        "| Round | Chats | Overlap attempted | Early flushes | Cache cycles/s | Checkout p50 us | Checkout p99 us | Restore p99 us | Flush-call p99 us |"
+    );
+    println!("|---|---|---|---|---|---|---|---|---|");
     for repetition in 0..3 {
         for chats in [1, 8, 32] {
             for overlap in [false, true] {
@@ -194,20 +197,27 @@ fn report() {
                 let mut checkouts = Vec::with_capacity(chats * rounds);
                 let mut restores = Vec::with_capacity(chats * rounds);
                 let mut flushes = Vec::with_capacity(rounds + 1);
+                let mut early_flushes = 0;
                 let start = Instant::now();
                 h.runtime.block_on(async {
                     tokio::time::timeout(DEADLINE, async {
                         for _ in 0..rounds {
                             let mut flush = pin!(h.cache.flush(&h.store));
                             let flush_start = Instant::now();
-                            if overlap {
-                                // The first poll acquires the cache lock and submits the SQLite job.
-                                // Hold that future pending until the sibling operations are issued.
-                                assert!(
-                                    poll_fn(|cx| Poll::Ready(flush.as_mut().poll(cx).is_pending()))
-                                        .await
-                                );
-                            }
+                            // A native blocking job can finish before its join handle is polled.
+                            // Count that case instead of assuming every flush yields.
+                            let early_duration = if overlap {
+                                match poll_fn(|cx| Poll::Ready(flush.as_mut().poll(cx))).await {
+                                    Poll::Ready(result) => {
+                                        result.expect("early flush");
+                                        early_flushes += 1;
+                                        Some(flush_start.elapsed())
+                                    }
+                                    Poll::Pending => None,
+                                }
+                            } else {
+                                None
+                            };
                             let tasks: Vec<_> = h
                                 .addresses
                                 .iter()
@@ -219,8 +229,13 @@ fn report() {
                                 })
                                 .collect();
                             if overlap {
-                                flush.await.expect("round flush");
-                                flushes.push(flush_start.elapsed());
+                                match early_duration {
+                                    Some(duration) => flushes.push(duration),
+                                    None => {
+                                        flush.await.expect("round flush");
+                                        flushes.push(flush_start.elapsed());
+                                    }
+                                }
                             }
                             for task in tasks {
                                 let (checkout, restore) = task.await.expect("task");
@@ -238,7 +253,7 @@ fn report() {
                 let elapsed = start.elapsed();
                 h.verify_persisted(u32::try_from(rounds + 1).expect("counter"));
                 println!(
-                    "| {} | {chats} | {overlap} | {:.0} | {:.2} | {:.2} | {:.2} | {:.2} |",
+                    "| {} | {chats} | {overlap} | {early_flushes} | {:.0} | {:.2} | {:.2} | {:.2} | {:.2} |",
                     repetition + 1,
                     (chats * rounds) as f64 / elapsed.as_secs_f64(),
                     percentile(&mut checkouts, 50),

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -6358,5 +6358,432 @@ mod cold_read_race_tests {
 }
 
 #[cfg(test)]
+mod flush_contention_reproduction_tests {
+    use super::*;
+    use crate::libsignal::protocol::{
+        ChainKey, IdentityKey, KeyPair, ProtocolAddress, RootKey, SessionRecord, SessionState,
+    };
+    use crate::store::in_memory::InMemoryBackend;
+    use crate::store::traits::SignalStore;
+    use core::time::Duration;
+    use std::future::poll_fn;
+    use std::pin::pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::Poll;
+
+    fn session_at_index(index: u32) -> SessionRecord {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let local = IdentityKey::new(KeyPair::generate(&mut rng).public_key);
+        let remote = IdentityKey::new(KeyPair::generate(&mut rng).public_key);
+        let base_key = KeyPair::generate(&mut rng).public_key;
+        let mut state = SessionState::new(3, &local, &remote, &RootKey::new([4u8; 32]), &base_key);
+        state.set_sender_chain(
+            &KeyPair::generate(&mut rng),
+            &ChainKey::new([7u8; 32], index),
+        );
+        SessionRecord::new(state)
+    }
+
+    fn chain_index_of(record: &SessionRecord) -> u32 {
+        record
+            .session_state()
+            .expect("session state")
+            .get_sender_chain_key()
+            .expect("sender chain")
+            .index()
+    }
+
+    fn signal_address(user: &str) -> ProtocolAddress {
+        ProtocolAddress::new(&format!("{user}@s.whatsapp.net"), 0.into())
+    }
+
+    struct ContentionGatedBackend {
+        inner: InMemoryBackend,
+        gating_enabled: AtomicBool,
+        entered_tx: async_channel::Sender<()>,
+        release_rx: async_channel::Receiver<()>,
+    }
+
+    impl ContentionGatedBackend {
+        fn new(
+            entered_tx: async_channel::Sender<()>,
+            release_rx: async_channel::Receiver<()>,
+        ) -> Self {
+            Self {
+                inner: InMemoryBackend::new(),
+                gating_enabled: AtomicBool::new(false),
+                entered_tx,
+                release_rx,
+            }
+        }
+
+        fn enable_gating(&self) {
+            self.gating_enabled.store(true, Ordering::Release);
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl SignalStore for ContentionGatedBackend {
+        async fn put_sessions_batch(
+            &self,
+            sessions: &[(Arc<str>, bytes::Bytes)],
+        ) -> crate::store::error::Result<()> {
+            if self.gating_enabled.load(Ordering::Acquire) {
+                let _ = self.entered_tx.send(()).await;
+                let _ = self.release_rx.recv().await;
+            }
+            self.inner.put_sessions_batch(sessions).await
+        }
+
+        async fn get_session(
+            &self,
+            address: &str,
+        ) -> crate::store::error::Result<Option<bytes::Bytes>> {
+            self.inner.get_session(address).await
+        }
+
+        async fn put_session(
+            &self,
+            address: &str,
+            session: &[u8],
+        ) -> crate::store::error::Result<()> {
+            self.inner.put_session(address, session).await
+        }
+
+        async fn delete_session(&self, address: &str) -> crate::store::error::Result<()> {
+            self.inner.delete_session(address).await
+        }
+
+        async fn delete_sessions_batch(
+            &self,
+            addresses: &[Arc<str>],
+        ) -> crate::store::error::Result<()> {
+            self.inner.delete_sessions_batch(addresses).await
+        }
+
+        async fn get_sessions_batch(
+            &self,
+            addresses: &[Arc<str>],
+        ) -> crate::store::error::Result<Vec<(Arc<str>, bytes::Bytes)>> {
+            self.inner.get_sessions_batch(addresses).await
+        }
+
+        async fn load_identity(
+            &self,
+            address: &str,
+        ) -> crate::store::error::Result<Option<[u8; 32]>> {
+            self.inner.load_identity(address).await
+        }
+
+        async fn put_identity(
+            &self,
+            address: &str,
+            key: [u8; 32],
+        ) -> crate::store::error::Result<()> {
+            self.inner.put_identity(address, key).await
+        }
+
+        async fn delete_identity(&self, address: &str) -> crate::store::error::Result<()> {
+            self.inner.delete_identity(address).await
+        }
+
+        async fn store_prekey(
+            &self,
+            id: u32,
+            record: &[u8],
+            uploaded: bool,
+        ) -> crate::store::error::Result<()> {
+            self.inner.store_prekey(id, record, uploaded).await
+        }
+
+        async fn load_prekey(&self, id: u32) -> crate::store::error::Result<Option<bytes::Bytes>> {
+            self.inner.load_prekey(id).await
+        }
+
+        async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> crate::store::error::Result<()> {
+            self.inner.mark_prekeys_uploaded(ids).await
+        }
+
+        async fn remove_prekey(&self, id: u32) -> crate::store::error::Result<()> {
+            self.inner.remove_prekey(id).await
+        }
+
+        async fn remove_prekeys_batch(&self, ids: &[u32]) -> crate::store::error::Result<()> {
+            self.inner.remove_prekeys_batch(ids).await
+        }
+
+        async fn get_max_prekey_id(&self) -> crate::store::error::Result<u32> {
+            self.inner.get_max_prekey_id().await
+        }
+
+        async fn store_signed_prekey(
+            &self,
+            id: u32,
+            record: &[u8],
+        ) -> crate::store::error::Result<()> {
+            self.inner.store_signed_prekey(id, record).await
+        }
+
+        async fn load_signed_prekey(
+            &self,
+            id: u32,
+        ) -> crate::store::error::Result<Option<Vec<u8>>> {
+            self.inner.load_signed_prekey(id).await
+        }
+
+        async fn load_all_signed_prekeys(
+            &self,
+        ) -> crate::store::error::Result<Vec<(u32, Vec<u8>)>> {
+            self.inner.load_all_signed_prekeys().await
+        }
+
+        async fn remove_signed_prekey(&self, id: u32) -> crate::store::error::Result<()> {
+            self.inner.remove_signed_prekey(id).await
+        }
+
+        async fn put_sender_key(
+            &self,
+            address: &str,
+            record: &[u8],
+        ) -> crate::store::error::Result<()> {
+            self.inner.put_sender_key(address, record).await
+        }
+
+        async fn get_sender_key(
+            &self,
+            address: &str,
+        ) -> crate::store::error::Result<Option<Vec<u8>>> {
+            self.inner.get_sender_key(address).await
+        }
+
+        async fn delete_sender_key(&self, address: &str) -> crate::store::error::Result<()> {
+            self.inner.delete_sender_key(address).await
+        }
+    }
+
+    #[tokio::test]
+    async fn deterministic_flush_of_a_blocks_checkout_and_put_of_independent_session_b() {
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let backend = Arc::new(ContentionGatedBackend::new(entered_tx, release_rx));
+        let cache = Arc::new(SignalStoreCache::new());
+
+        let addr_a = signal_address("19995551001");
+        let addr_b = signal_address("19995551002");
+
+        // Warm up B and flush it so it is Present and clean in cache.
+        cache.put_session(&addr_b, session_at_index(10)).await;
+        cache.flush(backend.as_ref()).await.expect("warmup flush");
+
+        // Dirty session A.
+        cache.put_session(&addr_a, session_at_index(20)).await;
+
+        // Enable gating so backend.put_sessions_batch will pause.
+        backend.enable_gating();
+
+        // Spawn flush of A.
+        let flush_task = tokio::spawn({
+            let (cache, backend) = (cache.clone(), backend.clone());
+            async move { cache.flush(backend.as_ref()).await }
+        });
+
+        // Wait for flush to enter put_sessions_batch while holding lock_sessions().
+        tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+            .await
+            .expect("timeout waiting for flush to enter put_sessions_batch")
+            .expect("channel alive");
+
+        // --- At this point, flush of A holds the sessions lock mid-I/O ---
+
+        // 1. Non-blocking checkout of independent warm session B must return None.
+        assert!(
+            cache.try_checkout_session(&addr_b).is_none(),
+            "try_checkout_session on warm independent session B must fail while flush holds sessions lock"
+        );
+
+        // 2. Async checkout of B must be Pending (blocked on sessions lock).
+        let mut checkout_b = pin!(cache.checkout_session(&addr_b, backend.as_ref()));
+        let pending_checkout =
+            poll_fn(|cx| Poll::Ready(checkout_b.as_mut().poll(cx).is_pending())).await;
+        assert!(
+            pending_checkout,
+            "checkout_session of warm independent session B must be Pending during flush"
+        );
+
+        // 3. Non-blocking put of independent session B must fail with Err(record).
+        let put_res = cache.try_put_session(&addr_b, session_at_index(11));
+        assert!(
+            put_res.is_err(),
+            "try_put_session on session B must fail while flush holds sessions lock"
+        );
+        let record_b_put = put_res.unwrap_err();
+
+        // 4. Async put of B must be Pending (blocked on sessions lock).
+        let mut put_b = pin!(cache.put_session(&addr_b, record_b_put));
+        let pending_put = poll_fn(|cx| Poll::Ready(put_b.as_mut().poll(cx).is_pending())).await;
+        assert!(
+            pending_put,
+            "put_session of independent session B must be Pending during flush"
+        );
+
+        // Release backend I/O to complete flush.
+        release_tx.send(()).await.expect("release backend");
+        tokio::time::timeout(Duration::from_secs(5), flush_task)
+            .await
+            .expect("flush timeout")
+            .unwrap()
+            .expect("flush must succeed");
+
+        // Both checkout and put of B can now complete without deadlock.
+        let (record_b, checkout_key_b) = checkout_b
+            .await
+            .expect("checkout B must succeed after flush releases lock");
+        assert_eq!(chain_index_of(&record_b.expect("record B present")), 10);
+        cache.cancel_session_checkout(&addr_b, checkout_key_b);
+
+        put_b.await;
+        let (updated_b, _) = cache
+            .checkout_session(&addr_b, backend.as_ref())
+            .await
+            .expect("checkout updated B");
+        assert_eq!(chain_index_of(&updated_b.expect("updated B present")), 11);
+    }
+
+    #[tokio::test]
+    async fn control_without_flush_independent_session_progresses_without_pending() {
+        let (entered_tx, _entered_rx) = async_channel::bounded(1);
+        let (_release_tx, release_rx) = async_channel::bounded(1);
+        let backend = Arc::new(ContentionGatedBackend::new(entered_tx, release_rx));
+        let cache = Arc::new(SignalStoreCache::new());
+
+        let addr_b = signal_address("19995551003");
+
+        // Warm up B.
+        cache.put_session(&addr_b, session_at_index(10)).await;
+        cache.flush(backend.as_ref()).await.expect("warmup flush");
+
+        // Without flush running, try_checkout_session succeeds immediately.
+        let checkout_opt = cache.try_checkout_session(&addr_b);
+        assert!(
+            checkout_opt.is_some(),
+            "try_checkout must succeed without flush"
+        );
+        let (record, checkout_key) = checkout_opt.unwrap().expect("checkout ok");
+        assert_eq!(chain_index_of(&record.expect("record present")), 10);
+        cache.cancel_session_checkout(&addr_b, checkout_key);
+
+        // try_put_session succeeds immediately.
+        let put_res = cache.try_put_session(&addr_b, session_at_index(11));
+        assert!(put_res.is_ok(), "try_put must succeed without flush");
+
+        // Async checkout is Ready on first poll.
+        let mut checkout_fut = pin!(cache.checkout_session(&addr_b, backend.as_ref()));
+        let is_ready = poll_fn(|cx| Poll::Ready(checkout_fut.as_mut().poll(cx).is_ready())).await;
+        assert!(
+            is_ready,
+            "checkout must be ready on first poll when warm and uncontented"
+        );
+    }
+
+    #[tokio::test]
+    async fn control_cold_read_blocked_at_cache_lock_during_flush_before_backend_io() {
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let backend = Arc::new(ContentionGatedBackend::new(entered_tx, release_rx));
+        let cache = Arc::new(SignalStoreCache::new());
+
+        let addr_a = signal_address("19995551004");
+        let addr_c = signal_address("19995551005");
+
+        // Seed C directly into backend, NOT into cache (C is cold).
+        let mut raw = Vec::new();
+        session_at_index(50).serialize_into_for_store(&mut raw, &[0xAA; 16]);
+        backend
+            .inner
+            .put_session(addr_c.as_str(), &raw)
+            .await
+            .expect("seed C");
+
+        // Dirty session A in cache.
+        cache.put_session(&addr_a, session_at_index(20)).await;
+        backend.enable_gating();
+
+        // Spawn flush of A.
+        let flush_task = tokio::spawn({
+            let (cache, backend) = (cache.clone(), backend.clone());
+            async move { cache.flush(backend.as_ref()).await }
+        });
+        tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+            .await
+            .expect("flush entry timeout")
+            .expect("flush in progress");
+
+        // Cold checkout of C must probe cache first before issuing backend get_session.
+        // Because flush holds lock_sessions(), cold checkout is blocked at the initial cache probe.
+        let mut cold_checkout = pin!(cache.checkout_session(&addr_c, backend.as_ref()));
+        let pending = poll_fn(|cx| Poll::Ready(cold_checkout.as_mut().poll(cx).is_pending())).await;
+        assert!(
+            pending,
+            "cold checkout of C must be Pending at the cache lock before even reaching the backend"
+        );
+
+        release_tx.send(()).await.expect("release flush");
+        tokio::time::timeout(Duration::from_secs(5), flush_task)
+            .await
+            .expect("flush completion timeout")
+            .expect("join")
+            .expect("flush ok");
+
+        // After flush releases lock, cold read proceeds to backend and completes.
+        let (record_c, key_c) = cold_checkout.await.expect("cold checkout ok");
+        assert_eq!(chain_index_of(&record_c.expect("record C present")), 50);
+        cache.cancel_session_checkout(&addr_c, key_c);
+    }
+
+    #[tokio::test]
+    async fn control_same_session_remains_serialized_during_flush() {
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let backend = Arc::new(ContentionGatedBackend::new(entered_tx, release_rx));
+        let cache = Arc::new(SignalStoreCache::new());
+
+        let addr_a = signal_address("19995551006");
+        cache.put_session(&addr_a, session_at_index(30)).await;
+        backend.enable_gating();
+
+        let flush_task = tokio::spawn({
+            let (cache, backend) = (cache.clone(), backend.clone());
+            async move { cache.flush(backend.as_ref()).await }
+        });
+        tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+            .await
+            .expect("flush entry timeout")
+            .expect("flush in progress");
+
+        // Operations on the SAME session A must remain blocked / pending during flush.
+        assert!(cache.try_checkout_session(&addr_a).is_none());
+        let mut checkout_a = pin!(cache.checkout_session(&addr_a, backend.as_ref()));
+        let pending = poll_fn(|cx| Poll::Ready(checkout_a.as_mut().poll(cx).is_pending())).await;
+        assert!(
+            pending,
+            "session A must be serialized while its flush is in flight"
+        );
+
+        release_tx.send(()).await.expect("release flush");
+        tokio::time::timeout(Duration::from_secs(5), flush_task)
+            .await
+            .expect("flush completion timeout")
+            .expect("join")
+            .expect("flush ok");
+
+        let (rec_a, key_a) = checkout_a.await.expect("checkout ok");
+        assert_eq!(chain_index_of(&rec_a.expect("record present")), 30);
+        cache.cancel_session_checkout(&addr_a, key_a);
+    }
+}
+
+#[cfg(test)]
 #[path = "signal_cache_durability_chaos.rs"]
 mod durability_chaos_tests;


### PR DESCRIPTION
## Summary

A Signal cache flush holds the sessions mutex while persisting records, so a checkout for another warm session can wait behind that I/O. Add deterministic gated tests that demonstrate this ordering, with controls for no flush, cold reads and the same session.

Add a fixed-size sequential cache-batch benchmark and a native `--report` workload that attempts to overlap a flush with independent cache cycles and counts flushes that finish before sibling operations are issued. The report uses checkout-token restoration, bounded waits, a timed final drain and backend reloads that verify all final chain indices. Its measurements are cache-operation durations and cycles/s; the flush-call duration includes more than mutex ownership.

The production flush synchronization remains intact. The tests capture why changing its ordering needs an explicit durability design.

## CI bootstrap fix

The binary-size job hit GitHub download rate limits twice and fell back to compiling its tools before `sccache` had been installed. Clear `RUSTC_WRAPPER` only for that bootstrap step in both PR and push jobs, so this existing fallback can work. The size thresholds and measurement commands are unchanged.

## Validation

- 3,602 library tests passed across wacore, whatsapp-rust and SQLite on the combined validation tree, including the new contention controls.
- The 128-seed × 256-step Signal durability matrix and SQLite SIGKILL/restart test passed.
- Native report completed three repetitions for 1/8/32 chats, with and without overlap, validating persisted counters after each workload.
- Sequential benchmark smokes for 1/8/32 sessions passed.
- Workspace clippy with all targets and `bench-harness`, and formatting passed.
- This independent branch adds tests and benchmarks; CI validates it against main.

