### PR TITLE
Add post-commit durability barriers (typed shared errors)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "scheduled-thread-pool",
  "serde_json",
  "sha2",
+ "thiserror 2.0.20",
  "tokio",
  "wacore",
 ]

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -32,6 +32,7 @@ log = { workspace = true }
 scheduled-thread-pool = "0.2"
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
+thiserror = { workspace = true }
 wacore = { workspace = true }
 
 [build-dependencies]

--- a/storages/sqlite-storage/src/lib.rs
+++ b/storages/sqlite-storage/src/lib.rs
@@ -11,7 +11,10 @@ pub(crate) mod upsert_queries;
 mod wire;
 
 pub use shared::SharedSqlite;
-pub use sqlite_store::{ConnectionInitHook, SqliteStore, SqliteStoreConfig, Synchronous};
+pub use sqlite_store::{
+    CommitBarrierError, CommitBarrierFuture, CommitBarrierHook, ConnectionInitHook, SqliteStore,
+    SqliteStoreConfig, Synchronous,
+};
 
 #[cfg(feature = "test-util")]
 #[doc(hidden)]

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -9,7 +9,7 @@ use diesel::sqlite::SqliteConnection;
 use std::sync::Arc;
 use wacore::store::error::{Result, StoreError};
 
-use crate::sqlite_store::{SqlitePool, SqliteStore};
+use crate::sqlite_store::{CommitBarrierHook, SqlitePool, SqliteStore, commit_barrier_error};
 
 /// Clonable handle onto a [`SqliteStore`]'s connection pool and serialization
 /// semaphore. Obtained via [`SqliteStore::shared`]. Holding one does not keep any
@@ -19,6 +19,7 @@ pub struct SharedSqlite {
     pool: SqlitePool,
     semaphore: Arc<tokio::sync::Semaphore>,
     reads: Option<crate::sqlite_store::ReadPool>,
+    commit_barrier: Option<CommitBarrierHook>,
 }
 
 impl SharedSqlite {
@@ -35,7 +36,13 @@ impl SharedSqlite {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        Self::run_on(self.pool.clone(), Arc::clone(&self.semaphore), f).await
+        Self::run_on(
+            self.pool.clone(),
+            Arc::clone(&self.semaphore),
+            self.commit_barrier.clone(),
+            f,
+        )
+        .await
     }
 
     /// Run a **read-only** `f` without queueing behind the write permit.
@@ -71,12 +78,13 @@ impl SharedSqlite {
             Some(reads) => (reads.pool.clone(), Arc::clone(&reads.semaphore)),
             None => (self.pool.clone(), Arc::clone(&self.semaphore)),
         };
-        Self::run_on(pool, semaphore, move |conn| read_snapshot(conn, f)).await
+        Self::run_on(pool, semaphore, None, move |conn| read_snapshot(conn, f)).await
     }
 
     async fn run_on<F, T>(
         pool: SqlitePool,
         semaphore: Arc<tokio::sync::Semaphore>,
+        commit_barrier: Option<CommitBarrierHook>,
         f: F,
     ) -> Result<T>
     where
@@ -87,15 +95,21 @@ impl SharedSqlite {
             .acquire_owned()
             .await
             .map_err(|e| StoreError::Database(Box::new(e)))?;
-        crate::pool::spawn_blocking(move || {
-            let _permit = permit;
+        let result = crate::pool::spawn_blocking(move || -> Result<(T, _)> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            f(&mut conn)
+            let result = f(&mut conn)?;
+            Ok((result, permit))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        let (result, permit) = result;
+        if let Some(barrier) = commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
+        drop(permit);
+        Ok(result)
     }
 }
 
@@ -135,6 +149,7 @@ impl SqliteStore {
             pool: self.pool.clone(),
             semaphore: self.db_semaphore.clone(),
             reads: self.reads.clone(),
+            commit_barrier: self.commit_barrier.clone(),
         }
     }
 }
@@ -142,6 +157,7 @@ impl SqliteStore {
 #[cfg(test)]
 mod tests {
     use diesel::prelude::*;
+    use std::sync::Arc;
 
     use crate::sqlite_store::SqliteStore;
     use wacore::store::error::StoreError;
@@ -203,6 +219,197 @@ mod tests {
             .expect("read through cloned handle");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].v, "b");
+    }
+
+    #[tokio::test]
+    async fn shared_write_awaits_barrier_but_read_does_not() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_hook = Arc::clone(&calls);
+        let barrier: CommitBarrierHook = Arc::new(move || {
+            calls_for_hook.fetch_add(1, Ordering::Relaxed);
+            Box::pin(async { Ok::<(), StoreError>(()) })
+        });
+        let store = SqliteStore::with_config(
+            &unique_db_name("barrier"),
+            SqliteStoreConfig::default().with_commit_barrier(barrier),
+        )
+        .await
+        .expect("barrier store");
+        let shared = store.shared();
+        shared
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE barrier_data (value TEXT)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("write");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+        shared
+            .read(|conn| {
+                diesel::sql_query("SELECT count(*) FROM barrier_data")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("read");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn a_constructor_barrier_failure_rejects_the_store() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+
+        let barrier: CommitBarrierHook = Arc::new(|| {
+            Box::pin(async { Err(StoreError::Validation("commit barrier failed".into())) })
+        });
+        let result = SqliteStore::with_config(
+            &unique_db_name("barrier_error"),
+            SqliteStoreConfig::default().with_commit_barrier(barrier),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "constructor must propagate barrier failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pending_barrier_holds_the_write_permit() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::sync::{Notify, Semaphore};
+
+        let entered = Arc::new(Notify::new());
+        let permits = Arc::new(Semaphore::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let hook: CommitBarrierHook = {
+            let entered = Arc::clone(&entered);
+            let permits = Arc::clone(&permits);
+            let calls = Arc::clone(&calls);
+            Arc::new(move || {
+                entered.notify_one();
+                calls.fetch_add(1, Ordering::Relaxed);
+                let permits = Arc::clone(&permits);
+                Box::pin(async move {
+                    permits
+                        .acquire()
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| StoreError::Database(Box::new(e)))
+                })
+            })
+        };
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("barrier_pending"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        store.commit_barrier = Some(hook);
+        let shared = store.shared();
+        let first = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(|conn| {
+                        diesel::sql_query("CREATE TABLE pending_data (value TEXT)")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        entered.notified().await;
+        let mut second = tokio::spawn({
+            let shared = shared.clone();
+            async move {
+                shared
+                    .run(|conn| {
+                        diesel::sql_query("INSERT INTO pending_data (value) VALUES ('later')")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        Ok(())
+                    })
+                    .await
+            }
+        });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut second)
+                .await
+                .is_err()
+        );
+        first.abort();
+        assert!(first.await.is_err(), "canceled write must not complete");
+        permits.add_permits(1);
+        entered.notified().await;
+        permits.add_permits(1);
+        second.await.expect("second join").expect("second write");
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn signal_batch_surfaces_barrier_error() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+        use bytes::Bytes;
+        use wacore::store::traits::SignalStore;
+
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("signal_barrier_error"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        let barrier: CommitBarrierHook =
+            Arc::new(|| Box::pin(async { Err(StoreError::Validation("IDB quota".into())) }));
+        store.commit_barrier = Some(barrier);
+        let result = store
+            .put_sessions_batch(&[(Arc::from("alice.1"), Bytes::from_static(b"state"))])
+            .await;
+        let error = result.expect_err("Signal writes must fail closed on barrier error");
+        let source = std::error::Error::source(&error).expect("barrier source");
+        assert!(
+            source
+                .downcast_ref::<crate::sqlite_store::CommitBarrierError>()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_write_surfaces_typed_barrier_error() {
+        use crate::sqlite_store::{CommitBarrierHook, SqliteStoreConfig};
+
+        let mut store = SqliteStore::with_config(
+            &unique_db_name("shared_barrier_error"),
+            SqliteStoreConfig::default(),
+        )
+        .await
+        .expect("store");
+        let barrier: CommitBarrierHook =
+            Arc::new(|| Box::pin(async { Err(StoreError::Validation("IDB quota".into())) }));
+        store.commit_barrier = Some(barrier);
+        let error = store
+            .shared()
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE shared_barrier_data (value TEXT)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect_err("shared write must fail closed");
+        let source = std::error::Error::source(&error).expect("barrier source");
+        assert!(
+            source
+                .downcast_ref::<crate::sqlite_store::CommitBarrierError>()
+                .is_some()
+        );
     }
 
     /// A file-backed store, since reader connections need real WAL and an

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -8,8 +8,11 @@ use diesel::sqlite::SqliteConnection;
 use diesel::upsert::excluded;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use log::warn;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
+use thiserror::Error;
 use wacore::appstate::hash::HashState;
 use wacore::appstate::processor::AppStateMutationMAC;
 use wacore::libsignal::protocol::{KeyPair, PrivateKey, PublicKey};
@@ -270,6 +273,7 @@ pub struct SqliteStore {
     /// `SQLITE_LOCKED_SHAREDCACHE`, which `busy_timeout` cannot absorb.
     pub(crate) snapshot_safe: bool,
     pub(crate) database_path: String,
+    pub(crate) commit_barrier: Option<CommitBarrierHook>,
     device_id: i32,
 }
 
@@ -308,6 +312,29 @@ pub type ConnectionInitHook = Arc<
         + Send
         + Sync,
 >;
+
+#[cfg(target_family = "wasm")]
+pub type CommitBarrierFuture = Pin<Box<dyn Future<Output = Result<()>> + 'static>>;
+
+#[cfg(not(target_family = "wasm"))]
+pub type CommitBarrierFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>;
+
+#[cfg(target_family = "wasm")]
+pub type CommitBarrierHook = Arc<dyn Fn() -> CommitBarrierFuture + Send + Sync + 'static>;
+
+/// A write reached SQLite's commit boundary, but its backing durability hook
+/// failed afterwards. Callers must treat the SQL mutation as committed in the
+/// live connection while retaining any retry state needed by the backend.
+#[derive(Debug, Error)]
+#[error("post-commit durability barrier failed")]
+pub struct CommitBarrierError(#[source] pub StoreError);
+
+pub(crate) fn commit_barrier_error(error: StoreError) -> StoreError {
+    StoreError::Database(Box::new(CommitBarrierError(error)))
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub type CommitBarrierHook = Arc<dyn Fn() -> CommitBarrierFuture + Send + Sync + 'static>;
 
 /// Per-store connection tuning. [`Default`] is a low-memory profile sized for one
 /// `SqliteStore` per WhatsApp session on a single process: a single pooled connection
@@ -402,6 +429,11 @@ pub struct SqliteStoreConfig {
     /// pragmas, WAL setup, and migrations. See [`ConnectionInitHook`] for the contract;
     /// set via [`SqliteStoreConfig::with_connection_init`].
     pub connection_init: Option<ConnectionInitHook>,
+    /// Optional awaitable called after each successful SQLite write commit.
+    /// Readers never call it. The callback runs while the write permit is held
+    /// and must not re-enter this store or a [`SharedSqlite`](crate::SharedSqlite)
+    /// handle, which would wait for the permit it already owns.
+    pub commit_barrier: Option<CommitBarrierHook>,
 }
 
 impl Default for SqliteStoreConfig {
@@ -420,6 +452,7 @@ impl Default for SqliteStoreConfig {
             synchronous: Synchronous::Normal,
             thread_pool: None,
             connection_init: None,
+            commit_barrier: None,
         }
     }
 }
@@ -472,6 +505,13 @@ impl SqliteStoreConfig {
             + 'static,
     {
         self.connection_init = Some(Arc::new(hook));
+        self
+    }
+
+    /// Install an awaitable that confirms a write reached the configured
+    /// backend before the write operation returns.
+    pub fn with_commit_barrier(mut self, barrier: CommitBarrierHook) -> Self {
+        self.commit_barrier = Some(barrier);
         self
     }
 }
@@ -715,6 +755,7 @@ impl SqliteStore {
         // Left as the `Option` the embedder gave; `pool::builder` resolves it.
         let thread_pool = config.thread_pool;
         let read_thread_pool = thread_pool.clone();
+        let commit_barrier = config.commit_barrier.clone();
 
         let options = ConnectionOptions {
             cache_size_kib: config.cache_size_kib,
@@ -780,6 +821,9 @@ impl SqliteStore {
         )
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        if let Some(barrier) = commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
 
         // Reader connections only pay off under WAL, and only with a page cache
         // per connection. Each of the two ways that can fail turns the intended
@@ -840,6 +884,7 @@ impl SqliteStore {
             reads,
             snapshot_safe: declined.is_none(),
             database_path,
+            commit_barrier: config.commit_barrier,
             device_id,
         })
     }
@@ -914,6 +959,7 @@ impl SqliteStore {
             reads: self.reads.clone(),
             snapshot_safe: self.snapshot_safe,
             database_path: self.database_path.clone(),
+            commit_barrier: self.commit_barrier.clone(),
             device_id,
         }
     }
@@ -1012,10 +1058,42 @@ impl SqliteStore {
         Ok(result)
     }
 
+    async fn await_commit_barrier(&self) -> Result<()> {
+        if let Some(barrier) = &self.commit_barrier {
+            barrier().await.map_err(commit_barrier_error)?;
+        }
+        Ok(())
+    }
+
     /// Execute a database operation with semaphore serialization and retry on
     /// transient SQLite lock/busy errors. Mirrors WhatsApp Web's PromiseQueue
     /// pattern that serializes database commits to avoid concurrent write contention.
     async fn with_retry<F, T>(&self, op_name: &str, make_op: F) -> Result<T>
+    where
+        F: Fn() -> Box<
+            dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
+        >,
+        T: Send + 'static,
+    {
+        self.with_retry_inner(op_name, make_op, true).await
+    }
+
+    async fn with_read_retry<F, T>(&self, op_name: &str, make_op: F) -> Result<T>
+    where
+        F: Fn() -> Box<
+            dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
+        >,
+        T: Send + 'static,
+    {
+        self.with_retry_inner(op_name, make_op, false).await
+    }
+
+    async fn with_retry_inner<F, T>(
+        &self,
+        op_name: &str,
+        make_op: F,
+        await_barrier: bool,
+    ) -> Result<T>
     where
         F: Fn() -> Box<
             dyn FnOnce(&mut SqliteConnection) -> std::result::Result<T, DieselError> + Send,
@@ -1035,21 +1113,32 @@ impl SqliteStore {
             let pool = self.pool.clone();
             let op = make_op();
 
-            let result =
-                crate::pool::spawn_blocking(move || -> std::result::Result<T, DieselOrStore> {
-                    let _permit = permit;
+            let result = crate::pool::spawn_blocking(move || {
+                let result = (|| {
                     let mut conn = pool
                         .get()
                         .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     op(&mut conn).map_err(DieselOrStore::Diesel)
-                })
-                .await;
+                })();
+                (result, permit)
+            })
+            .await;
 
             match result {
-                Ok(Ok(val)) => return Ok(val),
-                Ok(Err(DieselOrStore::Diesel(ref e)))
+                Ok((Ok(val), permit)) => {
+                    let barrier = if await_barrier {
+                        self.await_commit_barrier().await
+                    } else {
+                        Ok(())
+                    };
+                    drop(permit);
+                    barrier?;
+                    return Ok(val);
+                }
+                Ok((Err(DieselOrStore::Diesel(ref e)), permit))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
+                    drop(permit);
                     let delay_ms = 10u64 * (1u64 << attempt.min(4));
                     // Skip the first transient blip; warn from the second retry on so
                     // sustained busy/locked contention doesn't go unobserved.
@@ -1062,7 +1151,10 @@ impl SqliteStore {
                     }
                     retry_backoff(delay_ms).await;
                 }
-                Ok(Err(e)) => return Err(e.into()),
+                Ok((Err(e), permit)) => {
+                    drop(permit);
+                    return Err(e.into());
+                }
                 Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
@@ -1491,7 +1583,10 @@ impl SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -1534,6 +1629,7 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1622,7 +1718,10 @@ impl SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -1665,6 +1764,7 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1692,6 +1792,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1732,6 +1833,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -1809,6 +1911,7 @@ impl SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -2377,7 +2480,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2507,7 +2613,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2634,7 +2743,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -2717,7 +2829,10 @@ impl SignalStore for SqliteStore {
             drop(permit);
 
             match result {
-                Ok(Ok(())) => return Ok(()),
+                Ok(Ok(())) => {
+                    self.await_commit_barrier().await?;
+                    return Ok(());
+                }
                 Ok(Err(DieselOrStore::Diesel(ref e)))
                     if is_retriable_sqlite_error(e) && attempt < MAX_RETRIES =>
                 {
@@ -3985,7 +4100,7 @@ impl ProtocolStore for SqliteStore {
         let device_id = self.device_id;
         // Retry on SQLITE_BUSY: a transient lock here must not surface as a read
         // failure, which fails closed and forces an unnecessary redelivery.
-        self.with_retry("get_pending_inbound", || {
+        self.with_read_retry("get_pending_inbound", || {
             let chat = chat.clone();
             let sender = sender.clone();
             let id = id.clone();
@@ -4339,6 +4454,7 @@ impl DeviceStore for SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
+        self.await_commit_barrier().await?;
         Ok(())
     }
 
@@ -4824,6 +4940,7 @@ mod tests {
                     .build(),
             )),
             connection_init: None,
+            commit_barrier: None,
         };
         let store = SqliteStore::with_config(&db_name, config)
             .await


### PR DESCRIPTION
The web SQLite store currently treats SQLite's synchronous commit callback as durable even though relaxed IndexedDB persists blocks asynchronously. This patch adds an awaitable commit barrier and wires it through every write path, including `SharedSqlite::run`, while keeping readers off the barrier.

The barrier callback runs while the write permit is held and failures are wrapped in `CommitBarrierError`, so callers can distinguish a post-commit durability failure from a rollback. Store construction also confirms migrations before returning.

Validation:

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=3 cargo test -p whatsapp-rust-sqlite-storage --lib shared::tests::a_pending_barrier_holds_the_write_permit -- --exact`
- `CARGO_BUILD_JOBS=3 cargo test -p whatsapp-rust-sqlite-storage --lib shared::tests::signal_batch_surfaces_barrier_error -- --exact`
- `CARGO_BUILD_JOBS=3 cargo clippy -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings`
