### PR TITLE
fix(adv): correct hosted pairing and device signature validation

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -4165,7 +4165,7 @@ mod tests {
     #[allow(clippy::disallowed_methods)]
     async fn retry_key_bundle_validates_hosted_adv_before_installing_session() {
         use buffa::Message;
-        use wacore_binary::Server;
+        use wacore::adv::test_util;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
@@ -4177,27 +4177,15 @@ mod tests {
             .private_key
             .calculate_signature(&signed_prekey.public_key.serialize(), &mut rng)
             .unwrap();
-        let jids = [
-            Jid::pn_device("15550000001", 1),
-            Jid::lid_device("100000000000001", 1),
-            Jid::pn_device("15550000001", 99),
-            Jid::lid_device("100000000000001", 99),
-            Jid::new("15550000001", Server::Hosted).with_device(99),
-            Jid::new("100000000000001", Server::HostedLid).with_device(99),
-        ];
-        for jid in jids {
-            for hosted_signer in [false, true] {
+        for (jid, hosted_device) in test_util::device_cases() {
+            for device_type in test_util::ENCRYPTION_TYPES {
                 let details = wa::ADVDeviceIdentity {
                     key_index: Some(0),
-                    device_type: Some(if hosted_signer {
-                        wa::ADVEncryptionType::HOSTED
-                    } else {
-                        wa::ADVEncryptionType::E2EE
-                    }),
+                    device_type,
                     ..Default::default()
                 }
                 .encode_to_vec();
-                let acct_prefix: &[u8] = if hosted_signer { &[6, 5] } else { &[6, 0] };
+                let acct_prefix = test_util::account_prefix(device_type);
                 for include_account_key in [false, true] {
                     let client =
                         crate::test_utils::create_test_client_with_failing_http("retry_hosted_adv")
@@ -4207,36 +4195,19 @@ mod tests {
                         .put_identity(&jid.with_device(0).to_protocol_address(), account_key)
                         .await;
                     for valid in [false, true] {
-                        let dev_prefix: &[u8] = if jid.is_hosted() == valid {
+                        let dev_prefix: &[u8; 2] = if hosted_device == valid {
                             &[6, 6]
                         } else {
                             &[6, 1]
                         };
-                        let signed = wa::ADVSignedDeviceIdentity {
-                            details: Some(details.clone()),
-                            account_signature_key: include_account_key
-                                .then(|| account_key.to_vec()),
-                            account_signature: Some(
-                                account
-                                    .private_key
-                                    .calculate_signature(
-                                        &[acct_prefix, &details, identity].concat(),
-                                        &mut rng,
-                                    )
-                                    .unwrap()
-                                    .to_vec(),
-                            ),
-                            device_signature: Some(
-                                device
-                                    .private_key
-                                    .calculate_signature(
-                                        &[dev_prefix, &details, identity, account_key].concat(),
-                                        &mut rng,
-                                    )
-                                    .unwrap()
-                                    .to_vec(),
-                            ),
-                        };
+                        let signed = test_util::signed_identity(
+                            &account,
+                            &device,
+                            &details,
+                            acct_prefix,
+                            Some(dev_prefix),
+                            include_account_key,
+                        );
                         let keys = NodeBuilder::new("keys")
                             .children([
                                 NodeBuilder::new("type").bytes(vec![5]).build(),
@@ -4282,7 +4253,7 @@ mod tests {
                         .await
                         .expect("retry bundle processing must complete");
                         if valid {
-                            result.unwrap_or_else(|e| panic!("jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}: {e}"));
+                            result.unwrap_or_else(|e| panic!("jid={jid} device_type={device_type:?} in_blob={include_account_key}: {e}"));
                         } else {
                             assert!(
                                 result
@@ -4300,7 +4271,7 @@ mod tests {
                         assert_eq!(
                             session.is_some(),
                             valid,
-                            "jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}"
+                            "jid={jid} device_type={device_type:?} in_blob={include_account_key}"
                         );
                         if let Some(session) = session {
                             assert_eq!(session.remote_registration_id().unwrap(), 12345);

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1433,6 +1433,7 @@ impl Client {
                 device_identity,
                 &fetched_identity,
                 account_identity.as_ref(),
+                requester_jid,
             ) {
                 wacore::adv::AdvValidation::Valid => {}
                 wacore::adv::AdvValidation::Invalid => {
@@ -4158,6 +4159,156 @@ mod tests {
             .ensure_e2e_sessions_resolved(std::slice::from_ref(&resolved_jid))
             .await
             .expect("no-op when session exists");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)]
+    async fn retry_key_bundle_validates_hosted_adv_before_installing_session() {
+        use buffa::Message;
+        use wacore_binary::Server;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let signed_prekey = KeyPair::generate(&mut rng);
+        let one_time_prekey = KeyPair::generate(&mut rng);
+        let identity = device.public_key.public_key_bytes();
+        let account_key = account.public_key.public_key_bytes();
+        let prekey_signature = device
+            .private_key
+            .calculate_signature(&signed_prekey.public_key.serialize(), &mut rng)
+            .unwrap();
+        let jids = [
+            Jid::pn_device("15550000001", 1),
+            Jid::lid_device("100000000000001", 1),
+            Jid::pn_device("15550000001", 99),
+            Jid::lid_device("100000000000001", 99),
+            Jid::new("15550000001", Server::Hosted).with_device(99),
+            Jid::new("100000000000001", Server::HostedLid).with_device(99),
+        ];
+        for jid in jids {
+            for hosted_signer in [false, true] {
+                let details = wa::ADVDeviceIdentity {
+                    key_index: Some(0),
+                    device_type: Some(if hosted_signer {
+                        wa::ADVEncryptionType::HOSTED
+                    } else {
+                        wa::ADVEncryptionType::E2EE
+                    }),
+                    ..Default::default()
+                }
+                .encode_to_vec();
+                let acct_prefix: &[u8] = if hosted_signer { &[6, 5] } else { &[6, 0] };
+                for include_account_key in [false, true] {
+                    let client =
+                        crate::test_utils::create_test_client_with_failing_http("retry_hosted_adv")
+                            .await;
+                    client
+                        .signal_cache
+                        .put_identity(&jid.with_device(0).to_protocol_address(), account_key)
+                        .await;
+                    for valid in [false, true] {
+                        let dev_prefix: &[u8] = if jid.is_hosted() == valid {
+                            &[6, 6]
+                        } else {
+                            &[6, 1]
+                        };
+                        let signed = wa::ADVSignedDeviceIdentity {
+                            details: Some(details.clone()),
+                            account_signature_key: include_account_key
+                                .then(|| account_key.to_vec()),
+                            account_signature: Some(
+                                account
+                                    .private_key
+                                    .calculate_signature(
+                                        &[acct_prefix, &details, identity].concat(),
+                                        &mut rng,
+                                    )
+                                    .unwrap()
+                                    .to_vec(),
+                            ),
+                            device_signature: Some(
+                                device
+                                    .private_key
+                                    .calculate_signature(
+                                        &[dev_prefix, &details, identity, account_key].concat(),
+                                        &mut rng,
+                                    )
+                                    .unwrap()
+                                    .to_vec(),
+                            ),
+                        };
+                        let keys = NodeBuilder::new("keys")
+                            .children([
+                                NodeBuilder::new("type").bytes(vec![5]).build(),
+                                NodeBuilder::new("identity")
+                                    .bytes(identity.to_vec())
+                                    .build(),
+                                OneTimePreKeyNode::new(
+                                    1,
+                                    one_time_prekey.public_key.public_key_bytes().to_vec(),
+                                )
+                                .into_node(),
+                                SignedPreKeyNode::new(
+                                    2,
+                                    signed_prekey.public_key.public_key_bytes().to_vec(),
+                                    prekey_signature.to_vec(),
+                                )
+                                .into_node(),
+                                NodeBuilder::new("device-identity")
+                                    .bytes(waproto::codec::adv_signed_device_identity_to_vec(
+                                        &signed,
+                                    ))
+                                    .build(),
+                            ])
+                            .build();
+                        let receipt = NodeBuilder::new("receipt")
+                            .children([
+                                NodeBuilder::new("registration")
+                                    .bytes(12345u32.to_be_bytes().to_vec())
+                                    .build(),
+                                keys,
+                            ])
+                            .build();
+                        let addr = jid.to_protocol_address();
+                        let result = tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            client.process_retry_key_bundle(
+                                &receipt.as_node_ref(),
+                                &jid,
+                                false,
+                                false,
+                            ),
+                        )
+                        .await
+                        .expect("retry bundle processing must complete");
+                        if valid {
+                            result.unwrap_or_else(|e| panic!("jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}: {e}"));
+                        } else {
+                            assert!(
+                                result
+                                    .unwrap_err()
+                                    .to_string()
+                                    .contains("device-identity ADV validation failed")
+                            );
+                        }
+                        let snapshot = client.persistence_manager.get_device_snapshot();
+                        let session = client
+                            .signal_cache
+                            .peek_session(&addr, &*snapshot.backend)
+                            .await
+                            .unwrap();
+                        assert_eq!(
+                            session.is_some(),
+                            valid,
+                            "jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}"
+                        );
+                        if let Some(session) = session {
+                            assert_eq!(session.remote_registration_id().unwrap(), 12345);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -20,9 +20,9 @@ ignored = ["getrandom"]
 debug-snapshots = []
 # Typed interop with the decoded libsignal SessionRecord v1 model.
 legacy-session-interop = ["wacore-libsignal/legacy-session-interop"]
-# Expose the InMemoryBackend fault-injection / call-count hooks used by the e2e
-# suite. Off by default so normal builds carry no extra fields or per-call
-# bookkeeping. Enabled only from test crates.
+# Shared cryptographic fixtures and InMemoryBackend fault-injection/call-count
+# hooks for tests. Off by default so normal builds carry no test scaffolding
+# or per-call bookkeeping.
 test-util = []
 # Optional observability: emit tracing spans/events. Off by default (no dep).
 tracing = ["dep:tracing"]

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -17,11 +17,11 @@ const ADV_PREFIX_LEN: usize = 2;
 
 // WAWebAdvSignatureConstants.
 pub(crate) const ADV_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 0];
-pub(crate) const ADV_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 1];
+const ADV_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 1];
 pub(crate) const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 5];
 const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 6];
 
-pub(crate) fn account_signature_prefix(
+fn account_signature_prefix(
     device_type: Option<ADVEncryptionType>,
 ) -> &'static [u8; ADV_PREFIX_LEN] {
     // WAWebAdvSignatureApi uses the signed deviceType, independently of accountType.
@@ -32,12 +32,55 @@ pub(crate) fn account_signature_prefix(
     }
 }
 
-/// Stack-backed buffer for a signed ADV message.
-///
-/// The longest is `prefix(2) || details || identity(32) || accountKey(32)`, and
-/// `details` is an encoded `ADVDeviceIdentity` of a couple dozen bytes, so 256
-/// keeps both messages off the heap for every shape the server sends.
 type AdvSigBuffer = SmallVec<[u8; 256]>;
+
+#[derive(Clone, Copy)]
+pub(crate) enum DeviceSignatureKind {
+    Companion,
+    Hosted,
+}
+
+pub(crate) struct AccountSignatureMessage(AdvSigBuffer);
+
+impl AccountSignatureMessage {
+    pub(crate) fn new(
+        details: &[u8],
+        identity: &PublicKey,
+        device_type: Option<ADVEncryptionType>,
+    ) -> Self {
+        let identity = identity.public_key_bytes();
+        let mut message =
+            AdvSigBuffer::with_capacity(ADV_PREFIX_LEN + details.len() + identity.len());
+        message.extend_from_slice(account_signature_prefix(device_type));
+        message.extend_from_slice(details);
+        message.extend_from_slice(identity);
+        Self(message)
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn for_device(
+        &self,
+        account_key: &PublicKey,
+        kind: DeviceSignatureKind,
+    ) -> AdvSigBuffer {
+        let account_key = account_key.public_key_bytes();
+        let mut message = AdvSigBuffer::with_capacity(self.0.len() + account_key.len());
+        message.extend_from_slice(&self.0);
+        message[..ADV_PREFIX_LEN].copy_from_slice(match kind {
+            DeviceSignatureKind::Companion => &ADV_PREFIX_DEVICE_SIGNATURE,
+            DeviceSignatureKind::Hosted => &ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
+        });
+        message.extend_from_slice(account_key);
+        message
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+#[doc(hidden)]
+pub mod test_util;
 
 /// Outcome of validating a fetched companion device's `ADVSignedDeviceIdentity`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,10 +91,9 @@ pub enum AdvValidation {
     /// available account key. A relay swapping in a forged identity lands here;
     /// the caller must reject the bundle.
     Invalid,
-    /// No account key was available: the blob omits `account_signature_key` and
-    /// no trusted account identity was passed as a fallback, so the chain can't
-    /// be checked at all. The caller decides what to do (we log and proceed,
-    /// matching the existing "device-identity absent" handling).
+    /// The blob is structurally well-formed, but no account key is available.
+    /// Neither the blob nor the fallback supplies one, so the signatures cannot
+    /// be verified. The caller decides whether to proceed without verification.
     NoAccountKey,
 }
 
@@ -82,6 +124,12 @@ pub fn validate_adv_with_identity_key(
     ) else {
         return AdvValidation::Invalid;
     };
+    let (Ok(account_sig), Ok(device_sig)) = (
+        <&[u8; 64]>::try_from(account_sig),
+        <&[u8; 64]>::try_from(device_sig),
+    ) else {
+        return AdvValidation::Invalid;
+    };
     let Ok(identity_details) = waproto::whatsapp::ADVDeviceIdentityView::decode_view(details)
     else {
         return AdvValidation::Invalid;
@@ -102,23 +150,18 @@ pub fn validate_adv_with_identity_key(
         return AdvValidation::Invalid;
     };
 
-    let mut account_msg =
-        AdvSigBuffer::with_capacity(ADV_PREFIX_LEN + details.len() + fetched_identity_key.len());
-    account_msg.extend_from_slice(account_signature_prefix(identity_details.device_type));
-    account_msg.extend_from_slice(details);
-    account_msg.extend_from_slice(fetched_identity_key);
-    if !account_pub.verify_signature(&account_msg, account_sig) {
+    let account_msg =
+        AccountSignatureMessage::new(details, &device_pub, identity_details.device_type);
+    if !account_pub.verify_signature(account_msg.as_bytes(), account_sig) {
         return AdvValidation::Invalid;
     }
 
-    let mut device_msg = AdvSigBuffer::with_capacity(account_msg.len() + account_key.len());
-    device_msg.extend_from_slice(&account_msg);
-    device_msg[..ADV_PREFIX_LEN].copy_from_slice(if device_jid.is_hosted() {
-        &ADV_HOSTED_PREFIX_DEVICE_SIGNATURE
+    let kind = if device_jid.is_hosted() {
+        DeviceSignatureKind::Hosted
     } else {
-        &ADV_PREFIX_DEVICE_SIGNATURE
-    });
-    device_msg.extend_from_slice(account_key);
+        DeviceSignatureKind::Companion
+    };
+    let device_msg = account_msg.for_device(&account_pub, kind);
     let verified = device_pub.verify_signature(&device_msg, device_sig);
 
     if verified {
@@ -205,6 +248,7 @@ pub fn is_key_index_valid(key_index: Option<u32>, decoded: &DecodedKeyIndex) -> 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
+    use super::test_util::{ENCRYPTION_TYPES, TEST_PN, device_cases};
     use super::*;
     use buffa::Message;
 
@@ -368,32 +412,18 @@ mod tests {
         account: &KeyPair,
         device: &KeyPair,
         details: &[u8],
-        acct_prefix: &[u8],
-        dev_prefix: &[u8],
+        acct_prefix: &[u8; 2],
+        dev_prefix: &[u8; 2],
         include_account_key: bool,
     ) -> Vec<u8> {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let identity = device.public_key.public_key_bytes();
-        let account_key = account.public_key.public_key_bytes();
-        let account_sig = account
-            .private_key
-            .calculate_signature(&[acct_prefix, details, identity].concat(), &mut rng)
-            .unwrap()
-            .to_vec();
-        let device_sig = device
-            .private_key
-            .calculate_signature(
-                &[dev_prefix, details, identity, account_key].concat(),
-                &mut rng,
-            )
-            .unwrap()
-            .to_vec();
-        waproto::whatsapp::ADVSignedDeviceIdentity {
-            details: Some(details.to_vec()),
-            account_signature_key: include_account_key.then(|| account_key.to_vec()),
-            account_signature: Some(account_sig),
-            device_signature: Some(device_sig),
-        }
+        test_util::signed_identity(
+            account,
+            device,
+            details,
+            acct_prefix,
+            Some(dev_prefix),
+            include_account_key,
+        )
         .encode_to_vec()
     }
 
@@ -439,7 +469,7 @@ mod tests {
                 &signed.encode_to_vec(),
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Valid
         );
@@ -447,30 +477,11 @@ mod tests {
 
     #[test]
     fn adv_prefixes_follow_signed_device_type_and_address_independently() {
-        use wacore_binary::Server;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let types = [
-            None,
-            Some(ADVEncryptionType::E2EE),
-            Some(ADVEncryptionType::HOSTED),
-            Some(ADVEncryptionType::NON_E2EE),
-        ];
-        let addresses = [
-            (Jid::pn_device("15550000001", 1), false),
-            (Jid::lid_device("100000000000001", 1), false),
-            (Jid::pn_device("15550000001", 99), true),
-            (Jid::lid_device("100000000000001", 99), true),
-            (
-                Jid::new("15550000001", Server::Hosted).with_device(99),
-                true,
-            ),
-            (
-                Jid::new("100000000000001", Server::HostedLid).with_device(99),
-                true,
-            ),
-        ];
+        let types = ENCRYPTION_TYPES;
+        let addresses = device_cases();
         for account_type in types {
             for device_type in types {
                 let details = waproto::whatsapp::ADVDeviceIdentity {
@@ -480,11 +491,7 @@ mod tests {
                     ..Default::default()
                 }
                 .encode_to_vec();
-                let account_prefix = if device_type == Some(ADVEncryptionType::HOSTED) {
-                    &[6, 5]
-                } else {
-                    &[6, 0]
-                };
+                let account_prefix = test_util::account_prefix(device_type);
                 let wrong_account_prefix = if device_type == Some(ADVEncryptionType::HOSTED) {
                     &[6, 0]
                 } else {
@@ -526,6 +533,31 @@ mod tests {
     }
 
     #[test]
+    fn adv_rejects_invalid_signature_lengths_without_account_key() {
+        let jid = Jid::pn_device(TEST_PN, 1);
+        for account_len in [0, 63, 64, 65] {
+            for device_len in [0, 63, 64, 65] {
+                let signed = waproto::whatsapp::ADVSignedDeviceIdentity {
+                    details: Some(vec![0x18, 0]),
+                    account_signature: Some(vec![0; account_len]),
+                    device_signature: Some(vec![0; device_len]),
+                    ..Default::default()
+                };
+                let expected = if account_len == 64 && device_len == 64 {
+                    AdvValidation::NoAccountKey
+                } else {
+                    AdvValidation::Invalid
+                };
+                assert_eq!(
+                    validate_adv_with_identity_key(&signed.encode_to_vec(), &[0; 32], None, &jid),
+                    expected,
+                    "account_len={account_len} device_len={device_len}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn adv_rejects_signed_malformed_details_even_without_account_key() {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
@@ -544,7 +576,7 @@ mod tests {
                     &bytes,
                     &id32(&device),
                     None,
-                    &Jid::pn_device("15550000001", 1)
+                    &Jid::pn_device(TEST_PN, 1)
                 ),
                 AdvValidation::Invalid
             );
@@ -557,7 +589,7 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         for hosted in [false, true] {
-            let jid = Jid::pn_device("15550000001", if hosted { 99 } else { 1 });
+            let jid = Jid::pn_device(TEST_PN, if hosted { 99 } else { 1 });
             let device_prefix = if hosted { &[6, 6] } else { &[6, 1] };
             let bytes = signed_identity_with_prefixes(
                 &account,
@@ -614,7 +646,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Valid
         );
@@ -631,7 +663,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 99)
+                &Jid::pn_device(TEST_PN, 99)
             ),
             AdvValidation::Valid
         );
@@ -651,7 +683,7 @@ mod tests {
                 &bytes,
                 &id32(&attacker),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Invalid
         );
@@ -674,7 +706,7 @@ mod tests {
                 &no_dev_sig,
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Invalid
         );
@@ -689,7 +721,7 @@ mod tests {
                 &[1, 2, 3, 4],
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Invalid
         );
@@ -709,7 +741,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 Some(&id32(&account)),
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Valid
         );
@@ -728,7 +760,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 None,
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::NoAccountKey
         );
@@ -749,7 +781,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 Some(&id32(&attacker)),
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Invalid
         );
@@ -769,7 +801,7 @@ mod tests {
                 &bytes,
                 &id32(&device),
                 Some(&id32(&unrelated)),
-                &Jid::pn_device("15550000001", 1)
+                &Jid::pn_device(TEST_PN, 1)
             ),
             AdvValidation::Valid
         );

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -7,20 +7,30 @@
 
 use buffa::view::MessageView as _;
 use smallvec::SmallVec;
+use wacore_binary::{Jid, JidExt};
+use waproto::whatsapp::ADVEncryptionType;
 
 use crate::libsignal::protocol::PublicKey;
 use crate::store::traits::DeviceInfo;
 
-/// Every ADV prefix is a two-byte domain separator, which is what lets the
-/// signed messages be built once and re-prefixed per family below.
 const ADV_PREFIX_LEN: usize = 2;
 
-// ADV signature prefixes (WAWebAdvSignatureConstants). The hosted ([6,5]/[6,6])
-// variants apply to business-hosted companion devices.
-const ADV_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 0];
-const ADV_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 1];
-const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 5];
+// WAWebAdvSignatureConstants.
+pub(crate) const ADV_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 0];
+pub(crate) const ADV_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 1];
+pub(crate) const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 5];
 const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 6];
+
+pub(crate) fn account_signature_prefix(
+    device_type: Option<ADVEncryptionType>,
+) -> &'static [u8; ADV_PREFIX_LEN] {
+    // WAWebAdvSignatureApi uses the signed deviceType, independently of accountType.
+    if device_type == Some(ADVEncryptionType::HOSTED) {
+        &ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE
+    } else {
+        &ADV_PREFIX_ACCOUNT_SIGNATURE
+    }
+}
 
 /// Stack-backed buffer for a signed ADV message.
 ///
@@ -49,29 +59,17 @@ pub enum AdvValidation {
 /// fetched identity key to the account's ADV chain, mirroring WA Web
 /// `WAWebAdvSignatureApi.validateADVwithIdentityKey`.
 ///
-/// Two checks must both hold under one prefix family: the account signature over
-/// `prefix || details || identity`, and the device signature (made with the
-/// fetched identity key) over `prefix || details || identity || accountKey`. The
-/// device signature is what binds the fetched identity to the account, so a relay
-/// that substitutes a fabricated identity key is rejected. We try the E2EE then
-/// the hosted prefix set rather than replicating WA Web's `bizHostedDevicesEnabled`
-/// gating: the prefix is only a domain separator, so accepting whichever the
-/// signer used stays sound (an attacker still can't forge the account signature).
-///
-/// The account key is `blob.account_signature_key || account_identity_fallback`,
-/// exactly as WA Web's `P`/`w` helpers (`e.accountSignatureKey || t`): the server
-/// legitimately omits `account_signature_key` for a contact's companion device
-/// because it's the contact's primary (device 0) identity the client already
-/// holds, so the caller passes that stored identity as the fallback. When neither
-/// source has a key the chain is unverifiable and we return `NoAccountKey` rather
-/// than rejecting a bundle we simply lack the material to check.
+/// The account prefix follows the signed `ADVDeviceIdentity.device_type`; the
+/// device prefix follows `device_jid.is_hosted()`. Both signatures must verify
+/// with those exact prefixes, including mixed hosted-account/regular-device chains.
+/// An in-blob account key takes precedence over `account_identity_fallback`.
+/// Callers must supply the fetched device's JID, preserving its hosting identity.
 pub fn validate_adv_with_identity_key(
     device_identity_bytes: &[u8],
     fetched_identity_key: &[u8; 32],
     account_identity_fallback: Option<&[u8; 32]>,
+    device_jid: &Jid,
 ) -> AdvValidation {
-    // Decoded as a view: every field here is read once and compared, so the
-    // owned decode's four `Vec<u8>` copies bought nothing.
     let Ok(signed) =
         waproto::whatsapp::ADVSignedDeviceIdentityView::decode_view(device_identity_bytes)
     else {
@@ -82,6 +80,10 @@ pub fn validate_adv_with_identity_key(
         signed.account_signature,
         signed.device_signature,
     ) else {
+        return AdvValidation::Invalid;
+    };
+    let Ok(identity_details) = waproto::whatsapp::ADVDeviceIdentityView::decode_view(details)
+    else {
         return AdvValidation::Invalid;
     };
     // WA Web `e.accountSignatureKey || t`: prefer the in-blob key, else the
@@ -100,34 +102,24 @@ pub fn validate_adv_with_identity_key(
         return AdvValidation::Invalid;
     };
 
-    // Both signed messages differ between the two prefix families only in their
-    // leading `ADV_PREFIX_LEN` bytes, so they are assembled once and the prefix
-    // is overwritten per attempt. The zeroed placeholder is always replaced
-    // before either message is verified.
     let mut account_msg =
         AdvSigBuffer::with_capacity(ADV_PREFIX_LEN + details.len() + fetched_identity_key.len());
-    account_msg.extend_from_slice(&[0u8; ADV_PREFIX_LEN]);
+    account_msg.extend_from_slice(account_signature_prefix(identity_details.device_type));
     account_msg.extend_from_slice(details);
     account_msg.extend_from_slice(fetched_identity_key);
+    if !account_pub.verify_signature(&account_msg, account_sig) {
+        return AdvValidation::Invalid;
+    }
 
     let mut device_msg = AdvSigBuffer::with_capacity(account_msg.len() + account_key.len());
     device_msg.extend_from_slice(&account_msg);
-    device_msg.extend_from_slice(account_key);
-
-    let verified = [
-        (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE),
-        (
-            ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
-            ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
-        ),
-    ]
-    .into_iter()
-    .any(|(account_prefix, device_prefix)| {
-        account_msg[..ADV_PREFIX_LEN].copy_from_slice(&account_prefix);
-        device_msg[..ADV_PREFIX_LEN].copy_from_slice(&device_prefix);
-        account_pub.verify_signature(&account_msg, account_sig)
-            && device_pub.verify_signature(&device_msg, device_sig)
+    device_msg[..ADV_PREFIX_LEN].copy_from_slice(if device_jid.is_hosted() {
+        &ADV_HOSTED_PREFIX_DEVICE_SIGNATURE
+    } else {
+        &ADV_PREFIX_DEVICE_SIGNATURE
     });
+    device_msg.extend_from_slice(account_key);
+    let verified = device_pub.verify_signature(&device_msg, device_sig);
 
     if verified {
         AdvValidation::Valid
@@ -362,17 +354,27 @@ mod tests {
         hosted: bool,
         include_account_key: bool,
     ) -> Vec<u8> {
+        signed_identity_with_prefixes(
+            account,
+            device,
+            details,
+            if hosted { &[6, 5] } else { &[6, 0] },
+            if hosted { &[6, 6] } else { &[6, 1] },
+            include_account_key,
+        )
+    }
+
+    fn signed_identity_with_prefixes(
+        account: &KeyPair,
+        device: &KeyPair,
+        details: &[u8],
+        acct_prefix: &[u8],
+        dev_prefix: &[u8],
+        include_account_key: bool,
+    ) -> Vec<u8> {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let identity = device.public_key.public_key_bytes();
         let account_key = account.public_key.public_key_bytes();
-        let (acct_prefix, dev_prefix): (&[u8], &[u8]) = if hosted {
-            (
-                &ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
-                &ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
-            )
-        } else {
-            (&ADV_PREFIX_ACCOUNT_SIGNATURE, &ADV_PREFIX_DEVICE_SIGNATURE)
-        };
         let account_sig = account
             .private_key
             .calculate_signature(&[acct_prefix, details, identity].concat(), &mut rng)
@@ -409,13 +411,211 @@ mod tests {
     }
 
     #[test]
+    fn adv_chain_hosted_account_signature_with_regular_device_signature() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let details = &[0x28, 0x01];
+        let bytes = signed_identity(&account, &device, details, true);
+        let mut signed = waproto::codec::adv_signed_device_identity_decode(&bytes).unwrap();
+        signed.device_signature = Some(
+            device
+                .private_key
+                .calculate_signature(
+                    &[
+                        &[6, 1],
+                        details.as_slice(),
+                        device.public_key.public_key_bytes(),
+                        account.public_key.public_key_bytes(),
+                    ]
+                    .concat(),
+                    &mut rng,
+                )
+                .unwrap()
+                .to_vec(),
+        );
+        assert_eq!(
+            validate_adv_with_identity_key(
+                &signed.encode_to_vec(),
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
+            AdvValidation::Valid
+        );
+    }
+
+    #[test]
+    fn adv_prefixes_follow_signed_device_type_and_address_independently() {
+        use wacore_binary::Server;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let types = [
+            None,
+            Some(ADVEncryptionType::E2EE),
+            Some(ADVEncryptionType::HOSTED),
+            Some(ADVEncryptionType::NON_E2EE),
+        ];
+        let addresses = [
+            (Jid::pn_device("15550000001", 1), false),
+            (Jid::lid_device("100000000000001", 1), false),
+            (Jid::pn_device("15550000001", 99), true),
+            (Jid::lid_device("100000000000001", 99), true),
+            (
+                Jid::new("15550000001", Server::Hosted).with_device(99),
+                true,
+            ),
+            (
+                Jid::new("100000000000001", Server::HostedLid).with_device(99),
+                true,
+            ),
+        ];
+        for account_type in types {
+            for device_type in types {
+                let details = waproto::whatsapp::ADVDeviceIdentity {
+                    key_index: Some(0),
+                    account_type,
+                    device_type,
+                    ..Default::default()
+                }
+                .encode_to_vec();
+                let account_prefix = if device_type == Some(ADVEncryptionType::HOSTED) {
+                    &[6, 5]
+                } else {
+                    &[6, 0]
+                };
+                let wrong_account_prefix = if device_type == Some(ADVEncryptionType::HOSTED) {
+                    &[6, 0]
+                } else {
+                    &[6, 5]
+                };
+                for (jid, hosted) in &addresses {
+                    let device_prefix = if *hosted { &[6, 6] } else { &[6, 1] };
+                    let wrong_device_prefix = if *hosted { &[6, 1] } else { &[6, 6] };
+                    for include_account_key in [false, true] {
+                        let fallback = (!include_account_key).then(|| id32(&account));
+                        for (acct, dev, expected) in [
+                            (account_prefix, device_prefix, AdvValidation::Valid),
+                            (wrong_account_prefix, device_prefix, AdvValidation::Invalid),
+                            (account_prefix, wrong_device_prefix, AdvValidation::Invalid),
+                        ] {
+                            let bytes = signed_identity_with_prefixes(
+                                &account,
+                                &device,
+                                &details,
+                                acct,
+                                dev,
+                                include_account_key,
+                            );
+                            assert_eq!(
+                                validate_adv_with_identity_key(
+                                    &bytes,
+                                    &id32(&device),
+                                    fallback.as_ref(),
+                                    jid
+                                ),
+                                expected,
+                                "account={account_type:?} device={device_type:?} jid={jid} in_blob={include_account_key} prefixes={acct:?}/{dev:?}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn adv_rejects_signed_malformed_details_even_without_account_key() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        for include_key in [false, true] {
+            let bytes = signed_identity_with_prefixes(
+                &account,
+                &device,
+                &[0xff],
+                &[6, 0],
+                &[6, 1],
+                include_key,
+            );
+            assert_eq!(
+                validate_adv_with_identity_key(
+                    &bytes,
+                    &id32(&device),
+                    None,
+                    &Jid::pn_device("15550000001", 1)
+                ),
+                AdvValidation::Invalid
+            );
+        }
+    }
+
+    #[test]
+    fn adv_empty_account_key_uses_fallback_and_rejects_tampering() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        for hosted in [false, true] {
+            let jid = Jid::pn_device("15550000001", if hosted { 99 } else { 1 });
+            let device_prefix = if hosted { &[6, 6] } else { &[6, 1] };
+            let bytes = signed_identity_with_prefixes(
+                &account,
+                &device,
+                &[0x28, 1],
+                &[6, 5],
+                device_prefix,
+                false,
+            );
+            let mut signed = waproto::codec::adv_signed_device_identity_decode(&bytes).unwrap();
+            signed.account_signature_key = Some(vec![]);
+            assert_eq!(
+                validate_adv_with_identity_key(
+                    &signed.encode_to_vec(),
+                    &id32(&device),
+                    Some(&id32(&account)),
+                    &jid
+                ),
+                AdvValidation::Valid
+            );
+            assert_eq!(
+                validate_adv_with_identity_key(&signed.encode_to_vec(), &id32(&device), None, &jid),
+                AdvValidation::NoAccountKey
+            );
+            for field in 0..3 {
+                let mut corrupt = signed.clone();
+                match field {
+                    0 => corrupt.account_signature.as_mut().unwrap()[0] ^= 1,
+                    1 => corrupt.device_signature.as_mut().unwrap()[0] ^= 1,
+                    2 => corrupt.details = Some(vec![0x28, 0]),
+                    _ => unreachable!(),
+                }
+                assert_eq!(
+                    validate_adv_with_identity_key(
+                        &corrupt.encode_to_vec(),
+                        &id32(&device),
+                        Some(&id32(&account)),
+                        &jid
+                    ),
+                    AdvValidation::Invalid
+                );
+            }
+        }
+    }
+
+    #[test]
     fn adv_chain_valid_accepted() {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let bytes = signed_identity(&account, &device, b"details", false);
+        let bytes = signed_identity(&account, &device, b"\x18\x01", false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Valid
         );
     }
@@ -425,9 +625,14 @@ mod tests {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let bytes = signed_identity(&account, &device, b"hosted-details", true);
+        let bytes = signed_identity(&account, &device, b"\x28\x01", true);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 99)
+            ),
             AdvValidation::Valid
         );
     }
@@ -440,9 +645,14 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let attacker = KeyPair::generate(&mut rng);
-        let bytes = signed_identity(&account, &device, b"details", false);
+        let bytes = signed_identity(&account, &device, b"\x18\x01", false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&attacker), None),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&attacker),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Invalid
         );
     }
@@ -453,14 +663,19 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let no_dev_sig = waproto::whatsapp::ADVSignedDeviceIdentity {
-            details: Some(b"details".to_vec()),
+            details: Some(b"\x18\x01".to_vec()),
             account_signature_key: Some(account.public_key.public_key_bytes().to_vec()),
             account_signature: Some(vec![0u8; 64]),
             device_signature: None,
         }
         .encode_to_vec();
         assert_eq!(
-            validate_adv_with_identity_key(&no_dev_sig, &id32(&device), None),
+            validate_adv_with_identity_key(
+                &no_dev_sig,
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Invalid
         );
     }
@@ -470,7 +685,12 @@ mod tests {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let device = KeyPair::generate(&mut rng);
         assert_eq!(
-            validate_adv_with_identity_key(&[1, 2, 3, 4], &id32(&device), None),
+            validate_adv_with_identity_key(
+                &[1, 2, 3, 4],
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Invalid
         );
     }
@@ -483,9 +703,14 @@ mod tests {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        let bytes = signed_identity_opts(&account, &device, b"\x18\x01", false, false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&account))),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                Some(&id32(&account)),
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Valid
         );
     }
@@ -497,9 +722,14 @@ mod tests {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        let bytes = signed_identity_opts(&account, &device, b"\x18\x01", false, false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                None,
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::NoAccountKey
         );
     }
@@ -513,9 +743,14 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let attacker = KeyPair::generate(&mut rng);
-        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        let bytes = signed_identity_opts(&account, &device, b"\x18\x01", false, false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&attacker))),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                Some(&id32(&attacker)),
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Invalid
         );
     }
@@ -528,9 +763,14 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let unrelated = KeyPair::generate(&mut rng);
-        let bytes = signed_identity(&account, &device, b"details", false);
+        let bytes = signed_identity(&account, &device, b"\x18\x01", false);
         assert_eq!(
-            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&unrelated))),
+            validate_adv_with_identity_key(
+                &bytes,
+                &id32(&device),
+                Some(&id32(&unrelated)),
+                &Jid::pn_device("15550000001", 1)
+            ),
             AdvValidation::Valid
         );
     }

--- a/wacore/src/adv/test_util.rs
+++ b/wacore/src/adv/test_util.rs
@@ -1,0 +1,78 @@
+//! Synthetic ADV fixtures shared by unit and downstream integration tests.
+
+use crate::libsignal::protocol::KeyPair;
+use wacore_binary::{Jid, Server};
+use waproto::whatsapp::{self as wa, ADVEncryptionType};
+
+pub const TEST_PN: &str = "12025550111";
+
+pub const ENCRYPTION_TYPES: [Option<ADVEncryptionType>; 4] = [
+    None,
+    Some(ADVEncryptionType::E2EE),
+    Some(ADVEncryptionType::HOSTED),
+    Some(ADVEncryptionType::NON_E2EE),
+];
+
+pub fn device_cases() -> [(Jid, bool); 8] {
+    [
+        (Jid::pn_device(TEST_PN, 1), false),
+        (Jid::lid_device("100000000000001", 1), false),
+        (Jid::pn_device(TEST_PN, 99), true),
+        (Jid::lid_device("100000000000001", 99), true),
+        (Jid::new(TEST_PN, Server::Hosted).with_device(99), true),
+        (
+            Jid::new("100000000000001", Server::HostedLid).with_device(99),
+            true,
+        ),
+        // The JID API also permits hosted servers with non-99 device IDs.
+        (Jid::new(TEST_PN, Server::Hosted).with_device(7), true),
+        (
+            Jid::new("100000000000001", Server::HostedLid).with_device(7),
+            true,
+        ),
+    ]
+}
+
+// Keep the fixture oracle independent of production prefix and message builders.
+pub fn account_prefix(device_type: Option<ADVEncryptionType>) -> &'static [u8; 2] {
+    match device_type {
+        Some(ADVEncryptionType::HOSTED) => &[6, 5],
+        None | Some(ADVEncryptionType::E2EE | ADVEncryptionType::NON_E2EE) => &[6, 0],
+    }
+}
+
+pub fn signed_identity(
+    account: &KeyPair,
+    device: &KeyPair,
+    details: &[u8],
+    account_prefix: &[u8; 2],
+    device_prefix: Option<&[u8; 2]>,
+    include_account_key: bool,
+) -> wa::ADVSignedDeviceIdentity {
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let identity = device.public_key.public_key_bytes();
+    let account_key = account.public_key.public_key_bytes();
+    let account_signature = account
+        .private_key
+        .calculate_signature(
+            &[account_prefix.as_slice(), details, identity].concat(),
+            &mut rng,
+        )
+        .expect("synthetic account signature");
+    let device_signature = device_prefix.map(|prefix| {
+        device
+            .private_key
+            .calculate_signature(
+                &[prefix.as_slice(), details, identity, account_key].concat(),
+                &mut rng,
+            )
+            .expect("synthetic device signature")
+            .to_vec()
+    });
+    wa::ADVSignedDeviceIdentity {
+        details: Some(details.to_vec()),
+        account_signature_key: include_account_key.then(|| account_key.to_vec()),
+        account_signature: Some(account_signature.to_vec()),
+        device_signature,
+    }
+}

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -1,6 +1,6 @@
 use crate::adv::{
-    ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE,
-    account_signature_prefix,
+    ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_ACCOUNT_SIGNATURE, AccountSignatureMessage,
+    DeviceSignatureKind,
 };
 use crate::companion_reg::CompanionWebClientType;
 use crate::libsignal::crypto::aes_256_gcm_encrypt;
@@ -174,7 +174,6 @@ impl PairUtils {
         device_state: &DeviceState,
         device_identity_bytes: &[u8],
     ) -> Result<(Vec<u8>, u32), PairCryptoError> {
-        // 1. Unmarshal HMAC container and verify HMAC
         let hmac_container = waproto::codec::adv_signed_device_identity_hmac_decode(
             device_identity_bytes,
         )
@@ -184,7 +183,6 @@ impl PairUtils {
             source: e.into(),
         })?;
 
-        // Determine if this is a hosted account
         let is_hosted_account = hmac_container.account_type == Some(ADVEncryptionType::HOSTED);
 
         let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(&device_state.adv_secret_key)
@@ -193,7 +191,6 @@ impl PairUtils {
             text: "internal-error",
             source: e.into(),
         })?;
-        // Get details and hmac as slices, handling potential None values
         let details_bytes = hmac_container
             .details
             .as_deref()
@@ -225,7 +222,6 @@ impl PairUtils {
             source: anyhow::anyhow!("ADV signed-device-identity HMAC verification failed"),
         })?;
 
-        // 2. Unmarshal inner container and verify account signature
         let mut signed_identity = waproto::codec::adv_signed_device_identity_decode(details_bytes)
             .map_err(|e| PairCryptoError {
                 code: 500,
@@ -257,11 +253,11 @@ impl PairUtils {
                 source: e.into(),
             })?;
 
-        let msg_to_verify = Self::concat_bytes(&[
-            account_signature_prefix(identity_details.device_type),
+        let msg_to_verify = AccountSignatureMessage::new(
             inner_details_bytes,
-            device_state.identity_key.public_key.public_key_bytes(),
-        ]);
+            &device_state.identity_key.public_key,
+            identity_details.device_type,
+        );
 
         let account_public_key = PublicKey::from_djb_public_key_bytes(account_sig_key_bytes)
             .map_err(|e| PairCryptoError {
@@ -270,7 +266,7 @@ impl PairUtils {
                 source: e.into(),
             })?;
 
-        if !account_public_key.verify_signature(&msg_to_verify, account_sig_bytes) {
+        if !account_public_key.verify_signature(msg_to_verify.as_bytes(), account_sig_bytes) {
             return Err(PairCryptoError {
                 code: 401,
                 text: "signature-mismatch",
@@ -278,13 +274,15 @@ impl PairUtils {
             });
         }
 
+        let key_index = identity_details.key_index.ok_or_else(|| PairCryptoError {
+            code: 500,
+            text: "internal-error",
+            source: anyhow::anyhow!("ADVDeviceIdentity missing key_index"),
+        })?;
+
         // WAWebAdvSignatureApi.generateDeviceSignature always signs a regular companion.
-        let msg_to_sign = Self::concat_bytes(&[
-            &ADV_PREFIX_DEVICE_SIGNATURE,
-            inner_details_bytes,
-            device_state.identity_key.public_key.public_key_bytes(),
-            account_sig_key_bytes,
-        ]);
+        let msg_to_sign =
+            msg_to_verify.for_device(&account_public_key, DeviceSignatureKind::Companion);
         let device_signature = device_state
             .identity_key
             .private_key
@@ -296,13 +294,6 @@ impl PairUtils {
             })?;
         signed_identity.device_signature = Some(device_signature.to_vec());
 
-        let key_index = identity_details.key_index.ok_or_else(|| PairCryptoError {
-            code: 500,
-            text: "internal-error",
-            source: anyhow::anyhow!("ADVDeviceIdentity missing key_index"),
-        })?;
-
-        // 5. Marshal the modified signed_identity to send back
         let self_signed_identity_bytes =
             waproto::codec::adv_signed_device_identity_to_vec(&signed_identity);
 
@@ -443,17 +434,13 @@ impl PairUtils {
             .children([response_content])
             .build()
     }
-
-    /// Helper to concatenate multiple byte slices into a single Vec.
-    fn concat_bytes(slices: &[&[u8]]) -> Vec<u8> {
-        slices.iter().flat_map(|s| s.iter().cloned()).collect()
-    }
 }
 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use crate::adv::test_util::{self, ENCRYPTION_TYPES, TEST_PN};
     use buffa::Message;
     use rand::RngExt;
 
@@ -715,28 +702,17 @@ mod tests {
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account_kp = KeyPair::generate(&mut rng);
-        let account_sig_prefix: &[u8] = if details.device_type == Some(ADVEncryptionType::HOSTED) {
-            &[6, 5]
-        } else {
-            &[6, 0]
-        };
         let mut inner = details.encode_to_vec();
         // Preserve unknown signed fields byte-for-byte, including noncanonical field order.
         inner.splice(0..0, [0xa0, 0x06, 0x01]);
-        let mut to_sign = Vec::new();
-        to_sign.extend_from_slice(account_sig_prefix);
-        to_sign.extend_from_slice(&inner);
-        to_sign.extend_from_slice(state.identity_key.public_key.public_key_bytes());
-        let sig = account_kp
-            .private_key
-            .calculate_signature(&to_sign, &mut rng)
-            .unwrap();
-        let signed = wa::ADVSignedDeviceIdentity {
-            details: Some(inner),
-            account_signature_key: Some(account_kp.public_key.public_key_bytes().to_vec()),
-            account_signature: Some(sig.to_vec()),
-            device_signature: None,
-        }
+        let signed = test_util::signed_identity(
+            &account_kp,
+            &state.identity_key,
+            &inner,
+            test_util::account_prefix(details.device_type),
+            None,
+            true,
+        )
         .encode_to_vec();
         wrap_pair_success(adv_secret_for_hmac, account_type, signed)
     }
@@ -764,12 +740,7 @@ mod tests {
     fn pairing_account_and_device_types_are_independent() {
         use buffa::Message;
         let state = dummy_device_state();
-        let types = [
-            None,
-            Some(ADVEncryptionType::E2EE),
-            Some(ADVEncryptionType::HOSTED),
-            Some(ADVEncryptionType::NON_E2EE),
-        ];
+        let types = ENCRYPTION_TYPES;
         for outer in types {
             for account_type in types {
                 for device_type in types {
@@ -819,7 +790,7 @@ mod tests {
                                 .try_into()
                                 .unwrap(),
                             None,
-                            &Jid::pn_device("15550000001", 1),
+                            &Jid::pn_device(TEST_PN, 1),
                         ),
                         crate::adv::AdvValidation::Valid
                     );
@@ -838,6 +809,60 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn pairing_preserves_signed_details_when_signature_buffers_spill() {
+        let state = dummy_device_state();
+        let account = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+        let mut details = wa::ADVDeviceIdentity {
+            key_index: Some(0),
+            device_type: Some(ADVEncryptionType::HOSTED),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        // Unknown field 100 with a 512-byte payload forces both signature buffers to spill.
+        details.extend_from_slice(&[0xa2, 0x06, 0x80, 0x04]);
+        details.extend_from_slice(&[0xab; 512]);
+        let original = test_util::signed_identity(
+            &account,
+            &state.identity_key,
+            &details,
+            &[6, 5],
+            None,
+            true,
+        );
+        let payload = wrap_pair_success(&state.adv_secret_key, None, original.encode_to_vec());
+        let (result, index) = PairUtils::do_pair_crypto(&state, &payload).unwrap();
+        assert_eq!(index, 0);
+        let signed = waproto::codec::adv_signed_device_identity_decode(&result).unwrap();
+        assert_eq!(signed.details.as_deref(), Some(details.as_slice()));
+        assert!(
+            state.identity_key.public_key.verify_signature(
+                &[
+                    &[6, 1],
+                    details.as_slice(),
+                    state.identity_key.public_key.public_key_bytes(),
+                    account.public_key.public_key_bytes()
+                ]
+                .concat(),
+                signed.device_signature.as_deref().unwrap(),
+            )
+        );
+        assert_eq!(
+            crate::adv::validate_adv_with_identity_key(
+                &result,
+                state
+                    .identity_key
+                    .public_key
+                    .public_key_bytes()
+                    .try_into()
+                    .unwrap(),
+                None,
+                &Jid::pn_device(TEST_PN, 1),
+            ),
+            crate::adv::AdvValidation::Valid
+        );
     }
 
     #[test]
@@ -942,31 +967,19 @@ mod tests {
                     ..Default::default()
                 }
                 .encode_to_vec();
-                let wrong_prefix: &[u8] = if device_type == ADVEncryptionType::HOSTED {
+                let wrong_prefix: &[u8; 2] = if device_type == ADVEncryptionType::HOSTED {
                     &[6, 0]
                 } else {
                     &[6, 5]
                 };
-                let signed = wa::ADVSignedDeviceIdentity {
-                    details: Some(details.clone()),
-                    account_signature_key: Some(account.public_key.public_key_bytes().to_vec()),
-                    account_signature: Some(
-                        account
-                            .private_key
-                            .calculate_signature(
-                                &[
-                                    wrong_prefix,
-                                    &details,
-                                    state.identity_key.public_key.public_key_bytes(),
-                                ]
-                                .concat(),
-                                &mut rng,
-                            )
-                            .unwrap()
-                            .to_vec(),
-                    ),
-                    device_signature: None,
-                };
+                let signed = test_util::signed_identity(
+                    &account,
+                    &state.identity_key,
+                    &details,
+                    wrong_prefix,
+                    None,
+                    true,
+                );
                 let payload =
                     wrap_pair_success(&state.adv_secret_key, Some(outer), signed.encode_to_vec());
                 let err = PairUtils::do_pair_crypto(&state, &payload).unwrap_err();

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -1,3 +1,7 @@
+use crate::adv::{
+    ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE,
+    account_signature_prefix,
+};
 use crate::companion_reg::CompanionWebClientType;
 use crate::libsignal::crypto::aes_256_gcm_encrypt;
 use crate::libsignal::protocol::{KeyPair, PublicKey};
@@ -11,12 +15,6 @@ use wacore_binary::{Jid, SERVER_JID};
 use wacore_binary::{Node, NodeRef};
 use waproto::whatsapp as wa;
 use waproto::whatsapp::ADVEncryptionType;
-
-// Prefixes from whatsmeow/pair.go, crucial for signature verification
-const ADV_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 0];
-const ADV_PREFIX_DEVICE_SIGNATURE_GENERATE: &[u8] = &[6, 1];
-const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 5];
-const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE_VERIFICATION: &[u8] = &[6, 6];
 
 // Aliases for HMAC-SHA256
 type HmacSha256 = Hmac<Sha256>;
@@ -214,7 +212,7 @@ impl PairUtils {
             })?;
 
         if is_hosted_account {
-            mac.update(ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE);
+            mac.update(&ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE);
         }
         mac.update(details_bytes);
         // adv_secret is shared with the primary out-of-band (QR string or
@@ -243,21 +241,25 @@ impl PairUtils {
             .account_signature
             .as_deref()
             .unwrap_or_default();
-        let inner_details_bytes = signed_identity
-            .details
-            .as_deref()
-            .unwrap_or_default()
-            .to_vec();
-
-        let account_sig_prefix = if is_hosted_account {
-            ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE
-        } else {
-            ADV_PREFIX_ACCOUNT_SIGNATURE
-        };
+        let inner_details_bytes =
+            signed_identity
+                .details
+                .as_deref()
+                .ok_or_else(|| PairCryptoError {
+                    code: 500,
+                    text: "internal-error",
+                    source: anyhow::anyhow!("ADVSignedDeviceIdentity missing details"),
+                })?;
+        let identity_details = waproto::codec::adv_device_identity_decode(inner_details_bytes)
+            .map_err(|e| PairCryptoError {
+                code: 500,
+                text: "internal-error",
+                source: e.into(),
+            })?;
 
         let msg_to_verify = Self::concat_bytes(&[
-            account_sig_prefix,
-            &inner_details_bytes,
+            account_signature_prefix(identity_details.device_type),
+            inner_details_bytes,
             device_state.identity_key.public_key.public_key_bytes(),
         ]);
 
@@ -276,16 +278,10 @@ impl PairUtils {
             });
         }
 
-        // 3. Generate our device signature
-        let device_sig_prefix = if is_hosted_account {
-            ADV_HOSTED_PREFIX_DEVICE_SIGNATURE_VERIFICATION
-        } else {
-            ADV_PREFIX_DEVICE_SIGNATURE_GENERATE
-        };
-
+        // WAWebAdvSignatureApi.generateDeviceSignature always signs a regular companion.
         let msg_to_sign = Self::concat_bytes(&[
-            device_sig_prefix,
-            &inner_details_bytes,
+            &ADV_PREFIX_DEVICE_SIGNATURE,
+            inner_details_bytes,
             device_state.identity_key.public_key.public_key_bytes(),
             account_sig_key_bytes,
         ]);
@@ -300,13 +296,6 @@ impl PairUtils {
             })?;
         signed_identity.device_signature = Some(device_signature.to_vec());
 
-        // 4. Unmarshal final details to get key_index
-        let identity_details = waproto::codec::adv_device_identity_decode(&inner_details_bytes)
-            .map_err(|e| PairCryptoError {
-                code: 500,
-                text: "internal-error",
-                source: e.into(),
-            })?;
         let key_index = identity_details.key_index.ok_or_else(|| PairCryptoError {
             code: 500,
             text: "internal-error",
@@ -401,7 +390,7 @@ impl PairUtils {
 
         let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(adv_key)
             .map_err(|e| anyhow::anyhow!("Failed to init HMAC for master pairing: {e}"))?;
-        mac.update(ADV_PREFIX_ACCOUNT_SIGNATURE);
+        mac.update(&ADV_PREFIX_ACCOUNT_SIGNATURE);
         mac.update(dut_identity_pub);
         mac.update(master_ephemeral.public_key.public_key_bytes());
         let account_signature = mac.finalize().into_bytes();
@@ -683,9 +672,6 @@ mod tests {
         }
     }
 
-    /// Synthesize a signed pair-success payload whose HMAC is keyed by
-    /// `adv_secret_for_hmac`. Mirrors the verifier's hosted/E2EE branching
-    /// for both the account signature and the outer HMAC.
     fn build_pair_success_payload(
         state: &DeviceState,
         adv_secret_for_hmac: &[u8; 32],
@@ -700,29 +686,43 @@ mod tests {
         is_hosted: bool,
         key_index: Option<u32>,
     ) -> Vec<u8> {
-        use buffa::Message;
-        use waproto::whatsapp as wa;
-
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let account_kp = KeyPair::generate(&mut rng);
         let account_type = if is_hosted {
             ADVEncryptionType::HOSTED
         } else {
             ADVEncryptionType::E2EE
         };
-        let inner = wa::ADVDeviceIdentity {
-            raw_id: Some(1),
-            timestamp: Some(0),
-            key_index,
-            account_type: Some(account_type),
-            device_type: Some(account_type),
-        }
-        .encode_to_vec();
-        let account_sig_prefix: &[u8] = if is_hosted {
-            ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE
+        build_pair_success_payload_with_types(
+            state,
+            adv_secret_for_hmac,
+            Some(account_type),
+            wa::ADVDeviceIdentity {
+                raw_id: Some(1),
+                timestamp: Some(0),
+                key_index,
+                account_type: Some(account_type),
+                device_type: Some(account_type),
+            },
+        )
+    }
+
+    fn build_pair_success_payload_with_types(
+        state: &DeviceState,
+        adv_secret_for_hmac: &[u8; 32],
+        account_type: Option<ADVEncryptionType>,
+        details: wa::ADVDeviceIdentity,
+    ) -> Vec<u8> {
+        use buffa::Message;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account_kp = KeyPair::generate(&mut rng);
+        let account_sig_prefix: &[u8] = if details.device_type == Some(ADVEncryptionType::HOSTED) {
+            &[6, 5]
         } else {
-            ADV_PREFIX_ACCOUNT_SIGNATURE
+            &[6, 0]
         };
+        let mut inner = details.encode_to_vec();
+        // Preserve unknown signed fields byte-for-byte, including noncanonical field order.
+        inner.splice(0..0, [0xa0, 0x06, 0x01]);
         let mut to_sign = Vec::new();
         to_sign.extend_from_slice(account_sig_prefix);
         to_sign.extend_from_slice(&inner);
@@ -738,18 +738,261 @@ mod tests {
             device_signature: None,
         }
         .encode_to_vec();
-        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(adv_secret_for_hmac).unwrap();
-        if is_hosted {
-            mac.update(ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE);
+        wrap_pair_success(adv_secret_for_hmac, account_type, signed)
+    }
+
+    fn wrap_pair_success(
+        secret: &[u8; 32],
+        account_type: Option<ADVEncryptionType>,
+        signed: Vec<u8>,
+    ) -> Vec<u8> {
+        use buffa::Message;
+        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(secret).unwrap();
+        if account_type == Some(ADVEncryptionType::HOSTED) {
+            mac.update(&[6, 5]);
         }
         mac.update(&signed);
-        let hmac_bytes = mac.finalize().into_bytes().to_vec();
         wa::ADVSignedDeviceIdentityHMAC {
             details: Some(signed),
-            hmac: Some(hmac_bytes),
-            account_type: Some(account_type),
+            hmac: Some(mac.finalize().into_bytes().to_vec()),
+            account_type,
         }
         .encode_to_vec()
+    }
+
+    #[test]
+    fn pairing_account_and_device_types_are_independent() {
+        use buffa::Message;
+        let state = dummy_device_state();
+        let types = [
+            None,
+            Some(ADVEncryptionType::E2EE),
+            Some(ADVEncryptionType::HOSTED),
+            Some(ADVEncryptionType::NON_E2EE),
+        ];
+        for outer in types {
+            for account_type in types {
+                for device_type in types {
+                    let payload = build_pair_success_payload_with_types(
+                        &state,
+                        &state.adv_secret_key,
+                        outer,
+                        wa::ADVDeviceIdentity {
+                            key_index: Some(42),
+                            account_type,
+                            device_type,
+                            ..Default::default()
+                        },
+                    );
+                    let (result, index) = PairUtils::do_pair_crypto(&state, &payload)
+                        .unwrap_or_else(|e| panic!("outer={outer:?} account={account_type:?} device={device_type:?}: {e}"));
+                    assert_eq!(index, 42);
+                    let container =
+                        waproto::codec::adv_signed_device_identity_hmac_decode(&payload).unwrap();
+                    let mut wrong_account_type = container.clone();
+                    wrong_account_type.account_type =
+                        Some(if outer == Some(ADVEncryptionType::HOSTED) {
+                            ADVEncryptionType::E2EE
+                        } else {
+                            ADVEncryptionType::HOSTED
+                        });
+                    let err =
+                        PairUtils::do_pair_crypto(&state, &wrong_account_type.encode_to_vec())
+                            .unwrap_err();
+                    assert_eq!((err.code, err.text), (401, "hmac-mismatch"));
+                    let original = waproto::codec::adv_signed_device_identity_decode(
+                        container.details.as_deref().unwrap(),
+                    )
+                    .unwrap();
+                    let signed =
+                        waproto::codec::adv_signed_device_identity_decode(&result).unwrap();
+                    assert_eq!(signed.details, original.details);
+                    assert_eq!(signed.account_signature, original.account_signature);
+                    assert_eq!(signed.account_signature_key, original.account_signature_key);
+                    assert_eq!(
+                        crate::adv::validate_adv_with_identity_key(
+                            &result,
+                            state
+                                .identity_key
+                                .public_key
+                                .public_key_bytes()
+                                .try_into()
+                                .unwrap(),
+                            None,
+                            &Jid::pn_device("15550000001", 1),
+                        ),
+                        crate::adv::AdvValidation::Valid
+                    );
+                    let details = signed.details.as_deref().unwrap();
+                    let account_key = signed.account_signature_key.as_deref().unwrap();
+                    let identity = state.identity_key.public_key.public_key_bytes();
+                    let signature = signed.device_signature.as_deref().unwrap();
+                    assert!(state.identity_key.public_key.verify_signature(
+                        &[&[6, 1], details, identity, account_key].concat(),
+                        signature,
+                    ));
+                    assert!(!state.identity_key.public_key.verify_signature(
+                        &[&[6, 6], details, identity, account_key].concat(),
+                        signature,
+                    ));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pairing_rejects_authenticated_invalid_identity() {
+        use buffa::Message;
+        #[derive(Debug, Clone, Copy)]
+        enum Corruption {
+            Signature,
+            Details,
+            KeyLength,
+            MissingSignature,
+            MalformedDetails,
+            MissingDetails,
+            SubstitutedKey,
+        }
+        let state = dummy_device_state();
+        for hosted in [false, true] {
+            let payload = build_pair_success_payload(&state, &state.adv_secret_key, hosted);
+            let container =
+                waproto::codec::adv_signed_device_identity_hmac_decode(&payload).unwrap();
+            let original = waproto::codec::adv_signed_device_identity_decode(
+                container.details.as_deref().unwrap(),
+            )
+            .unwrap();
+            for case in [
+                Corruption::Signature,
+                Corruption::Details,
+                Corruption::KeyLength,
+                Corruption::MissingSignature,
+                Corruption::MalformedDetails,
+                Corruption::MissingDetails,
+                Corruption::SubstitutedKey,
+            ] {
+                let mut signed = original.clone();
+                let (code, text) = match case {
+                    Corruption::Signature => {
+                        signed.account_signature.as_mut().unwrap()[0] ^= 1;
+                        (401, "signature-mismatch")
+                    }
+                    Corruption::Details => {
+                        signed.details.as_mut().unwrap()[2] ^= 1;
+                        (401, "signature-mismatch")
+                    }
+                    Corruption::KeyLength => {
+                        signed.account_signature_key = Some(vec![0; 31]);
+                        (401, "invalid-key")
+                    }
+                    Corruption::MissingSignature => {
+                        signed.account_signature = None;
+                        (401, "signature-mismatch")
+                    }
+                    Corruption::MalformedDetails => {
+                        signed.details = Some(vec![0xff]);
+                        (500, "internal-error")
+                    }
+                    Corruption::MissingDetails => {
+                        signed.details = None;
+                        (500, "internal-error")
+                    }
+                    Corruption::SubstitutedKey => {
+                        let key = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+                        signed.account_signature_key =
+                            Some(key.public_key.public_key_bytes().to_vec());
+                        (401, "signature-mismatch")
+                    }
+                };
+                let payload = wrap_pair_success(
+                    &state.adv_secret_key,
+                    container.account_type,
+                    signed.encode_to_vec(),
+                );
+                let err = PairUtils::do_pair_crypto(&state, &payload)
+                    .expect_err("authenticated invalid identity");
+                assert_eq!(
+                    (err.code, err.text),
+                    (code, text),
+                    "hosted={hosted} case={case:?}"
+                );
+            }
+            let other = dummy_device_state();
+            let other = DeviceState {
+                adv_secret_key: state.adv_secret_key,
+                ..other
+            };
+            let err =
+                PairUtils::do_pair_crypto(&other, &payload).expect_err("identity substitution");
+            assert_eq!(err.text, "signature-mismatch");
+        }
+    }
+
+    #[test]
+    fn pairing_does_not_try_an_alternate_account_signature_prefix() {
+        use buffa::Message;
+        let state = dummy_device_state();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        for outer in [ADVEncryptionType::E2EE, ADVEncryptionType::HOSTED] {
+            for device_type in [ADVEncryptionType::E2EE, ADVEncryptionType::HOSTED] {
+                let details = wa::ADVDeviceIdentity {
+                    key_index: Some(0),
+                    device_type: Some(device_type),
+                    ..Default::default()
+                }
+                .encode_to_vec();
+                let wrong_prefix: &[u8] = if device_type == ADVEncryptionType::HOSTED {
+                    &[6, 0]
+                } else {
+                    &[6, 5]
+                };
+                let signed = wa::ADVSignedDeviceIdentity {
+                    details: Some(details.clone()),
+                    account_signature_key: Some(account.public_key.public_key_bytes().to_vec()),
+                    account_signature: Some(
+                        account
+                            .private_key
+                            .calculate_signature(
+                                &[
+                                    wrong_prefix,
+                                    &details,
+                                    state.identity_key.public_key.public_key_bytes(),
+                                ]
+                                .concat(),
+                                &mut rng,
+                            )
+                            .unwrap()
+                            .to_vec(),
+                    ),
+                    device_signature: None,
+                };
+                let payload =
+                    wrap_pair_success(&state.adv_secret_key, Some(outer), signed.encode_to_vec());
+                let err = PairUtils::do_pair_crypto(&state, &payload).unwrap_err();
+                assert_eq!((err.code, err.text), (401, "signature-mismatch"));
+            }
+        }
+    }
+
+    #[test]
+    fn pairing_authenticates_container_before_decoding_inner_identity() {
+        use buffa::Message;
+        let state = dummy_device_state();
+        for account_type in [
+            None,
+            Some(ADVEncryptionType::E2EE),
+            Some(ADVEncryptionType::HOSTED),
+        ] {
+            let payload = wrap_pair_success(&state.adv_secret_key, account_type, vec![0xff]);
+            let err = PairUtils::do_pair_crypto(&state, &payload).unwrap_err();
+            assert_eq!((err.code, err.text), (500, "internal-error"));
+            let mut container =
+                waproto::codec::adv_signed_device_identity_hmac_decode(&payload).unwrap();
+            container.hmac.as_mut().unwrap()[0] ^= 1;
+            let err = PairUtils::do_pair_crypto(&state, &container.encode_to_vec()).unwrap_err();
+            assert_eq!((err.code, err.text), (401, "hmac-mismatch"));
+        }
     }
 
     #[test]

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -717,23 +717,14 @@ mod tests {
 
     #[test]
     fn prekey_fetch_validates_mixed_and_hosted_adv_chains() {
+        use crate::adv::test_util;
         use buffa::Message;
-        use wacore_binary::{JidExt, Server};
         use waproto::whatsapp as wa;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
-        let identity = device.public_key.public_key_bytes();
         let account_key = account.public_key.public_key_bytes();
-        let jids = [
-            Jid::pn_device("15550000001", 1),
-            Jid::lid_device("100000000000001", 1),
-            Jid::pn_device("15550000001", 99),
-            Jid::lid_device("100000000000001", 99),
-            Jid::new("15550000001", Server::Hosted).with_device(99),
-            Jid::new("100000000000001", Server::HostedLid).with_device(99),
-        ];
-        for jid in jids {
+        for (jid, hosted_device) in test_util::device_cases() {
             let bundle = PreKeyBundle::new(
                 1,
                 u32::from(jid.device).into(),
@@ -744,50 +735,29 @@ mod tests {
                 IdentityKey::new(device.public_key),
             )
             .unwrap();
-            for hosted_signer in [false, true] {
+            for device_type in test_util::ENCRYPTION_TYPES {
                 let details = wa::ADVDeviceIdentity {
                     key_index: Some(0),
-                    device_type: Some(if hosted_signer {
-                        wa::ADVEncryptionType::HOSTED
-                    } else {
-                        wa::ADVEncryptionType::E2EE
-                    }),
+                    device_type,
                     ..Default::default()
                 }
                 .encode_to_vec();
-                let acct_prefix: &[u8] = if hosted_signer { &[6, 5] } else { &[6, 0] };
+                let acct_prefix = test_util::account_prefix(device_type);
                 for include_account_key in [false, true] {
                     for correct_device_prefix in [false, true] {
-                        let dev_prefix: &[u8] = if jid.is_hosted() == correct_device_prefix {
+                        let dev_prefix: &[u8; 2] = if hosted_device == correct_device_prefix {
                             &[6, 6]
                         } else {
                             &[6, 1]
                         };
-                        let signed = wa::ADVSignedDeviceIdentity {
-                            details: Some(details.clone()),
-                            account_signature_key: include_account_key
-                                .then(|| account_key.to_vec()),
-                            account_signature: Some(
-                                account
-                                    .private_key
-                                    .calculate_signature(
-                                        &[acct_prefix, &details, identity].concat(),
-                                        &mut rng,
-                                    )
-                                    .unwrap()
-                                    .to_vec(),
-                            ),
-                            device_signature: Some(
-                                device
-                                    .private_key
-                                    .calculate_signature(
-                                        &[dev_prefix, &details, identity, account_key].concat(),
-                                        &mut rng,
-                                    )
-                                    .unwrap()
-                                    .to_vec(),
-                            ),
-                        };
+                        let signed = test_util::signed_identity(
+                            &account,
+                            &device,
+                            &details,
+                            acct_prefix,
+                            Some(dev_prefix),
+                            include_account_key,
+                        );
                         let user = PreKeyBundleUserNode::from_bundle(
                             jid.clone(),
                             &bundle,
@@ -808,7 +778,7 @@ mod tests {
                         assert_eq!(
                             outcome.bundles.contains_key(&jid),
                             correct_device_prefix,
-                            "jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}"
+                            "jid={jid} device_type={device_type:?} in_blob={include_account_key}"
                         );
                     }
                 }

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -370,6 +370,7 @@ impl PreKeyUtils {
                     di,
                     &identity_key_array,
                     account_identity,
+                    jid,
                 ) {
                     crate::adv::AdvValidation::Valid => {}
                     crate::adv::AdvValidation::Invalid => {
@@ -715,6 +716,107 @@ mod tests {
     }
 
     #[test]
+    fn prekey_fetch_validates_mixed_and_hosted_adv_chains() {
+        use buffa::Message;
+        use wacore_binary::{JidExt, Server};
+        use waproto::whatsapp as wa;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let identity = device.public_key.public_key_bytes();
+        let account_key = account.public_key.public_key_bytes();
+        let jids = [
+            Jid::pn_device("15550000001", 1),
+            Jid::lid_device("100000000000001", 1),
+            Jid::pn_device("15550000001", 99),
+            Jid::lid_device("100000000000001", 99),
+            Jid::new("15550000001", Server::Hosted).with_device(99),
+            Jid::new("100000000000001", Server::HostedLid).with_device(99),
+        ];
+        for jid in jids {
+            let bundle = PreKeyBundle::new(
+                1,
+                u32::from(jid.device).into(),
+                Some((1u32.into(), device.public_key)),
+                2u32.into(),
+                device.public_key,
+                vec![0; 64],
+                IdentityKey::new(device.public_key),
+            )
+            .unwrap();
+            for hosted_signer in [false, true] {
+                let details = wa::ADVDeviceIdentity {
+                    key_index: Some(0),
+                    device_type: Some(if hosted_signer {
+                        wa::ADVEncryptionType::HOSTED
+                    } else {
+                        wa::ADVEncryptionType::E2EE
+                    }),
+                    ..Default::default()
+                }
+                .encode_to_vec();
+                let acct_prefix: &[u8] = if hosted_signer { &[6, 5] } else { &[6, 0] };
+                for include_account_key in [false, true] {
+                    for correct_device_prefix in [false, true] {
+                        let dev_prefix: &[u8] = if jid.is_hosted() == correct_device_prefix {
+                            &[6, 6]
+                        } else {
+                            &[6, 1]
+                        };
+                        let signed = wa::ADVSignedDeviceIdentity {
+                            details: Some(details.clone()),
+                            account_signature_key: include_account_key
+                                .then(|| account_key.to_vec()),
+                            account_signature: Some(
+                                account
+                                    .private_key
+                                    .calculate_signature(
+                                        &[acct_prefix, &details, identity].concat(),
+                                        &mut rng,
+                                    )
+                                    .unwrap()
+                                    .to_vec(),
+                            ),
+                            device_signature: Some(
+                                device
+                                    .private_key
+                                    .calculate_signature(
+                                        &[dev_prefix, &details, identity, account_key].concat(),
+                                        &mut rng,
+                                    )
+                                    .unwrap()
+                                    .to_vec(),
+                            ),
+                        };
+                        let user = PreKeyBundleUserNode::from_bundle(
+                            jid.clone(),
+                            &bundle,
+                            Some(signed.encode_to_vec()),
+                        )
+                        .unwrap()
+                        .into_node();
+                        let response = NodeBuilder::new("iq")
+                            .children([NodeBuilder::new("list").children([user]).build()])
+                            .build();
+                        let fallbacks =
+                            HashMap::from([(jid.clone(), account_key.try_into().unwrap())]);
+                        let outcome = PreKeyUtils::parse_prekeys_response(
+                            &response.as_node_ref(),
+                            &fallbacks,
+                        )
+                        .unwrap();
+                        assert_eq!(
+                            outcome.bundles.contains_key(&jid),
+                            correct_device_prefix,
+                            "jid={jid} hosted_signer={hosted_signer} in_blob={include_account_key}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn parse_skips_companion_bundle_with_invalid_device_identity() {
         let companion = Jid::lid_device("100000012345678", 33);
         let bundles = parse_one(companion.clone(), Some(vec![0xDE, 0xAD, 0xBE, 0xEF]));
@@ -738,7 +840,7 @@ mod tests {
         // device-identity without account_signature_key, signatures over the
         // bundle's identity key (create_mock_bundle's identity is unrelated, but
         // the NoAccountKey path short-circuits before signature checks anyway).
-        let di = trimmed_device_identity(&account, &device, b"details");
+        let di = trimmed_device_identity(&account, &device, b"\x18\x01");
         let bundles = parse_one(companion.clone(), Some(di));
         assert!(
             bundles.contains_key(&companion),


### PR DESCRIPTION
## Summary

Pairing fails with `401 signature-mismatch` when the outer ADV HMAC account type and the signed inner device type disagree. The verifier also generates a hosted device signature for an ordinary companion when the outer account is hosted. Select the account signature prefix from the signed `device_type`, retain the outer `account_type` for HMAC authentication, and always generate the companion signature with `[6, 1]`.

Closes #1439.

## Protocol evidence

Audited the official WhatsApp Web cache for build `2.3000.1044770897` and verified the bundle contents against its SHA-256 manifest. `WAWebHandlePairSuccess` uses the outer `accountType` for the hosted HMAC prefix. `WAWebAdvSignatureApi.verifyDeviceIdentityAccountSignature` decodes the signed details and selects `[6, 5]` only for `deviceType === HOSTED`; `generateDeviceSignature` always uses `[6, 1]`. For fetched devices, account verification uses that same signed field, while device verification selects `[6, 6]` from the target JID's hosted status. These are independent decisions.

The corresponding bundle content hashes are `0f6e0a36d254f65f13e4824c4222535cb12746f6584ea9a6ef7c42502b5dfe05` and `e855464a86b395cabf4aa380540a5585565e6e32db1765227c4a3aac5e94a3c7`.

## Changes

- Share a typed account-signature message builder between pairing and ADV validation, and derive device-signature messages from it with an explicit companion/hosted kind. Preserve HMAC-before-decode ordering and the original signed bytes, including unknown protobuf fields; remove the pairing details clone and duplicate concatenation helper.
- Validate fetched device signatures against the target JID, covering mixed hosted-account/regular-device chains and hosted devices. Prekey responses and retry receipts now supply that context, and invalid chains are rejected before session installation.
- Reject missing pairing details, malformed ADV details and invalid signature lengths explicitly. Structural validation precedes `NoAccountKey`, so an empty or truncated signature cannot enter the best-effort fallback. Preserve fallback behavior for well-formed identities with omitted or empty account keys.
- Share signed fixtures, encryption-type cases and fictional JIDs through the existing `test-util` feature. The fixture oracle uses independent literals and concatenation, without calling production prefix or message builders. Replace opaque detail strings with valid synthetic protobufs, and encode the outer and inner types independently.

## Compatibility

`wacore::adv::validate_adv_with_identity_key` now requires the device JID as its fourth argument: `validate_adv_with_identity_key(bytes, identity_key, account_key_fallback, &device_jid)`. Both repository callers are migrated. The high-level pairing API is unchanged. Missing pairing details now report `500 internal-error`, and malformed ADV details or signature lengths are rejected even when no account key is available.

## Validation

- Reproduced both defects with failing cryptographic regressions before changing the relevant production code.
- Synthetic matrices cover independent outer/inner account types, device types, PN/LID and hosted addresses, omitted/empty account keys, correct and incorrect prefixes, tampered signatures/details/keys, and preservation of signed bytes.
- Prekey parsing and retry session installation have positive and negative integration coverage with real Signal cryptography.
- `cargo nextest run -p wacore -p whatsapp-rust --lib --no-fail-fast`: 3,520 passed, 3 skipped on the final full run. The unchanged `online_device_sync_releases_its_dedup_entry` test failed once under concurrent load, then passed both the focused rerun and the final full run.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo test -p wacore -p whatsapp-rust --doc`: 21 passed, 28 ignored.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

The informational Semver check reports the documented fourth argument, alongside existing baseline incompatibilities with the last published release.

All functional CI checks passed on `9ce8d1988`, including E2E, all-features, feature matrices, stable Rust, wasm, Miri, binary size and benchmarks. The sole failing check is the informational Semver report described above.

No live Business account pairing was attempted; the production occurrence's exact payload was not supplied.
