### PR TITLE
fix(voip): preserve video capture timestamps across drops

### DIFF
--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -11497,7 +11497,12 @@ mod tests {
         let (_legacy_rx, timed_rx, ctl_rx) = shared.take_receivers();
         let (src_tx, src_rx) = async_channel::unbounded::<TimedVideoFrame>();
         let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
-        let source: Arc<dyn VideoSource> = Arc::new(TimedCaptureSource { frames: src_rx });
+        let source_impl = Arc::new(TimedCaptureSource { frames: src_rx });
+        assert!(
+            source_impl.frames().is_closed(),
+            "timed sources may leave legacy input closed"
+        );
+        let source: Arc<dyn VideoSource> = source_impl;
         let sink: Arc<dyn VideoSink> = Arc::new(vout_tx);
         shared.attach_endpoints(&client, &source, &sink, Arc::new(EndedFlag::default()));
         assert_eq!(
@@ -11518,6 +11523,7 @@ mod tests {
         let forwarded = timed_rx.recv().await.unwrap();
         assert_eq!(forwarded.data, vec![1, 2, 3]);
         assert_eq!(forwarded.timestamp, 12_000);
+        assert_eq!(forwarded.generation, 1);
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use log::warn;
+use portable_atomic::{AtomicU64, Ordering as PortableOrdering};
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
 use wacore::stanza::call::{
@@ -37,7 +38,7 @@ use wacore::voip::{
     AudioCodec, AudioConfig, AudioFormat, AudioRtpProfile, CallChannels, CallConfig, CallDirection,
     CallEngine, CallEvent, CallPhase, CodecDecisionSource, EncodedAudioFrame, GroupEngineConfig,
     KeyframeUrgency, VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame,
-    VideoUpgradeToken, run_call, video_control_channel,
+    VideoInput, VideoUpgradeToken, run_call, video_control_channel,
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
@@ -48,7 +49,7 @@ use crate::voip::audio::{
     AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource, WA_FRAME_SAMPLES,
 };
 use crate::voip::driver::RandTxIds;
-use crate::voip::video::{VideoSink, VideoSource};
+use crate::voip::video::{TimedVideoFrame, VideoSink, VideoSource};
 
 enum AudioEndpoints {
     Pcm {
@@ -3180,7 +3181,7 @@ async fn attach_engine(
 
     // Video plumbing: the drive loop always gets the channels; the endpoints attach now (a
     // `.video()` call) or later (an upgrade via CallHandle::start_video/accept_video).
-    let (video_in_rx, video_ctl_rx) = video_shared.take_receivers();
+    let (video_in_rx, timed_video_in_rx, video_ctl_rx) = video_shared.take_receivers();
     let (video_out_tx, video_out_rx) = async_channel::bounded::<VideoFrame>(VIDEO_OUT_CHANNEL_CAP);
     // Forwarder from the drive loop to whatever sink is CURRENTLY attached (swappable mid-call).
     // Ends when the drive loop drops its video_out sender; moved into the media task like mic_feed.
@@ -3230,6 +3231,7 @@ async fn attach_engine(
         events: ev_tx,
         rekey: rekey_rx,
         video_in: video_in_rx,
+        timed_video_in: Some(timed_video_in_rx),
         video_out: video_out_tx,
         video_ctl: video_ctl_rx,
         group_ctl,
@@ -3292,28 +3294,39 @@ pub(crate) struct VideoShared {
     ctl_tx: VideoControlSender,
     /// Outbound AUs into the drive loop; a `VideoFeed` pumps the attached source into it.
     in_tx: async_channel::Sender<Vec<u8>>,
+    /// Optional capture-timestamped AUs, kept separate so the legacy source channel remains ABI
+    /// compatible for callers that only provide a fixed cadence.
+    timed_in_tx: async_channel::Sender<VideoInput>,
     /// The CURRENTLY attached sink (swappable: upgrade attaches, downgrade clears). The
     /// out-forwarder task reads it per frame.
     sink_slot: Arc<std::sync::Mutex<Option<async_channel::Sender<VideoFrame>>>>,
     /// The live source feed, aborted on downgrade/replacement.
     feed: std::sync::Mutex<Option<wacore::runtime::AbortHandle>>,
+    generation: AtomicU64,
     /// Receiver halves parked until `attach_engine` hands them to the drive loop.
     receivers: std::sync::Mutex<Option<VideoReceivers>>,
 }
 
 /// The drive-loop halves of the video channels: (outbound AUs, plane control).
-type VideoReceivers = (async_channel::Receiver<Vec<u8>>, VideoControlReceiver);
+type VideoReceivers = (
+    async_channel::Receiver<Vec<u8>>,
+    async_channel::Receiver<VideoInput>,
+    VideoControlReceiver,
+);
 
 impl VideoShared {
     fn new() -> Self {
         let (ctl_tx, ctl_rx) = video_control_channel();
         let (in_tx, in_rx) = async_channel::bounded::<Vec<u8>>(VIDEO_IN_CHANNEL_CAP);
+        let (timed_in_tx, timed_in_rx) = async_channel::bounded::<VideoInput>(VIDEO_IN_CHANNEL_CAP);
         Self {
             ctl_tx,
             in_tx,
+            timed_in_tx,
             sink_slot: Arc::new(std::sync::Mutex::new(None)),
             feed: std::sync::Mutex::new(None),
-            receivers: std::sync::Mutex::new(Some((in_rx, ctl_rx))),
+            generation: AtomicU64::new(0),
+            receivers: std::sync::Mutex::new(Some((in_rx, timed_in_rx, ctl_rx))),
         }
     }
 
@@ -3326,7 +3339,11 @@ impl VideoShared {
             .take()
             .unwrap_or_else(|| {
                 let (_ctl_tx, ctl_rx) = video_control_channel();
-                (async_channel::bounded(1).1, ctl_rx)
+                (
+                    async_channel::bounded(1).1,
+                    async_channel::bounded(1).1,
+                    ctl_rx,
+                )
             })
     }
 
@@ -3343,30 +3360,48 @@ impl VideoShared {
         sink: &Arc<dyn VideoSink>,
         ended: Arc<EndedFlag>,
     ) {
+        // Retire queued AUs before replacing the source. The driver drains legacy input and
+        // generation filtering retires timestamped frames that race with the control.
+        let timed_source = source.timed_frames();
+        let old = self.feed.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(old) = old {
+            old.abort();
+            self.send_control(if timed_source.is_some() {
+                VideoControl::Disable
+            } else {
+                VideoControl::DisableKeepLegacy
+            });
+        }
+        let generation = self
+            .generation
+            .fetch_add(1, PortableOrdering::Relaxed)
+            .wrapping_add(1);
+        self.send_control(VideoControl::SetInputGeneration(generation));
         // Queue timing before the feed can make an AU ready. The driver's control arm is biased
         // ahead of media, so the first RTP timestamp already uses the source's cadence.
         self.send_control(VideoControl::SetTimestampStride(
             source.rtp_timestamp_stride(),
         ));
         *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(sink.playout());
-        let feed = VideoFeed {
-            source: source.clone(),
-            src: source.frames(),
-            out: self.in_tx.clone(),
-            ended,
+        let handle = if let Some(src) = timed_source {
+            let feed = TimedVideoFeed {
+                source: source.clone(),
+                src,
+                out: self.timed_in_tx.clone(),
+                ended,
+                generation,
+            };
+            client.runtime.spawn(Box::pin(feed.run()))
+        } else {
+            let feed = VideoFeed {
+                source: source.clone(),
+                src: source.frames(),
+                out: self.in_tx.clone(),
+                ended,
+            };
+            client.runtime.spawn(Box::pin(feed.run()))
         };
-        let handle = client.runtime.spawn(Box::pin(feed.run()));
-        // Abort outside the guard: edition 2024 keeps an `if let` scrutinee temporary
-        // alive for the whole matching arm, and a `Runtime` that cancels synchronously
-        // would drop the task inline and re-enter this non-reentrant mutex.
-        let old = self
-            .feed
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .replace(handle);
-        if let Some(old) = old {
-            old.abort();
-        }
+        *self.feed.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle);
     }
 
     /// Release the endpoints (downgrade / refused upgrade): the source feed is aborted, the sink is
@@ -3419,6 +3454,51 @@ struct VideoFeed {
     src: async_channel::Receiver<Vec<u8>>,
     out: async_channel::Sender<Vec<u8>>,
     ended: Arc<EndedFlag>,
+}
+
+struct TimedVideoFeed {
+    source: Arc<dyn VideoSource>,
+    src: async_channel::Receiver<TimedVideoFrame>,
+    out: async_channel::Sender<VideoInput>,
+    ended: Arc<EndedFlag>,
+    generation: u64,
+}
+
+impl TimedVideoFeed {
+    async fn run(self) {
+        use futures::FutureExt;
+        let _source = self.source;
+        loop {
+            let ended = self.ended.wait().fuse();
+            let recv = self.src.recv().fuse();
+            futures::pin_mut!(ended, recv);
+            let frame = futures::select_biased! {
+                _ = ended => break,
+                frame = recv => match frame {
+                    Ok(frame) => frame,
+                    Err(_) => break,
+                },
+            };
+            let ended = self.ended.wait().fuse();
+            let send = self
+                .out
+                .send(VideoInput {
+                    data: frame.data,
+                    timestamp: frame.timestamp,
+                    generation: self.generation,
+                })
+                .fuse();
+            futures::pin_mut!(ended, send);
+            futures::select_biased! {
+                _ = ended => break,
+                res = send => {
+                    if res.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl VideoFeed {
@@ -10532,6 +10612,20 @@ mod tests {
         timestamp_stride: u32,
     }
 
+    struct TimedCaptureSource {
+        frames: async_channel::Receiver<TimedVideoFrame>,
+    }
+
+    impl VideoSource for TimedCaptureSource {
+        fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
+            async_channel::bounded(1).1
+        }
+
+        fn timed_frames(&self) -> Option<async_channel::Receiver<TimedVideoFrame>> {
+            Some(self.frames.clone())
+        }
+    }
+
     impl VideoSource for TimedVideoSource {
         fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
             self.frames.clone()
@@ -11353,7 +11447,7 @@ mod tests {
     async fn video_feed_forwards_and_stops_on_ended() {
         let client = make_client().await;
         let shared = VideoShared::new();
-        let (in_rx, ctl_rx) = shared.take_receivers();
+        let (in_rx, _timed_rx, ctl_rx) = shared.take_receivers();
         let (src_tx, src_rx) = async_channel::unbounded::<Vec<u8>>();
         let sink: Arc<dyn VideoSink> = {
             let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
@@ -11367,6 +11461,10 @@ mod tests {
         let ended = Arc::new(EndedFlag::default());
         shared.attach_endpoints(&client, &source, &sink, ended.clone());
 
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetInputGeneration(1)
+        );
         assert_eq!(
             ctl_rx.recv().await.unwrap(),
             VideoControl::SetTimestampStride(4500)
@@ -11390,6 +11488,85 @@ mod tests {
             after.is_err(),
             "an AU sent after ended must not be forwarded (feed stopped)"
         );
+    }
+
+    #[tokio::test]
+    async fn timed_video_feed_forwards_capture_timestamp() {
+        let client = make_client().await;
+        let shared = VideoShared::new();
+        let (_legacy_rx, timed_rx, ctl_rx) = shared.take_receivers();
+        let (src_tx, src_rx) = async_channel::unbounded::<TimedVideoFrame>();
+        let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
+        let source: Arc<dyn VideoSource> = Arc::new(TimedCaptureSource { frames: src_rx });
+        let sink: Arc<dyn VideoSink> = Arc::new(vout_tx);
+        shared.attach_endpoints(&client, &source, &sink, Arc::new(EndedFlag::default()));
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetInputGeneration(1)
+        );
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetTimestampStride(6000)
+        );
+        src_tx
+            .send(TimedVideoFrame {
+                data: vec![1, 2, 3],
+                timestamp: 12_000,
+            })
+            .await
+            .unwrap();
+        let forwarded = timed_rx.recv().await.unwrap();
+        assert_eq!(forwarded.data, vec![1, 2, 3]);
+        assert_eq!(forwarded.timestamp, 12_000);
+    }
+
+    #[tokio::test]
+    async fn legacy_video_reattach_keeps_new_first_au_before_disable_is_consumed() {
+        let client = make_client().await;
+        let shared = VideoShared::new();
+        let (in_rx, _timed_rx, ctl_rx) = shared.take_receivers();
+        let (old_tx, old_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (new_tx, new_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
+        let sink: Arc<dyn VideoSink> = Arc::new(vout_tx);
+        let old: Arc<dyn VideoSource> = Arc::new(TimedVideoSource {
+            frames: old_rx,
+            timestamp_stride: 6000,
+        });
+        let new: Arc<dyn VideoSource> = Arc::new(TimedVideoSource {
+            frames: new_rx,
+            timestamp_stride: 6000,
+        });
+        let ended = Arc::new(EndedFlag::default());
+        shared.attach_endpoints(&client, &old, &sink, ended.clone());
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetInputGeneration(1)
+        );
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetTimestampStride(6000)
+        );
+        shared.attach_endpoints(&client, &new, &sink, ended);
+        new_tx.send(vec![7, 7, 7]).await.unwrap();
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::DisableKeepLegacy
+        );
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetInputGeneration(2)
+        );
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetTimestampStride(6000)
+        );
+        let got = tokio::time::timeout(Duration::from_secs(2), in_rx.recv())
+            .await
+            .expect("new AU must not be drained")
+            .expect("channel open");
+        assert_eq!(got, vec![7, 7, 7]);
+        drop(old_tx);
     }
 
     /// Runs a caller-supplied hook inline on `abort()`, standing in for a `Runtime` that
@@ -11506,7 +11683,7 @@ mod tests {
     fn video_shared_second_take_yields_closed_channels() {
         let shared = VideoShared::new();
         let _live = shared.take_receivers();
-        let (in_rx, ctl_rx) = shared.take_receivers();
+        let (in_rx, _timed_rx, ctl_rx) = shared.take_receivers();
         assert!(in_rx.is_closed());
         assert!(ctl_rx.is_closed());
     }
@@ -11514,7 +11691,7 @@ mod tests {
     #[test]
     fn video_control_queue_preserves_state_and_coalesces_orientation() {
         let shared = VideoShared::new();
-        let (_in_rx, ctl_rx) = shared.take_receivers();
+        let (_in_rx, _timed_rx, ctl_rx) = shared.take_receivers();
         shared.send_control(VideoControl::Disable);
         for orientation in 0..100u8 {
             shared.send_control(VideoControl::SetOrientation(orientation % 4));

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -50,7 +50,7 @@ pub use facade::{
     AcceptCall, CallHandle, CallLinkCall, CallTermination, GroupBoundCall, OutgoingCall,
     OutgoingGroupCall,
 };
-pub use video::{VideoFrame, VideoSink, VideoSource};
+pub use video::{TimedVideoFrame, VideoFrame, VideoSink, VideoSource};
 // Surface core types carried by the facade next to the builders and handle that expose them.
 pub use wacore::voip::{
     AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,

--- a/src/voip/transport/native.rs
+++ b/src/voip/transport/native.rs
@@ -1883,6 +1883,7 @@ mod udp_relay_e2e {
                     events: ev_tx,
                     rekey: None,
                     video_in: async_channel::bounded(1).1,
+                    timed_video_in: None,
                     video_out: async_channel::bounded(1).0,
                     video_ctl: video_control_channel().1,
                     group_ctl: None,

--- a/src/voip/video.rs
+++ b/src/voip/video.rs
@@ -7,12 +7,29 @@
 
 pub use wacore::voip::VideoFrame;
 
+/// One captured access unit with its 90 kHz RTP capture timestamp. The driver adds a private
+/// source generation when this crosses the facade boundary, so callers cannot forge generation
+/// ownership while replacing a source.
+#[derive(Debug, Clone)]
+pub struct TimedVideoFrame {
+    pub data: Vec<u8>,
+    pub timestamp: u32,
+}
+
 /// A video source for a call: one complete H.264 Annex-B access unit per item. Channel-factory
 /// shaped for the same reasons as [`AudioSource`](crate::voip::audio::AudioSource); a closed
 /// channel (encoder gone) does NOT end the call — audio keeps running.
 pub trait VideoSource: Send + Sync + 'static {
     /// The channel the facade reads encoded AUs from. Called once when video starts.
     fn frames(&self) -> async_channel::Receiver<Vec<u8>>;
+
+    /// An optional capture-timestamped channel. Sources that do not provide capture timestamps use
+    /// the legacy cadence path, which preserves the existing API and its fixed-stride semantics.
+    /// Implementations should return either this channel or the legacy channel for one attachment,
+    /// not both. The timestamp is the source's capture/presentation timeline, not dequeue time.
+    fn timed_frames(&self) -> Option<async_channel::Receiver<TimedVideoFrame>> {
+        None
+    }
 
     /// RTP clock increment between access units. It must match the source's pacing
     /// (`90_000 / frames_per_second`) and remain non-zero.

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -1705,11 +1705,11 @@ async fn run_call_with_clock_and_wallclock(
                                 packets: dropped.packets,
                             });
                         }
-                        // Discard any AUs still queued from the (now-detached) source, so a quick
-                        // re-Enable can't transmit stale frames from the previous session under the
-                        // new negotiation. Drained after the select block (the futures borrow the
-                        // channel).
-                        drain_video_in = true;
+                        // Keep queued legacy AUs: this control is used only while replacing one
+                        // legacy source with another, and the replacement shares this queue. The
+                        // legacy API never carried source generations, so an old tail may precede
+                        // the replacement's first AU exactly as it did before timestamped input.
+                        drain_video_in = false;
                     }
                     Ok(VideoControl::RequireKeyframe) => eng.require_video_keyframe(),
                     Ok(VideoControl::RequestPeerKeyframe(urgency)) => {
@@ -1806,10 +1806,9 @@ async fn run_call_with_clock_and_wallclock(
             },
             timed = timed_video_in_fut => match timed {
                 Ok(frame) => {
-                    if frame.generation != video_generation {
-                        continue;
+                    if frame.generation == video_generation {
+                        eng.handle_video_frame_at(now_ms(), &frame.data, frame.timestamp);
                     }
-                    eng.handle_video_frame_at(now_ms(), &frame.data, frame.timestamp);
                     let now = now_ms();
                     if let Some(at) = eng.poll_timeout()
                         && at != engine::NEVER
@@ -3537,6 +3536,7 @@ mod tests {
         let (vctl_tx, vctl_rx) = video_control_channel();
 
         // Control drains first (bias), so cadence, Enable, and orientation land before any AU.
+        assert!(vctl_tx.send(VideoControl::DisableKeepLegacy));
         assert!(vctl_tx.send(VideoControl::SetInputGeneration(7)));
         assert!(vctl_tx.send(VideoControl::SetTimestampStride(4500)));
         assert!(vctl_tx.send(VideoControl::Enable));
@@ -3558,13 +3558,15 @@ mod tests {
                 generation: 7,
             })
             .unwrap();
-        timed_tx
-            .try_send(VideoInput {
-                data: our_au,
-                timestamp: 9000,
-                generation: 6,
-            })
-            .unwrap();
+        for _ in 0..64 {
+            timed_tx
+                .try_send(VideoInput {
+                    data: our_au.clone(),
+                    timestamp: 9000,
+                    generation: 6,
+                })
+                .unwrap();
+        }
 
         let eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
         futures::executor::block_on(run_call(

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -138,6 +138,8 @@ impl Drop for GroupRawEpoch {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum VideoControl {
+    /// Select the source generation accepted by the timestamped input queue.
+    SetInputGeneration(u64),
     /// RTP clock increment for each access unit. Sent before attaching a source whose cadence is
     /// different from the 15 fps compatibility default.
     SetTimestampStride(u32),
@@ -149,6 +151,8 @@ pub enum VideoControl {
     EnableAwaitingAccept,
     /// Tear the video plane down (downgrade to audio).
     Disable,
+    /// Tear the video plane down while retaining queued legacy AUs for a legacy reattach.
+    DisableKeepLegacy,
     /// Require the next outbound access unit to be an IDR frame after changing its source role.
     RequireKeyframe,
     /// Ask the PEER for a keyframe, by RTCP PLI: the mirror of `RequireKeyframe`. See
@@ -542,6 +546,9 @@ pub struct CallChannels {
     pub rekey: Option<async_channel::Receiver<PeerAnswer>>,
     /// Outbound video: one pre-encoded H.264 Annex-B access unit per item.
     pub video_in: async_channel::Receiver<Vec<u8>>,
+    /// Optional capture-timestamped video input. The legacy `video_in` channel remains available
+    /// for sources whose only contract is a fixed cadence.
+    pub timed_video_in: Option<async_channel::Receiver<VideoInput>>,
     /// Inbound video: reassembled peer access units (dropped on sink overflow, like the speaker).
     pub video_out: async_channel::Sender<VideoFrame>,
     /// Mid-call video-plane control (lossless state, coalesced orientation).
@@ -550,6 +557,17 @@ pub struct CallChannels {
     pub group_ctl: Option<async_channel::Receiver<GroupControl>>,
     /// Where the drive loop publishes media counters for `CallHandle::media_stats`.
     pub media_stats: Arc<crate::voip::media_stats::MediaStatsCell>,
+}
+
+/// A pre-encoded video access unit with an RTP-clock capture timestamp.
+#[derive(Debug, Clone)]
+pub struct VideoInput {
+    /// Complete Annex-B H.264 access unit.
+    pub data: Vec<u8>,
+    /// Capture timestamp in the 90 kHz RTP clock, compared modulo `u32`.
+    pub timestamp: u32,
+    /// Source generation assigned by the facade. Stale generations are discarded at the driver.
+    pub generation: u64,
 }
 
 /// What the caller learned from the callee's `<accept>`, as one message.
@@ -1161,6 +1179,8 @@ async fn run_call_with_clock_and_wallclock(
     // Same closed-channel guards for the video arms: a call that never wires a video source/control
     // sender must not busy-spin on their always-ready `Err`.
     let mut video_in_open = true;
+    let mut timed_video_in_open = true;
+    let mut video_generation = 0u64;
     let mut video_ctl_open = true;
     // Set by a `Disable` to drain the video input queue after the select block (it can't be drained
     // inside, where the arm futures borrow the channel).
@@ -1453,6 +1473,21 @@ async fn run_call_with_clock_and_wallclock(
         .fuse();
         futures::pin_mut!(video_in_fut);
 
+        let timed_video_in = channels.timed_video_in.as_ref();
+        let timed_video_in_live = timed_video_in_open && timed_video_in.is_some();
+        let timed_video_in_fut = async move {
+            if timed_video_in_live {
+                timed_video_in
+                    .expect("timed_video_in_open implies Some")
+                    .recv()
+                    .await
+            } else {
+                std::future::pending().await
+            }
+        }
+        .fuse();
+        futures::pin_mut!(timed_video_in_fut);
+
         let video_ctl = &channels.video_ctl;
         let video_ctl_fut = async move {
             if video_ctl_open {
@@ -1630,6 +1665,9 @@ async fn run_call_with_clock_and_wallclock(
             // Enable can admit frames from the replacement source.
             ctl = video_ctl_fut => {
                 match ctl {
+                    Ok(VideoControl::SetInputGeneration(generation)) => {
+                        video_generation = generation;
+                    }
                     Ok(VideoControl::SetTimestampStride(ts_stride)) => {
                         let _ = eng.set_video_timestamp_stride(ts_stride);
                     }
@@ -1642,6 +1680,20 @@ async fn run_call_with_clock_and_wallclock(
                         let _ = eng.enable_video_gated();
                     }
                     Ok(VideoControl::Disable) => {
+                        eng.disable_video();
+                        let dropped = purge_unstarted_video(
+                            &mut send_queue,
+                            &mut awaiting_video_keyframe,
+                        );
+                        if dropped.packets != 0 {
+                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            });
+                        }
+                        drain_video_in = true;
+                    }
+                    Ok(VideoControl::DisableKeepLegacy) => {
                         eng.disable_video();
                         let dropped = purge_unstarted_video(
                             &mut send_queue,
@@ -1751,6 +1803,22 @@ async fn run_call_with_clock_and_wallclock(
                 // Video source gone (encoder EOF / downgrade released it): disable the arm but keep
                 // the call alive, exactly like the mic.
                 Err(_) => video_in_open = false,
+            },
+            timed = timed_video_in_fut => match timed {
+                Ok(frame) => {
+                    if frame.generation != video_generation {
+                        continue;
+                    }
+                    eng.handle_video_frame_at(now_ms(), &frame.data, frame.timestamp);
+                    let now = now_ms();
+                    if let Some(at) = eng.poll_timeout()
+                        && at != engine::NEVER
+                        && now >= at
+                    {
+                        eng.handle_input(now, Input::Timeout);
+                    }
+                }
+                Err(_) => timed_video_in_open = false,
             },
             _ = &mut timer => eng.handle_input(now_ms(), Input::Timeout),
         }
@@ -2391,6 +2459,7 @@ mod tests {
             events,
             rekey: None,
             video_in: vin_rx,
+            timed_video_in: None,
             video_out: vout_tx,
             video_ctl: vctl_rx,
             group_ctl: None,
@@ -3463,16 +3532,39 @@ mod tests {
         let (spk_tx, _spk_rx) = async_channel::unbounded();
         let (ev_tx, _ev_rx) = async_channel::unbounded();
         let (vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (timed_tx, timed_rx) = async_channel::unbounded::<VideoInput>();
         let (vout_tx, vout_rx) = async_channel::unbounded::<VideoFrame>();
         let (vctl_tx, vctl_rx) = video_control_channel();
 
         // Control drains first (bias), so cadence, Enable, and orientation land before any AU.
+        assert!(vctl_tx.send(VideoControl::SetInputGeneration(7)));
         assert!(vctl_tx.send(VideoControl::SetTimestampStride(4500)));
         assert!(vctl_tx.send(VideoControl::Enable));
         assert!(vctl_tx.send(VideoControl::SetOrientation(1)));
         let our_au = make_au(3000);
         vin_tx.try_send(our_au.clone()).unwrap();
-        vin_tx.try_send(our_au).unwrap();
+        vin_tx.try_send(our_au.clone()).unwrap();
+        timed_tx
+            .try_send(VideoInput {
+                data: our_au.clone(),
+                timestamp: 9000,
+                generation: 7,
+            })
+            .unwrap();
+        timed_tx
+            .try_send(VideoInput {
+                data: our_au.clone(),
+                timestamp: 18000,
+                generation: 7,
+            })
+            .unwrap();
+        timed_tx
+            .try_send(VideoInput {
+                data: our_au,
+                timestamp: 9000,
+                generation: 6,
+            })
+            .unwrap();
 
         let eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
         futures::executor::block_on(run_call(
@@ -3487,6 +3579,7 @@ mod tests {
                 events: ev_tx,
                 rekey: None,
                 video_in: vin_rx,
+                timed_video_in: Some(timed_rx),
                 video_out: vout_tx,
                 video_ctl: vctl_rx,
                 group_ctl: None,
@@ -3505,7 +3598,9 @@ mod tests {
             "SetOrientation must apply before the inbound AU reassembles"
         );
 
-        // Outbound: each 3KB AU fans out to four PT-97 packets and the 20 fps stride applies.
+        // Outbound: the two legacy AUs retain fixed-stride timestamps, while the two current timed AUs
+        // preserve their capture gap. The stale generation is ignored even though it was queued before
+        // the driver processed the replacement controls.
         let sent = transport.sent.lock().unwrap();
         let video_headers = sent
             .iter()
@@ -3513,15 +3608,14 @@ mod tests {
                 parse_rtp_header(packet).filter(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264)
             })
             .collect::<Vec<_>>();
-        assert_eq!(video_headers.len(), 8);
-        assert_eq!(
-            video_headers
-                .iter()
-                .filter(|header| header.marker)
-                .map(|header| header.timestamp)
-                .collect::<Vec<_>>(),
-            [0, 4500]
-        );
+        assert_eq!(video_headers.len(), 16);
+        let mut marker_timestamps = video_headers
+            .iter()
+            .filter(|header| header.marker)
+            .map(|header| header.timestamp)
+            .collect::<Vec<_>>();
+        marker_timestamps.sort_unstable();
+        assert_eq!(marker_timestamps, [0, 4500, 9000, 18000]);
     }
 
     // A relay stall backs the queue up past cap: the overflow policy must shed media, never the STUN

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -3896,10 +3896,9 @@ impl CallEngine {
         if let Some(video) = self.media.as_mut().and_then(|media| media.video.as_mut())
             && video.active
             && !video.send_gated
+            && !video.pipe.set_video_timestamp(timestamp)
         {
-            if !video.pipe.set_video_timestamp(timestamp) {
-                return;
-            }
+            return;
         }
         self.on_video(au);
     }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -2320,6 +2320,13 @@ impl CallEngine {
         }
     }
 
+    /// Apply a source-timestamped video access unit without changing the legacy `Input` enum.
+    pub fn handle_video_frame_at(&mut self, _now: Millis, au: &[u8], timestamp: u32) {
+        if !self.terminated {
+            self.on_video_at(au, timestamp);
+        }
+    }
+
     /// Drain one intent. Returns `Output::Timeout(deadline)` once the queue is empty; the shell
     /// stops draining there and arms a timer for `deadline` ([`NEVER`] = none).
     pub fn poll_output(&mut self) -> Output {
@@ -3883,6 +3890,18 @@ impl CallEngine {
         m.audio_tx_invalid_streak = 0;
         let packet = m.pipe.protect_audio(payload);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+    }
+
+    fn on_video_at(&mut self, au: &[u8], timestamp: u32) {
+        if let Some(video) = self.media.as_mut().and_then(|media| media.video.as_mut())
+            && video.active
+            && !video.send_gated
+        {
+            if !video.pipe.set_video_timestamp(timestamp) {
+                return;
+            }
+        }
+        self.on_video(au);
     }
 
     fn on_video(&mut self, au: &[u8]) {

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -58,7 +58,7 @@ pub use demux::{
 };
 pub use driver::{
     CallChannels, GroupControl, GroupRawEpoch, VideoControl, VideoControlReceiver,
-    VideoControlSender, run_call, video_control_channel,
+    VideoControlSender, VideoInput, run_call, video_control_channel,
 };
 pub use engine::{
     CallConfig, CallEngine, CallEvent, CodecDecisionSource, CodecSwitchError, DirectPeer,

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -476,6 +476,17 @@ impl VideoRtpStream {
         true
     }
 
+    /// Set the timestamp for the next access unit from a source-provided RTP capture clock.
+    pub(crate) fn set_timestamp(&mut self, timestamp: u32) -> bool {
+        if let Some(last) = self.last_sent_timestamp
+            && timestamp.wrapping_sub(last) > 0x8000_0000
+        {
+            return false;
+        }
+        self.timestamp = timestamp;
+        true
+    }
+
     /// Header for the next packet of the current AU; `last_in_au` sets the
     /// marker and moves the timestamp to the next AU. `media_frame_info` is an
     /// encoded-frame property and must be identical on every fragment of the AU.
@@ -666,6 +677,19 @@ mod tests {
         );
         assert!(!stream.set_timestamp_stride(0));
         assert!(VideoRtpStream::new(0x1122_3344, 0).is_none());
+    }
+
+    #[test]
+    fn video_source_timestamp_accepts_repeat_and_wrap_but_rejects_late() {
+        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS).unwrap();
+        let _ = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
+        assert!(stream.set_timestamp(0));
+        assert!(stream.set_timestamp(50));
+        assert!(!stream.set_timestamp(u32::MAX - 50));
+        let mut wrapped = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS).unwrap();
+        assert!(wrapped.set_timestamp(u32::MAX - 100));
+        let _ = wrapped.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
+        assert!(wrapped.set_timestamp(50));
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -927,6 +927,10 @@ impl VideoPipeline {
         self.rtp.set_timestamp_stride(ts_stride)
     }
 
+    pub(crate) fn set_video_timestamp(&mut self, timestamp: u32) -> bool {
+        self.rtp.set_timestamp(timestamp)
+    }
+
     /// Same answering-device rekey as [`MediaPipeline::rekey_recv`]; the video
     /// recv keys are derived from the identical participant id, so they go
     /// stale together with the audio ones. The in-flight reassembly state is
@@ -2404,6 +2408,31 @@ mod tests {
         // Empty AU produces no packets rather than a marker-only ghost.
         let mut ok = VideoPipeline::new(&video_params(&call_key, lid, lid)).unwrap();
         assert!(ok.protect_video(&[]).is_empty());
+    }
+
+    #[test]
+    fn timed_video_input_preserves_a_capture_gap_in_rtp() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let lid = "222222222222222:0@lid";
+        let stride = 6_000;
+        let mut pipe = VideoPipeline::new(&VideoPipelineParams {
+            call_key: &call_key,
+            self_lid: lid,
+            peer_lid: lid,
+            ssrc: 0x1234_5678,
+            ts_stride: stride,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap();
+        let au = [0, 0, 0, 1, 0x65, 1, 2, 3];
+        let first = parse_rtp_header(&pipe.protect_video(&au).pop().unwrap()).unwrap();
+        assert_eq!(first.timestamp, 0);
+
+        // The source captured one AU at the missing timestamp. Supplying the next capture clock
+        // value keeps the RTP timeline at 3 * stride even though only two AUs reach this pipeline.
+        pipe.set_video_timestamp(stride * 3);
+        let after_gap = parse_rtp_header(&pipe.protect_video(&au).pop().unwrap()).unwrap();
+        assert_eq!(after_gap.timestamp, stride * 3);
     }
 
     // The esp32 control/crypto plane. An embedded consumer with no UDP, no codec, and no audio


### PR DESCRIPTION
Summary

Video RTP timestamps previously advanced only when an access unit reached the engine. If a source captured an AU and a later AU reached the pipeline after an intermediate capture was dropped upstream, the later AU inherited the next fixed stride and compressed the capture timeline. This change adds an additive timestamped VideoSource path while preserving the legacy fixed-cadence path.

Evidence/Design

The real video driver path reproduced the distinction: `VideoRtpStream` advanced once per received AU, with no capture timestamp available at `VideoSource` or `CallChannels`. A source-provided 90 kHz RTP timestamp now reaches the pipeline through a separate optional channel. The library assigns source generations and sends a generation control before each attachment; stale timestamped frames are ignored across source replacement. A legacy-to-legacy reattach keeps its queued legacy AUs, preserving the pre-existing tail behavior, while a timed reattach or explicit downgrade drains legacy input; the first startup legacy IDR is never drained. The old feed is aborted before the replacement starts and the driver accepts only the current timestamped generation. Timestamps accept repeats and modulo-u32 forward wrap, and reject values more than half the RTP space behind the last emitted timestamp. Codec, packetization, relay, keyframe policy and renegotiation are unchanged.

Cost

Every `VideoShared` now allocates an additional bounded channel with capacity four and stores a portable generation counter, including calls that use only legacy input. A timestamped feed task is started only for a source that implements `timed_frames`. Each timestamped AU moves its existing data buffer with a `u32` capture timestamp and generation number. Legacy input retains its fixed-cadence channel. This is a source-breaking addition for direct `CallChannels` struct construction: callers must initialize `timed_video_in: None` or provide the receiver. Existing `VideoSource` implementations continue to compile because `timed_frames` has a default implementation.

Validation

`cargo fmt --all`
`cargo check -p wacore --features voip` passed.
`cargo check -p whatsapp-rust --features voip-encoded` passed.
`cargo test -p wacore --lib --features voip-mlow drive_loop_routes_video_both_ways` passed. This real driver test retains the two legacy AUs and fixed-stride markers, adds two current timestamped AUs with a capture gap, queues 64 stale-generation frames, and observes only the expected current RTP H.264 packets.
`cargo test -p wacore --lib --features voip video_source_timestamp` passed.
`cargo test -p wacore --lib --features voip timed_video_input_preserves` passed.
`cargo test -p whatsapp-rust --features voip-encoded timed_video_feed_forwards_capture_timestamp` passed.
`cargo test -p whatsapp-rust --features voip-encoded video_feed_forwards_and_stops_on_ended` passed.
`cargo test -p whatsapp-rust --features voip-encoded legacy_video_reattach_keeps_new_first_au_before_disable_is_consumed` passed.
Workspace clippy and the full VoIP suites were not run locally because the workspace was concurrently compiling several unrelated long-running jobs; CI covers those checks.

At `420b0b0a4`, a negative test restored the incorrect legacy drain and failed with 8 versus 16 expected packets; the corrected driver passed. Legacy input has no source generation: an already queued old-source tail can precede the replacement source, matching the prior behavior. Generation rejection applies to the timestamped path.
