### PR TITLE
refactor(protocol): clarify child parsing ownership

### DIFF
--- a/agent_docs/protocol_architecture.md
+++ b/agent_docs/protocol_architecture.md
@@ -4,7 +4,11 @@ Stanza builders and parsers live in `wacore/src/iq/`. Read this before adding a 
 
 ## The two traits
 
-- `ProtocolNode` (`wacore/src/protocol/mod.rs`) maps a struct to a node.
+- `ProtocolNode` (`wacore/src/protocol/mod.rs`) maps a struct to a node. The
+  trait supports attributes and children; the `ProtocolNode` derive currently
+  generates attribute-only implementations. Nodes with children use explicit
+  implementations so their presence, repetition, ordering, duplicate policy,
+  and parse errors remain visible in the implementation.
 - `IqSpec` (`wacore/src/iq/spec.rs`) pairs a request with its typed response.
 
 Both carry doc comments on every method; read the source rather than a copy here.
@@ -23,7 +27,7 @@ Non-obvious parts:
 | Derive | For |
 | --- | --- |
 | `EmptyNode` | Nodes that are only a tag |
-| `ProtocolNode` | Nodes with attributes and children |
+| `ProtocolNode` | Nodes with attributes and children; derive support is currently attribute-only |
 | `WireEnum` | Every protocol enum |
 
 `StringEnum` is **not** a derive — it is an internal attribute kind inside the `ProtocolNode` derive. Protocol enums use `WireEnum`.

--- a/agent_docs/protocol_architecture.md
+++ b/agent_docs/protocol_architecture.md
@@ -6,9 +6,8 @@ Stanza builders and parsers live in `wacore/src/iq/`. Read this before adding a 
 
 - `ProtocolNode` (`wacore/src/protocol/mod.rs`) maps a struct to a node. The
   trait supports attributes and children; the `ProtocolNode` derive currently
-  generates attribute-only implementations. Nodes with children use explicit
-  implementations so their presence, repetition, ordering, duplicate policy,
-  and parse errors remain visible in the implementation.
+  generates attribute-only implementations. Child-bearing nodes use explicit
+  implementations.
 - `IqSpec` (`wacore/src/iq/spec.rs`) pairs a request with its typed response.
 
 Both carry doc comments on every method; read the source rather than a copy here.
@@ -27,7 +26,7 @@ Non-obvious parts:
 | Derive | For |
 | --- | --- |
 | `EmptyNode` | Nodes that are only a tag |
-| `ProtocolNode` | Nodes with attributes and children; derive support is currently attribute-only |
+| `ProtocolNode` | Struct attributes (attribute-only derive) |
 | `WireEnum` | Every protocol enum |
 
 `StringEnum` is **not** a derive — it is an internal attribute kind inside the `ProtocolNode` derive. Protocol enums use `WireEnum`.

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -33,6 +33,11 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 /// Derive macro for implementing `ProtocolNode` on structs with attributes.
 ///
+/// Child fields are intentionally not accepted by this derive. Child
+/// cardinality and duplicate handling differ across protocol responses, so
+/// child-bearing nodes use an explicit implementation, optionally reusing the
+/// shared parsing helpers, instead of hiding those decisions in generated code.
+///
 /// # Attributes
 ///
 /// - `#[protocol(tag = "tagname")]` - Required. Specifies the XML tag name.


### PR DESCRIPTION
Summary

The protocol architecture documentation described `ProtocolNode` as if the derive supported child fields, while the derive only accepts attributes. This patch records the actual boundary and why child-bearing nodes remain explicit.

Evidence/Design

The trait supports nodes with attributes and children. The derive generates attribute-only implementations; 16 concrete implementations in the IQ layer parse children manually through borrowed `NodeRef` helpers, making required/optional, repeated, ordering, duplicate and error behavior visible. No macro syntax or protocol implementation was added, and no IQ was migrated.

Cost

No runtime or generated-code cost. The documentation and one derive rustdoc comment add no executable code.

Validation

`cargo fmt --all` passed.
`cargo test -p wacore-derive` passed: 0 unit tests, 3 ignored doctests.
`cargo check -p wacore --lib` passed.
`cargo nextest run -p wacore --lib` and `wacore-binary` were not rerun because this patch changes no implementation; the unchanged baseline suites are outside the affected contract.

Migration: none. Existing derive users and manual child parsers keep the same API and borrowed parsing behavior.
