### PR TITLE
Add post-commit durability barriers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "scheduled-thread-pool",
  "serde_json",
  "sha2",
+ "thiserror 2.0.20",
  "tokio",
  "wacore",
 ]

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -32,6 +32,7 @@ log = { workspace = true }
 scheduled-thread-pool = "0.2"
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
+thiserror = { workspace = true }
 wacore = { workspace = true }
 
 [build-dependencies]

--- a/storages/sqlite-storage/src/lib.rs
+++ b/storages/sqlite-storage/src/lib.rs
@@ -11,7 +11,10 @@ pub(crate) mod upsert_queries;
 mod wire;
 
 pub use shared::SharedSqlite;
-pub use sqlite_store::{ConnectionInitHook, SqliteStore, SqliteStoreConfig, Synchronous};
+pub use sqlite_store::{
+    CommitBarrierError, CommitBarrierFuture, CommitBarrierHook, ConnectionInitHook, SqliteStore,
+    SqliteStoreConfig, Synchronous,
+};
 
 #[cfg(feature = "test-util")]
 #[doc(hidden)]

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -353,6 +353,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn canceling_blocking_write_keeps_permit_until_worker_finishes() {
+        use tokio::sync::oneshot;
+
+        let store = create_test_store("cancel_blocking_write").await;
+        let shared = store.shared();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let first = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(move |conn| {
+                        diesel::sql_query("CREATE TABLE canceled_data (value TEXT)")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        let _ = started_tx.send(());
+                        release_rx
+                            .blocking_recv()
+                            .map_err(|_| StoreError::Validation("write release dropped".into()))?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        started_rx.await.expect("blocking write started");
+        first.abort();
+        assert!(first.await.is_err(), "canceled write must not complete");
+
+        let mut second = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(|conn| {
+                        diesel::sql_query(
+                            "INSERT INTO canceled_data (value) VALUES ('after-cancel')",
+                        )
+                        .execute(conn)
+                        .map_err(db_err)?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut second)
+                .await
+                .is_err(),
+            "the canceled worker must retain the write permit"
+        );
+        release_tx.send(()).expect("release blocking write");
+        second.await.expect("second join").expect("second write");
+    }
+
+    #[tokio::test]
     async fn signal_batch_surfaces_barrier_error() {
         use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
         use bytes::Bytes;

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -380,8 +380,13 @@ mod tests {
         started_rx.await.expect("blocking write started");
         first.abort();
         assert!(first.await.is_err(), "canceled write must not complete");
+        assert_eq!(
+            shared.semaphore.available_permits(),
+            0,
+            "the canceled worker must retain the write permit"
+        );
 
-        let mut second = tokio::spawn({
+        let second = tokio::spawn({
             let shared = shared.clone();
             async move {
                 shared
@@ -396,11 +401,10 @@ mod tests {
                     .await
             }
         });
+        tokio::task::yield_now().await;
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(25), &mut second)
-                .await
-                .is_err(),
-            "the canceled worker must retain the write permit"
+            !second.is_finished(),
+            "the second write must await the permit"
         );
         release_tx.send(()).expect("release blocking write");
         second.await.expect("second join").expect("second write");

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -401,11 +401,6 @@ mod tests {
                     .await
             }
         });
-        tokio::task::yield_now().await;
-        assert!(
-            !second.is_finished(),
-            "the second write must await the permit"
-        );
         release_tx.send(()).expect("release blocking write");
         second.await.expect("second join").expect("second write");
     }

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -9,7 +9,7 @@ use diesel::sqlite::SqliteConnection;
 use std::sync::Arc;
 use wacore::store::error::{Result, StoreError};
 
-use crate::sqlite_store::{SqlitePool, SqliteStore};
+use crate::sqlite_store::{CommitBarrierHook, SqlitePool, SqliteStore, commit_barrier_error};
 
 /// Clonable handle onto a [`SqliteStore`]'s connection pool and serialization
 /// semaphore. Obtained via [`SqliteStore::shared`]. Holding one does not keep any
@@ -19,6 +19,7 @@ pub struct SharedSqlite {
     pool: SqlitePool,
     semaphore: Arc<tokio::sync::Semaphore>,
     reads: Option<crate::sqlite_store::ReadPool>,
+    commit_barrier: Option<CommitBarrierHook>,
 }
 
 impl SharedSqlite {
@@ -35,7 +36,13 @@ impl SharedSqlite {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        Self::run_on(self.pool.clone(), Arc::clone(&self.semaphore), f).await
+        Self::run_on(
+            self.pool.clone(),
+            Arc::clone(&self.semaphore),
+            self.commit_barrier.clone(),
+            f,
+        )
+        .await
     }
 
     /// Run a **read-only** `f` without queueing behind the write permit.
@@ -71,12 +78,13 @@ impl SharedSqlite {
             Some(reads) => (reads.pool.clone(), Arc::clone(&reads.semaphore)),
             None => (self.pool.clone(), Arc::clone(&self.semaphore)),
         };
-        Self::run_on(pool, semaphore, move |conn| read_snapshot(conn, f)).await
+        Self::run_on(pool, semaphore, None, move |conn| read_snapshot(conn, f)).await
     }
 
     async fn run_on<F, T>(
         pool: SqlitePool,
         semaphore: Arc<tokio::sync::Semaphore>,
+        commit_barrier: Option<CommitBarrierHook>,
         f: F,
     ) -> Result<T>
     where
@@ -87,15 +95,21 @@ impl SharedSqlite {
             .acquire_owned()
             .await
             .map_err(|e| StoreError::Database(Box::new(e)))?;
-        crate::pool::spawn_blocking(move || {
-            let _permit = permit;
+        let result = crate::pool::spawn_blocking(move || -> Result<(T, _)> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            f(&mut conn)
+            let result = f(&mut conn)?;
+            Ok((result, permit))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        let (result, permit) = result;
+        if let Some(barrier) = commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
+        drop(permit);
+        Ok(result)
     }
 }
 
@@ -135,6 +149,7 @@ impl SqliteStore {
             pool: self.pool.clone(),
             semaphore: self.db_semaphore.clone(),
             reads: self.reads.clone(),
+            commit_barrier: self.commit_barrier.clone(),
         }
     }
 }
@@ -142,6 +157,7 @@ impl SqliteStore {
 #[cfg(test)]
 mod tests {
     use diesel::prelude::*;
+    use std::sync::Arc;
 
     use crate::sqlite_store::SqliteStore;
     use wacore::store::error::StoreError;
@@ -203,6 +219,197 @@ mod tests {
             .expect("read through cloned handle");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].v, "b");
+    }
+
+    #[tokio::test]
+    async fn shared_write_awaits_barrier_but_read_does_not() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_hook = Arc::clone(&calls);
+        let barrier: CommitBarrierHook = Arc::new(move || {
+            calls_for_hook.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async { Ok::<(), StoreError>(()) })
+        });
+        let store = SqliteStore::with_config(
+            &unique_db_name("barrier"),
+            SqliteStoreConfig::default().with_commit_barrier(barrier),
+        )
+        .await
+        .expect("barrier store");
+        let shared = store.shared();
+        shared
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE barrier_data (value TEXT)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("write");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+        shared
+            .read(|conn| {
+                diesel::sql_query("SELECT count(*) FROM barrier_data")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("read");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn a_constructor_barrier_failure_rejects_the_store() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+
+        let barrier: CommitBarrierHook = Arc::new(|| {
+            Box::pin(async { Err(StoreError::Validation("commit barrier failed".into())) })
+        });
+        let result = SqliteStore::with_config(
+            &unique_db_name("barrier_error"),
+            SqliteStoreConfig::default().with_commit_barrier(barrier),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "constructor must propagate barrier failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pending_barrier_holds_the_write_permit() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::{Notify, Semaphore};
+
+        let entered = Arc::new(Notify::new());
+        let permits = Arc::new(Semaphore::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let hook: CommitBarrierHook = {
+            let entered = Arc::clone(&entered);
+            let permits = Arc::clone(&permits);
+            let calls = Arc::clone(&calls);
+            Arc::new(move || {
+                entered.notify_one();
+                calls.fetch_add(1, Ordering::Relaxed);
+                let permits = Arc::clone(&permits);
+                Box::pin(async move {
+                    permits
+                        .acquire()
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| StoreError::Database(Box::new(e)))
+                })
+            })
+        };
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("barrier_pending"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        store.commit_barrier = Some(hook);
+        let shared = store.shared();
+        let first = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(|conn| {
+                        diesel::sql_query("CREATE TABLE pending_data (value TEXT)")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        entered.notified().await;
+        let mut second = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(|conn| {
+                        diesel::sql_query("INSERT INTO pending_data (value) VALUES ('later')")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut second)
+                .await
+                .is_err()
+        );
+        first.abort();
+        assert!(first.await.is_err(), "canceled write must not complete");
+        permits.add_permits(1);
+        entered.notified().await;
+        permits.add_permits(1);
+        second.await.expect("second join").expect("second write");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn signal_batch_surfaces_barrier_error() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use bytes::Bytes;
+        use wacore::store::traits::SignalStore;
+
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("signal_barrier_error"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        let barrier: CommitBarrierHook =
+            Arc::new(|| Box::pin(async { Err(StoreError::Validation("IDB quota".into())) }));
+        store.commit_barrier = Some(barrier);
+        let result = store
+            .put_sessions_batch(&[(Arc::from("alice.1"), Bytes::from_static(b"state"))])
+            .await;
+        let error = result.expect_err("Signal writes must fail closed on barrier error");
+        let source = std::error::Error::source(&error).expect("barrier source");
+        assert!(
+            source
+                .downcast_ref::<crate::sqlite_store::CommitBarrierError>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_write_surfaces_typed_barrier_error() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("shared_barrier_error"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        let barrier: CommitBarrierHook =
+            Arc::new(|| Box::pin(async { Err(StoreError::Validation("IDB quota".into())) }));
+        store.commit_barrier = Some(barrier);
+        let error = store
+            .shared()
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE shared_barrier_data (value TEXT)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect_err("shared write must fail closed");
+        let source = std::error::Error::source(&error).expect("barrier source");
+        assert!(
+            source
+                .downcast_ref::<crate::sqlite_store::CommitBarrierError>()
+                .is_some()
+        );
     }
 
     /// A file-backed store, since reader connections need real WAL and an

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -9,7 +9,7 @@ use diesel::sqlite::SqliteConnection;
 use std::sync::Arc;
 use wacore::store::error::{Result, StoreError};
 
-use crate::sqlite_store::{CommitBarrierHook, SqlitePool, SqliteStore, commit_barrier_error};
+use crate::sqlite_store::{CommitBarrierHook, SqlitePool, SqliteStore, await_barrier_hook};
 
 /// Clonable handle onto a [`SqliteStore`]'s connection pool and serialization
 /// semaphore. Obtained via [`SqliteStore::shared`]. Holding one does not keep any
@@ -105,9 +105,7 @@ impl SharedSqlite {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
         let (result, permit) = result;
-        if let Some(barrier) = commit_barrier {
-            barrier().await.map_err(commit_barrier_error)?;
-        }
+        await_barrier_hook(&commit_barrier).await?;
         drop(permit);
         Ok(result)
     }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -8,8 +8,11 @@ use diesel::sqlite::SqliteConnection;
 use diesel::upsert::excluded;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use log::warn;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+use thiserror::Error;
 use wacore::appstate::hash::HashState;
 use wacore::appstate::processor::AppStateMutationMAC;
 use wacore::libsignal::protocol::{KeyPair, PrivateKey, PublicKey};
@@ -270,6 +273,7 @@ pub struct SqliteStore {
     /// `SQLITE_LOCKED_SHAREDCACHE`, which `busy_timeout` cannot absorb.
     pub(crate) snapshot_safe: bool,
     pub(crate) database_path: String,
+    pub(crate) commit_barrier: Option<CommitBarrierHook>,
     device_id: i32,
 }
 
@@ -308,6 +312,29 @@ pub type ConnectionInitHook = Arc<
         + Send
         + Sync,
 >;
+
+#[cfg(target_family = "wasm")]
+pub type CommitBarrierFuture = Pin<Box<dyn Future<Output = Result<()>> + 'static>>;
+
+#[cfg(not(target_family = "wasm"))]
+pub type CommitBarrierFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>;
+
+#[cfg(target_family = "wasm")]
+pub type CommitBarrierHook = Arc<dyn Fn() -> CommitBarrierFuture + Send + Sync + 'static>;
+
+/// A write reached SQLite's commit boundary, but its backing durability hook
+/// failed afterwards. Callers must treat the SQL mutation as committed in the
+/// live connection while retaining any retry state needed by the backend.
+#[derive(Debug, Error)]
+#[error("post-commit durability barrier failed")]
+pub struct CommitBarrierError(#[source] pub StoreError);
+
+pub(crate) fn commit_barrier_error(error: StoreError) -> StoreError {
+    StoreError::Database(Box::new(CommitBarrierError(error)))
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub type CommitBarrierHook = Arc<dyn Fn() -> CommitBarrierFuture + Send + Sync + 'static>;
 
 /// Per-store connection tuning. [`Default`] is a low-memory profile sized for one
 /// `SqliteStore` per WhatsApp session on a single process: a single pooled connection
@@ -402,6 +429,11 @@ pub struct SqliteStoreConfig {
     /// pragmas, WAL setup, and migrations. See [`ConnectionInitHook`] for the contract;
     /// set via [`SqliteStoreConfig::with_connection_init`].
     pub connection_init: Option<ConnectionInitHook>,
+    /// Optional awaitable called after each successful SQLite write commit.
+    /// Readers never call it. The callback runs while the write permit is held
+    /// and must not re-enter this store or a [`SharedSqlite`](crate::SharedSqlite)
+    /// handle, which would wait for the permit it already owns.
+    pub commit_barrier: Option<CommitBarrierHook>,
 }
 
 impl Default for SqliteStoreConfig {
@@ -420,6 +452,7 @@ impl Default for SqliteStoreConfig {
             synchronous: Synchronous::Normal,
             thread_pool: None,
             connection_init: None,
+            commit_barrier: None,
         }
     }
 }
@@ -472,6 +505,13 @@ impl SqliteStoreConfig {
             + 'static,
     {
         self.connection_init = Some(Arc::new(hook));
+        self
+    }
+
+    /// Install an awaitable that confirms a write reached the configured
+    /// backend before the write operation returns.
+    pub fn with_commit_barrier(mut self, barrier: CommitBarrierHook) -> Self {
+        self.commit_barrier = Some(barrier);
         self
     }
 }
@@ -715,6 +755,7 @@ impl SqliteStore {
         // Left as the `Option` the embedder gave; `pool::builder` resolves it.
         let thread_pool = config.thread_pool;
         let read_thread_pool = thread_pool.clone();
+        let commit_barrier = config.commit_barrier.clone();
 
         let options = ConnectionOptions {
             cache_size_kib: config.cache_size_kib,
@@ -780,6 +821,9 @@ impl SqliteStore {
         )
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        if let Some(barrier) = commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
 
         // Reader connections only pay off under WAL, and only with a page cache
         // per connection. Each of the two ways that can fail turns the intended
@@ -840,6 +884,7 @@ impl SqliteStore {
             reads,
             snapshot_safe: declined.is_none(),
             database_path,
+            commit_barrier: config.commit_barrier,
             device_id,
         })
     }
@@ -914,6 +959,7 @@ impl SqliteStore {
             reads: self.reads.clone(),
             snapshot_safe: self.snapshot_safe,
             database_path: self.database_path.clone(),
+            commit_barrier: self.commit_barrier.clone(),
             device_id,
         }
     }
@@ -1012,10 +1058,42 @@ impl SqliteStore {
         Ok(result)
     }
 
+    async fn await_commit_barrier(&self) -> Result<()> {
+        if let Some(barrier) = &self.commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
+        Ok(())
+    }
+
     /// Execute a database operation with semaphore serialization and retry on
     /// transient SQLite lock/busy errors. Mirrors WhatsApp Web's PromiseQueue
     /// pattern that serializes database commits to avoid concurrent write contention.
     async fn with_retry<F, T>(&self, op_name: &str, make_op: F) -> Result<T>
+    where
+        F: Fn() -> Box<
+            dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
+        >,
+        T: Send + 'static,
+    {
+        self.with_retry_inner(op_name, make_op, true).await
+    }
+
+    async fn with_read_retry<F, T>(&self, op_name: &str, make_op: F) -> Result<T>
+    where
+        F: Fn() -> Box<
+            dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
+        >,
+        T: Send + 'static,
+    {
+        self.with_retry_inner(op_name, make_op, false).await
+    }
+
+    async fn with_retry_inner<F, T>(
+        &self,
+        op_name: &str,
+        make_op: F,
+        await_barrier: bool,
+    ) -> Result<T>
     where
         F: Fn() -> Box<
             dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
@@ -1035,21 +1113,32 @@ impl SqliteStore {
             let pool = self.pool.clone();
             let op = make_op();
 
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<T, DieselOrStore> {
-                    let _permit = permit;
+            let result = crate::pool::spawn_blocking(move || {
+                let result = (|| {
                     let mut conn = pool
                         .get()
                         .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     op(&mut conn).map_err(DieselOrStore::Diesel)
-                })
-                .await;
+                })();
+                (result, permit)
+            })
+            .await;
 
             match result {
-                Ok(Ok(val)) => return Ok(val),
-                Ok(Err(DieselOrStore::Diesel(ref e)))
+                Ok((Ok(val), permit)) => {
+                    let barrier = if await_barrier {
+                        self.await_commit_barrier().await
+                    } else {
+                        Ok(())
+                    };
+                    drop(permit);
+                    barrier?;
+                    return Ok(val);
+                }
+                Ok((Err(DieselOrStore::Diesel(ref e)), permit))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     // Skip the first transient blip; warn from the second retry on so
                     // sustained busy/locked contention doesn't go unobserved.
@@ -1062,7 +1151,10 @@ impl SqliteStore {
                     }
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok((Err(e), permit)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -1491,7 +1583,10 @@ impl SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -1534,6 +1629,7 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1622,7 +1718,10 @@ impl SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -1665,6 +1764,7 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1692,6 +1792,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1732,6 +1833,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1809,6 +1911,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -2377,7 +2480,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2507,7 +2613,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2634,7 +2743,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2717,7 +2829,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -3985,7 +4100,7 @@ impl ProtocolStore for SqliteStore {
         let device_id = self.device_id;
         // Retry on SQLITE_BUSY: a transient lock here must not surface as a read
         // failure, which fails closed and forces an unnecessary redelivery.
-        self.with_retry("get_pending_inbound", || {
+        self.with_read_retry("get_pending_inbound", || {
             let chat = chat.clone();
             let sender = sender.clone();
             let id = id.clone();
@@ -4339,6 +4454,7 @@ impl DeviceStore for SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -4824,6 +4940,7 @@ mod tests {
                     .build(),
             )),
             connection_init: None,
+            commit_barrier: None,
         };
         let store = SqliteStore::with_config(&db_name, config)
             .await

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1611,8 +1611,6 @@ impl SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -1621,6 +1619,7 @@ impl SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10 * 2u64.pow(attempt);
                     warn!(
                         "Identity write failed (attempt {}/{}): {e}. Retrying in {delay_ms}ms...",
@@ -1630,7 +1629,10 @@ impl SqliteStore {
                     retry_backoff(delay_ms).await;
                     continue;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -1737,8 +1739,6 @@ impl SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -1747,6 +1747,7 @@ impl SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10 * 2u64.pow(attempt);
                     warn!(
                         "Session write failed (attempt {}/{}): {e}. Retrying in {delay_ms}ms...",
@@ -1756,7 +1757,10 @@ impl SqliteStore {
                     retry_backoff(delay_ms).await;
                     continue;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -2469,8 +2473,6 @@ impl SignalStore for SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -2479,10 +2481,14 @@ impl SignalStore for SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -2602,8 +2608,6 @@ impl SignalStore for SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -2612,10 +2616,14 @@ impl SignalStore for SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -2732,8 +2740,6 @@ impl SignalStore for SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -2742,10 +2748,14 @@ impl SignalStore for SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -2818,8 +2828,6 @@ impl SignalStore for SqliteStore {
                 })
                 .await;
 
-            drop(permit);
-
             match result {
                 Ok(Ok(())) => {
                     self.await_commit_barrier().await?;
@@ -2828,10 +2836,14 @@ impl SignalStore for SqliteStore {
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok(Err(e)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -240,6 +240,8 @@ type ReadQuery<T> = Box<dyn FnOnce(&mut SqliteConnection) -> Result<T> + Send>;
 /// A unit of work for the write queue, erased for the same reason.
 type BlockingJob<T> = Box<dyn FnOnce() -> Result<T> + Send>;
 
+type WriteJob<T> = Box<dyn FnOnce(&mut SqliteConnection) -> Result<T> + Send>;
+
 /// Reader connections and the permits that bound how many run at once.
 #[derive(Clone)]
 pub(crate) struct ReadPool {
@@ -1075,6 +1077,11 @@ impl SqliteStore {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
+        self.write_blocking_erased(Box::new(f)).await
+    }
+
+    #[inline(never)]
+    async fn write_blocking_erased<T: Send + 'static>(&self, f: WriteJob<T>) -> Result<T> {
         let permit = self
             .db_semaphore
             .clone()
@@ -1577,69 +1584,22 @@ impl SqliteStore {
         key: [u8; 32],
         device_id: i32,
     ) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
-        // The key is a `Copy` array and the address is refcount-shared, so an
-        // attempt costs no heap allocation beyond the closure itself.
+        // The key is a `Copy` array and the address is refcount-shared, so a
+        // retry costs no heap allocation beyond the operation closure.
         let address_owned: Arc<str> = Arc::from(address);
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-            let address_clone = address_owned.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    crate::upsert_queries::UpsertIdentity {
-                        address: address_clone.as_ref(),
-                        key: &key[..],
-                        device_id,
-                    }
-                    .execute(&mut *conn)
-                    .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
+        self.with_retry("identity_write", move || {
+            let address = address_owned.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                crate::upsert_queries::UpsertIdentity {
+                    address: address.as_ref(),
+                    key: &key[..],
+                    device_id,
                 }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10 * 2u64.pow(attempt);
-                    warn!(
-                        "Identity write failed (attempt {}/{}): {e}. Retrying in {delay_ms}ms...",
-                        attempt + 1,
-                        MAX_RETRIES + 1,
-                    );
-                    retry_backoff(delay_ms).await;
-                    continue;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: format!("identity_write (after {} attempts)", MAX_RETRIES + 1),
+                .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     pub async fn delete_identity_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -1702,72 +1662,25 @@ impl SqliteStore {
         session: &[u8],
         device_id: i32,
     ) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
         // Copied once, then refcount-shared across attempts: this runs after
         // every Signal encrypt/decrypt, and a session record is several KiB,
         // so a per-attempt `Vec` clone was a memcpy on the happy path too.
         let address_owned: Arc<str> = Arc::from(address);
         let session_bytes = Bytes::copy_from_slice(session);
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-            let address_clone = address_owned.clone();
-            let session_clone = session_bytes.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    crate::upsert_queries::UpsertSession {
-                        address: address_clone.as_ref(),
-                        record: session_clone.as_ref(),
-                        device_id,
-                    }
-                    .execute(&mut *conn)
-                    .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
+        self.with_retry("session_write", move || {
+            let address = address_owned.clone();
+            let session = session_bytes.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                crate::upsert_queries::UpsertSession {
+                    address: address.as_ref(),
+                    record: session.as_ref(),
+                    device_id,
                 }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10 * 2u64.pow(attempt);
-                    warn!(
-                        "Session write failed (attempt {}/{}): {e}. Retrying in {delay_ms}ms...",
-                        attempt + 1,
-                        MAX_RETRIES + 1,
-                    );
-                    retry_backoff(delay_ms).await;
-                    continue;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: format!("session_write (after {} attempts)", MAX_RETRIES + 1),
+                .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     pub async fn delete_session_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -2431,71 +2344,30 @@ impl SignalStore for SqliteStore {
     }
 
     async fn store_prekey(&self, id: u32, record: &[u8], uploaded: bool) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
         let device_id = self.device_id;
         // One copy, then refcount clones per attempt (see put_session_for_device).
         let record = Bytes::copy_from_slice(record);
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-            let record_clone = record.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::insert_into(prekeys::table)
-                        .values((
-                            prekeys::id.eq(id as i32),
-                            prekeys::key.eq(record_clone.as_ref()),
-                            prekeys::uploaded.eq(uploaded),
-                            prekeys::device_id.eq(device_id),
-                        ))
-                        .on_conflict((prekeys::id, prekeys::device_id))
-                        .do_update()
-                        .set((
-                            prekeys::key.eq(record_clone.as_ref()),
-                            prekeys::uploaded.eq(uploaded),
-                        ))
-                        .execute(&mut *conn)
-                        .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
-                }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10u64 * (1u64 << attempt.min(4));
-                    retry_backoff(delay_ms).await;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: "store_prekey".to_string(),
+        self.with_retry("store_prekey", move || {
+            let record = record.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::insert_into(prekeys::table)
+                    .values((
+                        prekeys::id.eq(id as i32),
+                        prekeys::key.eq(record.as_ref()),
+                        prekeys::uploaded.eq(uploaded),
+                        prekeys::device_id.eq(device_id),
+                    ))
+                    .on_conflict((prekeys::id, prekeys::device_id))
+                    .do_update()
+                    .set((
+                        prekeys::key.eq(record.as_ref()),
+                        prekeys::uploaded.eq(uploaded),
+                    ))
+                    .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     async fn store_prekeys_batch(&self, keys: &[(u32, Bytes)], uploaded: bool) -> Result<()> {
@@ -2577,60 +2449,19 @@ impl SignalStore for SqliteStore {
     }
 
     async fn remove_prekey(&self, id: u32) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
         let device_id = self.device_id;
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::delete(
-                        prekeys::table
-                            .filter(prekeys::id.eq(id as i32))
-                            .filter(prekeys::device_id.eq(device_id)),
-                    )
-                    .execute(&mut *conn)
-                    .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
-                }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10u64 * (1u64 << attempt.min(4));
-                    retry_backoff(delay_ms).await;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: "remove_prekey".to_string(),
+        self.with_retry("remove_prekey", move || {
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::delete(
+                    prekeys::table
+                        .filter(prekeys::id.eq(id as i32))
+                        .filter(prekeys::device_id.eq(device_id)),
+                )
+                .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> Result<()> {
@@ -2702,67 +2533,26 @@ impl SignalStore for SqliteStore {
     }
 
     async fn store_signed_prekey(&self, id: u32, record: &[u8]) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
         let device_id = self.device_id;
         // One copy, then refcount clones per attempt (see put_session_for_device).
         let record = Bytes::copy_from_slice(record);
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-            let record_clone = record.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::insert_into(signed_prekeys::table)
-                        .values((
-                            signed_prekeys::id.eq(id as i32),
-                            signed_prekeys::record.eq(record_clone.as_ref()),
-                            signed_prekeys::device_id.eq(device_id),
-                        ))
-                        .on_conflict((signed_prekeys::id, signed_prekeys::device_id))
-                        .do_update()
-                        .set(signed_prekeys::record.eq(record_clone.as_ref()))
-                        .execute(&mut *conn)
-                        .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
-                }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10u64 * (1u64 << attempt.min(4));
-                    retry_backoff(delay_ms).await;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: "store_signed_prekey".to_string(),
+        self.with_retry("store_signed_prekey", move || {
+            let record = record.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::insert_into(signed_prekeys::table)
+                    .values((
+                        signed_prekeys::id.eq(id as i32),
+                        signed_prekeys::record.eq(record.as_ref()),
+                        signed_prekeys::device_id.eq(device_id),
+                    ))
+                    .on_conflict((signed_prekeys::id, signed_prekeys::device_id))
+                    .do_update()
+                    .set(signed_prekeys::record.eq(record.as_ref()))
+                    .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     async fn load_signed_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
@@ -2797,60 +2587,19 @@ impl SignalStore for SqliteStore {
     }
 
     async fn remove_signed_prekey(&self, id: u32) -> Result<()> {
-        let pool = self.pool.clone();
-        let db_semaphore = self.db_semaphore.clone();
         let device_id = self.device_id;
-
-        const MAX_RETRIES: u32 = 5;
-
-        for attempt in 0..=MAX_RETRIES {
-            let permit = db_semaphore
-                .clone()
-                .acquire_owned()
-                .await
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-            let pool_clone = pool.clone();
-
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
-                    let mut conn = pool_clone
-                        .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
-                    diesel::delete(
-                        signed_prekeys::table
-                            .filter(signed_prekeys::id.eq(id as i32))
-                            .filter(signed_prekeys::device_id.eq(device_id)),
-                    )
-                    .execute(&mut *conn)
-                    .map_err(DieselOrStore::Diesel)?;
-                    Ok(())
-                })
-                .await;
-
-            match result {
-                Ok(Ok(())) => {
-                    self.await_commit_barrier().await?;
-                    return Ok(());
-                }
-                Ok(Err(DieselOrStore::Diesel(ref e)))
-                    if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
-                {
-                    drop(permit);
-                    let delay_ms = 10u64 * (1u64 << attempt.min(4));
-                    retry_backoff(delay_ms).await;
-                }
-                Ok(Err(e)) => {
-                    drop(permit);
-                    return Err(e.into());
-                }
-                Err(e) => return Err(StoreError::Database(Box::new(e))),
-            }
-        }
-
-        Err(StoreError::RetriesExhausted {
-            op: "remove_signed_prekey".to_string(),
+        self.with_retry("remove_signed_prekey", move || {
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::delete(
+                    signed_prekeys::table
+                        .filter(signed_prekeys::id.eq(id as i32))
+                        .filter(signed_prekeys::device_id.eq(device_id)),
+                )
+                .execute(conn)
+            })
         })
+        .await
+        .map(|_| ())
     }
 
     async fn put_sender_key(&self, address: &str, record: &[u8]) -> Result<()> {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1070,6 +1070,32 @@ impl SqliteStore {
         await_barrier_hook(&self.commit_barrier).await
     }
 
+    async fn write_blocking<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let permit = self
+            .db_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+        let pool = self.pool.clone();
+        let (result, permit) = crate::pool::spawn_blocking(move || -> Result<(T, _)> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let result = f(&mut conn)?;
+            Ok((result, permit))
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
+        drop(permit);
+        Ok(result)
+    }
+
     /// Execute a database operation with semaphore serialization and retry on
     /// transient SQLite lock/busy errors. Mirrors WhatsApp Web's PromiseQueue
     /// pattern that serializes database commits to avoid concurrent write contention.
@@ -1615,27 +1641,18 @@ impl SqliteStore {
     }
 
     pub async fn delete_identity_for_device(&self, address: &str, device_id: i32) -> Result<()> {
-        let pool = self.pool.clone();
         let address_owned = address.to_string();
-
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 identities::table
                     .filter(identities::address.eq(address_owned))
                     .filter(identities::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-
-        self.await_commit_barrier().await?;
-        Ok(())
     }
 
     pub async fn load_identity_for_device(
@@ -1750,27 +1767,18 @@ impl SqliteStore {
     }
 
     pub async fn delete_session_for_device(&self, address: &str, device_id: i32) -> Result<()> {
-        let pool = self.pool.clone();
         let address_owned = address.to_string();
-
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 sessions::table
                     .filter(sessions::address.eq(address_owned))
                     .filter(sessions::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-
-        self.await_commit_barrier().await?;
-        Ok(())
     }
 
     pub async fn put_sender_key_for_device(
@@ -1779,26 +1787,19 @@ impl SqliteStore {
         record: &[u8],
         device_id: i32,
     ) -> Result<()> {
-        let pool = self.pool.clone();
         let address = address.to_string();
         let record_vec = record.to_vec();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             crate::upsert_queries::UpsertSenderKey {
                 address: &address,
                 record: &record_vec,
                 device_id,
             }
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        self.await_commit_barrier().await?;
-        Ok(())
     }
 
     pub async fn get_sender_key_for_device(
@@ -1821,25 +1822,18 @@ impl SqliteStore {
     }
 
     pub async fn delete_sender_key_for_device(&self, address: &str, device_id: i32) -> Result<()> {
-        let pool = self.pool.clone();
         let address = address.to_string();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 sender_keys::table
                     .filter(sender_keys::address.eq(address))
                     .filter(sender_keys::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        self.await_commit_barrier().await?;
-        Ok(())
     }
 
     pub async fn get_app_state_sync_key_for_device(
@@ -1894,13 +1888,9 @@ impl SqliteStore {
         key: AppStateSyncKey,
         device_id: i32,
     ) -> Result<()> {
-        let pool = self.pool.clone();
         let key_id = key_id.to_vec();
         let data = crate::wire::encode_app_state_sync_key(&key);
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::insert_into(app_state_keys::table)
                 .values((
                     app_state_keys::key_id.eq(&key_id),
@@ -1910,14 +1900,11 @@ impl SqliteStore {
                 .on_conflict((app_state_keys::key_id, app_state_keys::device_id))
                 .do_update()
                 .set(app_state_keys::key_data.eq(&data))
-                .execute(&mut *conn)
+                .execute(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        self.await_commit_barrier().await?;
-        Ok(())
     }
 
     pub async fn get_latest_app_state_sync_key_id_for_device(
@@ -3362,16 +3349,12 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn save_base_key(&self, address: &str, message_id: &str, base_key: &[u8]) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let address = address.to_string();
         let message_id = message_id.to_string();
         let base_key = base_key.to_vec();
         let now = wacore::time::now_secs() as i32;
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::insert_into(base_keys::table)
                 .values((
                     base_keys::address.eq(&address),
@@ -3387,13 +3370,11 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .do_update()
                 .set(base_keys::base_key.eq(&base_key))
-                .execute(&mut *conn)
+                .execute(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn has_same_base_key(
@@ -3421,27 +3402,21 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn delete_base_key(&self, address: &str, message_id: &str) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let address = address.to_string();
         let message_id = message_id.to_string();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 base_keys::table
                     .filter(base_keys::address.eq(&address))
                     .filter(base_keys::message_id.eq(&message_id))
                     .filter(base_keys::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn delete_expired_base_keys(&self, cutoff_timestamp: i64) -> Result<u32> {
@@ -3461,15 +3436,11 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn update_device_list(&self, record: DeviceListRecord) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let devices_json = serde_json::to_string(&*record.devices)
             .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         let now = wacore::time::now_secs() as i32;
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             let raw_id_i32 = record.raw_id.map(|r| r as i32);
             crate::upsert_queries::UpsertDeviceRegistry {
                 user_id: record.user.as_ref(),
@@ -3480,13 +3451,11 @@ impl ProtocolStore for SqliteStore {
                 updated_at: now,
                 raw_id: raw_id_i32,
             }
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn update_device_lists(&self, records: Vec<DeviceListRecord>) -> Result<()> {
@@ -3602,25 +3571,19 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn delete_devices(&self, user: &str) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let user = user.to_string();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 device_registry::table
                     .filter(device_registry::user_id.eq(&user))
                     .filter(device_registry::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn get_group_metadata(&self, group_jid: &str) -> Result<Option<Vec<u8>>> {
@@ -3640,15 +3603,11 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn put_group_metadata(&self, group_jid: &str, blob: &[u8]) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let group_jid = group_jid.to_string();
         let blob = blob.to_vec();
         let now = wacore::time::now_secs();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::insert_into(group_metadata::table)
                 .values((
                     group_metadata::group_jid.eq(&group_jid),
@@ -3662,35 +3621,27 @@ impl ProtocolStore for SqliteStore {
                     group_metadata::info.eq(&blob),
                     group_metadata::updated_at.eq(now),
                 ))
-                .execute(&mut *conn)
+                .execute(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn delete_group_metadata(&self, group_jid: &str) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let group_jid = group_jid.to_string();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 group_metadata::table
                     .filter(group_metadata::group_jid.eq(&group_jid))
                     .filter(group_metadata::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
@@ -3775,15 +3726,11 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
         let entry = entry.clone();
         let now = wacore::time::now_secs();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::insert_into(tc_tokens::table)
                 .values((
                     tc_tokens::jid.eq(&jid),
@@ -3801,35 +3748,27 @@ impl ProtocolStore for SqliteStore {
                     tc_tokens::sender_timestamp.eq(entry.sender_timestamp),
                     tc_tokens::updated_at.eq(now),
                 ))
-                .execute(&mut *conn)
+                .execute(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn delete_tc_token(&self, jid: &str) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             diesel::delete(
                 tc_tokens::table
                     .filter(tc_tokens::jid.eq(&jid))
                     .filter(tc_tokens::device_id.eq(device_id)),
             )
-            .execute(&mut *conn)
+            .execute(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn get_all_tc_token_jids(&self) -> Result<Vec<String>> {
@@ -3940,14 +3879,10 @@ impl ProtocolStore for SqliteStore {
         jid: &str,
         sender_timestamp: i64,
     ) -> Result<()> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
         let now = wacore::time::now_secs();
-        crate::pool::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.write_blocking(move |conn| {
             // On conflict touch only sender_timestamp, and only to advance it,
             // so a concurrently stored real token is never overwritten and the
             // sender bucket never regresses.
@@ -3977,13 +3912,11 @@ impl ProtocolStore for SqliteStore {
                     .sql(")")),
                     tc_tokens::updated_at.eq(now),
                 ))
-                .execute(&mut *conn)
+                .execute(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
-        Ok(())
     }
 
     async fn store_sent_message(

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -7752,6 +7752,7 @@ mod read_routing_tests {
                         "self.pool",
                         "with_semaphore(",
                         "with_retry(",
+                        "with_read_retry(",
                         "spawn_blocking(",
                         // The sibling-crate write path; `shared().read(` is the
                         // read one and is what `read_query` itself uses.

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -333,6 +333,14 @@ pub(crate) fn commit_barrier_error(error: StoreError) -> StoreError {
     StoreError::Database(Box::new(CommitBarrierError(error)))
 }
 
+#[inline(never)]
+pub(crate) async fn await_barrier_hook(hook: &Option<CommitBarrierHook>) -> Result<()> {
+    if let Some(barrier) = hook {
+        barrier().await.map_err(commit_barrier_error)?;
+    }
+    Ok(())
+}
+
 #[cfg(not(target_family = "wasm"))]
 pub type CommitBarrierHook = Arc<dyn Fn() -> CommitBarrierFuture + Send + Sync + 'static>;
 
@@ -822,7 +830,7 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
         if let Some(barrier) = commit_barrier {
-            barrier().await.map_err(commit_barrier_error)?;
+            await_barrier_hook(&Some(barrier)).await?;
         }
 
         // Reader connections only pay off under WAL, and only with a page cache
@@ -1059,10 +1067,7 @@ impl SqliteStore {
     }
 
     async fn await_commit_barrier(&self) -> Result<()> {
-        if let Some(barrier) = &self.commit_barrier {
-            barrier().await.map_err(commit_barrier_error)?;
-        }
-        Ok(())
+        await_barrier_hook(&self.commit_barrier).await
     }
 
     /// Execute a database operation with semaphore serialization and retry on


### PR DESCRIPTION
The web SQLite store currently treats SQLite's synchronous commit callback as durable even though relaxed IndexedDB persists blocks asynchronously. This patch adds an awaitable commit barrier and wires it through every write path, including `SharedSqlite::run`, while keeping readers off the barrier.

The barrier callback runs while the write permit is held and failures are wrapped in `CommitBarrierError`, so callers can distinguish a post-commit durability failure from a rollback. Store construction also confirms migrations before returning.

Validation:

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=3 cargo test -p whatsapp-rust-sqlite-storage --lib shared::tests::a_pending_barrier_holds_the_write_permit -- --exact`
- `CARGO_BUILD_JOBS=3 cargo test -p whatsapp-rust-sqlite-storage --lib shared::tests::signal_batch_surfaces_barrier_error -- --exact`
- `CARGO_BUILD_JOBS=3 cargo clippy -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings`
