### PR TITLE
feat(client): expose supervision completion reasons

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -423,7 +423,7 @@ impl EventHandler for CallbackBusAdapter {
 #[must_use = "dropping the handle aborts the bot; bind it and await it, or call .shutdown()"]
 pub struct BotHandle {
     client: Arc<Client>,
-    done_rx: futures::channel::oneshot::Receiver<()>,
+    done_rx: futures::channel::oneshot::Receiver<crate::RunCompletionReason>,
     abort_handle: wacore::runtime::AbortHandle,
 }
 
@@ -435,9 +435,16 @@ impl BotHandle {
     /// Gracefully stop the bot: disconnects (flushing the device snapshot,
     /// buffered receipts and message secrets) and waits for the run loop to
     /// exit.
-    pub async fn shutdown(mut self) {
+    pub async fn shutdown(self) {
+        let _ = self.shutdown_with_reason().await;
+    }
+
+    /// Gracefully stop and report why the supervised client finished.
+    pub async fn shutdown_with_reason(mut self) -> crate::RunCompletionReason {
         self.client.disconnect().await;
-        let _ = (&mut self.done_rx).await;
+        (&mut self.done_rx)
+            .await
+            .unwrap_or(crate::RunCompletionReason::ShutdownRequested)
     }
 
     /// Abort the bot task immediately. Skips the flush work
@@ -466,10 +473,10 @@ impl std::future::Future for BotHandle {
 /// CPU-relevant work of a session would be missing from the hook on the
 /// common `bot.run().await` launch path. `Bot::spawn` needs no equivalent:
 /// it routes the same loop through `Runtime::spawn`.
-async fn run_metered<F: std::future::Future<Output = ()>>(
+async fn run_metered<F: std::future::Future>(
     fut: F,
     instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
-) {
+) -> F::Output {
     match instrument {
         // Stack-pinned, not boxed: `MeteredFuture` only needs an `Unpin` inner,
         // and `Pin<&mut F>` is one without an allocation.
@@ -562,11 +569,17 @@ impl Bot {
     /// (linker-shared) function, so callers poll through a vtable and the
     /// graph is compiled once, here. One allocation per process.
     pub async fn run(self) {
+        let _ = self.run_with_reason().await;
+    }
+
+    /// Run the bot and report why its client supervision ended. Existing
+    /// callers can continue using [`Self::run`], which returns `()`.
+    pub async fn run_with_reason(self) -> crate::RunCompletionReason {
         self.run_boxed().await
     }
 
     #[inline(never)]
-    fn run_boxed(self) -> wacore::runtime::BoxFuture<'static, ()> {
+    fn run_boxed(self) -> wacore::runtime::BoxFuture<'static, crate::RunCompletionReason> {
         Box::pin(self.run_graph())
     }
 
@@ -574,10 +587,10 @@ impl Bot {
         feature = "tracing",
         tracing::instrument(name = "wa.bot.run", level = "debug", skip_all)
     )]
-    async fn run_graph(self) {
+    async fn run_graph(self) -> crate::RunCompletionReason {
         let instrument = self.task_instrument.clone();
         let client = self.start_background();
-        run_metered(client.run(), instrument).await;
+        run_metered(client.run_with_reason(), instrument).await
     }
 
     /// Start the bot on its runtime and return a [`BotHandle`] to await,
@@ -586,10 +599,9 @@ impl Bot {
         let client = self.start_background();
 
         let run_client = client.clone();
-        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<crate::RunCompletionReason>();
         let abort_handle = client.runtime.spawn(Box::pin(async move {
-            run_client.run().await;
-            let _ = done_tx.send(());
+            let _ = done_tx.send(run_client.run_with_reason().await);
         }));
 
         BotHandle {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -423,7 +423,7 @@ impl EventHandler for CallbackBusAdapter {
 #[must_use = "dropping the handle aborts the bot; bind it and await it, or call .shutdown()"]
 pub struct BotHandle {
     client: Arc<Client>,
-    done_rx: futures::channel::oneshot::Receiver<crate::RunCompletionReason>,
+    done_rx: futures::channel::oneshot::Receiver<()>,
     abort_handle: wacore::runtime::AbortHandle,
 }
 
@@ -436,15 +436,9 @@ impl BotHandle {
     /// buffered receipts and message secrets) and waits for the run loop to
     /// exit.
     pub async fn shutdown(self) {
-        let _ = self.shutdown_with_reason().await;
-    }
-
-    /// Gracefully stop and report why the supervised client finished.
-    pub async fn shutdown_with_reason(mut self) -> crate::RunCompletionReason {
         self.client.disconnect().await;
-        (&mut self.done_rx)
-            .await
-            .unwrap_or(crate::RunCompletionReason::ShutdownRequested)
+        let mut done_rx = self.done_rx;
+        let _ = (&mut done_rx).await;
     }
 
     /// Abort the bot task immediately. Skips the flush work
@@ -599,9 +593,10 @@ impl Bot {
         let client = self.start_background();
 
         let run_client = client.clone();
-        let (done_tx, done_rx) = futures::channel::oneshot::channel::<crate::RunCompletionReason>();
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
         let abort_handle = client.runtime.spawn(Box::pin(async move {
-            let _ = done_tx.send(run_client.run_with_reason().await);
+            run_client.run_with_reason().await;
+            let _ = done_tx.send(());
         }));
 
         BotHandle {

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ use extension_lifecycle::LifecycleRegistration;
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-pub use lifecycle::{Connection, Reachability, RunCompletionReason};
+pub use lifecycle::{Connection, ProtocolTerminalReason, Reachability, RunCompletionReason};
 pub use voip::{CallError, Voip};
 
 use crate::cache::Cache;
@@ -1475,6 +1475,9 @@ pub struct Client {
     /// error / connect_failure / disconnect. Per-connection subscribers
     /// (keepalive, request waiters, read loop, offline flush) observe this.
     pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
+    /// Protocol-level terminal cause captured by the reader before its
+    /// expected-disconnect flag suppresses the transport outcome.
+    pub(crate) protocol_terminal_reason: std::sync::Mutex<Option<ProtocolTerminalReason>>,
     /// Allocated only when an extension host installs lifecycle callbacks.
     #[cfg(feature = "client-lifecycle")]
     lifecycle: Option<Arc<LifecycleRegistration>>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ use extension_lifecycle::LifecycleRegistration;
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-pub use lifecycle::{Connection, Reachability};
+pub use lifecycle::{Connection, Reachability, RunCompletionReason};
 pub use voip::{CallError, Voip};
 
 use crate::cache::Cache;

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2979,7 +2979,7 @@ mod tests {
         let (client, entered, release) = client_parked_in_connect().await;
 
         let runner = Arc::clone(&client);
-        let run = tokio::spawn(async move { runner.run().await });
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
         next_connect_attempt(&entered).await;
 
         // Parked, so this is guaranteed to land before the loop reaches the
@@ -2987,10 +2987,11 @@ mod tests {
         client.disconnect().await;
         drop(release);
 
-        tokio::time::timeout(Duration::from_secs(10), run)
+        let reason = tokio::time::timeout(Duration::from_secs(10), run)
             .await
             .expect("run() must return once the client has been disconnected")
             .expect("the run task must not panic");
+        assert!(matches!(reason, RunCompletionReason::ShutdownRequested));
 
         let said = logs.records_for(RUN_LOOP_LOG);
         assert!(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -3086,7 +3086,7 @@ mod tests {
         let (client, entered, release) = client_parked_in_connect().await;
 
         let runner = Arc::clone(&client);
-        let run = tokio::spawn(async move { runner.run().await });
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
         next_connect_attempt(&entered).await;
 
         // What a 515 leaves behind: the end was planned, and nobody asked the
@@ -3141,10 +3141,11 @@ mod tests {
         client.expected_disconnect.store(false, Ordering::Relaxed);
         drop(release);
 
-        tokio::time::timeout(Duration::from_secs(10), run)
+        let reason = tokio::time::timeout(Duration::from_secs(10), run)
             .await
             .expect("run() must return even with its verdict flag erased")
             .expect("the run task must not panic");
+        assert!(matches!(reason, RunCompletionReason::ShutdownRequested));
 
         let said = logs.records_for(RUN_LOOP_LOG);
         assert!(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -3018,7 +3018,11 @@ mod tests {
             RunCompletionReason::AutoReconnectDisabled {
                 connection: None,
                 connect_error: Some(ConnectError::Version(error)),
-            } => assert!(error.to_string().contains("client_revision")),
+            } => assert!(
+                error
+                    .to_string()
+                    .contains("Failed to fetch latest WhatsApp version")
+            ),
             other => panic!("unexpected completion: {other:?}"),
         }
     }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -10,17 +10,36 @@ pub enum RunCompletionReason {
     /// A terminal shutdown was requested through `disconnect`, `logout`, or drop.
     ShutdownRequested,
     /// The current connection ended while automatic reconnection was disabled.
+    /// Logout may publish this observation while its best-effort deregistration
+    /// request is still in flight; the terminal shutdown latch follows that IQ.
     AutoReconnectDisabled {
         /// The final reader outcome, when a connection was established.
         connection: Option<DisconnectReason>,
         /// The final connect failure, when no connection was established.
         connect_error: Option<ConnectError>,
+        /// Terminal stream or connect-failure code, when the reader captured one.
+        protocol_error: Option<ProtocolTerminalReason>,
     },
-    /// The supervision flag was cleared without a terminal shutdown verdict.
-    /// This is an internal stop and carries no claim about the protocol cause.
+    /// The supervision flag was observed cleared without a classified terminal
+    /// verdict. The source may be a concurrent teardown or an internal stop,
+    /// so this carries no claim about the protocol cause.
     Stopped,
-    /// Another task already owns the supervision loop.
+    /// Another task already owns the client's read loop, whether it is the
+    /// supervision loop or a directly driven connection.
     AlreadyRunning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProtocolTerminalReason {
+    StreamErrorCode(u16),
+    ConnectFailure(ConnectFailureReason),
+    Conflict,
+}
+
+struct ConnectionEnd {
+    unexpected: Option<DisconnectReason>,
+    terminal_reason: Option<ProtocolTerminalReason>,
 }
 
 /// `authenticated_generation` when no connection has published one.
@@ -37,6 +56,26 @@ impl Drop for Client {
 }
 
 impl Client {
+    fn clear_protocol_terminal_reason(&self) {
+        *self
+            .protocol_terminal_reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    }
+
+    pub(crate) fn record_protocol_terminal_reason(&self, reason: ProtocolTerminalReason) {
+        *self
+            .protocol_terminal_reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(reason);
+    }
+
+    fn take_protocol_terminal_reason(&self) -> Option<ProtocolTerminalReason> {
+        self.protocol_terminal_reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
     /// WA Web `resetDelay: 30000` — only after a connection has stayed up this
     /// long is the reconnect backoff counter reset to its base.
     pub(crate) const STABLE_CONNECTION_RESET: Duration = Duration::from_secs(30);
@@ -468,6 +507,7 @@ impl Client {
             ik_handshake_failures: AtomicU32::new(0),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
+            protocol_terminal_reason: std::sync::Mutex::new(None),
             #[cfg(feature = "client-lifecycle")]
             lifecycle,
             #[cfg(feature = "plugins")]
@@ -711,7 +751,10 @@ impl Client {
         let _ = self.run_with_reason().await;
     }
 
-    /// Drive the session until supervision ends and report the terminal cause.
+    /// Drive the session until supervision ends and report the observed
+    /// completion reason. A policy stop can race another teardown operation,
+    /// so this value describes the branch that ended this run, not a durable
+    /// account of every operation still in flight.
     /// This additive companion preserves the unit-returning [`Self::run`]
     /// contract for existing callers.
     pub async fn run_with_reason(self: &Arc<Self>) -> RunCompletionReason {
@@ -742,6 +785,7 @@ impl Client {
         let mut first_connect = true;
         let mut last_connect_error: Option<ConnectError>;
         let mut last_disconnect_reason: Option<DisconnectReason>;
+        let mut last_protocol_reason: Option<ProtocolTerminalReason>;
         let mut completion = RunCompletionReason::Stopped;
         while self.is_running.load(Ordering::Relaxed) {
             // The one place a pause is honoured, and it is before the attempt
@@ -762,6 +806,10 @@ impl Client {
             first_connect = false;
             last_connect_error = None;
             last_disconnect_reason = None;
+            *self
+                .protocol_terminal_reason
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             match self.connect().await {
@@ -789,10 +837,13 @@ impl Client {
                         _ => error!("Failed to connect: {connect_err:#}. Will retry..."),
                     }
                     last_connect_error = Some(connect_err);
+                    last_protocol_reason = self.take_protocol_terminal_reason();
                 }
                 Ok(connection) => {
                     wacore::telemetry::connect("ok");
-                    last_disconnect_reason = connection.read_until_disconnected().await;
+                    let end = connection.read_until_disconnected_with_outcome().await;
+                    last_disconnect_reason = end.unexpected;
+                    last_protocol_reason = end.terminal_reason;
                 }
             }
 
@@ -840,6 +891,7 @@ impl Client {
                 completion = RunCompletionReason::AutoReconnectDisabled {
                     connection: last_disconnect_reason,
                     connect_error: last_connect_error,
+                    protocol_error: last_protocol_reason,
                 };
                 break;
             }
@@ -1041,7 +1093,7 @@ impl Client {
     /// asked for. Shared by [`run`](Self::run)'s loop body and by the
     /// single-connection [`Connection::read_until_disconnected`], so the two
     /// cannot drift on what a connection ending means.
-    async fn drive_connection(self: &Arc<Self>) -> Option<DisconnectReason> {
+    async fn drive_connection_with_outcome(self: &Arc<Self>) -> ConnectionEnd {
         // Started here rather than at the end of connect: its ping goes through
         // `can_reach_server`, so a tick taken before anything reads is refused
         // as NotConnected, which the loop classifies as fatal and exits on,
@@ -1071,6 +1123,7 @@ impl Client {
         // Some(reason) = unexpected disconnect worth a `Disconnected` event; the
         // reason distinguishes a routine server recycle from a real failure so
         // consumers don't have to.
+        let terminal_reason = self.take_protocol_terminal_reason();
         let unexpected_disconnect = match loop_result {
             Ok(node_io::ReadLoopExit::Expected) => {
                 debug!("Message loop exited gracefully (expected disconnect).");
@@ -1109,7 +1162,10 @@ impl Client {
                     .build(),
             ));
         }
-        unexpected_disconnect
+        ConnectionEnd {
+            unexpected: unexpected_disconnect,
+            terminal_reason,
+        }
     }
 
     /// Hand a connection to a test without a server to handshake with.
@@ -1148,6 +1204,7 @@ impl Client {
         if self.is_connected() {
             return Err(ConnectError::AlreadyConnected);
         }
+        self.clear_protocol_terminal_reason();
         let _t = wacore::telemetry::timer(wacore::telemetry::CONNECT_DURATION);
         // Read once, compared at every checkpoint below: this is the attempt's
         // claim to belong to the current pause era.
@@ -2403,6 +2460,10 @@ impl Connection<'_> {
     /// it. Only the reader flag is given back, so a later `run` is not refused
     /// as already running.
     pub async fn read_until_disconnected(self) -> Option<DisconnectReason> {
+        self.read_until_disconnected_with_outcome().await.unexpected
+    }
+
+    async fn read_until_disconnected_with_outcome(self) -> ConnectionEnd {
         // Reading is what the Drop warning asks for, so the drop that ends this
         // call must not fire it.
         let this = std::mem::ManuallyDrop::new(self);
@@ -2428,7 +2489,7 @@ impl Connection<'_> {
                 this.client.stop_supervision_loop();
             })
         });
-        this.client.drive_connection().await
+        this.client.drive_connection_with_outcome().await
     }
 }
 
@@ -2700,6 +2761,42 @@ mod tests {
         assert!(
             matches!(reason, Some(DisconnectReason::StreamEnded)),
             "an unannounced close must come back as the reason, got {reason:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_terminal_stream_error_reaches_connection_outcome_before_cleanup() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .send_node(NodeBuilder::new("stream:error").attr("code", "401").build())
+            .await
+            .expect("the terminal fixture frame must reach the mock transport");
+        crate::test_utils::poll_until("the terminal fixture frame to be written", || {
+            transport.sent_count() >= 1
+        })
+        .await;
+        let frame = transport.sent().remove(0);
+        let (events, receiver) = async_channel::bounded(2);
+        *client.transport_events.lock().await = Some(receiver);
+        events
+            .send(crate::transport::TransportEvent::DataReceived(frame))
+            .await
+            .expect("the fixture channel must accept the terminal frame");
+
+        let end = client
+            .connection_for_test()
+            .read_until_disconnected_with_outcome()
+            .await;
+        assert_eq!(
+            end.terminal_reason,
+            Some(ProtocolTerminalReason::StreamErrorCode(401))
+        );
+        assert!(!client.is_connected(), "cleanup retires the connection");
+
+        client.clear_protocol_terminal_reason();
+        assert_eq!(
+            client.protocol_terminal_reason.lock().unwrap().clone(),
+            None
         );
     }
 
@@ -2988,6 +3085,7 @@ mod tests {
     async fn disabling_reconnect_after_a_connect_failure_preserves_the_error() {
         let (client, entered, release) = client_parked_in_connect().await;
         client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        client.record_protocol_terminal_reason(ProtocolTerminalReason::StreamErrorCode(401));
         let runner = Arc::clone(&client);
         let run = tokio::spawn(async move { runner.run_with_reason().await });
         next_connect_attempt(&entered).await;
@@ -2998,7 +3096,27 @@ mod tests {
             RunCompletionReason::AutoReconnectDisabled {
                 connection: None,
                 connect_error: Some(error),
+                protocol_error: None,
+                ..
             } => assert!(!error.to_string().is_empty()),
+            other => panic!("unexpected completion: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn expected_stream_flag_during_failed_connect_preserves_no_transport_cause() {
+        let (client, entered, release) = client_parked_in_connect().await;
+        let node = NodeBuilder::new("stream:error").attr("code", "401").build();
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
+        next_connect_attempt(&entered).await;
+        client.handle_stream_error(&node.as_node_ref()).await;
+        release.send(()).await.unwrap();
+        match run.await.unwrap() {
+            RunCompletionReason::AutoReconnectDisabled {
+                protocol_error: Some(ProtocolTerminalReason::StreamErrorCode(401)),
+                ..
+            } => {}
             other => panic!("unexpected completion: {other:?}"),
         }
     }
@@ -3018,6 +3136,7 @@ mod tests {
             RunCompletionReason::AutoReconnectDisabled {
                 connection: None,
                 connect_error: Some(ConnectError::Version(error)),
+                ..
             } => assert!(
                 error
                     .to_string()
@@ -3134,7 +3253,7 @@ mod tests {
         let (client, entered, release) = client_parked_in_connect().await;
 
         let runner = Arc::clone(&client);
-        let run = tokio::spawn(async move { runner.run().await });
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
         next_connect_attempt(&entered).await;
 
         client.disconnect().await;

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -939,7 +939,7 @@ impl Client {
         #[cfg(feature = "client-lifecycle")]
         self.shutdown_lifecycle().await;
         info!("Client run loop has shut down.");
-        if shutdown.is_fired() {
+        if matches!(completion, RunCompletionReason::Stopped) && shutdown.is_fired() {
             RunCompletionReason::ShutdownRequested
         } else {
             completion
@@ -2963,6 +2963,66 @@ mod tests {
             .expect("the observer channel must stay open");
     }
 
+    #[tokio::test]
+    async fn a_second_run_reports_already_running_without_stopping_the_first() {
+        let (client, entered, release) = client_parked_in_connect().await;
+        let first_client = Arc::clone(&client);
+        let first = tokio::spawn(async move { first_client.run_with_reason().await });
+        next_connect_attempt(&entered).await;
+
+        assert!(matches!(
+            client.run_with_reason().await,
+            RunCompletionReason::AlreadyRunning
+        ));
+        assert!(!first.is_finished());
+
+        client.disconnect().await;
+        drop(release);
+        assert!(matches!(
+            first.await.unwrap(),
+            RunCompletionReason::ShutdownRequested
+        ));
+    }
+
+    #[tokio::test]
+    async fn disabling_reconnect_after_a_connect_failure_preserves_the_error() {
+        let (client, entered, release) = client_parked_in_connect().await;
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
+        next_connect_attempt(&entered).await;
+        release.send(()).await.unwrap();
+
+        let reason = run.await.unwrap();
+        match reason {
+            RunCompletionReason::AutoReconnectDisabled {
+                connection: None,
+                connect_error: Some(error),
+            } => assert!(!error.to_string().is_empty()),
+            other => panic!("unexpected completion: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn expected_disconnect_with_reconnect_disabled_has_no_connection_cause() {
+        let (client, entered, release) = client_parked_in_connect().await;
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
+        next_connect_attempt(&entered).await;
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        release.send(()).await.unwrap();
+
+        let reason = run.await.unwrap();
+        assert!(matches!(
+            reason,
+            RunCompletionReason::AutoReconnectDisabled {
+                connection: None,
+                connect_error: Some(_),
+            }
+        ));
+    }
+
     /// The misreport this branch's guard exists for. `disconnect()` is
     /// terminal: it clears `is_running`, which is the loop's own stop
     /// condition. Landing it while a connect attempt is in flight used to make
@@ -3235,7 +3295,7 @@ mod tests {
         let (client, entered, release) = client_parked_in_connect().await;
 
         let runner = Arc::clone(&client);
-        let run = tokio::spawn(async move { runner.run().await });
+        let run = tokio::spawn(async move { runner.run_with_reason().await });
         next_connect_attempt(&entered).await;
 
         client.pause().await;
@@ -3243,10 +3303,11 @@ mod tests {
         crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
 
         client.disconnect().await;
-        tokio::time::timeout(Duration::from_secs(10), run)
+        let reason = tokio::time::timeout(Duration::from_secs(10), run)
             .await
             .expect("a paused run loop must still return when the client is disconnected")
             .expect("the run task must not panic");
+        assert!(matches!(reason, RunCompletionReason::ShutdownRequested));
         assert!(client.is_terminal(), "and the client is finished for good");
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -3,6 +3,23 @@
 use super::*;
 use wacore::net::DisconnectReason;
 
+/// Why [`Client::run`] stopped supervising the session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunCompletionReason {
+    /// A terminal shutdown was requested through `disconnect`, `logout`, or drop.
+    ShutdownRequested,
+    /// The current connection ended while automatic reconnection was disabled.
+    AutoReconnectDisabled {
+        /// The final reader outcome, when a connection was established.
+        connection: Option<DisconnectReason>,
+        /// The final connect failure, when no connection was established.
+        connect_error: Option<String>,
+    },
+    /// Another task already owns the supervision loop.
+    AlreadyRunning,
+}
+
 /// `authenticated_generation` when no connection has published one.
 ///
 /// Not zero: that is a real generation, the one a freshly built client is on,
@@ -688,31 +705,44 @@ impl Client {
     // keepalive-loop span. Identity (lid/pn) attribution comes from the
     // per-operation spans (send/request), which record it themselves.
     pub async fn run(self: &Arc<Self>) {
+        let _ = self.run_with_reason().await;
+    }
+
+    /// Drive the session until supervision ends and report the terminal cause.
+    /// This additive companion preserves the unit-returning [`Self::run`]
+    /// contract for existing callers.
+    pub async fn run_with_reason(self: &Arc<Self>) -> RunCompletionReason {
         #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle
             && !lifecycle.wait_until_active().await
         {
             warn!("Client `run` rejected before construction completed.");
-            return;
+            return RunCompletionReason::ShutdownRequested;
         }
         let shutdown = self.shutdown_signal();
         if shutdown.is_fired() {
             warn!("Client `run` called after shutdown.");
-            return;
+            return RunCompletionReason::ShutdownRequested;
         }
         if self.is_running.swap(true, Ordering::SeqCst) {
             warn!("Client `run` method called while already running.");
-            return;
+            return RunCompletionReason::AlreadyRunning;
         }
         if shutdown.is_fired() {
             self.is_running.store(false, Ordering::SeqCst);
-            return;
+            return RunCompletionReason::ShutdownRequested;
         }
         // Reconnects are counted at iteration start: every pass after the
         // first is an attempt actually being made. Counting at the branches
         // below would also count a final pass that never reconnects (a user
         // disconnect() flips is_running while the branch runs).
         let mut first_connect = true;
+        let mut last_connect_error: Option<String>;
+        let mut last_disconnect_reason: Option<DisconnectReason>;
+        let mut completion = RunCompletionReason::AutoReconnectDisabled {
+            connection: None,
+            connect_error: None,
+        };
         while self.is_running.load(Ordering::Relaxed) {
             // The one place a pause is honoured, and it is before the attempt
             // rather than after one fails: a `pause()` can land during a
@@ -730,10 +760,13 @@ impl Client {
                 self.stats.record_reconnect();
             }
             first_connect = false;
+            last_connect_error = None;
+            last_disconnect_reason = None;
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             match self.connect().await {
                 Err(connect_err) => {
+                    last_connect_error = Some(connect_err.to_string());
                     wacore::telemetry::connect("fail");
                     match &connect_err {
                         // The loop is about to exit on the same shutdown, so this
@@ -759,7 +792,7 @@ impl Client {
                 }
                 Ok(connection) => {
                     wacore::telemetry::connect("ok");
-                    let _ = connection.read_until_disconnected().await;
+                    last_disconnect_reason = connection.read_until_disconnected().await;
                 }
             }
 
@@ -797,12 +830,17 @@ impl Client {
             {
                 self.clear_connection_backoff_state();
                 info!("Disconnect requested, shutting down without reconnecting.");
+                completion = RunCompletionReason::ShutdownRequested;
                 break;
             }
 
             if !self.enable_auto_reconnect.load(Ordering::Relaxed) {
                 info!("Auto-reconnect disabled, shutting down.");
                 self.stop_supervision_loop();
+                completion = RunCompletionReason::AutoReconnectDisabled {
+                    connection: last_disconnect_reason.clone(),
+                    connect_error: last_connect_error.clone(),
+                };
                 break;
             }
 
@@ -901,6 +939,11 @@ impl Client {
         #[cfg(feature = "client-lifecycle")]
         self.shutdown_lifecycle().await;
         info!("Client run loop has shut down.");
+        if shutdown.is_fired() {
+            RunCompletionReason::ShutdownRequested
+        } else {
+            completion
+        }
     }
 
     /// Open one connection and hand it back for the caller to read.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -16,6 +16,9 @@ pub enum RunCompletionReason {
         /// The final connect failure, when no connection was established.
         connect_error: Option<ConnectError>,
     },
+    /// The supervision flag was cleared without a terminal shutdown verdict.
+    /// This is an internal stop and carries no claim about the protocol cause.
+    Stopped,
     /// Another task already owns the supervision loop.
     AlreadyRunning,
 }
@@ -739,10 +742,7 @@ impl Client {
         let mut first_connect = true;
         let mut last_connect_error: Option<ConnectError>;
         let mut last_disconnect_reason: Option<DisconnectReason>;
-        let mut completion = RunCompletionReason::AutoReconnectDisabled {
-            connection: None,
-            connect_error: None,
-        };
+        let mut completion = RunCompletionReason::Stopped;
         while self.is_running.load(Ordering::Relaxed) {
             // The one place a pause is honoured, and it is before the attempt
             // rather than after one fails: a `pause()` can land during a

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -4,7 +4,7 @@ use super::*;
 use wacore::net::DisconnectReason;
 
 /// Why [`Client::run`] stopped supervising the session.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum RunCompletionReason {
     /// A terminal shutdown was requested through `disconnect`, `logout`, or drop.
@@ -14,7 +14,7 @@ pub enum RunCompletionReason {
         /// The final reader outcome, when a connection was established.
         connection: Option<DisconnectReason>,
         /// The final connect failure, when no connection was established.
-        connect_error: Option<String>,
+        connect_error: Option<ConnectError>,
     },
     /// Another task already owns the supervision loop.
     AlreadyRunning,
@@ -737,7 +737,7 @@ impl Client {
         // below would also count a final pass that never reconnects (a user
         // disconnect() flips is_running while the branch runs).
         let mut first_connect = true;
-        let mut last_connect_error: Option<String>;
+        let mut last_connect_error: Option<ConnectError>;
         let mut last_disconnect_reason: Option<DisconnectReason>;
         let mut completion = RunCompletionReason::AutoReconnectDisabled {
             connection: None,
@@ -766,7 +766,6 @@ impl Client {
 
             match self.connect().await {
                 Err(connect_err) => {
-                    last_connect_error = Some(connect_err.to_string());
                     wacore::telemetry::connect("fail");
                     match &connect_err {
                         // The loop is about to exit on the same shutdown, so this
@@ -789,6 +788,7 @@ impl Client {
                         }
                         _ => error!("Failed to connect: {connect_err:#}. Will retry..."),
                     }
+                    last_connect_error = Some(connect_err);
                 }
                 Ok(connection) => {
                     wacore::telemetry::connect("ok");
@@ -838,8 +838,8 @@ impl Client {
                 info!("Auto-reconnect disabled, shutting down.");
                 self.stop_supervision_loop();
                 completion = RunCompletionReason::AutoReconnectDisabled {
-                    connection: last_disconnect_reason.clone(),
-                    connect_error: last_connect_error.clone(),
+                    connection: last_disconnect_reason,
+                    connect_error: last_connect_error,
                 };
                 break;
             }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -3004,7 +3004,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expected_disconnect_with_reconnect_disabled_has_no_connection_cause() {
+    async fn expected_disconnect_during_failed_connect_has_no_connection_cause() {
         let (client, entered, release) = client_parked_in_connect().await;
         client.enable_auto_reconnect.store(false, Ordering::Relaxed);
         let runner = Arc::clone(&client);
@@ -3014,13 +3014,13 @@ mod tests {
         release.send(()).await.unwrap();
 
         let reason = run.await.unwrap();
-        assert!(matches!(
-            reason,
+        match reason {
             RunCompletionReason::AutoReconnectDisabled {
                 connection: None,
-                connect_error: Some(_),
-            }
-        ));
+                connect_error: Some(ConnectError::Version(error)),
+            } => assert!(error.to_string().contains("client_revision")),
+            other => panic!("unexpected completion: {other:?}"),
+        }
     }
 
     /// The misreport this branch's guard exists for. `disconnect()` is

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1,5 +1,6 @@
 //! Inbound node I/O: read loop, frame decryption, node routing, acks and stream errors.
 
+use super::lifecycle::ProtocolTerminalReason;
 use super::*;
 use crate::client::{PhashWaiter, ResponseWaiter, StreamedResponse};
 use wacore::net::DisconnectReason;
@@ -17,7 +18,7 @@ pub(crate) enum ReadLoopExit {
 
 /// Genuine failures of [`Client::read_messages_loop`] — everything here is worth
 /// reporting loudly, unlike [`ReadLoopExit`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub(crate) enum ReadLoopError {
     #[error("cannot start message loop: {0}")]
     NotStarted(&'static str),
@@ -1947,6 +1948,7 @@ impl Client {
         let mut should_disconnect = false;
 
         if !conflict_type.is_empty() {
+            self.record_protocol_terminal_reason(ProtocolTerminalReason::Conflict);
             info!(
                 "Got stream error indicating client was removed or replaced (conflict={}). Logging out.",
                 conflict_type
@@ -1978,6 +1980,11 @@ impl Client {
                 }
                 "516" => {
                     info!("Got 516 stream error (device removed). Logging out.");
+                    if let Ok(code) = code.parse() {
+                        self.record_protocol_terminal_reason(
+                            ProtocolTerminalReason::StreamErrorCode(code),
+                        );
+                    }
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
@@ -1991,6 +1998,11 @@ impl Client {
                 }
                 "401" => {
                     info!("Got 401 stream error (unauthorized). Logging out.");
+                    if let Ok(code) = code.parse() {
+                        self.record_protocol_terminal_reason(
+                            ProtocolTerminalReason::StreamErrorCode(code),
+                        );
+                    }
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(Box::new(
@@ -2004,6 +2016,11 @@ impl Client {
                 }
                 "409" => {
                     info!("Got 409 stream error (conflict). Another session replaced this one.");
+                    if let Ok(code) = code.parse() {
+                        self.record_protocol_terminal_reason(
+                            ProtocolTerminalReason::StreamErrorCode(code),
+                        );
+                    }
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::StreamReplaced(
@@ -2120,6 +2137,7 @@ impl Client {
         // against a server that just refused us. (WA Web drops the stanza
         // outright; it has a UI to fall back on, an embedder does not.)
         let reason = failure.reason.unwrap_or(ConnectFailureReason::Unknown(0));
+        self.record_protocol_terminal_reason(ProtocolTerminalReason::ConnectFailure(reason));
 
         if reason.should_reconnect() {
             self.expected_disconnect.store(false, Ordering::Relaxed);

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3327,6 +3327,14 @@ async fn test_stream_error_401_disables_reconnect() {
         !client.enable_auto_reconnect.load(Ordering::Relaxed),
         "401 should disable auto-reconnect"
     );
+    assert_eq!(
+        client
+            .protocol_terminal_reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref(),
+        Some(&ProtocolTerminalReason::StreamErrorCode(401))
+    );
 }
 
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,9 @@ pub use client::{
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-pub use client::{ConnectError, ConnectStage, Reachability, SignalMaintenanceError};
+pub use client::{
+    ConnectError, ConnectStage, Reachability, RunCompletionReason, SignalMaintenanceError,
+};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,8 @@ pub use client::{
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use client::{
-    ConnectError, ConnectStage, Reachability, RunCompletionReason, SignalMaintenanceError,
+    ConnectError, ConnectStage, ProtocolTerminalReason, Reachability, RunCompletionReason,
+    SignalMaintenanceError,
 };
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
@@ -361,7 +362,9 @@ pub mod prelude {
     #[cfg(feature = "client-lifecycle")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     pub use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-    pub use crate::client::{ConnectError, ConnectStage};
+    pub use crate::client::{
+        ConnectError, ConnectStage, ProtocolTerminalReason, RunCompletionReason,
+    };
     #[cfg(feature = "plugins")]
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub use crate::plugins::{

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -27,7 +27,7 @@ pub const WHATSAPP_WEB_ORIGIN: &str = "https://web.whatsapp.com";
 /// Serialize: carried by `events::Disconnected`, whose payload consumers forward
 /// as JSON (webhooks, dashboards) — snake_case so the wire shape doesn't leak
 /// Rust variant naming.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DisconnectReason {
     /// The peer sent a WebSocket Close frame. `code` is the RFC 6455 close


### PR DESCRIPTION
Summary

Client and Bot supervision expose an additive `run_with_reason()` API while preserving the existing unit-returning `run()` methods. Completion observations distinguish explicit shutdown, an already-owned reader, policy-driven stop, and an unclassified stop. Terminal protocol causes are preserved when the reader captures them before connection cleanup.

Evidence/Design

The terminal shutdown notifier remains the sole monotonic shutdown latch. Each connection outcome takes its typed `ProtocolTerminalReason` before `cleanup_connection_state`; the run future consumes that local outcome, so a later generation or manual connection cannot rewrite it. The Client adds one `Mutex<Option<ProtocolTerminalReason>>` used only when a connection attempt starts, a terminal stream/connect failure is classified, or the completion result is built. It is not read per frame and adds no event-path lock.

| observation | preserved data | limitation |
| --- | --- | --- |
| `ShutdownRequested` | terminal shutdown latch from disconnect/logout/drop | logout may still be completing its deregistration IQ when the run branch first observes auto-reconnect disabled; the result describes the run branch, while the terminal latch follows the IQ |
| `AlreadyRunning` | ownership collision on `is_running` | covers any existing reader, including a directly driven `Connection`, not only a supervisor |
| `AutoReconnectDisabled` | final transport/connect outcome and typed protocol reason when captured | policy observation; absent protocol data remains absent |
| `Stopped` | cleared supervision flag without classified verdict | no claim about whether concurrent teardown or an internal stop caused it |

`ProtocolTerminalReason` preserves stream codes (401/409/516), typed non-retryable connect-failure reasons, and conflict classification. Expected reconnects remain transient. Existing `Connection::read_until_disconnected()` behavior is unchanged; the private outcome path used by supervision preserves the additional reason.

Cost

The added `Mutex<Option<ProtocolTerminalReason>>` is fixed per Client. It is reset once per connect attempt, written only on terminal protocol classification, taken once during connection teardown, and read once while building the completion result. No per-frame await, lock, or allocation was added.

Validation

Final SHA: `91e73ef12940f6c717fe919b859c95d728ad7b02`.

`cargo fmt --all -- --check` passed.
`cargo clippy -p whatsapp-rust --lib --tests -- -D warnings` passed.
`cargo check -p whatsapp-rust --lib` passed.
Final targeted nextest passed 3/3: real encrypted 401 stream frame reaches `ConnectionEnd` before cleanup, the failed-connect case preserves the absence of a transport cause and resets stale protocol state, and the existing 401 parser captures the typed reason.
The earlier full `cargo nextest run -p whatsapp-rust --lib` run passed 1915 tests with 1 skipped before the final protocol-cause additions; it is identified as an earlier run rather than claimed as validation of this exact SHA.

Migration: none. Existing callers continue using `run()`, `Bot::run()`, and awaiting `BotHandle` unchanged. Callers needing the observation use `Client::run_with_reason()` or `Bot::run_with_reason()`.
