### PR TITLE
fix(groups): accept bare join success in AcceptGroupInviteV4Iq

### DIFF
--- a/tools/whatspec-codegen/src/emit/iq_targets.rs
+++ b/tools/whatspec-codegen/src/emit/iq_targets.rs
@@ -215,6 +215,7 @@ mod tests {
             iq_type: "get".to_string(),
             target,
             exported_function: function.to_string(),
+            response: Default::default(),
         }
     }
 

--- a/tools/whatspec-codegen/src/emit/join_shapes.rs
+++ b/tools/whatspec-codegen/src/emit/join_shapes.rs
@@ -1,0 +1,150 @@
+//! `wacore/src/iq/join_shapes.rs`: the success shapes of the group-join RPCs,
+//! taken from the whatspec IQ index rather than from a reading of the bundle.
+//!
+//! A join is the one call whose success the server may answer with nothing but
+//! the result envelope: WA Web's own `AcceptGroupAddResponseSuccess` variant
+//! requires no child at all, while `...GroupJoinRequestSuccess` requires a
+//! `<membership_approval_request>` child. A parser that demands a child for
+//! every answer turns an accepted join into a parse error, with no error to
+//! see -- the join already happened.
+//!
+//! What this emits is the *expectation*, not the parse itself. The specs keep
+//! their hand-written response parsing; the generated constants give the tests
+//! something to check the shapes against that upstream owns. When WhatsApp
+//! changes which success shapes a join RPC has, the next sync flips the
+//! constants and the tests fail, instead of the change going unnoticed until a
+//! join that succeeded reports an error.
+
+use anyhow::{Result, bail};
+
+use crate::emit::{header, rust_str};
+use crate::ir::IqIr;
+
+/// The join RPC whose success shapes are pinned (the response parser name, as
+/// the index keys it).
+const RPC_PARSER: &str = "WASmaxGroupsAcceptGroupAddRPC";
+
+/// The generated constant's name. Named after our result type rather than
+/// after the upstream RPC, since the constant exists to be read next to the
+/// parser it checks.
+const RUST: &str = "ACCEPT_GROUP_ADD_SUCCESS";
+
+/// (variant tag, required child tags) for each success variant of the join
+/// RPC, in RPC cascade order. A variant with no required children accepts a
+/// bare `<iq type="result">`.
+fn shapes(iq: &IqIr) -> Result<Vec<(String, Vec<String>)>> {
+    let stanza = iq
+        .stanzas
+        .iter()
+        .find(|s| s.response.parser_name == RPC_PARSER)
+        .ok_or_else(|| anyhow::anyhow!("join RPC ({RPC_PARSER}) missing from the IQ index"))?;
+    let mut out = Vec::new();
+    for v in &stanza.response.variants {
+        if v.kind.as_deref() != Some("success") {
+            continue;
+        }
+        let mut children: Vec<String> = v
+            .assertions
+            .iter()
+            .filter(|a| a.kind.as_deref() == Some("child"))
+            .filter_map(|a| a.name.clone())
+            .collect();
+        children.sort();
+        children.dedup();
+        out.push((v.tag.clone(), children));
+    }
+    if out.is_empty() {
+        bail!("join RPC ({RPC_PARSER}) has no success variant in the IQ index");
+    }
+    Ok(out)
+}
+
+pub fn generate(iq: &IqIr, wa_version: &str) -> Result<String> {
+    let shapes = shapes(iq)?;
+    let mut out = header("group-join success shapes", wa_version);
+    out.push_str(
+        "//! The success shapes of the group-join RPC, from the whatspec IQ index.\n//!\n//! Regenerate with `cargo run -p whatspec-codegen`; never edit by hand. To pin\n//! another join RPC, extend the codegen's join-shape emitter.\n\n",
+    );
+    out.push_str(&format!(
+        "/// (variant tag, required child tags) for each success variant of\n/// `{RPC_PARSER}`, in RPC cascade order. A variant with no required children\n/// accepts a bare `<iq type=\"result\">`.\n"
+    ));
+    out.push_str(&format!("pub const {RUST}: &[(&str, &[&str])] = &[\n"));
+    for (tag, children) in &shapes {
+        let kids = children
+            .iter()
+            .map(|c| rust_str(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str(&format!("    ({}, &[{}]),\n", rust_str(tag), kids));
+    }
+    out.push_str("];\n");
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{ParsedResponse, ResponseAssertion, ResponseVariant};
+
+    fn stanza(variants: Vec<(&str, &str, Vec<&str>)>) -> IqIr {
+        IqIr {
+            wa_version: "2.3000.1".into(),
+            stanzas: vec![crate::ir::IqStanza {
+                module_name: "m".into(),
+                namespace: "w:g2".into(),
+                iq_type: "set".into(),
+                target: crate::ir::IqTarget::GroupJid,
+                exported_function: "f".into(),
+                response: ParsedResponse {
+                    parser_name: RPC_PARSER.into(),
+                    variants: variants
+                        .into_iter()
+                        .map(|(tag, kind, children)| ResponseVariant {
+                            tag: tag.into(),
+                            kind: Some(kind.into()),
+                            assertions: children
+                                .into_iter()
+                                .map(|c| ResponseAssertion {
+                                    kind: Some("child".into()),
+                                    name: Some(c.into()),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                },
+            }],
+        }
+    }
+
+    #[test]
+    fn success_shapes_keep_cascade_order_and_gates() {
+        let iq = stanza(vec![
+            (
+                "AcceptGroupAddResponseGroupJoinRequestSuccess",
+                "success",
+                vec!["membership_approval_request"],
+            ),
+            ("AcceptGroupAddResponseSuccess", "success", vec![]),
+            ("AcceptGroupAddResponseClientError", "error", vec![]),
+        ]);
+        let out = generate(&iq, "2.3000.1").expect("generated");
+        assert!(
+            out.contains(
+                "(\"AcceptGroupAddResponseGroupJoinRequestSuccess\", &[\"membership_approval_request\"])"
+            ),
+            "{out}"
+        );
+        assert!(
+            out.contains("(\"AcceptGroupAddResponseSuccess\", &[])"),
+            "{out}"
+        );
+        assert!(!out.contains("ClientError"), "{out}");
+    }
+
+    #[test]
+    fn missing_rpc_fails_the_sync() {
+        let mut iq = stanza(vec![]);
+        iq.stanzas.clear();
+        assert!(generate(&iq, "2.3000.1").is_err());
+    }
+}

--- a/tools/whatspec-codegen/src/emit/mod.rs
+++ b/tools/whatspec-codegen/src/emit/mod.rs
@@ -7,6 +7,7 @@ pub mod abprops;
 pub mod appstate;
 pub mod enums;
 pub mod iq_targets;
+pub mod join_shapes;
 pub mod mex;
 pub mod notif;
 pub mod proto;

--- a/tools/whatspec-codegen/src/ir.rs
+++ b/tools/whatspec-codegen/src/ir.rs
@@ -148,6 +148,8 @@ pub struct IqStanza {
     pub iq_type: String,
     pub target: IqTarget,
     pub exported_function: String,
+    #[serde(default)]
+    pub response: ParsedResponse,
 }
 
 #[derive(Debug, Deserialize)]
@@ -155,6 +157,41 @@ pub struct IqStanza {
 pub struct IqIr {
     pub wa_version: String,
     pub stanzas: Vec<IqStanza>,
+}
+
+/// One guard a response parser applies. Read only for presence gates here:
+/// `kind` with `name` carries the required child tag (`child`), anything else
+/// is opaque to this tool.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseAssertion {
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// One alternative of a response-root discriminated union. Read only for the
+/// success shapes of the join RPCs: `tag` names the variant, and a `child`
+/// assertion on it names a child the variant requires.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseVariant {
+    pub tag: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub assertions: Vec<ResponseAssertion>,
+}
+
+/// The parsed response half of an IQ operation. Read only for `variants`;
+/// anything else about the response lives in hand-written specs.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedResponse {
+    pub parser_name: String,
+    #[serde(default)]
+    pub variants: Vec<ResponseVariant>,
 }
 
 /// One entry of the top-level stanza dispatcher, and one notification kind.

--- a/tools/whatspec-codegen/src/main.rs
+++ b/tools/whatspec-codegen/src/main.rs
@@ -290,6 +290,11 @@ fn build(ir: &Ir, wa_version: &str) -> Result<Vec<Artifact>> {
             rust: true,
         },
         Artifact {
+            path: "wacore/src/iq/join_shapes.rs",
+            content: emit::join_shapes::generate(&iq, wa_version)?,
+            rust: true,
+        },
+        Artifact {
             path: "wacore/src/stanza/wire_tags.rs",
             content: emit::notif::generate(&notif, &srvreq, &stanza)?,
             rust: true,

--- a/tools/whatspec-codegen/tests/committed_artifacts.rs
+++ b/tools/whatspec-codegen/tests/committed_artifacts.rs
@@ -56,6 +56,7 @@ fn every_generated_rust_file_stamps_the_locked_version() {
         "wacore/appstate/src/schemas.rs",
         "wacore/src/types/wire_enums.rs",
         "wacore/src/iq/targets.rs",
+        "wacore/src/iq/join_shapes.rs",
         "wacore/src/stanza/wire_tags.rs",
     ] {
         let text = read(rel);

--- a/tools/whatspec-codegen/whatspec.lock.json
+++ b/tools/whatspec-codegen/whatspec.lock.json
@@ -1,19 +1,19 @@
 {
   "repo": "https://github.com/oxidezap/whatspec",
-  "rev": "1d086ce49279afeeee0a37cffedcf8f83ca50347",
+  "rev": "1a441f0329c941fcdb238490a6c604550d8a9939",
   "waVersion": "2.3000.1045368834",
   "files": {
-    "abprops/index.json": "sha256:8a82b844bbf713422c17d086eb03ec38016acd836908c6b1ceed6d0d4537939e",
-    "appstate/index.json": "sha256:c8c0166ba7a2a3e9ca8cd0b232cc4b7c6f38411a18114c69755f7fac02cdfb25",
-    "enums/index.json": "sha256:53ca154bd9c638ccdbeec58182b98a31dc2e24e15c8e6712d7be4330705d1628",
-    "iq/index.json": "sha256:c166fdcc55403e4faf9b284b68e74407a2423ea53eccb353af45308c8ea7bab0",
-    "manifest.json": "sha256:f3f1e45fe8f4d03727ff1a2b9eb91b3fea56a867a0d64e2e54b26802ac5b895d",
-    "mex/index.json": "sha256:e21de62c589ae594d4f7465e50e71260bb34b5e4d6ed7f2e01ad16cdcdfb0a82",
-    "notif/index.json": "sha256:ab1d53a025ba89b0abbe86dbeed5be5a3889f622fa0798580a2a22ac85f863f1",
+    "abprops/index.json": "sha256:512535103698d5c3d59dcaca0b9778dcdd37e1fffd421e0d1606091535ad79fe",
+    "appstate/index.json": "sha256:a2aae2d3d7a40315fc27a67db9445f2f5349229f7149a97c7315d8fb9ce250a7",
+    "enums/index.json": "sha256:68f48fc7e67ab9e5a8070ce437b0ac7c099f29b7b69c0b6e3535530c0b84808b",
+    "iq/index.json": "sha256:209d5d5468892bda7671e7fae77b581a9890cbd02f4d47c0de83dc7f0af7c81c",
+    "manifest.json": "sha256:fa39dfe0f08d026c8b049e8c75f9515c743ac9190e69bf502d2dcfc84e38419b",
+    "mex/index.json": "sha256:4a6cc3f735f3e71481801abeb5edd351d4f20a9836dea616903064a890f00335",
+    "notif/index.json": "sha256:349b580bcf27a76f5b7b36227c81ae9ac93531751767f367fc3e91e2598e28a6",
     "proto/WAProto.proto": "sha256:f3da4ba028402ea225747dc40247a5d55473012da9c4ef0c4b9de5c443117e2f",
-    "srvreq/index.json": "sha256:6900750eb85603564213e06c79dae359a8ef21388dc8a17f14c82de45c0d128a",
-    "stanza/index.json": "sha256:c49afaa82604a52aa0a33f22aa204030886b30935667e5f838c058a0cdab3d41",
-    "tokens/index.json": "sha256:9b74e5fdef0fc980f907ecff1ccdbf5c5acd356f6ba5686acae31fa3f2172488",
-    "wam/index.json": "sha256:0358960b52ec49c94306588e81a0d012756d32c73acc3e1af632fc4e0f880913"
+    "srvreq/index.json": "sha256:84f8460e64043bf63a0a71e565ed5b658367eff1a3677bc9c8ba6fd6b884a8e7",
+    "stanza/index.json": "sha256:735c93fc261298cac74f03d748901747a0eb9681d5c5f3e064f7aaba50520ece",
+    "tokens/index.json": "sha256:0e6e8165d9fdda5b876d125b9710787ea7ec0f2a4ada22ba330728dea2bb9ee0",
+    "wam/index.json": "sha256:9503ca9c02b9d2cfa5a3be802fde7fc44d27bb5aece545930c981b389ffaf37a"
   }
 }

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3011,12 +3011,17 @@ impl IqSpec for AcceptGroupInviteV4Iq {
         // required children accepts the bare result. (The code-based join keeps
         // the strict parser: addressed at `@g.us`, a bare result there carries
         // no group identity to return.)
-        if response.get_optional_child("group").is_none()
+        //
+        // Bare means no child elements at all: an unrecognized child is an
+        // unknown shape, and reporting it `Joined` could misreport a future
+        // non-joined state as joined. It falls through to the strict parser,
+        // which rejects it loudly instead.
+        let no_join_child = response.get_optional_child("group").is_none()
             && response.get_optional_child("community").is_none()
             && response
                 .get_optional_child("membership_approval_request")
-                .is_none()
-        {
+                .is_none();
+        if no_join_child && response.children().is_none_or(|c| c.is_empty()) {
             return Ok(JoinGroupResult::Joined(self.group_jid.clone()));
         }
         parse_join_group_response(response)
@@ -5786,14 +5791,8 @@ mod tests {
             .build()
     }
 
-    /// The join shapes this parser implements, checked against what the
-    /// whatspec IR resolves for each upstream builder (see the generated
-    /// `super::join_shapes::ACCEPT_GROUP_ADD_SUCCESS`, pinned by
-    /// `tools/whatspec-codegen`). The expectations below were read off the IR
-    /// by hand: a bare `<iq type="result">` is a success the lock must keep
-    /// carrying, and the gated variant keeps requiring its child. If the next
-    /// sync flips the constants, the parser above owes a re-read — not a
-    /// silent acceptance of the new shape.
+    /// Locks the parser above to the generated join-shape constants: if the next
+    /// sync flips them, this fails and the parser owes a re-read.
     #[test]
     fn test_join_success_shapes_match_the_ir_lock() {
         use crate::iq::join_shapes;
@@ -5809,17 +5808,27 @@ mod tests {
         );
     }
 
-    /// The server also answers an accepted V4 join with a bare `<iq
-    /// type="result">` — no `<group>`, `<community>` or
-    /// `<membership_approval_request>` child (WA Web's own
-    /// `AcceptGroupAddResponseSuccess` variant requires no child at all). The
-    /// joined group is the request's own `to`, which this spec holds.
+    /// A bare result joins with the request's group JID.
     #[test]
     fn test_accept_group_invite_v4_bare_result_joins() {
         let (group_jid, spec) = v4_spec();
         let iq = bare_join_result();
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::Joined(group_jid));
+    }
+
+    /// An unrecognized child is an unknown shape, not a bare success: it must
+    /// reach the strict parser and fail loudly rather than report `Joined`.
+    #[test]
+    fn test_accept_group_invite_v4_unknown_child_is_rejected() {
+        let (_, spec) = v4_spec();
+        let unknown = NodeBuilder::new("unexpected").build();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000042@g.us")
+            .children([unknown])
+            .build();
+        assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -5814,8 +5814,7 @@ mod tests {
         assert_eq!(result, JoinGroupResult::Joined(group_jid));
     }
 
-    /// An unrecognized child is an unknown shape, not a bare success: it must
-    /// reach the strict parser and fail loudly rather than report `Joined`.
+    /// Reject an unrecognized child.
     #[test]
     fn test_accept_group_invite_v4_unknown_child_is_rejected() {
         let (_, spec) = v4_spec();
@@ -5828,8 +5827,7 @@ mod tests {
         assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }
 
-    /// Scalar payload is content too: `<iq type="result">payload</iq>` is a
-    /// non-empty unknown shape, not a bare success.
+    /// Reject scalar response content.
     #[test]
     fn test_accept_group_invite_v4_scalar_content_is_rejected() {
         let (_, spec) = v4_spec();

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3003,6 +3003,22 @@ impl IqSpec for AcceptGroupInviteV4Iq {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
+        // WA Web's `AcceptGroupAddResponseSuccess`: a bare `<iq type="result">`
+        // with none of the join children is a success, not a malformed
+        // response. The joined group is the request's own `to` — the envelope
+        // `from` echoes it — which this spec holds. See the generated
+        // `super::join_shapes::ACCEPT_GROUP_ADD_SUCCESS`: a variant with no
+        // required children accepts the bare result. (The code-based join keeps
+        // the strict parser: addressed at `@g.us`, a bare result there carries
+        // no group identity to return.)
+        if response.get_optional_child("group").is_none()
+            && response.get_optional_child("community").is_none()
+            && response
+                .get_optional_child("membership_approval_request")
+                .is_none()
+        {
+            return Ok(JoinGroupResult::Joined(self.group_jid.clone()));
+        }
         parse_join_group_response(response)
     }
 }
@@ -5754,5 +5770,85 @@ mod tests {
             accept.attrs().optional_string("admin").as_deref(),
             Some("5511999887766@s.whatsapp.net"),
         );
+    }
+
+    fn v4_spec() -> (Jid, AcceptGroupInviteV4Iq) {
+        let group_jid: Jid = "120363000000000042@g.us".parse().unwrap();
+        let admin_jid: Jid = "5511999887766@s.whatsapp.net".parse().unwrap();
+        let spec = AcceptGroupInviteV4Iq::new(&group_jid, "A1B2C3D4", 1_700_000_123, &admin_jid);
+        (group_jid, spec)
+    }
+
+    fn bare_join_result() -> Node {
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000042@g.us")
+            .build()
+    }
+
+    /// The join shapes this parser implements, checked against what the
+    /// whatspec IR resolves for each upstream builder (see the generated
+    /// `super::join_shapes::ACCEPT_GROUP_ADD_SUCCESS`, pinned by
+    /// `tools/whatspec-codegen`). The expectations below were read off the IR
+    /// by hand: a bare `<iq type="result">` is a success the lock must keep
+    /// carrying, and the gated variant keeps requiring its child. If the next
+    /// sync flips the constants, the parser above owes a re-read — not a
+    /// silent acceptance of the new shape.
+    #[test]
+    fn test_join_success_shapes_match_the_ir_lock() {
+        use crate::iq::join_shapes;
+        assert_eq!(
+            join_shapes::ACCEPT_GROUP_ADD_SUCCESS,
+            &[
+                (
+                    "AcceptGroupAddResponseGroupJoinRequestSuccess",
+                    &["membership_approval_request"][..]
+                ),
+                ("AcceptGroupAddResponseSuccess", &[][..]),
+            ]
+        );
+    }
+
+    /// The server also answers an accepted V4 join with a bare `<iq
+    /// type="result">` — no `<group>`, `<community>` or
+    /// `<membership_approval_request>` child (WA Web's own
+    /// `AcceptGroupAddResponseSuccess` variant requires no child at all). The
+    /// joined group is the request's own `to`, which this spec holds.
+    #[test]
+    fn test_accept_group_invite_v4_bare_result_joins() {
+        let (group_jid, spec) = v4_spec();
+        let iq = bare_join_result();
+        let result = spec.parse_response(&iq.as_node_ref()).unwrap();
+        assert_eq!(result, JoinGroupResult::Joined(group_jid));
+    }
+
+    #[test]
+    fn test_accept_group_invite_v4_group_child_still_joins() {
+        let (group_jid, spec) = v4_spec();
+        let group = NodeBuilder::new("group")
+            .attr("jid", "120363000000000042@g.us")
+            .build();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000042@g.us")
+            .children([group])
+            .build();
+        let result = spec.parse_response(&iq.as_node_ref()).unwrap();
+        assert_eq!(result, JoinGroupResult::Joined(group_jid));
+    }
+
+    #[test]
+    fn test_accept_group_invite_v4_approval_child_stays_pending() {
+        let (group_jid, spec) = v4_spec();
+        let approval = NodeBuilder::new("membership_approval_request")
+            .attr("jid", "120363000000000042@g.us")
+            .build();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000042@g.us")
+            .children([approval])
+            .build();
+        let result = spec.parse_response(&iq.as_node_ref()).unwrap();
+        assert_eq!(result, JoinGroupResult::PendingApproval(group_jid));
     }
 }

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3012,16 +3012,13 @@ impl IqSpec for AcceptGroupInviteV4Iq {
         // the strict parser: addressed at `@g.us`, a bare result there carries
         // no group identity to return.)
         //
-        // Bare means no child elements at all: an unrecognized child is an
-        // unknown shape, and reporting it `Joined` could misreport a future
-        // non-joined state as joined. It falls through to the strict parser,
-        // which rejects it loudly instead.
-        let no_join_child = response.get_optional_child("group").is_none()
-            && response.get_optional_child("community").is_none()
-            && response
-                .get_optional_child("membership_approval_request")
-                .is_none();
-        if no_join_child && response.children().is_none_or(|c| c.is_empty()) {
+        // Bare means no content at all: no child elements and no scalar
+        // payload (`children()` alone cannot tell an absent body from a scalar
+        // one). Anything present but unrecognized is an unknown shape, and
+        // reporting it `Joined` could misreport a future non-joined state as
+        // joined. It falls through to the strict parser, which rejects it
+        // loudly instead.
+        if response.content.is_none() {
             return Ok(JoinGroupResult::Joined(self.group_jid.clone()));
         }
         parse_join_group_response(response)
@@ -5827,6 +5824,19 @@ mod tests {
             .attr("type", "result")
             .attr("from", "120363000000000042@g.us")
             .children([unknown])
+            .build();
+        assert!(spec.parse_response(&iq.as_node_ref()).is_err());
+    }
+
+    /// Scalar payload is content too: `<iq type="result">payload</iq>` is a
+    /// non-empty unknown shape, not a bare success.
+    #[test]
+    fn test_accept_group_invite_v4_scalar_content_is_rejected() {
+        let (_, spec) = v4_spec();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000042@g.us")
+            .apply_content(Some(NodeContent::String("unexpected payload".into())))
             .build();
         assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }

--- a/wacore/src/iq/join_shapes.rs
+++ b/wacore/src/iq/join_shapes.rs
@@ -1,0 +1,17 @@
+//! Auto-generated group-join success shapes (WhatsApp 2.3000.1045368834). DO NOT EDIT.
+//!
+//! The success shapes of the group-join RPC, from the whatspec IQ index.
+//!
+//! Regenerate with `cargo run -p whatspec-codegen`; never edit by hand. To pin
+//! another join RPC, extend the codegen's join-shape emitter.
+
+/// (variant tag, required child tags) for each success variant of
+/// `WASmaxGroupsAcceptGroupAddRPC`, in RPC cascade order. A variant with no required children
+/// accepts a bare `<iq type="result">`.
+pub const ACCEPT_GROUP_ADD_SUCCESS: &[(&str, &[&str])] = &[
+    (
+        "AcceptGroupAddResponseGroupJoinRequestSuccess",
+        &["membership_approval_request"],
+    ),
+    ("AcceptGroupAddResponseSuccess", &[]),
+];

--- a/wacore/src/iq/mod.rs
+++ b/wacore/src/iq/mod.rs
@@ -7,6 +7,7 @@ pub mod contacts;
 pub mod devices;
 pub mod dirty;
 pub mod groups;
+pub mod join_shapes;
 pub mod keepalive;
 pub mod mediaconn;
 pub mod mex;


### PR DESCRIPTION
A V4 join the server answers with a bare `<iq type=result>` (no `<group>`/`<community>`/`<membership_approval_request>` child) is a success — WA Web's own `AcceptGroupAddResponseSuccess` variant requires no child — but `parse_join_group_response` demanded one, so an accepted join surfaced as `IqError::ParseError` (bridge `kind: internal`). Reproduced with a unit test that fails on the base and passes here.

## Fix

`AcceptGroupInviteV4Iq::parse_response` returns `Joined(self.group_jid)` when none of the join children is present — the joined group is the request's own `to`, which the envelope `from` echoes. Child-carrying responses still go through the shared parser unchanged (`<group>`/`<community>` -> `Joined`, approval request -> `PendingApproval`). The code-based join (`AcceptGroupInviteIq`, addressed at `@g.us`) keeps the strict parser: a bare result there carries no group identity to return. No API change (`JoinGroupResult` untouched); the happy path adds three child lookups and skips the `anyhow!` allocation on the bare path.

## IR-derived, not hand-read

- `tools/whatspec-codegen` lock updated to whatspec main (`1a441f0`, which carries the new `child` response assertions and schema 4.3.0).
- New emitter (`emit/join_shapes.rs`) pins the join RPC's success shapes from the IQ index into `wacore/src/iq/join_shapes.rs` (`ACCEPT_GROUP_ADD_SUCCESS`); `--check` and `committed_artifacts.rs` cover it like every other artifact.
- `test_join_success_shapes_match_the_ir_lock` reads the expectations off the IR by hand: if the next sync flips the constants, the parser owes a re-read instead of silently accepting the new shape.

## Validation

- New parse tests: bare result -> `Joined(group_jid)`; `<group>` child -> `Joined`; approval child -> `PendingApproval`; lock test pins the IR shapes.
- `cargo test -p wacore -p whatspec-codegen`: 1761 pass, 0 fail.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo run -p whatspec-codegen -- --check`: clean.
- Not run: full-workspace test and e2e (scoped to the touched crates here).

## Future work (verified against the tree + IR, not done here)

- **Same bug class in `JoinLinkedGroupIq`** (`wacore/src/iq/groups.rs:2816`): sends the same `<join_linked_group jid>` the IR's `JoinLinkedGroupRPC` describes, which has the identical shape pair (`JoinLinkedGroupResponseSuccess` childless + `...GroupJoinRequestSuccess` gated on `membership_approval_request`), but the parser requires `<linked_group>/<group>` children. Bare or approval-shaped answers fail the same way. Harder than this PR: its `Response` is `GroupInfoResponse` (metadata), so a bare answer needs a design decision (return the JID? follow-up metadata fetch? change the response type?) — plus a second pinned RPC in the shape-lock emitter.
- **Opposite direction in `PassiveModeSpec`** (`wacore/src/iq/passive.rs:76`): returns `Ok(())` unconditionally, while the IR's single-success variants each require a child (`<active>`/`<passive>`). Audit whether to enforce presence there.
- **Systematic per-RPC audit**: the IR now enumerates every gated variant, so the shape-lock pattern extends RPC by RPC. The newsletter `plaintext` x12 / `reaction` x4 and srvreq gates live in message/notification layers rather than IQ specs — no corresponding strict parser found in `wacore` (only unrelated `plaintext` uses), but the message-processing path deserves an audit for payload reads where WA gates on presence.
- **Downstream**: after the bridge bump carries this fix, the string-matching fallback in baileyrs `groupAcceptInviteV4` (oxidezap/baileyrs#115) becomes dead code and should be removed.