### PR TITLE
feat(voip): expose received video generation

### DIFF
--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3191,17 +3191,25 @@ async fn attach_engine(
     // actually goes missing, and it is the last boundary that still knows a picture was lost -- past
     // here the consumer's channel is opaque to us.
     let keyframe_recovery = video_shared.ctl_tx.clone();
+    // Authoritative call generation, stamped here so a same-call-id replacement's frames never
+    // masquerade as this call's: the engine leaves `generation` at zero and only this boundary
+    // knows the registry generation. Never replaced by per-source or arrival metadata.
     let media_generation = generation;
     let video_out_feed = client.runtime.spawn(Box::pin(async move {
         while let Ok(mut frame) = video_out_rx.recv().await {
             frame.generation = media_generation;
             let tx = sink_slot.lock().unwrap_or_else(|e| e.into_inner()).clone();
-            if let Some(tx) = tx {
-                if let Err(async_channel::TrySendError::Full(_)) = tx.try_send(frame) {
-                    keyframe_recovery.send(VideoControl::RequestPeerKeyframe(
-                        KeyframeUrgency::Coalesced,
-                    ));
-                }
+            // Loss tolerant, like the speaker: a stalled sink sheds frames.
+            // Only `Full` is a shed worth recovering from -- a closed sink is
+            // a consumer that has gone away, and asking it for a keyframe an
+            // interval until the call ends buys the peer nothing but its
+            // largest frame.
+            if let Some(tx) = tx
+                && let Err(async_channel::TrySendError::Full(_)) = tx.try_send(frame)
+            {
+                keyframe_recovery.send(VideoControl::RequestPeerKeyframe(
+                    KeyframeUrgency::Coalesced,
+                ));
             }
         }
     }));

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3191,15 +3191,12 @@ async fn attach_engine(
     // actually goes missing, and it is the last boundary that still knows a picture was lost -- past
     // here the consumer's channel is opaque to us.
     let keyframe_recovery = video_shared.ctl_tx.clone();
+    let media_generation = generation;
     let video_out_feed = client.runtime.spawn(Box::pin(async move {
-        while let Ok(frame) = video_out_rx.recv().await {
+        while let Ok(mut frame) = video_out_rx.recv().await {
+            frame.generation = media_generation;
             let tx = sink_slot.lock().unwrap_or_else(|e| e.into_inner()).clone();
             if let Some(tx) = tx {
-                // Loss tolerant, like the speaker: a stalled sink sheds frames.
-                // Only `Full` is a shed worth recovering from -- a closed sink is
-                // a consumer that has gone away, and asking it for a keyframe an
-                // interval until the call ends buys the peer nothing but its
-                // largest frame.
                 if let Err(async_channel::TrySendError::Full(_)) = tx.try_send(frame) {
                     keyframe_recovery.send(VideoControl::RequestPeerKeyframe(
                         KeyframeUrgency::Coalesced,

--- a/src/voip/video.rs
+++ b/src/voip/video.rs
@@ -7,9 +7,8 @@
 
 pub use wacore::voip::VideoFrame;
 
-/// One captured access unit with its 90 kHz RTP capture timestamp. The driver adds a private
-/// source generation when this crosses the facade boundary, so callers cannot forge generation
-/// ownership while replacing a source.
+/// One captured access unit with its 90 kHz RTP capture timestamp. This is the outbound source
+/// contract; received media uses [`VideoFrame`], which also carries keyframe and RTP metadata.
 #[derive(Debug, Clone)]
 pub struct TimedVideoFrame {
     pub data: Vec<u8>,

--- a/src/voip/video.rs
+++ b/src/voip/video.rs
@@ -38,7 +38,9 @@ pub trait VideoSource: Send + Sync + 'static {
 }
 
 /// A video sink for a call: reassembled peer access units, with keyframe/orientation metadata.
-/// VoIP is loss tolerant, so the facade drops a frame if the sink can't keep up.
+/// Each frame also carries its 90 kHz RTP timestamp and the authoritative call generation
+/// stamped by the facade, so consumers can fence stale generations after a same-call-id
+/// replacement. VoIP is loss tolerant, so the facade drops a frame if the sink can't keep up.
 pub trait VideoSink: Send + Sync + 'static {
     /// The channel the facade writes received AUs to. Called once when video starts.
     fn playout(&self) -> async_channel::Sender<VideoFrame>;

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -3009,7 +3009,7 @@ impl CallEngine {
                     now,
                     VIDEO_CLOCK_RATE,
                 );
-                for au in completed {
+                for (timestamp, au) in completed {
                     let keyframe = au_is_keyframe(&au);
                     self.outbox.push_back(Output::VideoPlayout(VideoFrame {
                         data: au,
@@ -3018,7 +3018,7 @@ impl CallEngine {
                         sender: None,
                         device: None,
                         pid: None,
-                        timestamp: header.timestamp,
+                        timestamp,
                         generation: 0,
                     }));
                 }
@@ -3416,7 +3416,7 @@ impl CallEngine {
                 .or_else(|| group.video_orientations.get(&video.user_jid))
                 .copied()
                 .unwrap_or_default();
-            for access_unit in video.access_units {
+            for (timestamp, access_unit) in video.access_units {
                 let keyframe = au_is_keyframe(&access_unit);
                 self.outbox.push_back(Output::VideoPlayout(VideoFrame {
                     data: access_unit,
@@ -3425,7 +3425,7 @@ impl CallEngine {
                     sender: Some(video.user_jid.clone()),
                     device: Some(video.device_jid.clone()),
                     pid: video.pid,
-                    timestamp: video.header.timestamp,
+                    timestamp,
                     generation: 0,
                 }));
             }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -3018,6 +3018,8 @@ impl CallEngine {
                         sender: None,
                         device: None,
                         pid: None,
+                        timestamp: header.timestamp,
+                        generation: 0,
                     }));
                 }
             }
@@ -3423,6 +3425,8 @@ impl CallEngine {
                     sender: Some(video.user_jid.clone()),
                     device: Some(video.device_jid.clone()),
                     pid: video.pid,
+                    timestamp: video.header.timestamp,
+                    generation: 0,
                 }));
             }
             return;

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -102,7 +102,7 @@ pub struct ParticipantVideo {
     pub device_jid: Jid,
     pub pid: Option<u32>,
     pub header: RtpHeader,
-    pub access_units: Vec<Vec<u8>>,
+    pub access_units: Vec<(u32, Vec<u8>)>,
 }
 
 struct ParticipantReceiver {

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -1308,7 +1308,8 @@ mod tests {
                 .find_map(|packet| registry.unprotect_video(packet))
                 .expect("participant video packet");
             assert_eq!(decoded.device_jid, *peer);
-            assert_eq!(decoded.access_units, [access_unit.to_vec()]);
+            assert_eq!(decoded.access_units.len(), 1);
+            assert_eq!(decoded.access_units[0].1, access_unit);
         }
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -1309,6 +1309,7 @@ mod tests {
                 .expect("participant video packet");
             assert_eq!(decoded.device_jid, *peer);
             assert_eq!(decoded.access_units.len(), 1);
+            assert_eq!(decoded.access_units[0].0, decoded.header.timestamp);
             assert_eq!(decoded.access_units[0].1, access_unit);
         }
     }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -40,6 +40,10 @@ pub struct VideoFrame {
     pub device: Option<Jid>,
     /// Relay participant id from the authoritative roster.
     pub pid: Option<u32>,
+    /// RTP capture timestamp of the access unit (90 kHz video clock).
+    pub timestamp: u32,
+    /// Call media generation that produced this frame.
+    pub generation: u64,
 }
 
 impl VideoFrame {
@@ -50,8 +54,9 @@ impl VideoFrame {
             keyframe,
             orientation: 0,
             sender: None,
-            device: None,
             pid: None,
+            timestamp: 0,
+            generation: 0,
         }
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -356,8 +356,10 @@ impl H264Depacketizer {
                 // is a reordered packet from an already-past AU — discard it rather than flush the
                 // current partial as complete, which would corrupt video on normal reordering.
                 if (timestamp.wrapping_sub(cur) as i32) > 0 {
+                    // A timestamp boundary invalidates any partial FU, even when
+                    // no complete NAL has reached the access-unit buffer yet.
+                    self.drop_partial_fu();
                     if !self.au_buf.is_empty() {
-                        self.drop_partial_fu();
                         let au = std::mem::take(&mut self.au_buf);
                         self.queue_ready(cur, au);
                     }
@@ -742,6 +744,23 @@ mod tests {
             out, None,
             "a gapped fragment must not extend the partial NAL"
         );
+    }
+
+    #[test]
+    fn timestamp_change_clears_incomplete_fu_before_middle_fragment() {
+        let au = au_from_nals(&[nal(5, 2500)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        assert!(payloads.len() >= 3);
+
+        let mut d = H264Depacketizer::default();
+        assert_eq!(d.push(0, 1000, &payloads[0], false), None);
+        // A middle fragment from a new AU must not inherit the old FU.
+        assert_eq!(d.push(1, 2000, &payloads[1], false), None);
+        assert_eq!(d.push(2, 2000, &payloads[2], true), None);
+
+        let next = nal(1, 40);
+        assert_eq!(d.push(3, 3000, &next, true), Some(au_from_nals(&[next])));
     }
 
     #[test]

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -54,6 +54,7 @@ impl VideoFrame {
             keyframe,
             orientation: 0,
             sender: None,
+            device: None,
             pid: None,
             timestamp: 0,
             generation: 0,
@@ -300,9 +301,8 @@ pub struct H264Depacketizer {
     au_timestamp: Option<u32>,
     /// Keeps a marker-completed AU closed when one of its packets arrives late.
     last_completed_timestamp: Option<u32>,
-    /// AUs completed this or a prior push but not yet handed back (drained one per
-    /// `push`), so a timestamp boundary coinciding with a marker never drops one.
-    ready: std::collections::VecDeque<Vec<u8>>,
+    /// AUs completed but not yet returned, paired with their RTP timestamps.
+    ready: std::collections::VecDeque<(u32, Vec<u8>)>,
 }
 
 impl H264Depacketizer {
@@ -315,15 +315,15 @@ impl H264Depacketizer {
         self.ready.clear();
     }
 
-    fn queue_ready(&mut self, au: Vec<u8>) {
+    fn queue_ready(&mut self, timestamp: u32, au: Vec<u8>) {
         if self.ready.len() >= H264_MAX_READY_AUS {
             self.ready.pop_front();
         }
-        self.ready.push_back(au);
+        self.ready.push_back((timestamp, au));
     }
 
-    /// Take another AU completed by the previous [`push`](Self::push).
-    pub fn pop_ready(&mut self) -> Option<Vec<u8>> {
+    /// Take another completed AU while preserving its RTP timestamp.
+    pub fn pop_ready(&mut self) -> Option<(u32, Vec<u8>)> {
         self.ready.pop_front()
     }
 
@@ -348,7 +348,7 @@ impl H264Depacketizer {
         timestamp: u32,
         payload: &[u8],
         marker: bool,
-    ) -> Option<Vec<u8>> {
+    ) -> Option<(u32, Vec<u8>)> {
         if let Some(cur) = self.au_timestamp {
             if timestamp != cur {
                 // Signed wrap-aware compare (RFC 3550): a FORWARD jump begins a new AU, so flush the
@@ -359,19 +359,19 @@ impl H264Depacketizer {
                     if !self.au_buf.is_empty() {
                         self.drop_partial_fu();
                         let au = std::mem::take(&mut self.au_buf);
-                        self.queue_ready(au);
+                        self.queue_ready(cur, au);
                     }
                     self.last_completed_timestamp = Some(cur);
                     self.au_timestamp = Some(timestamp);
                 } else {
-                    return self.ready.pop_front();
+                    return self.pop_ready();
                 }
             }
         } else {
             if let Some(completed) = self.last_completed_timestamp
                 && (timestamp.wrapping_sub(completed) as i32) <= 0
             {
-                return self.ready.pop_front();
+                return self.pop_ready();
             }
             self.au_timestamp = Some(timestamp);
         }
@@ -429,24 +429,13 @@ impl H264Depacketizer {
             // Type 0 (empty/garbage) and unsupported aggregation types are ignored.
             _ => {}
         }
-        if let Some(au) = self.flush_on(marker) {
-            self.queue_ready(au);
+        if marker && !self.au_buf.is_empty() {
+            self.drop_partial_fu();
+            let completed_timestamp = self.au_timestamp.take().unwrap_or(timestamp);
+            let au = std::mem::take(&mut self.au_buf);
+            self.queue_ready(completed_timestamp, au);
         }
-        // The caller must drain `pop_ready` immediately: a timestamp boundary and marker can finish
-        // two access units in one push.
-        self.ready.pop_front()
-    }
-
-    fn flush_on(&mut self, marker: bool) -> Option<Vec<u8>> {
-        if !marker {
-            return None;
-        }
-        self.drop_partial_fu();
-        self.last_completed_timestamp = self.au_timestamp.take();
-        if self.au_buf.is_empty() {
-            return None;
-        }
-        Some(std::mem::take(&mut self.au_buf))
+        self.pop_ready()
     }
 }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -528,7 +528,7 @@ mod tests {
         let mut au = None;
         // All packets of one AU share a timestamp.
         for (i, p) in payloads.enumerate() {
-            if let Some(got) = d.push(i as u16, 9000, p, i == last) {
+            if let Some((_, got)) = d.push(i as u16, 9000, p, i == last) {
                 au = Some(got);
             }
         }
@@ -760,7 +760,10 @@ mod tests {
         assert_eq!(d.push(2, 2000, &payloads[2], true), None);
 
         let next = nal(1, 40);
-        assert_eq!(d.push(3, 3000, &next, true), Some(au_from_nals(&[next])));
+        assert_eq!(
+            d.push(3, 3000, &next, true),
+            Some((3000, au_from_nals(&[next])))
+        );
     }
 
     #[test]
@@ -779,7 +782,7 @@ mod tests {
         let got = d
             .push(100, 13000, &tail, true)
             .expect("fresh NAL must flush");
-        assert_eq!(got, au_from_nals(&[tail]));
+        assert_eq!(got, (13000, au_from_nals(&[tail])));
     }
 
     #[test]
@@ -822,17 +825,13 @@ mod tests {
         let flushed = d
             .push(2, 2000, &b1, false)
             .expect("a new timestamp must flush the previous AU whose marker was lost");
-        assert_eq!(
-            flushed,
-            au_from_nals(&[a1]),
-            "the flushed AU is the buffered first frame, not a merge of both"
-        );
+        assert_eq!(flushed, (1000, au_from_nals(&[a1])));
         // AU2 completes normally on its marker.
         let b2 = nal(5, 30);
         let au2 = d
             .push(3, 2000, &b2, true)
             .expect("AU2 completes on its marker");
-        assert_eq!(au2, au_from_nals(&[b1, b2]));
+        assert_eq!(au2, (2000, au_from_nals(&[b1, b2])));
     }
 
     // A reordered packet from an OLDER timestamp must not flush the current AU as complete: it is
@@ -843,7 +842,7 @@ mod tests {
         // AU1 @ ts 1000 completes cleanly.
         let a1 = nal(1, 20);
         let want_a1 = au_from_nals(std::slice::from_ref(&a1));
-        assert_eq!(d.push(0, 1000, &a1, true), Some(want_a1));
+        assert_eq!(d.push(0, 1000, &a1, true), Some((1000, want_a1)));
         // AU2 @ ts 2000 starts (first of two packets, no marker yet).
         let b1 = nal(1, 30);
         assert_eq!(d.push(1, 2000, &b1, false), None);
@@ -859,7 +858,7 @@ mod tests {
         let b2 = nal(5, 25);
         assert_eq!(
             d.push(3, 2000, &b2, true),
-            Some(au_from_nals(&[b1, b2])),
+            Some((2000, au_from_nals(&[b1, b2]))),
             "the in-progress AU survives the reordered packet and completes on its marker"
         );
     }
@@ -870,7 +869,7 @@ mod tests {
         let completed = nal(5, 20);
         assert_eq!(
             d.push(10, 1000, &completed, true),
-            Some(au_from_nals(std::slice::from_ref(&completed)))
+            Some((1000, au_from_nals(std::slice::from_ref(&completed))))
         );
 
         let late = nal(1, 15);
@@ -878,7 +877,7 @@ mod tests {
         let next = nal(1, 25);
         assert_eq!(
             d.push(11, 2000, &next, true),
-            Some(au_from_nals(std::slice::from_ref(&next))),
+            Some((2000, au_from_nals(std::slice::from_ref(&next)))),
             "a late packet from the completed timestamp must not leak into the next AU"
         );
     }
@@ -896,11 +895,11 @@ mod tests {
         let first = d
             .push(1, 2000, &b1, true)
             .expect("boundary flush returns AU1");
-        assert_eq!(first, au_from_nals(&[a1]));
+        assert_eq!(first, (1000, au_from_nals(&[a1])));
         let second = d
             .pop_ready()
             .expect("the second completed AU is ready without another packet");
-        assert_eq!(second, au_from_nals(&[b1]));
+        assert_eq!(second, (2000, au_from_nals(&[b1])));
         assert_eq!(d.pop_ready(), None);
     }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -432,6 +432,7 @@ impl H264Depacketizer {
         if marker && !self.au_buf.is_empty() {
             self.drop_partial_fu();
             let completed_timestamp = self.au_timestamp.take().unwrap_or(timestamp);
+            self.last_completed_timestamp = Some(completed_timestamp);
             let au = std::mem::take(&mut self.au_buf);
             self.queue_ready(completed_timestamp, au);
         }

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -1048,7 +1048,12 @@ impl VideoPipeline {
     /// the reassembled access unit is returned on the AU's marker packet.
     pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<Vec<Vec<u8>>> {
         let completed = self.unprotect_video_packet(packet)?.1;
-        (!completed.is_empty()).then_some(completed)
+        (!completed.is_empty()).then_some(
+            completed
+                .into_iter()
+                .map(|(_, access_unit)| access_unit)
+                .collect(),
+        )
     }
 
     pub(crate) fn unprotect_video_packet(

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -785,6 +785,9 @@ fn unprotect_srtp_packet(
 /// per media type) and WARP MI tag, but H.264 packetization on top and its own
 /// SSRC/sequencer. One access unit fans out to N RTP packets on send and is
 /// reassembled from them on receive.
+type TimestampedAccessUnit = (u32, Vec<u8>);
+type VideoPacketResult = (RtpHeader, Vec<TimestampedAccessUnit>);
+
 pub struct VideoPipeline {
     send_keys: E2eSrtpKeys,
     recv_keys: E2eSrtpKeys,
@@ -1056,10 +1059,7 @@ impl VideoPipeline {
         )
     }
 
-    pub(crate) fn unprotect_video_packet(
-        &mut self,
-        packet: &[u8],
-    ) -> Option<(RtpHeader, Vec<(u32, Vec<u8>)>)> {
+    pub(crate) fn unprotect_video_packet(&mut self, packet: &[u8]) -> Option<VideoPacketResult> {
         let (header, payload) = unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_streams,

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -1054,7 +1054,7 @@ impl VideoPipeline {
     pub(crate) fn unprotect_video_packet(
         &mut self,
         packet: &[u8],
-    ) -> Option<(RtpHeader, Vec<Vec<u8>>)> {
+    ) -> Option<(RtpHeader, Vec<(u32, Vec<u8>)>)> {
         let (header, payload) = unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_streams,


### PR DESCRIPTION
Closes oxidezap/whatsapp-rust#1450

## Summary
- expose inbound H.264 RTP timestamp on `VideoFrame`
- carry authoritative call generation through the existing bounded `VideoSink` path
- preserve `VideoFrame::new` and existing sink/source APIs
- populate timestamps for 1:1 and group inbound video

## Why
Applications forwarding or recording received media need source timing and generation fencing. Arrival-time inference cannot safely handle reconnects, packet loss, or same-call-id replacement.

## Verification
- `cargo test -p wacore --lib voip -- --nocapture` (2 passed)
- `cargo check -p whatsapp-rust --lib` (passed)
- `git diff --check` (passed)

## Scope
This keeps media fan-out, downstream processing, and application lifecycle ownership outside whatsapp-rust. No application-specific media dependency was added.