### PR TITLE
fix(benchmark): scope Noise bypass to explicit mock mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac 0.13.0",
+ "http",
  "itoa",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,9 +319,9 @@ name = "demo"
 # config tests a nextest target, so the default CI run executes them instead of
 # only compiling the example. `required-features` names what the example
 # actually needs to link (runtime, transport, HTTP client — all in `default`),
-# so `--no-default-features` builds still skip it. Compiling needs no insecure
-# TLS: `danger-skip-tls-verify` stays a runtime opt-in for talking to the
-# mock's own-root TLS chain, never a build requirement.
+# so `--no-default-features` builds still skip it. `danger-skip-tls-verify`
+# stays an opt-in Cargo feature for talking to the mock's own-root TLS chain,
+# never a build requirement.
 [[example]]
 name = "benchmark"
 test = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,10 @@ aes = { workspace = true }
 cbc = { workspace = true, features = ["block-padding"] }
 divan = { workspace = true }
 env_logger = { workspace = true }
+# URL parser for the benchmark example's mock admin endpoint derivation.
+# Dev-only so production builds carry no new dependency; already in the tree
+# via the Tokio transport, so this adds no new crate to compile.
+http = "1"
 # `total_listeners()` (how tests observe that a waiter parked) is std-gated.
 event-listener = { workspace = true, features = ["std"] }
 flate2 = { workspace = true }
@@ -311,9 +315,17 @@ workspace = true
 [[example]]
 name = "demo"
 
+# The mock-capable benchmark client. `test = true` makes its `#[cfg(test)]`
+# config tests a nextest target, so the default CI run executes them instead of
+# only compiling the example. `required-features` names what the example
+# actually needs to link (runtime, transport, HTTP client — all in `default`),
+# so `--no-default-features` builds still skip it. Compiling needs no insecure
+# TLS: `danger-skip-tls-verify` stays a runtime opt-in for talking to the
+# mock's own-root TLS chain, never a build requirement.
 [[example]]
 name = "benchmark"
-required-features = ["danger-skip-tls-verify"]
+test = true
+required-features = ["tokio-runtime", "tokio-transport", "ureq-client"]
 
 [[example]]
 name = "observability"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -11,14 +11,14 @@ use wacore::store::InMemoryBackend;
 use wacore::types::events::{Event, EventKind};
 use whatsapp_rust::TokioRuntime;
 use whatsapp_rust::bot::{Bot, MessageContext};
+use whatsapp_rust::handshake::NoiseCertPolicy;
 use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 use whatsapp_rust_ureq_http_client::UreqHttpClient;
 
 /// Derive the mock-server admin scan-qr endpoint from a `ws[s]://host:port/...`
 /// WebSocket URL. Same host/port, scheme `ws`→`http` / `wss`→`https`, path
 /// `/admin/mock-phone/scan-qr`. Mirrors `tests/e2e/src/lib.rs`. Returns `None`
-/// for URLs that don't match the ws scheme — the autoresponder would
-/// no-op on real WhatsApp anyway, but skipping the POST keeps logs clean.
+/// for URLs that don't match the ws scheme.
 fn mock_admin_scan_qr_url(ws_url: &str) -> Option<String> {
     let http_scheme = if ws_url.starts_with("wss://") {
         "https://"
@@ -30,6 +30,71 @@ fn mock_admin_scan_qr_url(ws_url: &str) -> Option<String> {
     let after_scheme = ws_url.split("://").nth(1)?;
     let host_port = after_scheme.split('/').next()?;
     Some(format!("{http_scheme}{host_port}/admin/mock-phone/scan-qr"))
+}
+
+/// Endpoint + Noise policy selection for this example.
+///
+/// - Default (neither var set): production default URL, `Strict`, no admin POST.
+/// - `WHATSAPP_WS_URL` set: custom/production URL, always `Strict`, never an
+///   admin POST. Wins over `MOCK_SERVER_URL` so a production override cannot
+///   inherit the mock bypass.
+/// - Only `MOCK_SERVER_URL` set: mock URL, `DangerSkipCertChainVerify`, admin
+///   POST derived from that URL. The mock cannot produce a WhatsApp-rooted
+///   chain, so the bypass is scoped to this explicitly selected mode.
+///
+/// No hostname guessing and no core-global policy: the bypass travels as a
+/// per-client builder value, exactly like `tests/e2e`.
+struct BenchmarkEndpoint {
+    ws_url: Option<String>,
+    cert_policy: NoiseCertPolicy,
+    admin_scan_url: Option<String>,
+    is_mock: bool,
+}
+
+fn resolve_benchmark_endpoint(
+    whatsapp_ws_url: Option<String>,
+    mock_server_url: Option<String>,
+) -> BenchmarkEndpoint {
+    let normalize = |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let whatsapp_ws_url = normalize(whatsapp_ws_url);
+    let mock_server_url = normalize(mock_server_url);
+    if let Some(url) = whatsapp_ws_url {
+        return BenchmarkEndpoint {
+            ws_url: Some(url),
+            cert_policy: NoiseCertPolicy::Strict,
+            admin_scan_url: None,
+            is_mock: false,
+        };
+    }
+    if let Some(url) = mock_server_url {
+        let admin_scan_url = mock_admin_scan_qr_url(&url);
+        return BenchmarkEndpoint {
+            ws_url: Some(url),
+            cert_policy: NoiseCertPolicy::DangerSkipCertChainVerify,
+            admin_scan_url,
+            is_mock: true,
+        };
+    }
+    BenchmarkEndpoint {
+        ws_url: None,
+        cert_policy: NoiseCertPolicy::Strict,
+        admin_scan_url: None,
+        is_mock: false,
+    }
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn resolve_benchmark_endpoint_from_env() -> BenchmarkEndpoint {
+    resolve_benchmark_endpoint(
+        non_empty_env("WHATSAPP_WS_URL"),
+        non_empty_env("MOCK_SERVER_URL"),
+    )
 }
 
 fn main() {
@@ -53,28 +118,27 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        // Accept either WHATSAPP_WS_URL or MOCK_SERVER_URL — the latter
-        // matches the convention the e2e suite uses.
-        let configured_ws_url = std::env::var("WHATSAPP_WS_URL")
-            .ok()
-            .or_else(|| std::env::var("MOCK_SERVER_URL").ok());
+        // Mock mode is explicit: MOCK_SERVER_URL only counts when
+        // WHATSAPP_WS_URL is unset. Build with
+        // `--features danger-skip-tls-verify` for the mock's self-signed TLS;
+        // the Noise bypass below is still per-client and mock-only.
+        let endpoint = resolve_benchmark_endpoint_from_env();
+        if endpoint.is_mock {
+            info!("Mock mode: Noise cert bypass scoped to this client");
+        }
         let mut transport_factory = TokioWebSocketTransportFactory::new();
-        if let Some(url) = configured_ws_url.as_ref() {
+        if let Some(url) = endpoint.ws_url.as_ref() {
             transport_factory = transport_factory.with_url(url.clone());
         }
-        // Pre-derive the admin scan-qr URL so the on_event closure can
-        // auto-pair against a mock server. None for real WhatsApp (or any
-        // non-ws URL) — the closure simply skips the POST in that case.
-        let admin_scan_url = configured_ws_url
-            .as_deref()
-            .and_then(mock_admin_scan_qr_url);
+        let admin_scan_url = endpoint.admin_scan_url.clone();
         let http_client = UreqHttpClient::new();
 
         let builder = Bot::builder()
             .with_backend(InMemoryBackend::new())
             .with_transport_factory(transport_factory)
             .with_http_client(http_client)
-            .with_runtime(TokioRuntime);
+            .with_runtime(TokioRuntime)
+            .with_noise_cert_policy(endpoint.cert_policy);
 
         let bot = builder
             .on_event_for(
@@ -105,10 +169,9 @@ fn main() {
                             Event::PairingQrCode(qr) => {
                                 let code = &qr.code;
                                 // Mirrors tests/e2e/src/lib.rs::spawn_qr_autoresponder_http.
-                                // Auto-pair against the mock server's admin endpoint
-                                // when the configured WS URL looks like a mock
-                                // server; real WhatsApp connections fall back to
-                                // manual scan via the printed code below.
+                                // Auto-pair only in explicit mock mode (MOCK_SERVER_URL
+                                // without WHATSAPP_WS_URL); production and custom URLs
+                                // fall back to manual scan via the printed code below.
                                 if let Some(url) = admin_scan_url.as_ref() {
                                     let http = UreqHttpClient::new();
                                     let req = HttpRequest {
@@ -153,4 +216,89 @@ fn main() {
 
         bot.run().await;
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_strict_with_no_admin_post() {
+        let endpoint = resolve_benchmark_endpoint(None, None);
+        assert!(!endpoint.is_mock);
+        assert_eq!(endpoint.cert_policy, NoiseCertPolicy::Strict);
+        assert!(endpoint.ws_url.is_none());
+        assert!(endpoint.admin_scan_url.is_none());
+    }
+
+    #[test]
+    fn production_override_stays_strict_without_admin_post() {
+        let endpoint =
+            resolve_benchmark_endpoint(Some("wss://example.invalid/ws/chat".to_string()), None);
+        assert!(!endpoint.is_mock);
+        assert_eq!(endpoint.cert_policy, NoiseCertPolicy::Strict);
+        assert_eq!(
+            endpoint.ws_url.as_deref(),
+            Some("wss://example.invalid/ws/chat")
+        );
+        assert!(endpoint.admin_scan_url.is_none());
+    }
+
+    #[test]
+    fn mock_selection_gets_bypass_and_admin_post() {
+        let endpoint =
+            resolve_benchmark_endpoint(None, Some("wss://127.0.0.1:8080/ws/chat".to_string()));
+        assert!(endpoint.is_mock);
+        assert_eq!(
+            endpoint.cert_policy,
+            NoiseCertPolicy::DangerSkipCertChainVerify
+        );
+        assert_eq!(
+            endpoint.ws_url.as_deref(),
+            Some("wss://127.0.0.1:8080/ws/chat")
+        );
+        assert_eq!(
+            endpoint.admin_scan_url.as_deref(),
+            Some("https://127.0.0.1:8080/admin/mock-phone/scan-qr")
+        );
+    }
+
+    #[test]
+    fn production_override_wins_over_mock() {
+        let endpoint = resolve_benchmark_endpoint(
+            Some("wss://example.invalid/ws/chat".to_string()),
+            Some("wss://127.0.0.1:8080/ws/chat".to_string()),
+        );
+        assert!(!endpoint.is_mock);
+        assert_eq!(endpoint.cert_policy, NoiseCertPolicy::Strict);
+        assert_eq!(
+            endpoint.ws_url.as_deref(),
+            Some("wss://example.invalid/ws/chat")
+        );
+        assert!(
+            endpoint.admin_scan_url.is_none(),
+            "a production override must never inherit the mock admin POST"
+        );
+    }
+
+    #[test]
+    fn blank_values_count_as_unset() {
+        let endpoint = resolve_benchmark_endpoint(Some("  ".to_string()), Some("".to_string()));
+        assert!(!endpoint.is_mock);
+        assert_eq!(endpoint.cert_policy, NoiseCertPolicy::Strict);
+        assert!(endpoint.ws_url.is_none());
+    }
+
+    #[test]
+    fn admin_url_scheme_mapping() {
+        assert_eq!(
+            mock_admin_scan_qr_url("wss://127.0.0.1:8080/ws/chat").as_deref(),
+            Some("https://127.0.0.1:8080/admin/mock-phone/scan-qr")
+        );
+        assert_eq!(
+            mock_admin_scan_qr_url("ws://127.0.0.1:8080/ws/chat").as_deref(),
+            Some("http://127.0.0.1:8080/admin/mock-phone/scan-qr")
+        );
+        assert!(mock_admin_scan_qr_url("https://127.0.0.1:8080/ws/chat").is_none());
+    }
 }

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -22,8 +22,6 @@ use whatsapp_rust_ureq_http_client::UreqHttpClient;
 /// `tests/e2e/src/lib.rs`. Returns `None` for URLs without a ws scheme or
 /// without an authority.
 fn mock_admin_scan_qr_url(ws_url: &str) -> Option<String> {
-    // Fragments are client-side only and never reach the wire; strip one up
-    // front so the parser below sees only what an HTTP request would carry.
     let ws_url = ws_url.split('#').next()?;
     let uri: http::Uri = ws_url.parse().ok()?;
     let http_scheme = match uri.scheme_str() {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -16,20 +16,28 @@ use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 use whatsapp_rust_ureq_http_client::UreqHttpClient;
 
 /// Derive the mock-server admin scan-qr endpoint from a `ws[s]://host:port/...`
-/// WebSocket URL. Same host/port, scheme `ws`→`http` / `wss`→`https`, path
-/// `/admin/mock-phone/scan-qr`. Mirrors `tests/e2e/src/lib.rs`. Returns `None`
-/// for URLs that don't match the ws scheme.
+/// WebSocket URL. Changes only the scheme (`ws`→`http` / `wss`→`https`) and the
+/// path (`/admin/mock-phone/scan-qr`); host, port and query carry over, and any
+/// fragment is dropped (fragments are never sent over HTTP). Mirrors
+/// `tests/e2e/src/lib.rs`. Returns `None` for URLs without a ws scheme or
+/// without an authority.
 fn mock_admin_scan_qr_url(ws_url: &str) -> Option<String> {
-    let http_scheme = if ws_url.starts_with("wss://") {
-        "https://"
-    } else if ws_url.starts_with("ws://") {
-        "http://"
-    } else {
-        return None;
+    // Fragments are client-side only and never reach the wire; strip one up
+    // front so the parser below sees only what an HTTP request would carry.
+    let ws_url = ws_url.split('#').next()?;
+    let uri: http::Uri = ws_url.parse().ok()?;
+    let http_scheme = match uri.scheme_str() {
+        Some("ws") => "http",
+        Some("wss") => "https",
+        _ => return None,
     };
-    let after_scheme = ws_url.split("://").nth(1)?;
-    let host_port = after_scheme.split('/').next()?;
-    Some(format!("{http_scheme}{host_port}/admin/mock-phone/scan-qr"))
+    let authority = uri.authority()?;
+    let mut admin = format!("{http_scheme}://{authority}/admin/mock-phone/scan-qr");
+    if let Some(query) = uri.query() {
+        admin.push('?');
+        admin.push_str(query);
+    }
+    Some(admin)
 }
 
 /// Endpoint + Noise policy selection for this example.
@@ -118,10 +126,8 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        // Mock mode is explicit: MOCK_SERVER_URL only counts when
-        // WHATSAPP_WS_URL is unset. Build with
-        // `--features danger-skip-tls-verify` for the mock's self-signed TLS;
-        // the Noise bypass below is still per-client and mock-only.
+        // `--features danger-skip-tls-verify` is needed only to talk to the
+        // mock's own-root TLS chain.
         let endpoint = resolve_benchmark_endpoint_from_env();
         if endpoint.is_mock {
             info!("Mock mode: Noise cert bypass scoped to this client");
@@ -169,9 +175,7 @@ fn main() {
                             Event::PairingQrCode(qr) => {
                                 let code = &qr.code;
                                 // Mirrors tests/e2e/src/lib.rs::spawn_qr_autoresponder_http.
-                                // Auto-pair only in explicit mock mode (MOCK_SERVER_URL
-                                // without WHATSAPP_WS_URL); production and custom URLs
-                                // fall back to manual scan via the printed code below.
+                                // Set only in mock mode; otherwise manual scan below.
                                 if let Some(url) = admin_scan_url.as_ref() {
                                     let http = UreqHttpClient::new();
                                     let req = HttpRequest {
@@ -299,6 +303,37 @@ mod tests {
             mock_admin_scan_qr_url("ws://127.0.0.1:8080/ws/chat").as_deref(),
             Some("http://127.0.0.1:8080/admin/mock-phone/scan-qr")
         );
-        assert!(mock_admin_scan_qr_url("https://127.0.0.1:8080/ws/chat").is_none());
+        for non_ws in [
+            "https://127.0.0.1:8080/ws/chat",
+            "http://127.0.0.1:8080/ws/chat",
+            "ftp://127.0.0.1:8080/ws/chat",
+            "not a url",
+            "wss://",
+        ] {
+            assert!(
+                mock_admin_scan_qr_url(non_ws).is_none(),
+                "{non_ws:?} must not yield an admin URL"
+            );
+        }
+    }
+
+    #[test]
+    fn admin_url_preserves_query_and_drops_fragment() {
+        assert_eq!(
+            mock_admin_scan_qr_url("wss://127.0.0.1:8080?session=1").as_deref(),
+            Some("https://127.0.0.1:8080/admin/mock-phone/scan-qr?session=1")
+        );
+        assert_eq!(
+            mock_admin_scan_qr_url("wss://127.0.0.1:8080/ws/chat#frag").as_deref(),
+            Some("https://127.0.0.1:8080/admin/mock-phone/scan-qr")
+        );
+    }
+
+    #[test]
+    fn admin_url_handles_ipv6_authority() {
+        assert_eq!(
+            mock_admin_scan_qr_url("wss://[::1]:8080/ws/chat").as_deref(),
+            Some("https://[::1]:8080/admin/mock-phone/scan-qr")
+        );
     }
 }


### PR DESCRIPTION
Example-only follow-up to #1444.

benchmark.rs used MOCK_SERVER_URL without a runtime Noise policy, so mock runs failed Strict verification. Mock mode is now explicit: MOCK_SERVER_URL applies only when WHATSAPP_WS_URL is unset, selecting per-client DangerSkipCertChainVerify; WHATSAPP_WS_URL and defaults stay Strict. Mock admin auto-QR POST follows the same mode, so production URLs never receive it.

Evidence: 6 example config tests pass; wacore-noise Strict-rejects-zero-signed test passes; mock smoke shows XX handshake, auto-pair, and connected.