### PR TITLE
bench(recv): cover runtime bursts and production chat lanes

### DIFF
--- a/benches/client_receive.rs
+++ b/benches/client_receive.rs
@@ -8,11 +8,11 @@
 //! event bus, the delivery receipt — lives in the `whatsapp-rust` crate, and
 //! this target is what puts a number on it.
 //!
-//! What it does not cover, stated once so no number here is over-read:
+//! The direct receive and `_burst` cases enter at `handle_incoming_message`
+//! and exclude the queue hop. The `worker_*` cases include enqueue and the
+//! production chat-lane worker; `worker_lanes` also includes lane shutdown.
 //!
-//! - **The chat lane.** A stanza enters at `handle_incoming_message`, which
-//!   is what the lane worker awaits per message; the queue hop itself is not
-//!   measured.
+//! These fixtures exclude:
 //! - **The SQLite backend.** The fixture stores through `InMemoryBackend`.
 //! - **First contact.** Session and sender key are established in setup.
 //! - **The socket write.** The delivery receipt is marshalled, noise-encrypted

--- a/benches/client_receive.rs
+++ b/benches/client_receive.rs
@@ -29,7 +29,9 @@ fn main() {
 // Few, large samples: the fixture's flush worker fires on its own 25 ms clock
 // and a coalesced flush that lands mid-sample is amortised over a long sample
 // rather than moving a short one.
+#[allow(dead_code)]
 const SAMPLE_COUNT: u32 = 20;
+#[allow(dead_code)]
 const SAMPLE_SIZE: u32 = 50;
 
 /// One harness for both benches, so the second does not pay a second fixture.
@@ -69,4 +71,107 @@ fn group_receive(bencher: divan::Bencher) {
             harness.receive(black_box(node));
         });
     assert_eq!(harness.messages_delivered() - before, received);
+}
+
+const BURST_SIZE: usize = 50;
+
+/// Limit 2 (Harness control): A 1:1 text message received in a burst under a single
+/// runtime entry (`block_on`), matching the exact decrypt, event, and receipt flush work
+/// while isolating the per-message processing cost from the `block_on` future passing artifact.
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = 1)]
+fn dm_receive_burst(bencher: divan::Bencher) {
+    let harness = harness();
+    let before = harness.messages_delivered();
+    let mut round_delivered = 0u64;
+    bencher
+        .counter(divan::counter::ItemsCount::new(BURST_SIZE as u64))
+        .with_inputs(|| {
+            (0..BURST_SIZE)
+                .map(|_| harness.dm_stanza())
+                .collect::<Vec<_>>()
+        })
+        .bench_local_values(|batch| {
+            round_delivered += batch.len() as u64;
+            harness.receive_burst(black_box(&batch));
+        });
+    assert_eq!(harness.messages_delivered() - before, round_delivered);
+    assert!(round_delivered > 0);
+}
+
+/// Limit 2 (Harness control): A group text message received in a burst under a single
+/// runtime entry (`block_on`).
+#[divan::bench(sample_count = SAMPLE_COUNT, sample_size = 1)]
+fn group_receive_burst(bencher: divan::Bencher) {
+    let harness = harness();
+    let before = harness.messages_delivered();
+    let mut round_delivered = 0u64;
+    bencher
+        .counter(divan::counter::ItemsCount::new(BURST_SIZE as u64))
+        .with_inputs(|| {
+            (0..BURST_SIZE)
+                .map(|_| harness.group_stanza())
+                .collect::<Vec<_>>()
+        })
+        .bench_local_values(|batch| {
+            round_delivered += batch.len() as u64;
+            harness.receive_burst(black_box(&batch));
+        });
+    assert_eq!(harness.messages_delivered() - before, round_delivered);
+    assert!(round_delivered > 0);
+}
+
+/// Multi-lane harness initialized with 256 distinct groups and installed sender keys.
+fn multilane_harness() -> &'static whatsapp_rust::bench_support::MultiLaneReceiveHarness {
+    static HARNESS: OnceLock<whatsapp_rust::bench_support::MultiLaneReceiveHarness> =
+        OnceLock::new();
+    HARNESS.get_or_init(|| whatsapp_rust::bench_support::MultiLaneReceiveHarness::new(256))
+}
+
+const LANE_COUNTS: &[usize] = &[1, 32, 256];
+const WORKER_BURST_SIZE: usize = 256;
+#[allow(dead_code)]
+const WORKER_SAMPLE_COUNT: u32 = 10;
+
+/// Limit 3 (Production worker): A single warm chat lane processing bursts through
+/// `MessageHandler::handle_inline` into its worker task without closing the worker
+/// between samples.
+#[divan::bench(sample_count = WORKER_SAMPLE_COUNT, sample_size = 1)]
+fn worker_hot_burst_warm(bencher: divan::Bencher) {
+    let harness = harness();
+    let before = harness.messages_delivered();
+    let mut round_delivered = 0u64;
+    bencher
+        .counter(divan::counter::ItemsCount::new(BURST_SIZE as u64))
+        .with_inputs(|| {
+            (0..BURST_SIZE)
+                .map(|_| harness.group_stanza())
+                .collect::<Vec<_>>()
+        })
+        .bench_local_values(|batch| {
+            round_delivered += batch.len() as u64;
+            harness.enqueue_and_drain(black_box(&batch));
+        });
+    assert_eq!(harness.messages_delivered() - before, round_delivered);
+    assert!(round_delivered > 0);
+    harness.close_lanes();
+}
+
+/// Limit 3 (Production worker): Production chat lane worker pipeline across 1, 32,
+/// and 256 active lanes with valid sender key ratchets, fixed total message count (256),
+/// and closing all worker tasks per round to verify task lifecycle and memory reclamation.
+#[divan::bench(args = LANE_COUNTS, sample_count = WORKER_SAMPLE_COUNT, sample_size = 1)]
+fn worker_lanes(bencher: divan::Bencher, lanes: usize) {
+    let harness = multilane_harness();
+    let before = harness.messages_delivered();
+    let mut round_delivered = 0u64;
+    bencher
+        .counter(divan::counter::ItemsCount::new(WORKER_BURST_SIZE as u64))
+        .with_inputs(|| harness.generate_burst(lanes, WORKER_BURST_SIZE))
+        .bench_local_values(|batch| {
+            round_delivered += batch.len() as u64;
+            harness.enqueue_and_drain(black_box(&batch));
+            harness.close_lanes();
+        });
+    assert_eq!(harness.messages_delivered() - before, round_delivered);
+    assert_eq!(harness.active_lanes(), 0);
 }

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use crate::Client;
+use crate::client::ChatLane;
 use crate::http::{HttpClient, HttpRequest, HttpResponse};
 use crate::runtime_impl::TokioRuntime;
 use crate::store::persistence_manager::PersistenceManager;
@@ -932,6 +933,53 @@ impl ReceiveHarness {
         })
     }
 
+    /// Receive a burst of stanzas within a single runtime entry (`block_on`),
+    /// awaiting each `handle_incoming_message` inline and flushing outbound receipts,
+    /// matching the exact decrypt, event, and receipt work of [`Self::receive`]
+    /// while isolating the per-message processing cost from the `block_on` future passing artifact.
+    pub fn receive_burst(&self, nodes: &[Arc<wacore_binary::OwnedNodeRef>]) {
+        self.runtime.block_on(async {
+            for node in nodes {
+                Arc::clone(&self.client)
+                    .handle_incoming_message(Arc::clone(node))
+                    .await;
+                self.client
+                    .outbound_flush
+                    .flush(&*self.client.runtime, std::time::Duration::from_secs(5))
+                    .await;
+            }
+        });
+    }
+
+    /// Enqueue stanzas through the real production `MessageHandler::handle_inline` into
+    /// chat lanes, driving the lane workers to process them, and flush outbound receipts.
+    pub fn enqueue_and_drain(&self, nodes: &[Arc<wacore_binary::OwnedNodeRef>]) {
+        self.runtime.block_on(async {
+            let target = self.messages_delivered() + nodes.len() as u64;
+            for node in nodes {
+                let mut cancelled = false;
+                let accepted = crate::handlers::message::MessageHandler::handle_inline(
+                    Arc::clone(&self.client),
+                    Arc::clone(node),
+                    &mut cancelled,
+                )
+                .await;
+                assert!(accepted && !cancelled, "message enqueue failed");
+            }
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                while self.messages_delivered() < target {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("lane delivery timed out: a decrypt, commit, or worker failed");
+            self.client
+                .outbound_flush
+                .flush(&*self.client.runtime, std::time::Duration::from_secs(5))
+                .await;
+        });
+    }
+
     /// How many `Event::Messages` batches reached the subscriber so far (one
     /// per received stanza in live mode). A benchmark
     /// asserts this against its iteration count, so a silent decrypt failure
@@ -1042,6 +1090,35 @@ impl ReceiveHarness {
         });
     }
 
+    /// Gracefully terminate all active chat lane workers by closing their channels,
+    /// awaiting their termination, and clearing the lane cache.
+    pub fn close_lanes(&self) {
+        self.runtime.block_on(async {
+            let lanes: Vec<ChatLane> = self
+                .client
+                .chat_lanes
+                .fold_entries(Vec::new(), |mut acc, _k, lane| {
+                    acc.push(lane.clone());
+                    acc
+                })
+                .await;
+
+            for lane in &lanes {
+                lane.queue_tx.close();
+            }
+
+            self.client.chat_lanes.clear().await;
+
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                for lane in &lanes {
+                    let _guard = lane.worker_running.lock().await;
+                }
+            })
+            .await
+            .expect("lane shutdown timed out");
+        });
+    }
+
     /// Let the outbound work the processed stanzas queued (their transport
     /// `<ack>`s) finish, so it cannot leak into the next benchmark.
     pub fn flush(&self) {
@@ -1064,6 +1141,302 @@ impl Default for ReceiveHarness {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// A harness supporting multiple concurrent chat lanes (e.g. 1, 32, 256 lanes)
+/// with valid sender key ratchets per group, measuring production chat-lane
+/// enqueue, worker execution, and shutdown.
+pub struct MultiLaneReceiveHarness {
+    runtime: tokio::runtime::Runtime,
+    client: Arc<Client>,
+    peer: Arc<Client>,
+    peer_jid: Jid,
+    groups: Vec<Jid>,
+    group_sender_keys: Vec<wacore::libsignal::protocol::SenderKeyName>,
+    counter: Arc<MessageCounter>,
+    _subscription: wacore::types::events::Subscription,
+    next_id: portable_atomic::AtomicU64,
+}
+
+impl MultiLaneReceiveHarness {
+    /// Build a multi-lane harness with `num_lanes` pre-configured groups and installed
+    /// sender keys.
+    pub fn new(num_lanes: usize) -> Self {
+        assert!(num_lanes >= 1, "at least 1 lane is required");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let (client, peer, peer_jid, groups, group_sender_keys, counter, subscription) =
+            runtime.block_on(build_multilane_receive_fixture(num_lanes));
+        Self {
+            runtime,
+            client,
+            peer,
+            peer_jid,
+            groups,
+            group_sender_keys,
+            counter,
+            _subscription: subscription,
+            next_id: portable_atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Number of configured groups available in the harness.
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Generate a burst of valid encrypted stanzas distributed across `active_lanes` groups.
+    /// Each stanza advances the peer's sender key chain for that group.
+    pub fn generate_burst(
+        &self,
+        active_lanes: usize,
+        count: usize,
+    ) -> Vec<Arc<wacore_binary::OwnedNodeRef>> {
+        use wacore::libsignal::protocol::group_encrypt;
+
+        assert!(active_lanes >= 1 && active_lanes <= self.groups.len());
+        let plaintext = wacore::messages::MessageUtils::encode_and_pad(&wa::Message::text("bench"));
+
+        self.runtime.block_on(async {
+            let mut adapter = self.peer.signal_adapter();
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut stanzas = Vec::with_capacity(count);
+
+            for i in 0..count {
+                let lane_idx = i % active_lanes;
+                let group = &self.groups[lane_idx];
+                let sender_key = &self.group_sender_keys[lane_idx];
+
+                let ciphertext = group_encrypt(
+                    &mut adapter.sender_key_store,
+                    sender_key,
+                    &plaintext,
+                    &mut rng,
+                )
+                .await
+                .expect("peer encrypts to the group");
+
+                let enc = wacore_binary::builder::NodeBuilder::new("enc")
+                    .attr("type", "skmsg")
+                    .attr("v", "2")
+                    .bytes(ciphertext.serialized().to_vec())
+                    .build();
+                let node = wacore_binary::builder::NodeBuilder::new("message")
+                    .attr("from", group.to_string())
+                    .attr("participant", self.peer_jid.to_string())
+                    .attr("id", self.next_message_id())
+                    .attr("t", wacore::time::now_secs().to_string())
+                    .attr("type", "text")
+                    .attr("notify", "Bench Peer")
+                    .children([enc])
+                    .build();
+
+                stanzas.push(decoded(&node));
+            }
+            stanzas
+        })
+    }
+
+    /// Enqueue a batch of stanzas through production `MessageHandler::handle_inline` into
+    /// their respective chat lanes, await their processing, and flush outbound receipts.
+    pub fn enqueue_and_drain(&self, nodes: &[Arc<wacore_binary::OwnedNodeRef>]) {
+        self.runtime.block_on(async {
+            let target = self.messages_delivered() + nodes.len() as u64;
+            for node in nodes {
+                let mut cancelled = false;
+                let accepted = crate::handlers::message::MessageHandler::handle_inline(
+                    Arc::clone(&self.client),
+                    Arc::clone(node),
+                    &mut cancelled,
+                )
+                .await;
+                assert!(accepted && !cancelled, "message enqueue failed");
+            }
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                while self.messages_delivered() < target {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("lane delivery timed out: a decrypt, commit, or worker failed");
+            self.client
+                .outbound_flush
+                .flush(&*self.client.runtime, std::time::Duration::from_secs(5))
+                .await;
+        });
+    }
+
+    /// Receive a burst of stanzas within a single runtime entry (`block_on`),
+    /// calling `handle_incoming_message` inline, matching the exact decrypt,
+    /// event, and receipt work without chat lane hopping.
+    pub fn receive_burst(&self, nodes: &[Arc<wacore_binary::OwnedNodeRef>]) {
+        self.runtime.block_on(async {
+            for node in nodes {
+                Arc::clone(&self.client)
+                    .handle_incoming_message(Arc::clone(node))
+                    .await;
+                self.client
+                    .outbound_flush
+                    .flush(&*self.client.runtime, std::time::Duration::from_secs(5))
+                    .await;
+            }
+        });
+    }
+
+    /// Gracefully terminate all active chat lane workers by closing their channels,
+    /// awaiting their termination, and clearing the lane cache.
+    pub fn close_lanes(&self) {
+        self.runtime.block_on(async {
+            let lanes: Vec<ChatLane> = self
+                .client
+                .chat_lanes
+                .fold_entries(Vec::new(), |mut acc, _k, lane| {
+                    acc.push(lane.clone());
+                    acc
+                })
+                .await;
+
+            for lane in &lanes {
+                lane.queue_tx.close();
+            }
+
+            self.client.chat_lanes.clear().await;
+
+            tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                for lane in &lanes {
+                    let _guard = lane.worker_running.lock().await;
+                }
+            })
+            .await
+            .expect("lane shutdown timed out");
+        });
+    }
+
+    /// How many `Event::Messages` batches reached the subscriber so far.
+    pub fn messages_delivered(&self) -> u64 {
+        self.counter.delivered.load(Ordering::Relaxed)
+    }
+
+    /// Number of active lanes currently present in `client.chat_lanes`.
+    pub fn active_lanes(&self) -> u64 {
+        self.runtime.block_on(async {
+            self.client
+                .chat_lanes
+                .fold_entries(0u64, |count, _k, _v| count + 1)
+                .await
+        })
+    }
+
+    /// Reference to the underlying client.
+    pub fn client(&self) -> &Arc<Client> {
+        &self.client
+    }
+
+    fn next_message_id(&self) -> String {
+        let n = self.next_id.fetch_add(1, Ordering::Relaxed);
+        format!("3EB0BENCH{n:011}")
+    }
+}
+
+async fn build_multilane_receive_fixture(
+    num_lanes: usize,
+) -> (
+    Arc<Client>,
+    Arc<Client>,
+    Jid,
+    Vec<Jid>,
+    Vec<wacore::libsignal::protocol::SenderKeyName>,
+    Arc<MessageCounter>,
+    wacore::types::events::Subscription,
+) {
+    use wacore::libsignal::protocol::create_sender_key_distribution_message;
+    use wacore::types::jid::{JidExt, make_sender_key_name};
+
+    let backend = Arc::new(InMemoryBackend::new());
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager"),
+    );
+    let (client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        Arc::new(SinkTransportFactory),
+        Arc::new(NoopHttpClient),
+        None,
+    )
+    .await;
+
+    let own_pn = Jid::new(OWN_USER, Server::Pn);
+    let own_lid = Jid::new("100000000000001", Server::Lid);
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+        .await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(own_lid)))
+        .await;
+
+    seed_registry(&client, PEER_USER, &[0]).await;
+    seed_registry(&client, OWN_USER, &[0, 1]).await;
+
+    let peer_jid = Jid::new(PEER_USER, Server::Pn);
+    let peer = establish_acknowledged_session(&client, &peer_jid).await;
+
+    let mut groups = Vec::with_capacity(num_lanes);
+    let mut group_sender_keys = Vec::with_capacity(num_lanes);
+
+    let mut adapter = peer.signal_adapter();
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+    for i in 0..num_lanes {
+        let group: Jid = format!("12036300000{i:05}@g.us")
+            .parse()
+            .expect("valid group jid");
+        let group_sender_key = make_sender_key_name(&group, &peer_jid.to_protocol_address());
+        let skdm = create_sender_key_distribution_message(
+            &group_sender_key,
+            &mut adapter.sender_key_store,
+            &mut rng,
+        )
+        .await
+        .expect("peer sender key");
+
+        client
+            .handle_sender_key_distribution_message(
+                &group,
+                &peer_jid,
+                &format!("bench-skdm-{i}"),
+                skdm.serialized(),
+            )
+            .await;
+
+        groups.push(group);
+        group_sender_keys.push(group_sender_key);
+    }
+    drop(adapter);
+
+    let counter = Arc::new(MessageCounter {
+        delivered: portable_atomic::AtomicU64::new(0),
+    });
+    let subscription = client
+        .subscribe_handler(Arc::clone(&counter) as Arc<dyn wacore::types::events::EventHandler>);
+
+    install_offline_socket(&client).await;
+    settle_signal_flush_worker(&client).await;
+
+    (
+        client,
+        peer,
+        peer_jid,
+        groups,
+        group_sender_keys,
+        counter,
+        subscription,
+    )
 }
 
 /// The decoded form the read loop produces: marshalled and decoded back, so

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -799,10 +799,9 @@ impl wacore::types::events::EventHandler for StanzaEventCounter {
 /// measured is everything from the decoded stanza to the dispatched event:
 /// classification, the session or sender-key decrypt through the signal
 /// cache, plaintext handling, dispatch, and the delivery receipt written to
-/// the sink socket. The chat lane is not on the bill: a stanza enters at
-/// `Client::handle_incoming_message`, which is what the lane worker awaits
-/// per message, so the queue hop is excluded by construction and the
-/// per-message work is not.
+/// the sink socket. [`Self::receive`] and [`Self::receive_burst`] enter at
+/// `Client::handle_incoming_message` and exclude the queue hop.
+/// [`Self::enqueue_and_drain`] also measures the chat-lane queue and worker.
 pub struct ReceiveHarness {
     runtime: tokio::runtime::Runtime,
     client: Arc<Client>,

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -395,7 +395,13 @@ mod tests {
         }
     }
 
+    #[test]
+    fn queued_chat_message_keeps_two_handles() {
+        assert_eq!(size_of::<QueuedChatMessage>(), 2 * size_of::<usize>());
+    }
+
     #[tokio::test]
+    #[ignore = "layout diagnostic: run explicitly with --ignored --nocapture"]
     async fn audit_receive_future_and_struct_layouts() {
         let sizes = Arc::new(std::sync::Mutex::new(Vec::new()));
         let sizing_runtime = SizingRuntime {

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -284,7 +284,7 @@ mod tests {
         assert!(!first_tx.is_closed());
 
         // Paused time: the sleep advances the clock instead of waiting.
-        tokio::time::sleep(LANE_IDLE_TIMEOUT + std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(LANE_IDLE_TIMEOUT + Duration::from_secs(1)).await;
         for _ in 0..100 {
             if first_tx.is_closed() {
                 break;
@@ -347,5 +347,281 @@ mod tests {
         let same = client.chat_lanes.get(&chat).await.expect("lane kept");
         assert!(same.queue_tx.same_channel(&lane.queue_tx));
         assert!(!lane.queue_tx.is_closed());
+    }
+
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::time::Duration;
+
+    struct SizingRuntime {
+        inner: crate::runtime_impl::TokioRuntime,
+        sizes: Arc<std::sync::Mutex<Vec<usize>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl wacore::runtime::Runtime for SizingRuntime {
+        fn spawn(
+            &self,
+            future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+        ) -> wacore::runtime::AbortHandle {
+            self.sizes
+                .lock()
+                .expect("sizes mutex")
+                .push(size_of_val(&*future));
+            self.inner.spawn(future)
+        }
+
+        fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            self.sizes
+                .lock()
+                .expect("sizes mutex")
+                .push(size_of_val(&*future));
+            self.inner.spawn_detached(future);
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            self.inner.sleep(duration)
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            self.inner.spawn_blocking(f)
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            self.inner.yield_now()
+        }
+    }
+
+    #[tokio::test]
+    async fn audit_receive_future_and_struct_layouts() {
+        let sizes = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sizing_runtime = SizingRuntime {
+            inner: crate::runtime_impl::TokioRuntime,
+            sizes: Arc::clone(&sizes),
+        };
+        let persistence_manager = Arc::new(
+            crate::store::persistence_manager::PersistenceManager::new(
+                crate::test_utils::create_test_backend().await,
+            )
+            .await
+            .expect("persistence manager"),
+        );
+        let client = Client::builder()
+            .with_runtime(sizing_runtime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(crate::transport::mock::MockTransportFactory::new())
+            .with_http_client(crate::test_utils::MockHttpClient)
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+
+        let dummy_chat: Jid = "120363000000000031@g.us".parse().unwrap();
+        let dummy_node = message_for(&dummy_chat, "test_msg");
+
+        // 1. Concrete task future spawned in create_chat_lane
+        let _lane = create_chat_lane(
+            &client,
+            Arc::new(async_lock::Mutex::new(())),
+            Arc::new(async_lock::Mutex::new(())),
+        );
+        let chat_lane_task_size = sizes.lock().unwrap().pop().unwrap();
+
+        // 2. process_queued future
+        let queued = QueuedChatMessage {
+            node: Arc::clone(&dummy_node),
+            lane_liveness: Arc::new(async_lock::Mutex::new(())),
+        };
+        let process_queued_fut = process_queued(&client, queued, 0);
+        let process_queued_size = size_of_val(&process_queued_fut);
+        drop(process_queued_fut);
+
+        // 3. handle_incoming_message_scoped future
+        let handle_scoped_fut =
+            Arc::clone(&client).handle_incoming_message_scoped(Arc::clone(&dummy_node), 0);
+        let handle_scoped_size = size_of_val(&handle_scoped_fut);
+        drop(handle_scoped_fut);
+
+        // 4. handle_incoming_message future
+        let handle_fut = Arc::clone(&client).handle_incoming_message(Arc::clone(&dummy_node));
+        let handle_size = size_of_val(&handle_fut);
+        drop(handle_fut);
+
+        // 5. classify_incoming_message future
+        let classify_fut = client.classify_incoming_message(&dummy_node);
+        let classify_size = size_of_val(&classify_fut);
+        drop(classify_fut);
+
+        // 6. process_classified_message future
+        let dummy_classified = crate::message::ClassifiedMessage {
+            info: Arc::new(wacore::types::message::MessageInfo::default()),
+            sender_encryption_jid: dummy_chat.clone(),
+            session_payloads: Vec::new(),
+            group_payloads: Vec::new(),
+            bot_payloads: Vec::new(),
+            max_sender_retry_count: 0,
+            decrypt_fail_mode: crate::types::events::DecryptFailMode::default(),
+        };
+        let process_classified_fut =
+            Arc::clone(&client).process_classified_message(dummy_classified, 0);
+        let process_classified_size = size_of_val(&process_classified_fut);
+        drop(process_classified_fut);
+
+        // 7. process_session_enc_batch future
+        let dummy_info = Arc::new(wacore::types::message::MessageInfo::default());
+        let session_batch_fut = Arc::clone(&client).process_session_enc_batch(
+            Vec::new(),
+            &dummy_info,
+            &dummy_chat,
+            crate::types::events::DecryptFailMode::default(),
+        );
+        let session_batch_size = size_of_val(&session_batch_fut);
+        drop(session_batch_fut);
+
+        // 8. handle_decrypted_plaintext future
+        let handle_plaintext_fut = client.handle_decrypted_plaintext(
+            "msg",
+            Vec::new(),
+            0,
+            0,
+            crate::message::EncNodeAnnotations {
+                state: None,
+                session_type: None,
+            },
+            &dummy_info,
+        );
+        let handle_plaintext_size = size_of_val(&handle_plaintext_fut);
+        drop(handle_plaintext_fut);
+
+        // 9. dispatch_parsed_message future
+        let dispatch_fut = client.dispatch_parsed_message(
+            waproto::whatsapp::Message::default(),
+            &dummy_info,
+            false,
+        );
+        let dispatch_size = size_of_val(&dispatch_fut);
+        drop(dispatch_fut);
+
+        // 10. harness receive async block future
+        let harness_fut = async {
+            Arc::clone(&client)
+                .handle_incoming_message(Arc::clone(&dummy_node))
+                .await;
+            client
+                .outbound_flush
+                .flush(&*client.runtime, Duration::from_secs(5))
+                .await;
+        };
+        let harness_fut_size = size_of_val(&harness_fut);
+        drop(harness_fut);
+
+        println!("=== SIZEOF REPORT ===");
+        println!("chat_lane task future (pointee): {chat_lane_task_size} bytes");
+        println!("process_queued future: {process_queued_size} bytes");
+        println!("handle_incoming_message_scoped future: {handle_scoped_size} bytes");
+        println!("handle_incoming_message future: {handle_size} bytes");
+        println!("harness block_on future: {harness_fut_size} bytes");
+        println!("classify_incoming_message future: {classify_size} bytes");
+        println!("process_classified_message future: {process_classified_size} bytes");
+        println!("process_session_enc_batch future: {session_batch_size} bytes");
+        println!("handle_decrypted_plaintext future: {handle_plaintext_size} bytes");
+        println!("dispatch_parsed_message future: {dispatch_size} bytes");
+
+        println!(
+            "waproto::whatsapp::Message: {} bytes",
+            size_of::<waproto::whatsapp::Message>()
+        );
+        println!(
+            "MessageInfo: {} bytes",
+            size_of::<wacore::types::message::MessageInfo>()
+        );
+        println!(
+            "ClassifiedMessage: {} bytes",
+            size_of::<crate::message::ClassifiedMessage>()
+        );
+        println!(
+            "QueuedChatMessage: {} bytes",
+            size_of::<QueuedChatMessage>()
+        );
+        println!("ChatLane: {} bytes", size_of::<ChatLane>());
+        println!(
+            "EncPayload: {} bytes",
+            size_of::<crate::message::EncPayload>()
+        );
+        println!(
+            "SessionBatchOutcome: {} bytes",
+            size_of::<crate::message::SessionBatchOutcome>()
+        );
+        println!(
+            "PlaintextHandleOutcome: {} bytes",
+            size_of::<crate::message::PlaintextHandleOutcome>()
+        );
+        println!(
+            "InboundCommitState: {} bytes",
+            size_of::<crate::message::InboundCommitState>()
+        );
+        println!("=== END SIZEOF REPORT ===");
+    }
+
+    #[test]
+    #[cfg(feature = "bench-harness")]
+    fn harness_receive_burst_and_worker_drain() {
+        let harness = crate::bench_support::ReceiveHarness::new();
+        let before = harness.messages_delivered();
+
+        // Limit 2 control: receive_burst under single block_on
+        let dm_batch: Vec<_> = (0..5).map(|_| harness.dm_stanza()).collect();
+        harness.receive_burst(&dm_batch);
+        assert_eq!(harness.messages_delivered() - before, 5);
+
+        let grp_batch: Vec<_> = (0..5).map(|_| harness.group_stanza()).collect();
+        harness.receive_burst(&grp_batch);
+        assert_eq!(harness.messages_delivered() - before, 10);
+
+        // Limit 3 production worker: enqueue_and_drain through chat lane
+        let dm_lane_batch: Vec<_> = (0..5).map(|_| harness.dm_stanza()).collect();
+        harness.enqueue_and_drain(&dm_lane_batch);
+        assert_eq!(harness.messages_delivered() - before, 15);
+
+        let grp_lane_batch: Vec<_> = (0..5).map(|_| harness.group_stanza()).collect();
+        harness.enqueue_and_drain(&grp_lane_batch);
+        assert_eq!(harness.messages_delivered() - before, 20);
+
+        harness.close_lanes();
+    }
+
+    #[test]
+    #[cfg(feature = "bench-harness")]
+    fn multilane_harness_burst_and_worker_drain() {
+        let harness = crate::bench_support::MultiLaneReceiveHarness::new(256);
+        assert_eq!(harness.group_count(), 256);
+        assert_eq!(harness.active_lanes(), 0);
+
+        // 1 lane: 10 messages to group 0
+        let stanzas_1 = harness.generate_burst(1, 10);
+        harness.enqueue_and_drain(&stanzas_1);
+        assert_eq!(harness.messages_delivered(), 10);
+        assert_eq!(harness.active_lanes(), 1);
+        harness.close_lanes();
+        assert_eq!(harness.active_lanes(), 0);
+
+        // 32 lanes: 64 messages across 32 groups
+        let stanzas_32 = harness.generate_burst(32, 64);
+        harness.enqueue_and_drain(&stanzas_32);
+        assert_eq!(harness.messages_delivered(), 74);
+        assert_eq!(harness.active_lanes(), 32);
+        harness.close_lanes();
+        assert_eq!(harness.active_lanes(), 0);
+
+        // 256 lanes: 256 messages across 256 groups
+        let stanzas_256 = harness.generate_burst(256, 256);
+        harness.enqueue_and_drain(&stanzas_256);
+        assert_eq!(harness.messages_delivered(), 330);
+        assert_eq!(harness.active_lanes(), 256);
+        harness.close_lanes();
+        assert_eq!(harness.active_lanes(), 0);
     }
 }


### PR DESCRIPTION
## Summary

The existing receive benchmark enters `Runtime::block_on` for each message, while production processes messages inside a persistent chat-lane worker. Add burst benchmarks that amortize runtime entry, and benchmarks that enqueue valid encrypted group messages through the actual lane workers.

Cover a warm worker and fixed 256-message workloads spread across 1/32/256 lanes. Delivery counts are asserted, receipts are drained, and delivery/shutdown waits have deadlines so a decrypt or worker failure produces a diagnostic instead of hanging the benchmark.

Add fixture tests, a regression assertion for the two-handle queue payload and an opt-in layout diagnostic for the receive futures. Lane-map emptiness verifies lifecycle bookkeeping; it is not used as a claim of zero retained heap memory.

## Validation

- 3,602 library tests passed across wacore, whatsapp-rust and SQLite with `bench-harness` on the combined validation tree, including the burst and multi-lane fixture tests.
- The queue-payload size test passed after the review update.
- Workspace clippy with all targets and `bench-harness`, and formatting passed.
- Existing per-message benchmark cases are retained alongside the new measurement boundaries.
- No receive-path layout or protocol behavior changes are included. CI validates this isolated benchmark branch.

