### PR TITLE
fix(handshake): preserve strict verification across public builders and helpers

### DIFF
--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -49,9 +49,13 @@ chain accepted under it is typed as nothing to persist (`XxHandshakeOutcome`
 carries `None`) and never authorizes IK (`select_pattern` stays at XX), so it
 is neither read from nor written to the trusted cache. The legacy
 `danger-skip-cert-chain-verify` feature only changes what the *default*
-policy is; an explicit `Strict` verifies regardless of it. `tests/e2e`
-enables the feature because the mock server does not sign its chain.
-**Production builds verify.** The `wacore/noise` integration tests in
+policy is; an explicit `Strict` verifies regardless of it, and the public
+`HandshakeUtils::verify_server_cert` helper always verifies strictly — it
+never consults the default, so with the feature its integration test still
+runs and still rejects the zero-signed fixture. `tests/e2e` passes the
+bypass per client at construction because the mock server does not sign its
+chain. **Default builds verify; only an explicit per-client bypass skips
+the signature checks.** The `wacore/noise` integration tests in
 `tests/cert_chain_verify.rs` load the crate as a regular dependency, so no
 in-crate test bypass can mask them.
 
@@ -72,8 +76,10 @@ Breaking note: `XxHandshakeOutcome.server_cert_chain` is now
 `Option<VerifiedServerCertChain>` (`None` for bypass-accepted chains), and
 `CachedServerCertChain` has the new `signature_verified` field (struct
 literals and the SQLite `ServerCertChain` wire message gain it; old rows
-decode as untrusted). Low-level constructors keep their signatures and take
-the default policy; `*_with_cert_policy` variants select explicitly.
+decode as untrusted). The low-level handshake constructors keep their
+signatures and take the default policy; `*_with_cert_policy` variants select
+explicitly. `HandshakeUtils::verify_server_cert` keeps its two-argument
+shape but always verifies strictly instead of taking the default.
 
 ## Logs
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -20,6 +20,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use thiserror::Error;
+use wacore::handshake::NoiseCertPolicy;
 use wacore::proto_helpers::MessageBuilderExt;
 use wacore::runtime::Runtime;
 use wacore::store::DevicePropsOverride;
@@ -719,6 +720,7 @@ pub struct BotBuilder<
     skip_history_sync: bool,
     ab_props_fetch: bool,
     presence_policy: PresencePolicy,
+    noise_cert_policy: NoiseCertPolicy,
     initial_push_name: Option<String>,
     cache_config: CacheConfig,
     wanted_pre_key_count: Option<usize>,
@@ -750,6 +752,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             skip_history_sync: false,
             ab_props_fetch: true,
             presence_policy: PresencePolicy::default(),
+            noise_cert_policy: NoiseCertPolicy::default(),
             initial_push_name: None,
             cache_config: CacheConfig::default(),
             wanted_pre_key_count: None,
@@ -785,6 +788,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             skip_history_sync: self.skip_history_sync,
             ab_props_fetch: self.ab_props_fetch,
             presence_policy: self.presence_policy,
+            noise_cert_policy: self.noise_cert_policy,
             initial_push_name: self.initial_push_name,
             cache_config: self.cache_config,
             wanted_pre_key_count: self.wanted_pre_key_count,
@@ -1404,6 +1408,16 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         self
     }
 
+    /// Select the Noise server-cert verification policy for handshakes made
+    /// by the built client. Defaults to strict; pass
+    /// [`NoiseCertPolicy::DangerSkipCertChainVerify`] only for testing
+    /// against a mock server that cannot sign its chain. Fixed at build
+    /// time and applied to every connect, including reconnects.
+    pub fn with_noise_cert_policy(mut self, policy: NoiseCertPolicy) -> Self {
+        self.noise_cert_policy = policy;
+        self
+    }
+
     /// Set how many one-time pre-keys are generated and uploaded per batch.
     ///
     /// Defaults to WA Web's UPLOAD_KEYS_COUNT (812). The value is clamped to the
@@ -1546,6 +1560,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             .with_transport_factory_arc(transport_factory)
             .with_http_client_arc(http_client)
             .with_cache_config(self.cache_config)
+            .with_noise_cert_policy(self.noise_cert_policy)
             .with_custom_enc_handlers(self.custom_enc_handlers)
             .with_skip_history_sync(self.skip_history_sync)
             .with_ab_props_fetch(self.ab_props_fetch)
@@ -1687,6 +1702,57 @@ mod tests {
             Some(&"installed")
         );
         bot.client().disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn bot_builder_noise_cert_policy_reaches_built_client() {
+        use wacore::handshake::NoiseCertPolicy;
+
+        let default_bot = Bot::builder()
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("default bot build");
+        assert_eq!(
+            default_bot.client().noise_cert_policy,
+            NoiseCertPolicy::default()
+        );
+        default_bot.client().disconnect().await;
+
+        let bypass_bot = Bot::builder()
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .with_noise_cert_policy(NoiseCertPolicy::DangerSkipCertChainVerify)
+            .build()
+            .await
+            .expect("bypass bot build");
+        assert_eq!(
+            bypass_bot.client().noise_cert_policy,
+            NoiseCertPolicy::DangerSkipCertChainVerify
+        );
+        bypass_bot.client().disconnect().await;
+
+        // Explicit Strict survives even when the legacy feature moves the
+        // default: the setter, not the build flag, decides.
+        let strict_bot = Bot::builder()
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .with_noise_cert_policy(NoiseCertPolicy::Strict)
+            .build()
+            .await
+            .expect("explicit strict bot build");
+        assert_eq!(
+            strict_bot.client().noise_cert_policy,
+            NoiseCertPolicy::Strict
+        );
+        strict_bot.client().disconnect().await;
     }
 
     fn pairing_code_event(code: &str) -> Arc<Event> {

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -524,36 +524,61 @@ mod tests {
         }
     }
 
-    fn paired_device() -> wacore::store::Device {
-        let mut device = wacore::store::Device::new();
-        device.pn = Some("12345@s.whatsapp.net".parse().unwrap());
-        device
+    async fn paired_pm() -> Arc<PersistenceManager> {
+        let pm = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        pm.process_command(DeviceCommand::SetId(Some(
+            "12345@s.whatsapp.net".parse().unwrap(),
+        )))
+        .await;
+        pm
     }
 
-    #[test]
-    fn select_pattern_no_cache_returns_xx() {
-        let device = paired_device();
+    async fn snapshot_with_chain(
+        pm: &PersistenceManager,
+        chain: CachedServerCertChain,
+    ) -> Arc<crate::store::Device> {
+        pm.process_command(DeviceCommand::SetServerCertChain(chain.clone()))
+            .await;
+        let snapshot = pm.get_device_snapshot();
+        assert_eq!(
+            snapshot.server_cert_chain.as_ref(),
+            Some(&chain),
+            "command-applied chain must be visible through the cached snapshot"
+        );
+        snapshot
+    }
+
+    #[tokio::test]
+    async fn select_pattern_no_cache_returns_xx() {
+        let pm = paired_pm().await;
+        let device = pm.get_device_snapshot();
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_with_valid_cache_returns_ik() {
-        let mut device = paired_device();
+    #[tokio::test]
+    async fn select_pattern_with_valid_cache_returns_ik() {
+        let pm = paired_pm().await;
         let pub_key = [0xAA; 32];
-        device.server_cert_chain = Some(cached_chain(pub_key, 1_900_000_000, 1_900_000_000));
+        let device =
+            snapshot_with_chain(&pm, cached_chain(pub_key, 1_900_000_000, 1_900_000_000)).await;
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Ik(pub_key)
         );
     }
 
-    #[test]
-    fn select_pattern_after_one_failure_returns_xx() {
-        let mut device = paired_device();
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000));
+    #[tokio::test]
+    async fn select_pattern_after_one_failure_returns_xx() {
+        let pm = paired_pm().await;
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000)).await;
         assert_eq!(
             select_pattern(
                 &device,
@@ -565,66 +590,72 @@ mod tests {
         );
     }
 
-    #[test]
-    fn select_pattern_with_expired_leaf_returns_xx() {
-        let mut device = paired_device();
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_700_000_500, 1_900_000_000));
+    #[tokio::test]
+    async fn select_pattern_with_expired_leaf_returns_xx() {
+        let pm = paired_pm().await;
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_700_000_500, 1_900_000_000)).await;
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_with_expired_intermediate_returns_xx() {
-        let mut device = paired_device();
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_900_000_000, 1_700_000_500));
+    #[tokio::test]
+    async fn select_pattern_with_expired_intermediate_returns_xx() {
+        let pm = paired_pm().await;
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_900_000_000, 1_700_000_500)).await;
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_with_clock_before_leaf_not_before_returns_xx() {
-        let mut device = paired_device();
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000));
+    #[tokio::test]
+    async fn select_pattern_with_clock_before_leaf_not_before_returns_xx() {
+        let pm = paired_pm().await;
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000)).await;
         assert_eq!(
             select_pattern(&device, 0, 1_699_999_999, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_with_clock_before_intermediate_not_before_returns_xx() {
-        let mut device = paired_device();
+    #[tokio::test]
+    async fn select_pattern_with_clock_before_intermediate_not_before_returns_xx() {
+        let pm = paired_pm().await;
         let mut chain = cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000);
         chain.intermediate.not_before = 1_800_000_001;
-        device.server_cert_chain = Some(chain);
+        let device = snapshot_with_chain(&pm, chain).await;
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_unregistered_device_returns_xx_even_with_valid_cache() {
-        let mut device = wacore::store::Device::new();
-        assert!(
-            !device.is_registered(),
-            "fresh Device::new() must be unpaired"
+    #[tokio::test]
+    async fn select_pattern_unregistered_device_returns_xx_even_with_valid_cache() {
+        let pm = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
         );
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000));
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000)).await;
+        assert!(!device.is_registered(), "fresh backend must be unpaired");
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
         );
     }
 
-    #[test]
-    fn select_pattern_bypass_ignores_valid_cache() {
-        let mut device = paired_device();
-        device.server_cert_chain = Some(cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000));
+    #[tokio::test]
+    async fn select_pattern_bypass_ignores_valid_cache() {
+        let pm = paired_pm().await;
+        let device =
+            snapshot_with_chain(&pm, cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000)).await;
         assert_eq!(
             select_pattern(
                 &device,
@@ -636,15 +667,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn select_pattern_unmarked_cache_returns_xx() {
+    #[tokio::test]
+    async fn select_pattern_unmarked_cache_returns_xx() {
         // Records predating signature provenance (including chains cached
         // while a global bypass was enabled) cannot authorize IK, even when
         // fresh and otherwise valid.
-        let mut device = paired_device();
+        let pm = paired_pm().await;
         let mut chain = cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000);
         chain.signature_verified = false;
-        device.server_cert_chain = Some(chain);
+        let device = snapshot_with_chain(&pm, chain).await;
         assert_eq!(
             select_pattern(&device, 0, 1_800_000_000, NoiseCertPolicy::Strict),
             HandshakePattern::Xx
@@ -675,9 +706,10 @@ mod tests {
         assert!(!should_persist_cert_chain(&device));
     }
 
-    #[test]
-    fn should_persist_cert_chain_registered_returns_true() {
-        let device = paired_device();
+    #[tokio::test]
+    async fn should_persist_cert_chain_registered_returns_true() {
+        let pm = paired_pm().await;
+        let device = pm.get_device_snapshot();
         assert!(device.is_registered());
         assert!(should_persist_cert_chain(&device));
     }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -21,7 +21,6 @@ uuid = { workspace = true, features = ["v4"] }
 wacore = { path = "../../wacore", features = ["test-util"] }
 wacore-binary = { path = "../../wacore/binary" }
 whatsapp-rust = { path = "../..", default-features = false, features = [
-    "danger-skip-cert-chain-verify",
     "danger-skip-tls-verify",
     "tokio-runtime",
     "tokio-native",

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -202,6 +202,11 @@ impl TestClient {
             .with_transport_factory(transport_factory)
             .with_http_client(UreqHttpClient::new())
             .with_runtime(whatsapp_rust::TokioRuntime)
+            // The mock server cannot sign its chain; scope the bypass to
+            // these test clients instead of a global feature.
+            .with_noise_cert_policy(
+                whatsapp_rust::handshake::NoiseCertPolicy::DangerSkipCertChainVerify,
+            )
             .with_version((2, 3000, 0));
 
         let push_name_pre_seeded = push_name.is_some();

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -137,12 +137,13 @@ pub struct VerifiedServerCertChain {
 /// Handshake utilities for WhatsApp protocol operations
 pub struct HandshakeUtils;
 
-/// What chain verification established. Only `Trusted` may flow into the
-/// handshake outcome that populates the IK cache; `Untrusted` still binds
-/// the leaf to the decrypted static, but its signatures were never checked.
+/// What chain verification established. Only `Trusted` carries a chain into
+/// the handshake outcome that populates the IK cache; `Untrusted` records
+/// that the leaf was structurally bound to the decrypted static without any
+/// signature check, with nothing to persist.
 enum ChainAcceptance {
     Trusted(VerifiedServerCertChain),
-    Untrusted(VerifiedServerCertChain),
+    Untrusted,
 }
 
 impl HandshakeUtils {
@@ -223,22 +224,21 @@ impl HandshakeUtils {
         ))
     }
 
-    /// Verifies the server's certificate chain. Legacy entrypoint: selects
-    /// `NoiseCertPolicy::default()`, so a build with the legacy
-    /// `danger-skip-cert-chain-verify` feature keeps its old behavior while
-    /// normal builds verify strictly. Prefer the `*_with_cert_policy`
-    /// constructors on the handshake states, which never promote a
-    /// bypass-accepted chain into the trusted outcome type.
+    /// Verifies the server's certificate chain, always strictly. The legacy
+    /// `danger-skip-cert-chain-verify` feature changes only what the
+    /// *default* policy is for the handshake-state constructors; it never
+    /// weakens this helper. Bypass remains available through the
+    /// `*_with_cert_policy` constructors, whose outcomes carry no trusted
+    /// chain instead of a differently-typed one.
     pub fn verify_server_cert(
         cert_decrypted: &[u8],
         static_decrypted: &[u8; 32],
     ) -> Result<VerifiedServerCertChain> {
-        match Self::verify_chain(cert_decrypted, static_decrypted, NoiseCertPolicy::default()) {
+        match Self::verify_chain(cert_decrypted, static_decrypted, NoiseCertPolicy::Strict) {
             Ok(ChainAcceptance::Trusted(chain)) => Ok(chain),
-            // Legacy behavior under the legacy feature's default: the chain
-            // is structurally sound and bound to the static, but its
-            // signatures were not checked.
-            Ok(ChainAcceptance::Untrusted(chain)) => Ok(chain),
+            Ok(ChainAcceptance::Untrusted) => Err(HandshakeError::CertVerification(
+                "chain accepted without signature checks cannot be verified".into(),
+            )),
             Err(err) => Err(err),
         }
     }
@@ -330,9 +330,11 @@ impl HandshakeUtils {
             leaf_not_before: leaf_details.not_before.unwrap_or(0) as i64,
             leaf_not_after: leaf_details.not_after.unwrap_or(0) as i64,
         };
-        // Only a policy that checked the signatures may hand out trust.
+        // Only a policy that checked the signatures may hand out trust; a
+        // bypassed chain authenticates this session and nothing else, so it
+        // carries no chain value at all.
         if cert_policy.skip_signature_check() {
-            Ok(ChainAcceptance::Untrusted(chain))
+            Ok(ChainAcceptance::Untrusted)
         } else {
             Ok(ChainAcceptance::Trusted(chain))
         }
@@ -576,7 +578,7 @@ fn finish_xx_outcome(
 ) -> Result<XxHandshakeOutcome> {
     let server_cert_chain = match cert_chain {
         Some(ChainAcceptance::Trusted(chain)) => Some(chain),
-        Some(ChainAcceptance::Untrusted(_)) => None,
+        Some(ChainAcceptance::Untrusted) => None,
         None => return Err(HandshakeError::IncompleteResponse),
     };
     let (write_cipher, read_cipher) = noise.finish()?;

--- a/wacore/noise/tests/cert_chain_verify.rs
+++ b/wacore/noise/tests/cert_chain_verify.rs
@@ -50,13 +50,10 @@ fn build_chain_with_issuer_serial(server_static_pub: &[u8; 32], issuer_serial: u
     chain.encode_to_vec()
 }
 
-// The legacy entrypoint selects the default policy, which is strict without
-// the legacy feature: the zero-signed chain must fail XEdDSA verify. (With
-// the feature the default selects the documented legacy bypass, so this
-// stays gated; explicit-Strict rejection under the feature is covered by
-// the `xx_handshake_with_strict_policy_rejects_zero_signed_chain` unit
-// test, run with the feature enabled.)
-#[cfg(not(feature = "danger-skip-cert-chain-verify"))]
+// The public helper always verifies strictly, even with the legacy feature
+// enabled: the zero-signed fixture must fail XEdDSA verify in every build.
+// Bypass remains available only through the explicit-policy handshake
+// constructors, whose outcomes carry no trusted chain.
 #[test]
 fn verify_server_cert_rejects_fixture_with_zero_signed_certs() {
     // The chain is structurally valid (right shape, leaf.key matches the
@@ -72,6 +69,30 @@ fn verify_server_cert_rejects_fixture_with_zero_signed_certs() {
     assert!(
         msg.contains("intermediate signature failed XEdDSA verify"),
         "expected an intermediate XEdDSA-verify failure, got: {msg}"
+    );
+}
+
+// Pins the reported bug: with the legacy feature the default policy selects
+// the bypass, yet the public helper must still reject the zero-signed chain
+// — it never consults the default, so no `VerifiedServerCertChain` exists
+// here that `From` could mark `signature_verified`.
+#[cfg(feature = "danger-skip-cert-chain-verify")]
+#[test]
+fn verify_server_cert_ignores_legacy_default_policy() {
+    use wacore_noise::NoiseCertPolicy;
+
+    assert_eq!(
+        NoiseCertPolicy::default(),
+        NoiseCertPolicy::DangerSkipCertChainVerify
+    );
+    let server_static_pub = [0xAAu8; 32];
+    let chain_bytes = build_zero_signed_chain(&server_static_pub);
+    let err = HandshakeUtils::verify_server_cert(&chain_bytes, &server_static_pub)
+        .expect_err("public helper must stay strict under the legacy feature");
+    assert!(
+        err.to_string()
+            .contains("intermediate signature failed XEdDSA verify"),
+        "expected an XEdDSA-verify failure, got: {err}"
     );
 }
 


### PR DESCRIPTION
The public certificate verifier could return an unchecked chain as `VerifiedServerCertChain` when the legacy bypass feature was enabled, allowing later conversion into a trusted IK cache. It now always verifies signatures; explicit bypass remains available through the policy-aware handshake constructors, which return no trusted chain.

`BotBuilder` now forwards the immutable certificate policy to its internal client builder, so one process can construct strict and test clients independently. The E2E harness selects its test policy at runtime and drops the global bypass feature. Handshake selection tests now configure state through persistence commands and read the resulting cached snapshot.

This follow-up addresses the three review findings from #1441. Existing verifier arguments remain unchanged; callers that used the legacy feature to weaken the standalone verifier must use the explicit policy-aware handshake API.

Validation: the complete source tree matches the tested `b75d108` tree; this commit reapplies that patch directly onto the merged #1441 base. Noise tests passed in both feature configurations (50 unit tests; 3 default and 4 legacy-feature integration tests), as did 10 handshake integration tests, 16 snapshot-based handshake tests, 1,586 wacore tests, 1,931 client tests, and 105 SQLite tests. Formatting, Clippy and E2E compilation passed. Independent checks also passed for the four public-verifier tests and the built-Bot policy test with the legacy feature enabled.

CI on this PR is pending. No live-service handshake or production-issuer-signed success fixture was tested locally. The existing informational semver report and the compatibility changes documented in #1441 are not suppressed by this patch.
