### PR TITLE
fix(handshake): clarify noise policy docs and drop duplicate test rationale

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1409,10 +1409,12 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     }
 
     /// Select the Noise server-cert verification policy for handshakes made
-    /// by the built client. Defaults to strict; pass
+    /// by the built client. Defaults to strict without the legacy
+    /// `danger-skip-cert-chain-verify` feature (explicit `Strict` always
+    /// verifies); pass
     /// [`NoiseCertPolicy::DangerSkipCertChainVerify`] only for testing
-    /// against a mock server that cannot sign its chain. Fixed at build
-    /// time and applied to every connect, including reconnects.
+    /// against a mock server that cannot produce a WhatsApp-rooted chain.
+    /// Fixed at build time and applied to every connect, including reconnects.
     pub fn with_noise_cert_policy(mut self, policy: NoiseCertPolicy) -> Self {
         self.noise_cert_policy = policy;
         self

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -309,10 +309,12 @@ impl ClientBuilder {
     }
 
     /// Select the Noise server-cert verification policy for handshakes made
-    /// by the built client. Defaults to strict; pass
+    /// by the built client. Defaults to strict without the legacy
+    /// `danger-skip-cert-chain-verify` feature (explicit `Strict` always
+    /// verifies); pass
     /// [`NoiseCertPolicy::DangerSkipCertChainVerify`] only for testing
-    /// against a mock server that cannot sign its chain. Fixed at build
-    /// time and applied to every connect, including reconnects.
+    /// against a mock server that cannot produce a WhatsApp-rooted chain.
+    /// Fixed at build time and applied to every connect, including reconnects.
     pub fn with_noise_cert_policy(mut self, policy: NoiseCertPolicy) -> Self {
         self.noise_cert_policy = policy;
         self

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -669,9 +669,6 @@ mod tests {
 
     #[tokio::test]
     async fn select_pattern_unmarked_cache_returns_xx() {
-        // Records predating signature provenance (including chains cached
-        // while a global bypass was enabled) cannot authorize IK, even when
-        // fresh and otherwise valid.
         let pm = paired_pm().await;
         let mut chain = cached_chain([0xAA; 32], 1_900_000_000, 1_900_000_000);
         chain.signature_verified = false;

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -23,7 +23,8 @@ pub const WA_CERT_PUB_KEY: [u8; 32] = [
 pub enum NoiseCertPolicy {
     /// Verify both XEdDSA signatures and reuse the trusted IK cache.
     Strict,
-    /// Testing-only opt-in for mock servers that cannot sign their chain.
+    /// Testing-only opt-in for mock servers that cannot produce a
+    /// WhatsApp-rooted chain.
     /// Skips the two XEdDSA signature checks and nothing else: framing,
     /// Noise crypto, structural checks and the leaf-to-static binding still
     /// run, and a chain accepted here is never read from or written to the


### PR DESCRIPTION
Follow-up to #1442 (remaining review thread on `src/handshake.rs`).

Scope (documentation-only, no runtime/code/type/test changes):
- `src/handshake.rs`: remove the duplicated 3-line rationale in `select_pattern_unmarked_cache_returns_xx`; the decision-point comment in `select_pattern` is unchanged and all test logic is preserved.
- `src/client/builder.rs`, `src/bot.rs`: qualify the default as strict without the legacy `danger-skip-cert-chain-verify` feature, note an explicit `Strict` always verifies, and reword the mock case to "cannot produce a WhatsApp-rooted chain".
- `wacore/noise/src/handshake.rs`: same mock-chain wording fix on `NoiseCertPolicy::DangerSkipCertChainVerify`.

Validation:
- `git diff --check` clean.
- `cargo fmt --check` clean.
- No tests run for comment/doc edits; CI workflow will run its normal checks.
