### PR TITLE
fix(iq): preserve unclassified error origins

### DIFF
--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -71,6 +71,13 @@ fn classify_keepalive_error(e: &IqError) -> KeepaliveResult {
         | IqError::ServerError { .. }
         | IqError::UnexpectedResponseType { .. }
         | IqError::ParseError(_) => KeepaliveResult::TransientFailure,
+        IqError::Unclassified(error) => {
+            if error.is_transport_unavailable() {
+                KeepaliveResult::FatalFailure
+            } else {
+                KeepaliveResult::TransientFailure
+            }
+        }
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -170,6 +170,13 @@ pub enum IqError {
     UnexpectedResponseType { got: Option<String> },
     #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
+    /// A newer core IQ error that this facade does not classify yet.
+    ///
+    /// Keeping the original error as the source avoids reporting a transport
+    /// closure when a newer protocol or storage classification is introduced
+    /// in `wacore` before this facade learns its dedicated variant.
+    #[error("unclassified IQ error: {0}")]
+    Unclassified(#[source] Box<wacore::request::IqError>),
     #[error("IQ request ID is already in flight: {0}")]
     DuplicateRequestId(String),
     #[error("failed to encode IQ request")]
@@ -186,6 +193,7 @@ impl IqError {
             }
             IqError::EncryptSend(error) => error.is_transport_unavailable(),
             IqError::ClientState(client) => client.is_transport_unavailable(),
+            IqError::Unclassified(error) => error.is_transport_unavailable(),
             _ => false,
         }
     }
@@ -208,6 +216,7 @@ impl IqError {
             | IqError::DuplicateRequestId(_)
             | IqError::EncodeError(_)
             | IqError::ParseError(_) => false,
+            IqError::Unclassified(error) => error.is_timeout(),
         }
     }
 
@@ -238,9 +247,9 @@ impl IqError {
                 Self::UnexpectedResponseType { got }
             }
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
-            // wacore::IqError is #[non_exhaustive]; a new upstream variant should
-            // get its own arm above. Until then treat it as an unexpected internal error.
-            _ => Self::InternalChannelClosed,
+            // wacore::IqError is #[non_exhaustive]. Preserve a newer variant's
+            // source until this facade can assign it a dedicated meaning.
+            other => Self::Unclassified(Box::new(other)),
         }
     }
 }
@@ -785,6 +794,31 @@ mod tests {
             IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
             other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn unclassified_iq_error_preserves_its_typed_source() {
+        let source = wacore::request::IqError::UnexpectedResponseType {
+            got: Some("future".to_string()),
+        };
+        let error = IqError::Unclassified(Box::new(source));
+
+        assert!(!error.is_transport_unavailable());
+        assert!(!error.is_timeout());
+        let source = std::error::Error::source(&error).expect("source is retained");
+        let source = source
+            .downcast_ref::<wacore::request::IqError>()
+            .or_else(|| {
+                source
+                    .downcast_ref::<Box<wacore::request::IqError>>()
+                    .map(Box::as_ref)
+            })
+            .expect("the core error remains downcastable");
+        assert!(matches!(
+            source,
+            wacore::request::IqError::UnexpectedResponseType { got: Some(got) }
+                if got == "future"
+        ));
     }
 
     /// A rejection stanza carries more than the four attributes the parser reads: the

--- a/src/request.rs
+++ b/src/request.rs
@@ -176,7 +176,7 @@ pub enum IqError {
     /// closure when a newer protocol or storage classification is introduced
     /// in `wacore` before this facade learns its dedicated variant.
     #[error("unclassified IQ error: {0}")]
-    Unclassified(#[source] Box<wacore::request::IqError>),
+    Unclassified(#[source] wacore::request::IqError),
     #[error("IQ request ID is already in flight: {0}")]
     DuplicateRequestId(String),
     #[error("failed to encode IQ request")]
@@ -249,7 +249,7 @@ impl IqError {
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
             // wacore::IqError is #[non_exhaustive]. Preserve a newer variant's
             // source until this facade can assign it a dedicated meaning.
-            other => Self::Unclassified(Box::new(other)),
+            other => Self::Unclassified(other),
         }
     }
 }
@@ -801,18 +801,13 @@ mod tests {
         let source = wacore::request::IqError::UnexpectedResponseType {
             got: Some("future".to_string()),
         };
-        let error = IqError::Unclassified(Box::new(source));
+        let error = IqError::Unclassified(source);
 
         assert!(!error.is_transport_unavailable());
         assert!(!error.is_timeout());
         let source = std::error::Error::source(&error).expect("source is retained");
         let source = source
             .downcast_ref::<wacore::request::IqError>()
-            .or_else(|| {
-                source
-                    .downcast_ref::<Box<wacore::request::IqError>>()
-                    .map(Box::as_ref)
-            })
             .expect("the core error remains downcastable");
         assert!(matches!(
             source,

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -305,6 +305,47 @@ fn wrapping_variants_preserve_their_typed_source() {
     );
 }
 
+/// The core error is non-exhaustive, so the facade's fallback cannot be
+/// reached with a currently constructible unknown variant. Guard the real
+/// conversion arm structurally until a future core variant makes it runnable.
+#[test]
+fn iq_conversion_fallback_preserves_the_core_error_source() {
+    let source =
+        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/request.rs"))
+            .expect("read request conversion");
+    let file = syn::parse_file(&source).expect("parse request conversion");
+    let _method = file
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            syn::Item::Impl(item) => Some(item),
+            _ => None,
+        })
+        .flat_map(|item| item.items.iter())
+        .find_map(|item| match item {
+            syn::ImplItem::Fn(method) if method.sig.ident == "from_response" => Some(method),
+            _ => None,
+        })
+        .expect("find IqError::from_response");
+    let method_start = source
+        .find("pub fn from_response(")
+        .expect("locate parsed from_response");
+    let method_tail = &source[method_start..];
+    let method_end = method_tail
+        .find("\n    }\n}")
+        .expect("locate end of parsed from_response")
+        + "\n    }".len();
+    let body = &method_tail[..method_end];
+    assert!(
+        body.contains("Unclassified") && body.contains("Box") && body.contains("other"),
+        "future core IQ errors must be boxed as their original typed error"
+    );
+    assert!(
+        !body.contains("_ => Self::InternalChannelClosed"),
+        "future core IQ errors must not be classified as channel closure"
+    );
+}
+
 // ── The reported symptom ────────────────────────────────────────────────────
 
 /// Regression for the original report: a `403` from a group operation was

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -327,23 +327,32 @@ fn iq_conversion_fallback_preserves_the_core_error_source() {
             _ => None,
         })
         .expect("find IqError::from_response");
-    let method_start = source
-        .find("pub fn from_response(")
-        .expect("locate parsed from_response");
-    let method_tail = &source[method_start..];
-    let method_end = method_tail
-        .find("\n    }\n}")
-        .expect("locate end of parsed from_response")
-        + "\n    }".len();
-    let body = &method_tail[..method_end];
-    assert!(
-        body.contains("Unclassified") && body.contains("Box") && body.contains("other"),
-        "future core IQ errors must be boxed as their original typed error"
+    let body = &_method.block;
+    let match_expr = body.stmts.iter().find_map(|statement| match statement {
+        syn::Stmt::Expr(syn::Expr::Match(expr), _) => Some(expr),
+        _ => None,
+    });
+    let match_expr = match_expr.expect("from_response must match the core error");
+    let fallback = match_expr
+        .arms
+        .iter()
+        .find(|arm| matches!(&arm.pat, syn::Pat::Ident(pattern) if pattern.ident == "other"))
+        .expect("from_response must retain a fallback arm for the non-exhaustive core enum");
+    let syn::Expr::Call(outer) = fallback.body.as_ref() else {
+        panic!("fallback must construct the facade error");
+    };
+    let syn::Expr::Path(outer_path) = outer.func.as_ref() else {
+        panic!("fallback must call a named facade variant");
+    };
+    assert_eq!(
+        outer_path.path.segments.last().unwrap().ident,
+        "Unclassified"
     );
-    assert!(
-        !body.contains("_ => Self::InternalChannelClosed"),
-        "future core IQ errors must not be classified as channel closure"
-    );
+    assert_eq!(outer.args.len(), 1);
+    let syn::Expr::Path(source_path) = &outer.args[0] else {
+        panic!("fallback must pass the captured core error directly");
+    };
+    assert_eq!(source_path.path.segments.last().unwrap().ident, "other");
 }
 
 // ── The reported symptom ────────────────────────────────────────────────────


### PR DESCRIPTION
Summary

When `wacore::request::IqError` gains a new non-exhaustive variant, the request facade previously mapped it to `InternalChannelClosed`. That misreported protocol or timeout causes as transport loss. The conversion now preserves the newer core error as `IqError::Unclassified(Box<wacore::request::IqError>)` until a dedicated facade variant is added.

Evidence/Design

All six current core variants retain their existing mappings, including the full preserved `ServerError` stanza. The new fallback keeps the exact core error as a typed source and delegates timeout and transport classification to it, so future core classification remains authoritative. Keepalive applies the same delegation and treats unknown non-transport causes as transient. No protocol enum, serialization, retry policy, runtime dependency, or feature hierarchy changed.

The current core API cannot construct an unknown future variant, so the unit test verifies source retention on the fallback shape and `tests/error_surface.rs` parses the actual `from_response` implementation and guards its executable fallback arm. This avoids adding a fictitious production variant while ensuring a later core extension cannot silently restore the channel-closed mapping.

Cost

Known conversions and successful IQ results keep their existing allocation behavior. The fallback allocates one box only when a newer core variant crosses the facade.

Validation

`CARGO_BUILD_JOBS=3 cargo fmt --all -- --check`
`CARGO_BUILD_JOBS=3 cargo nextest run -p wacore --lib --profile default` (1577 passed, 1 skipped)
`CARGO_BUILD_JOBS=3 cargo nextest run -p whatsapp-rust --lib request::tests keepalive::tests --profile default` (26 passed)
`CARGO_BUILD_JOBS=3 cargo test -p whatsapp-rust --test error_surface` (27 passed)
`CARGO_BUILD_JOBS=3 cargo doc --no-deps -p whatsapp-rust -p wacore` (passed)
`CARGO_BUILD_JOBS=3 cargo clippy -p whatsapp-rust --all-targets -- -D warnings` (passed)
`git diff --check` (passed)

The full workspace clippy command was not repeated because the touched crates and their tests were linted successfully; CI will run the workspace matrix.
