### PR TITLE
feat(handshake)!: remove danger-skip-cert-chain-verify cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,6 @@ tracing-pii = ["wacore/tracing-pii", "wacore-binary/tracing-pii"]
 # internals it measures. Never enable it in a shipping build.
 bench-harness = ["tokio-runtime", "tokio/rt-multi-thread"]
 danger-skip-tls-verify = ["whatsapp-rust-tokio-transport?/danger-skip-tls-verify"]
-danger-skip-cert-chain-verify = ["wacore/danger-skip-cert-chain-verify"]
 default = [
     "sqlite-storage",
     "tokio-transport",

--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -47,12 +47,11 @@ one process can disagree and no reconnect can observe a change. The explicit
 code against zero-signed fixtures — it skips only the two XEdDSA steps, and a
 chain accepted under it is typed as nothing to persist (`XxHandshakeOutcome`
 carries `None`) and never authorizes IK (`select_pattern` stays at XX), so it
-is neither read from nor written to the trusted cache. The legacy
-`danger-skip-cert-chain-verify` feature only changes what the *default*
-policy is; an explicit `Strict` verifies regardless of it, and the public
+is neither read from nor written to the trusted cache. There is no Cargo
+feature for this: migration is deleting the feature flag and choosing the
+explicit per-client policy only where a mock server needs it. The public
 `HandshakeUtils::verify_server_cert` helper always verifies strictly — it
-never consults the default, so with the feature its integration test still
-runs and still rejects the zero-signed fixture. `tests/e2e` passes the
+never consults the default. `tests/e2e` passes the
 bypass per client at construction because the mock server does not sign its
 chain. **Default builds verify; only an explicit per-client bypass skips
 the signature checks.** The `wacore/noise` integration tests in

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1409,8 +1409,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     }
 
     /// Select the Noise server-cert verification policy for handshakes made
-    /// by the built client. Defaults to strict without the legacy
-    /// `danger-skip-cert-chain-verify` feature (explicit `Strict` always
+    /// by the built client. Defaults to strict (explicit `Strict` always
     /// verifies); pass
     /// [`NoiseCertPolicy::DangerSkipCertChainVerify`] only for testing
     /// against a mock server that cannot produce a WhatsApp-rooted chain.
@@ -1739,8 +1738,8 @@ mod tests {
         );
         bypass_bot.client().disconnect().await;
 
-        // Explicit Strict survives even when the legacy feature moves the
-        // default: the setter, not the build flag, decides.
+        // Explicit Strict is distinct from the default only when the
+        // default changes: the setter, not a build flag, decides.
         let strict_bot = Bot::builder()
             .with_backend_arc(create_test_sqlite_backend().await)
             .with_transport_factory(TokioWebSocketTransportFactory::new())

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -309,8 +309,7 @@ impl ClientBuilder {
     }
 
     /// Select the Noise server-cert verification policy for handshakes made
-    /// by the built client. Defaults to strict without the legacy
-    /// `danger-skip-cert-chain-verify` feature (explicit `Strict` always
+    /// by the built client. Defaults to strict (explicit `Strict` always
     /// verifies); pass
     /// [`NoiseCertPolicy::DangerSkipCertChainVerify`] only for testing
     /// against a mock server that cannot produce a WhatsApp-rooted chain.
@@ -983,7 +982,6 @@ mod tests {
         assert_eq!(strict.noise_cert_policy, NoiseCertPolicy::default());
     }
 
-    #[cfg(not(feature = "danger-skip-cert-chain-verify"))]
     #[test]
     fn noise_cert_policy_default_is_strict() {
         assert_eq!(NoiseCertPolicy::default(), NoiseCertPolicy::Strict);

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -687,10 +687,7 @@ mod tests {
         assert!(NoiseCertPolicy::DangerSkipCertChainVerify.skip_signature_check());
     }
 
-    // Without the legacy feature the default policy is strict. (With the
-    // feature it selects the bypass, which is the documented legacy
-    // behavior for pre-policy entrypoints.)
-    #[cfg(not(feature = "danger-skip-cert-chain-verify"))]
+    // The default policy is strict.
     #[test]
     fn cert_policy_default_is_strict() {
         assert_eq!(NoiseCertPolicy::default(), NoiseCertPolicy::Strict);

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -30,9 +30,6 @@ tracing = ["dep:tracing"]
 metrics = ["dep:metrics"]
 # Render raw phone numbers in tracing fields instead of redacted tokens (debug only).
 tracing-pii = ["wacore-binary/tracing-pii"]
-# Disables XEdDSA verification of the server's Noise cert chain. Required
-# for the e2e mock server (self-signed certs). NEVER enable in prod.
-danger-skip-cert-chain-verify = ["wacore-noise/danger-skip-cert-chain-verify"]
 # Enable JS-based random number generation for wasm32 targets.
 # Activates getrandom's wasm_js backend so rand works in the browser.
 js = ["getrandom/wasm_js"]

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -15,10 +15,6 @@ crate-type = ["rlib"]
 # Exposes `wacore_noise::test_util` (cert-chain bytes builder, etc.) so
 # downstream crates can share fixtures with the unit tests in this crate.
 test-util = []
-# Skips XEdDSA signature verification of the server's Noise cert chain.
-# Required for the e2e mock server, which uses self-signed certs that
-# can't be verified against the real WA root key. NEVER enable in prod.
-danger-skip-cert-chain-verify = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -19,9 +19,10 @@ pub const WA_CERT_PUB_KEY: [u8; 32] = [
 /// two clients in one process can hold different policies and no in-flight
 /// reconnect can observe a change. Consulted only while setting up or
 /// verifying a handshake, never on the per-message path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NoiseCertPolicy {
     /// Verify both XEdDSA signatures and reuse the trusted IK cache.
+    #[default]
     Strict,
     /// Testing-only opt-in for mock servers that cannot produce a
     /// WhatsApp-rooted chain.
@@ -30,20 +31,6 @@ pub enum NoiseCertPolicy {
     /// run, and a chain accepted here is never read from or written to the
     /// trusted IK cache.
     DangerSkipCertChainVerify,
-}
-
-impl Default for NoiseCertPolicy {
-    fn default() -> Self {
-        // Sole place where the legacy feature still matters: legacy
-        // entrypoints (which predate the policy) select the default, so a
-        // build with the feature keeps its old behavior without any verifier
-        // consulting the feature behind an explicit Strict's back.
-        if cfg!(feature = "danger-skip-cert-chain-verify") {
-            NoiseCertPolicy::DangerSkipCertChainVerify
-        } else {
-            NoiseCertPolicy::Strict
-        }
-    }
 }
 
 impl NoiseCertPolicy {
@@ -225,12 +212,10 @@ impl HandshakeUtils {
         ))
     }
 
-    /// Verifies the server's certificate chain, always strictly. The legacy
-    /// `danger-skip-cert-chain-verify` feature changes only what the
-    /// *default* policy is for the handshake-state constructors; it never
-    /// weakens this helper. Bypass remains available through the
-    /// `*_with_cert_policy` constructors, whose outcomes carry no trusted
-    /// chain instead of a differently-typed one.
+    /// Verifies the server's certificate chain, always strictly. Bypass
+    /// remains available only through the `*_with_cert_policy`
+    /// constructors, whose outcomes carry no trusted chain instead of a
+    /// differently-typed one.
     pub fn verify_server_cert(
         cert_decrypted: &[u8],
         static_decrypted: &[u8; 32],
@@ -1145,9 +1130,8 @@ mod tests {
         let client_static = KeyPair::generate(&mut rand::rng());
         let payload = b"login-payload".to_vec();
 
-        // Explicit Strict: must reject even though this test compiles under
-        // cfg(test), and even with the legacy feature unified in. No build
-        // flag bypasses an explicit Strict.
+        // Explicit Strict: must reject. No build flag bypasses an explicit
+        // Strict.
         let mut state = XxHandshakeState::new_with_cert_policy(
             client_static.clone(),
             payload.clone(),

--- a/wacore/noise/tests/cert_chain_verify.rs
+++ b/wacore/noise/tests/cert_chain_verify.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the `HandshakeUtils::verify_server_cert` path.
-//! These load `wacore-noise` as a regular dependency, so the legacy
-//! `cfg(test)` bypass (removed) could never apply here; what runs is the
-//! real verify. The strict test below is additionally run with the legacy
-//! feature enabled to prove an explicit Strict rejects regardless.
+//! These load `wacore-noise` as a regular dependency and exercise the real
+//! verify: the public helper always verifies strictly, and the default
+//! policy is strict while the explicit per-handshake bypass still drives
+//! zero-signed fixtures.
 
 #![allow(clippy::disallowed_methods)]
 
@@ -50,10 +50,10 @@ fn build_chain_with_issuer_serial(server_static_pub: &[u8; 32], issuer_serial: u
     chain.encode_to_vec()
 }
 
-// The public helper always verifies strictly, even with the legacy feature
-// enabled: the zero-signed fixture must fail XEdDSA verify in every build.
-// Bypass remains available only through the explicit-policy handshake
-// constructors, whose outcomes carry no trusted chain.
+// The public helper always verifies strictly: the zero-signed fixture
+// must fail XEdDSA verify in every build. Bypass remains available only
+// through the explicit-policy handshake constructors, whose outcomes
+// carry no trusted chain.
 #[test]
 fn verify_server_cert_rejects_fixture_with_zero_signed_certs() {
     // The chain is structurally valid (right shape, leaf.key matches the
@@ -72,23 +72,19 @@ fn verify_server_cert_rejects_fixture_with_zero_signed_certs() {
     );
 }
 
-// Pins the reported bug: with the legacy feature the default policy selects
-// the bypass, yet the public helper must still reject the zero-signed chain
-// — it never consults the default, so no `VerifiedServerCertChain` exists
-// here that `From` could mark `signature_verified`.
-#[cfg(feature = "danger-skip-cert-chain-verify")]
+// The default policy is strict, yet the public helper must still reject
+// the zero-signed chain — it never consults the default, so no
+// `VerifiedServerCertChain` exists here that `From` could mark
+// `signature_verified`.
 #[test]
-fn verify_server_cert_ignores_legacy_default_policy() {
+fn verify_server_cert_default_is_strict_and_helper_stays_strict() {
     use wacore_noise::NoiseCertPolicy;
 
-    assert_eq!(
-        NoiseCertPolicy::default(),
-        NoiseCertPolicy::DangerSkipCertChainVerify
-    );
+    assert_eq!(NoiseCertPolicy::default(), NoiseCertPolicy::Strict);
     let server_static_pub = [0xAAu8; 32];
     let chain_bytes = build_zero_signed_chain(&server_static_pub);
     let err = HandshakeUtils::verify_server_cert(&chain_bytes, &server_static_pub)
-        .expect_err("public helper must stay strict under the legacy feature");
+        .expect_err("public helper must stay strict");
     assert!(
         err.to_string()
             .contains("intermediate signature failed XEdDSA verify"),
@@ -112,8 +108,7 @@ fn verify_server_cert_rejects_when_leaf_key_does_not_match_static() {
 
 #[test]
 fn verify_server_cert_rejects_unexpected_issuer_serial() {
-    // The issuer pin is structural and runs under every policy, so this
-    // holds with or without the legacy feature.
+    // The issuer pin is structural and runs under every policy.
     let server_static_pub = [0xAAu8; 32];
     let chain_bytes = build_chain_with_issuer_serial(&server_static_pub, 7);
     let err = HandshakeUtils::verify_server_cert(&chain_bytes, &server_static_pub)


### PR DESCRIPTION
Removes the `danger-skip-cert-chain-verify` Cargo feature from `whatsapp-rust`, `wacore`, and `wacore-noise`.

`NoiseCertPolicy::default()` is now unconditionally `Strict` via `#[default]`; the explicit per-client `DangerSkipCertChainVerify` runtime policy is unchanged and remains the only bypass (used by `tests/e2e` against the mock server). Migration: delete the feature flag; pass the runtime policy only where a mock server needs it.
