### PR TITLE
feat(groups): derive join and passive shapes from the IR

### DIFF
--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -16,7 +16,7 @@ use log::warn;
 use thiserror::Error;
 use wacore::iq::groups::{
     CommunityParticipatingIq, DeleteCommunityIq, GetLinkedGroupsParticipantsIq, GroupCreateOptions,
-    JoinLinkedGroupIq, LinkSubgroupsIq, QueryLinkedGroupIq, UnlinkSubgroupsIq,
+    JoinGroupResult, JoinLinkedGroupIq, LinkSubgroupsIq, QueryLinkedGroupIq, UnlinkSubgroupsIq,
 };
 use wacore::iq::mex_operations::{fetch_all_subgroups, query_subgroup_participant_count};
 use wacore_binary::Jid;
@@ -41,6 +41,10 @@ pub enum CommunityError {
     /// The request was malformed or the server response was missing required data.
     #[error("invalid community request: {0}")]
     InvalidRequest(String),
+    /// The subgroup join was received but requires membership approval: the
+    /// caller is not in the group yet.
+    #[error("subgroup join requires membership approval: {0}")]
+    MembershipApprovalRequired(Jid),
 }
 
 // Types
@@ -434,6 +438,11 @@ impl<'a> Community<'a> {
     }
 
     /// Join a linked subgroup via the parent community.
+    ///
+    /// The join RPC itself carries no metadata (WA Web's success variants hold
+    /// no fields), so a joined result is followed by a metadata query. An
+    /// approval-pending join is reported rather than resolved: the caller is
+    /// not in the group, so there is no metadata to return.
     pub async fn join_subgroup(
         &self,
         community_jid: impl Into<Jid>,
@@ -441,11 +450,18 @@ impl<'a> Community<'a> {
     ) -> Result<GroupMetadata, CommunityError> {
         let community_jid = &community_jid.into();
         let subgroup_jid = &subgroup_jid.into();
-        let response = self
+        match self
             .client
             .execute(JoinLinkedGroupIq::new(community_jid, subgroup_jid))
-            .await?;
-        Ok(GroupMetadata::from(response))
+            .await?
+        {
+            JoinGroupResult::Joined(_) => {
+                self.query_linked_group(community_jid, subgroup_jid).await
+            }
+            JoinGroupResult::PendingApproval(jid) => {
+                Err(CommunityError::MembershipApprovalRequired(jid))
+            }
+        }
     }
 
     /// Get all participants across all linked groups of a community.

--- a/tools/whatspec-codegen/src/emit/join_shapes.rs
+++ b/tools/whatspec-codegen/src/emit/join_shapes.rs
@@ -1,43 +1,68 @@
-//! `wacore/src/iq/join_shapes.rs`: the success shapes of the group-join RPCs,
-//! taken from the whatspec IQ index rather than from a reading of the bundle.
+//! `wacore/src/iq/join_shapes.rs`: the success shapes of RPCs whose answers
+//! carry presence gates, taken from the whatspec IQ index rather than from a
+//! reading of the bundle.
 //!
-//! A join is the one call whose success the server may answer with nothing but
-//! the result envelope: WA Web's own `AcceptGroupAddResponseSuccess` variant
+//! A join is the call whose success the server may answer with nothing but the
+//! result envelope: WA Web's own `AcceptGroupAddResponseSuccess` variant
 //! requires no child at all, while `...GroupJoinRequestSuccess` requires a
 //! `<membership_approval_request>` child. A parser that demands a child for
 //! every answer turns an accepted join into a parse error, with no error to
-//! see -- the join already happened.
+//! see -- the join already happened. Passive-mode setters are the mirror
+//! image: a single success variant that requires its child.
 //!
 //! What this emits is the *expectation*, not the parse itself. The specs keep
 //! their hand-written response parsing; the generated constants give the tests
 //! something to check the shapes against that upstream owns. When WhatsApp
-//! changes which success shapes a join RPC has, the next sync flips the
-//! constants and the tests fail, instead of the change going unnoticed until a
-//! join that succeeded reports an error.
+//! changes which success shapes an RPC has, the next sync flips the constants
+//! and the tests fail, instead of the change going unnoticed.
 
 use anyhow::{Result, bail};
 
 use crate::emit::{header, rust_str};
 use crate::ir::IqIr;
 
-/// The join RPC whose success shapes are pinned (the response parser name, as
-/// the index keys it).
-const RPC_PARSER: &str = "WASmaxGroupsAcceptGroupAddRPC";
+/// One RPC whose success shapes are pinned, keyed the way the index is: the
+/// response parser name, since neither the request module nor the exported
+/// function is unique across shapes.
+pub struct Wanted {
+    /// Response parser name, as the index keys it.
+    pub parser: &'static str,
+    /// The generated constant's name. Named after our result type rather than
+    /// after the upstream RPC, since the constant exists to be read next to the
+    /// parser it checks.
+    pub rust: &'static str,
+}
 
-/// The generated constant's name. Named after our result type rather than
-/// after the upstream RPC, since the constant exists to be read next to the
-/// parser it checks.
-const RUST: &str = "ACCEPT_GROUP_ADD_SUCCESS";
+/// The RPCs whose success shapes are pinned. To pin another one, add a row:
+/// the next sync either emits its shapes or fails loudly on a missing parser.
+pub const WANTED: &[Wanted] = &[
+    Wanted {
+        parser: "WASmaxGroupsAcceptGroupAddRPC",
+        rust: "ACCEPT_GROUP_ADD_SUCCESS",
+    },
+    Wanted {
+        parser: "WASmaxGroupsJoinLinkedGroupRPC",
+        rust: "JOIN_LINKED_GROUP_SUCCESS",
+    },
+    Wanted {
+        parser: "WASmaxPassiveModeActiveIQRPC",
+        rust: "PASSIVE_ACTIVE_SUCCESS",
+    },
+    Wanted {
+        parser: "WASmaxPassiveModePassiveIQRPC",
+        rust: "PASSIVE_PASSIVE_SUCCESS",
+    },
+];
 
-/// (variant tag, required child tags) for each success variant of the join
-/// RPC, in RPC cascade order. A variant with no required children accepts a
-/// bare `<iq type="result">`.
-fn shapes(iq: &IqIr) -> Result<Vec<(String, Vec<String>)>> {
+/// (variant tag, required child tags) for each success variant of one RPC, in
+/// RPC cascade order. A variant with no required children accepts a bare
+/// `<iq type="result">`.
+fn shapes(iq: &IqIr, parser: &str) -> Result<Vec<(String, Vec<String>)>> {
     let stanza = iq
         .stanzas
         .iter()
-        .find(|s| s.response.parser_name == RPC_PARSER)
-        .ok_or_else(|| anyhow::anyhow!("join RPC ({RPC_PARSER}) missing from the IQ index"))?;
+        .find(|s| s.response.parser_name == parser)
+        .ok_or_else(|| anyhow::anyhow!("join RPC ({parser}) missing from the IQ index"))?;
     let mut out = Vec::new();
     for v in &stanza.response.variants {
         if v.kind.as_deref() != Some("success") {
@@ -54,30 +79,33 @@ fn shapes(iq: &IqIr) -> Result<Vec<(String, Vec<String>)>> {
         out.push((v.tag.clone(), children));
     }
     if out.is_empty() {
-        bail!("join RPC ({RPC_PARSER}) has no success variant in the IQ index");
+        bail!("join RPC ({parser}) has no success variant in the IQ index");
     }
     Ok(out)
 }
 
 pub fn generate(iq: &IqIr, wa_version: &str) -> Result<String> {
-    let shapes = shapes(iq)?;
-    let mut out = header("group-join success shapes", wa_version);
+    let mut out = header("response presence-gate shapes", wa_version);
     out.push_str(
-        "//! The success shapes of the group-join RPC, from the whatspec IQ index.\n//!\n//! Regenerate with `cargo run -p whatspec-codegen`; never edit by hand. To pin\n//! another join RPC, extend the codegen's join-shape emitter.\n\n",
+        "//! The success shapes of RPCs whose answers carry presence gates, from the\n//! whatspec IQ index.\n//!\n//! Regenerate with `cargo run -p whatspec-codegen`; never edit by hand. To pin\n//! another RPC, add it to `WANTED` in the codegen's join-shape emitter.\n\n",
     );
-    out.push_str(&format!(
-        "/// (variant tag, required child tags) for each success variant of\n/// `{RPC_PARSER}`, in RPC cascade order. A variant with no required children\n/// accepts a bare `<iq type=\"result\">`.\n"
-    ));
-    out.push_str(&format!("pub const {RUST}: &[(&str, &[&str])] = &[\n"));
-    for (tag, children) in &shapes {
-        let kids = children
-            .iter()
-            .map(|c| rust_str(c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        out.push_str(&format!("    ({}, &[{}]),\n", rust_str(tag), kids));
+    for w in WANTED {
+        let shapes = shapes(iq, w.parser)?;
+        out.push_str(&format!(
+            "/// (variant tag, required child tags) for each success variant of\n/// `{}`, in RPC cascade order. A variant with no required children\n/// accepts a bare `<iq type=\"result\">`.\n",
+            w.parser
+        ));
+        out.push_str(&format!("pub const {}: &[(&str, &[&str])] = &[\n", w.rust));
+        for (tag, children) in &shapes {
+            let kids = children
+                .iter()
+                .map(|c| rust_str(c))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&format!("    ({}, &[{}]),\n", rust_str(tag), kids));
+        }
+        out.push_str("];\n\n");
     }
-    out.push_str("];\n");
     Ok(out)
 }
 
@@ -86,7 +114,7 @@ mod tests {
     use super::*;
     use crate::ir::{ParsedResponse, ResponseAssertion, ResponseVariant};
 
-    fn stanza(variants: Vec<(&str, &str, Vec<&str>)>) -> IqIr {
+    fn stanza(parser: &str, variants: Vec<(&str, &str, Vec<&str>)>) -> IqIr {
         IqIr {
             wa_version: "2.3000.1".into(),
             stanzas: vec![crate::ir::IqStanza {
@@ -96,7 +124,7 @@ mod tests {
                 target: crate::ir::IqTarget::GroupJid,
                 exported_function: "f".into(),
                 response: ParsedResponse {
-                    parser_name: RPC_PARSER.into(),
+                    parser_name: parser.into(),
                     variants: variants
                         .into_iter()
                         .map(|(tag, kind, children)| ResponseVariant {
@@ -118,15 +146,39 @@ mod tests {
 
     #[test]
     fn success_shapes_keep_cascade_order_and_gates() {
-        let iq = stanza(vec![
-            (
-                "AcceptGroupAddResponseGroupJoinRequestSuccess",
-                "success",
-                vec!["membership_approval_request"],
-            ),
-            ("AcceptGroupAddResponseSuccess", "success", vec![]),
-            ("AcceptGroupAddResponseClientError", "error", vec![]),
-        ]);
+        let mut iq = stanza(
+            "WASmaxGroupsAcceptGroupAddRPC",
+            vec![
+                (
+                    "AcceptGroupAddResponseGroupJoinRequestSuccess",
+                    "success",
+                    vec!["membership_approval_request"],
+                ),
+                ("AcceptGroupAddResponseSuccess", "success", vec![]),
+                ("AcceptGroupAddResponseClientError", "error", vec![]),
+            ],
+        );
+        // generate() pins every WANTED parser; the others carry a bare success.
+        for w in WANTED {
+            if w.parser == "WASmaxGroupsAcceptGroupAddRPC" {
+                continue;
+            }
+            iq.stanzas.push(crate::ir::IqStanza {
+                module_name: "m".into(),
+                namespace: "w:g2".into(),
+                iq_type: "set".into(),
+                target: crate::ir::IqTarget::GroupJid,
+                exported_function: "f".into(),
+                response: ParsedResponse {
+                    parser_name: w.parser.into(),
+                    variants: vec![ResponseVariant {
+                        tag: "SomeSuccess".into(),
+                        kind: Some("success".into()),
+                        assertions: vec![],
+                    }],
+                },
+            });
+        }
         let out = generate(&iq, "2.3000.1").expect("generated");
         assert!(
             out.contains(
@@ -143,8 +195,41 @@ mod tests {
 
     #[test]
     fn missing_rpc_fails_the_sync() {
-        let mut iq = stanza(vec![]);
+        let mut iq = stanza("WASmaxGroupsAcceptGroupAddRPC", vec![]);
         iq.stanzas.clear();
         assert!(generate(&iq, "2.3000.1").is_err());
+    }
+
+    #[test]
+    fn every_wanted_rpc_emits_its_own_constant() {
+        let iq = IqIr {
+            wa_version: "2.3000.1".into(),
+            stanzas: WANTED
+                .iter()
+                .map(|w| crate::ir::IqStanza {
+                    module_name: "m".into(),
+                    namespace: "w:g2".into(),
+                    iq_type: "set".into(),
+                    target: crate::ir::IqTarget::GroupJid,
+                    exported_function: "f".into(),
+                    response: ParsedResponse {
+                        parser_name: w.parser.into(),
+                        variants: vec![ResponseVariant {
+                            tag: "SomeSuccess".into(),
+                            kind: Some("success".into()),
+                            assertions: vec![],
+                        }],
+                    },
+                })
+                .collect(),
+        };
+        let out = generate(&iq, "2.3000.1").expect("generated");
+        for w in WANTED {
+            assert!(
+                out.contains(&format!("pub const {}: ", w.rust)),
+                "missing constant for {}: {out}",
+                w.parser
+            );
+        }
     }
 }

--- a/tools/whatspec-codegen/src/emit/join_shapes.rs
+++ b/tools/whatspec-codegen/src/emit/join_shapes.rs
@@ -65,14 +65,13 @@ fn shapes(iq: &IqIr, parser: &str) -> Result<Vec<(String, Vec<String>)>> {
         .ok_or_else(|| anyhow::anyhow!("join RPC ({parser}) missing from the IQ index"))?;
     let mut out = Vec::new();
     for v in &stanza.response.variants {
-        if v.kind.as_deref() != Some("success") {
+        if !v.is_success() {
             continue;
         }
         let mut children: Vec<String> = v
             .assertions
             .iter()
-            .filter(|a| a.kind.as_deref() == Some("child"))
-            .filter_map(|a| a.name.clone())
+            .filter_map(|a| a.child_gate().map(str::to_string))
             .collect();
         children.sort();
         children.dedup();

--- a/tools/whatspec-codegen/src/ir.rs
+++ b/tools/whatspec-codegen/src/ir.rs
@@ -171,6 +171,16 @@ pub struct ResponseAssertion {
     pub name: Option<String>,
 }
 
+impl ResponseAssertion {
+    /// The required child tag when this assertion is a presence gate
+    /// (`kind == "child"` with a tag), `None` otherwise.
+    pub fn child_gate(&self) -> Option<&str> {
+        (self.kind.as_deref() == Some("child"))
+            .then(|| self.name.as_deref())
+            .flatten()
+    }
+}
+
 /// One alternative of a response-root discriminated union. Read only for the
 /// success shapes of the join RPCs: `tag` names the variant, and a `child`
 /// assertion on it names a child the variant requires.
@@ -182,6 +192,13 @@ pub struct ResponseVariant {
     pub kind: Option<String>,
     #[serde(default)]
     pub assertions: Vec<ResponseAssertion>,
+}
+
+impl ResponseVariant {
+    /// Whether this alternative is a success shape (rather than an error arm).
+    pub fn is_success(&self) -> bool {
+        self.kind.as_deref() == Some("success")
+    }
 }
 
 /// The parsed response half of an IQ operation. Read only for `variants`;

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -2815,17 +2815,9 @@ impl IqSpec for JoinLinkedGroupIq {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
-        // Same shape pair as the V4 accept (`JoinLinkedGroupResponseSuccess`
-        // bare beside `...GroupJoinRequestSuccess` gated on
-        // `<membership_approval_request>` — see the generated
-        // `super::join_shapes::JOIN_LINKED_GROUP_SUCCESS`): a bare `<iq
-        // type="result">` joins the request's own subgroup, not a malformed
-        // response. Anything present but unrecognized falls through to the
-        // strict parser and fails loudly instead of reporting `Joined`.
-        if response.content.is_none() {
-            return Ok(JoinGroupResult::Joined(self.subgroup_jid.clone()));
-        }
-        parse_join_group_response(response)
+        // Bare joins the request's own subgroup (same shape pair as the V4
+        // accept — see the generated shapes).
+        parse_join_or_bare(response, &self.subgroup_jid)
     }
 }
 
@@ -2910,11 +2902,17 @@ fn parse_group_id(id_str: &str) -> Result<Jid> {
     }
 }
 
+/// Child tags of the join-response shapes, shared by the strict parser and
+/// the bare-result fallbacks below so the two cannot drift apart.
+const JOIN_GROUP_CHILD: &str = "group";
+const JOIN_COMMUNITY_CHILD: &str = "community";
+const JOIN_APPROVAL_CHILD: &str = "membership_approval_request";
+
 /// Shared response parser for group join IQs (both code-based and V4 invite).
 fn parse_join_group_response(response: &NodeRef<'_>) -> Result<JoinGroupResult> {
     if let Some(group_node) = response
-        .get_optional_child("group")
-        .or_else(|| response.get_optional_child("community"))
+        .get_optional_child(JOIN_GROUP_CHILD)
+        .or_else(|| response.get_optional_child(JOIN_COMMUNITY_CHILD))
     {
         let jid_str = required_attr(group_node, "jid")?;
         let jid: Jid = jid_str
@@ -2922,16 +2920,29 @@ fn parse_join_group_response(response: &NodeRef<'_>) -> Result<JoinGroupResult> 
             .map_err(|e| anyhow!("invalid group jid: {e}"))?;
         return Ok(JoinGroupResult::Joined(jid));
     }
-    if let Some(approval_node) = response.get_optional_child("membership_approval_request") {
+    if let Some(approval_node) = response.get_optional_child(JOIN_APPROVAL_CHILD) {
         let jid_str = required_attr(approval_node, "jid")?;
         let jid: Jid = jid_str
             .parse()
             .map_err(|e| anyhow!("invalid group jid: {e}"))?;
         return Ok(JoinGroupResult::PendingApproval(jid));
     }
+    // NOTE: this message is matched downstream (bridge/baileyrs surfaces it);
+    // keep it byte-identical when touching the tags above.
     Err(anyhow!(
         "expected <group>, <community>, or <membership_approval_request> in join response"
     ))
+}
+
+/// Parse a join response that may be a bare `<iq type="result">`: with no
+/// content at all the join succeeded and the group is the request's own
+/// addressee (`fallback`); anything present but unrecognized falls through to
+/// the strict parser and fails loudly instead of reporting `Joined`.
+fn parse_join_or_bare(response: &NodeRef<'_>, fallback: &Jid) -> Result<JoinGroupResult> {
+    if response.content.is_none() {
+        return Ok(JoinGroupResult::Joined(fallback.clone()));
+    }
+    parse_join_group_response(response)
 }
 
 /// ```xml
@@ -3011,25 +3022,10 @@ impl IqSpec for AcceptGroupInviteV4Iq {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
-        // WA Web's `AcceptGroupAddResponseSuccess`: a bare `<iq type="result">`
-        // with none of the join children is a success, not a malformed
-        // response. The joined group is the request's own `to` — the envelope
-        // `from` echoes it — which this spec holds. See the generated
-        // `super::join_shapes::ACCEPT_GROUP_ADD_SUCCESS`: a variant with no
-        // required children accepts the bare result. (The code-based join keeps
-        // the strict parser: addressed at `@g.us`, a bare result there carries
-        // no group identity to return.)
-        //
-        // Bare means no content at all: no child elements and no scalar
-        // payload (`children()` alone cannot tell an absent body from a scalar
-        // one). Anything present but unrecognized is an unknown shape, and
-        // reporting it `Joined` could misreport a future non-joined state as
-        // joined. It falls through to the strict parser, which rejects it
-        // loudly instead.
-        if response.content.is_none() {
-            return Ok(JoinGroupResult::Joined(self.group_jid.clone()));
-        }
-        parse_join_group_response(response)
+        // Bare joins the request's own `to` (`AcceptGroupAddResponseSuccess`
+        // in the generated shapes); the code-based join keeps the strict
+        // parser, whose bare result carries no group identity.
+        parse_join_or_bare(response, &self.group_jid)
     }
 }
 
@@ -5782,17 +5778,43 @@ mod tests {
         );
     }
 
+    const TEST_GROUP_JID: &str = "120363000000000042@g.us";
+    const TEST_PARENT_JID: &str = "120363000000000001@g.us";
+    const TEST_ADMIN_JID: &str = "5511999887766@s.whatsapp.net";
+    const TEST_INVITE_CODE: &str = "A1B2C3D4";
+    const TEST_INVITE_EXPIRATION: i64 = 1_700_000_123;
+
     fn v4_spec() -> (Jid, AcceptGroupInviteV4Iq) {
-        let group_jid: Jid = "120363000000000042@g.us".parse().unwrap();
-        let admin_jid: Jid = "5511999887766@s.whatsapp.net".parse().unwrap();
-        let spec = AcceptGroupInviteV4Iq::new(&group_jid, "A1B2C3D4", 1_700_000_123, &admin_jid);
+        let group_jid: Jid = TEST_GROUP_JID.parse().unwrap();
+        let admin_jid: Jid = TEST_ADMIN_JID.parse().unwrap();
+        let spec = AcceptGroupInviteV4Iq::new(
+            &group_jid,
+            TEST_INVITE_CODE,
+            TEST_INVITE_EXPIRATION,
+            &admin_jid,
+        );
         (group_jid, spec)
     }
 
-    fn bare_join_result() -> Node {
-        NodeBuilder::new("iq")
+    /// `<iq type="result" from=...>` carrying `children` (empty means a bare
+    /// result: no content at all, not an empty child list).
+    fn result_iq(from: &str, children: Vec<Node>) -> Node {
+        let mut iq = NodeBuilder::new("iq")
             .attr("type", "result")
-            .attr("from", "120363000000000042@g.us")
+            .attr("from", from);
+        if !children.is_empty() {
+            iq = iq.children(children);
+        }
+        iq.build()
+    }
+
+    fn bare_join_result() -> Node {
+        result_iq(TEST_GROUP_JID, Vec::new())
+    }
+
+    fn approval_child(jid: &str) -> Node {
+        NodeBuilder::new(JOIN_APPROVAL_CHILD)
+            .attr("jid", jid)
             .build()
     }
 
@@ -5826,12 +5848,7 @@ mod tests {
     #[test]
     fn test_accept_group_invite_v4_unknown_child_is_rejected() {
         let (_, spec) = v4_spec();
-        let unknown = NodeBuilder::new("unexpected").build();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000042@g.us")
-            .children([unknown])
-            .build();
+        let iq = result_iq(TEST_GROUP_JID, vec![NodeBuilder::new("unexpected").build()]);
         assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }
 
@@ -5841,7 +5858,7 @@ mod tests {
         let (_, spec) = v4_spec();
         let iq = NodeBuilder::new("iq")
             .attr("type", "result")
-            .attr("from", "120363000000000042@g.us")
+            .attr("from", TEST_GROUP_JID)
             .apply_content(Some(NodeContent::String("unexpected payload".into())))
             .build();
         assert!(spec.parse_response(&iq.as_node_ref()).is_err());
@@ -5850,14 +5867,10 @@ mod tests {
     #[test]
     fn test_accept_group_invite_v4_group_child_still_joins() {
         let (group_jid, spec) = v4_spec();
-        let group = NodeBuilder::new("group")
-            .attr("jid", "120363000000000042@g.us")
+        let group = NodeBuilder::new(JOIN_GROUP_CHILD)
+            .attr("jid", TEST_GROUP_JID)
             .build();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000042@g.us")
-            .children([group])
-            .build();
+        let iq = result_iq(TEST_GROUP_JID, vec![group]);
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::Joined(group_jid));
     }
@@ -5865,21 +5878,14 @@ mod tests {
     #[test]
     fn test_accept_group_invite_v4_approval_child_stays_pending() {
         let (group_jid, spec) = v4_spec();
-        let approval = NodeBuilder::new("membership_approval_request")
-            .attr("jid", "120363000000000042@g.us")
-            .build();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000042@g.us")
-            .children([approval])
-            .build();
+        let iq = result_iq(TEST_GROUP_JID, vec![approval_child(TEST_GROUP_JID)]);
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::PendingApproval(group_jid));
     }
 
     fn linked_spec() -> (Jid, JoinLinkedGroupIq) {
-        let parent: Jid = "120363000000000001@g.us".parse().unwrap();
-        let subgroup: Jid = "120363000000000042@g.us".parse().unwrap();
+        let parent: Jid = TEST_PARENT_JID.parse().unwrap();
+        let subgroup: Jid = TEST_GROUP_JID.parse().unwrap();
         let spec = JoinLinkedGroupIq::new(&parent, &subgroup);
         (subgroup, spec)
     }
@@ -5904,10 +5910,7 @@ mod tests {
     #[test]
     fn test_join_linked_group_bare_result_joins_subgroup() {
         let (subgroup, spec) = linked_spec();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000001@g.us")
-            .build();
+        let iq = result_iq(TEST_PARENT_JID, Vec::new());
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::Joined(subgroup));
     }
@@ -5915,14 +5918,7 @@ mod tests {
     #[test]
     fn test_join_linked_group_approval_child_stays_pending() {
         let (subgroup, spec) = linked_spec();
-        let approval = NodeBuilder::new("membership_approval_request")
-            .attr("jid", "120363000000000042@g.us")
-            .build();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000001@g.us")
-            .children([approval])
-            .build();
+        let iq = result_iq(TEST_PARENT_JID, vec![approval_child(TEST_GROUP_JID)]);
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::PendingApproval(subgroup));
     }
@@ -5930,12 +5926,10 @@ mod tests {
     #[test]
     fn test_join_linked_group_unknown_child_is_rejected() {
         let (_, spec) = linked_spec();
-        let unknown = NodeBuilder::new("unexpected").build();
-        let iq = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "120363000000000001@g.us")
-            .children([unknown])
-            .build();
+        let iq = result_iq(
+            TEST_PARENT_JID,
+            vec![NodeBuilder::new("unexpected").build()],
+        );
         assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }
 }

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -2800,7 +2800,7 @@ impl JoinLinkedGroupIq {
 }
 
 impl IqSpec for JoinLinkedGroupIq {
-    type Response = GroupInfoResponse;
+    type Response = JoinGroupResult;
 
     fn build_iq(&self) -> InfoQuery<'static> {
         let node = NodeBuilder::new("join_linked_group")
@@ -2815,9 +2815,17 @@ impl IqSpec for JoinLinkedGroupIq {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
-        let linked_node = required_child(response, "linked_group")?;
-        let group_node = required_child(linked_node, "group")?;
-        GroupInfoResponse::try_from_node_ref(group_node)
+        // Same shape pair as the V4 accept (`JoinLinkedGroupResponseSuccess`
+        // bare beside `...GroupJoinRequestSuccess` gated on
+        // `<membership_approval_request>` — see the generated
+        // `super::join_shapes::JOIN_LINKED_GROUP_SUCCESS`): a bare `<iq
+        // type="result">` joins the request's own subgroup, not a malformed
+        // response. Anything present but unrecognized falls through to the
+        // strict parser and fails loudly instead of reporting `Joined`.
+        if response.content.is_none() {
+            return Ok(JoinGroupResult::Joined(self.subgroup_jid.clone()));
+        }
+        parse_join_group_response(response)
     }
 }
 
@@ -5867,5 +5875,67 @@ mod tests {
             .build();
         let result = spec.parse_response(&iq.as_node_ref()).unwrap();
         assert_eq!(result, JoinGroupResult::PendingApproval(group_jid));
+    }
+
+    fn linked_spec() -> (Jid, JoinLinkedGroupIq) {
+        let parent: Jid = "120363000000000001@g.us".parse().unwrap();
+        let subgroup: Jid = "120363000000000042@g.us".parse().unwrap();
+        let spec = JoinLinkedGroupIq::new(&parent, &subgroup);
+        (subgroup, spec)
+    }
+
+    /// Locks the linked-group join parser to its generated shapes: a bare
+    /// result and an approval-gated variant, like the V4 accept.
+    #[test]
+    fn test_join_linked_group_shapes_match_the_ir_lock() {
+        use crate::iq::join_shapes;
+        assert_eq!(
+            join_shapes::JOIN_LINKED_GROUP_SUCCESS,
+            &[
+                (
+                    "JoinLinkedGroupResponseGroupJoinRequestSuccess",
+                    &["membership_approval_request"][..]
+                ),
+                ("JoinLinkedGroupResponseSuccess", &[][..]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_join_linked_group_bare_result_joins_subgroup() {
+        let (subgroup, spec) = linked_spec();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000001@g.us")
+            .build();
+        let result = spec.parse_response(&iq.as_node_ref()).unwrap();
+        assert_eq!(result, JoinGroupResult::Joined(subgroup));
+    }
+
+    #[test]
+    fn test_join_linked_group_approval_child_stays_pending() {
+        let (subgroup, spec) = linked_spec();
+        let approval = NodeBuilder::new("membership_approval_request")
+            .attr("jid", "120363000000000042@g.us")
+            .build();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000001@g.us")
+            .children([approval])
+            .build();
+        let result = spec.parse_response(&iq.as_node_ref()).unwrap();
+        assert_eq!(result, JoinGroupResult::PendingApproval(subgroup));
+    }
+
+    #[test]
+    fn test_join_linked_group_unknown_child_is_rejected() {
+        let (_, spec) = linked_spec();
+        let unknown = NodeBuilder::new("unexpected").build();
+        let iq = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "120363000000000001@g.us")
+            .children([unknown])
+            .build();
+        assert!(spec.parse_response(&iq.as_node_ref()).is_err());
     }
 }

--- a/wacore/src/iq/join_shapes.rs
+++ b/wacore/src/iq/join_shapes.rs
@@ -1,9 +1,10 @@
-//! Auto-generated group-join success shapes (WhatsApp 2.3000.1045368834). DO NOT EDIT.
+//! Auto-generated response presence-gate shapes (WhatsApp 2.3000.1045368834). DO NOT EDIT.
 //!
-//! The success shapes of the group-join RPC, from the whatspec IQ index.
+//! The success shapes of RPCs whose answers carry presence gates, from the
+//! whatspec IQ index.
 //!
 //! Regenerate with `cargo run -p whatspec-codegen`; never edit by hand. To pin
-//! another join RPC, extend the codegen's join-shape emitter.
+//! another RPC, add it to `WANTED` in the codegen's join-shape emitter.
 
 /// (variant tag, required child tags) for each success variant of
 /// `WASmaxGroupsAcceptGroupAddRPC`, in RPC cascade order. A variant with no required children
@@ -15,3 +16,25 @@ pub const ACCEPT_GROUP_ADD_SUCCESS: &[(&str, &[&str])] = &[
     ),
     ("AcceptGroupAddResponseSuccess", &[]),
 ];
+
+/// (variant tag, required child tags) for each success variant of
+/// `WASmaxGroupsJoinLinkedGroupRPC`, in RPC cascade order. A variant with no required children
+/// accepts a bare `<iq type="result">`.
+pub const JOIN_LINKED_GROUP_SUCCESS: &[(&str, &[&str])] = &[
+    (
+        "JoinLinkedGroupResponseGroupJoinRequestSuccess",
+        &["membership_approval_request"],
+    ),
+    ("JoinLinkedGroupResponseSuccess", &[]),
+];
+
+/// (variant tag, required child tags) for each success variant of
+/// `WASmaxPassiveModeActiveIQRPC`, in RPC cascade order. A variant with no required children
+/// accepts a bare `<iq type="result">`.
+pub const PASSIVE_ACTIVE_SUCCESS: &[(&str, &[&str])] = &[("ActiveIQResponseSuccess", &["active"])];
+
+/// (variant tag, required child tags) for each success variant of
+/// `WASmaxPassiveModePassiveIQRPC`, in RPC cascade order. A variant with no required children
+/// accepts a bare `<iq type="result">`.
+pub const PASSIVE_PASSIVE_SUCCESS: &[(&str, &[&str])] =
+    &[("PassiveIQResponseSuccess", &["passive"])];

--- a/wacore/src/iq/passive.rs
+++ b/wacore/src/iq/passive.rs
@@ -16,7 +16,9 @@
 //! </iq>
 //!
 //! <!-- Response -->
-//! <iq from="s.whatsapp.net" id="..." type="result"/>
+//! <iq from="s.whatsapp.net" id="..." type="result">
+//!   <active/>
+//! </iq>
 //! ```
 
 use crate::iq::spec::IqSpec;
@@ -66,8 +68,18 @@ impl IqSpec for PassiveModeSpec {
         )
     }
 
-    fn parse_response(&self, _response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        // Passive mode just needs a successful response
+    fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
+        // WA Web's `ActiveIQResponseSuccess` / `PassiveIQResponseSuccess`: the
+        // answer echoes the requested mode as a child (`<active/>` or
+        // `<passive/>`), and the parser gates on its presence without reading
+        // anything off it (see the generated
+        // `super::join_shapes::PASSIVE_ACTIVE_SUCCESS` /
+        // `PASSIVE_PASSIVE_SUCCESS`). A result without it is not this RPC's
+        // success.
+        let tag = if self.passive { "passive" } else { "active" };
+        if response.get_optional_child(tag).is_none() {
+            anyhow::bail!("expected <{tag}> in passive-mode response");
+        }
         Ok(())
     }
 }
@@ -108,12 +120,54 @@ mod tests {
         }
     }
 
+    /// Locks both mode parsers to the generated shape constants: the answer
+    /// must echo the requested mode child. If the next sync flips the
+    /// constants, the parsers above owe a re-read.
+    #[test]
+    fn test_passive_mode_shapes_match_the_ir_lock() {
+        use crate::iq::join_shapes;
+        assert_eq!(
+            join_shapes::PASSIVE_ACTIVE_SUCCESS,
+            &[("ActiveIQResponseSuccess", &["active"][..])]
+        );
+        assert_eq!(
+            join_shapes::PASSIVE_PASSIVE_SUCCESS,
+            &[("PassiveIQResponseSuccess", &["passive"][..])]
+        );
+    }
+
     #[test]
     fn test_passive_mode_spec_parse_response() {
+        let spec = PassiveModeSpec::passive();
+        let child = NodeBuilder::new("passive").build();
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([child])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_passive_mode_spec_rejects_result_without_mode_child() {
         let spec = PassiveModeSpec::passive();
         let response = NodeBuilder::new("iq").attr("type", "result").build();
 
         let result = spec.parse_response(&response.as_node_ref());
-        assert!(result.is_ok());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_passive_mode_spec_rejects_wrong_mode_child() {
+        let spec = PassiveModeSpec::passive();
+        let child = NodeBuilder::new("active").build();
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([child])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref());
+        assert!(result.is_err());
     }
 }

--- a/wacore/src/iq/passive.rs
+++ b/wacore/src/iq/passive.rs
@@ -21,6 +21,7 @@
 //! </iq>
 //! ```
 
+use crate::iq::node::required_child;
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;
 use wacore_binary::builder::NodeBuilder;
@@ -77,9 +78,7 @@ impl IqSpec for PassiveModeSpec {
         // `PASSIVE_PASSIVE_SUCCESS`). A result without it is not this RPC's
         // success.
         let tag = if self.passive { "passive" } else { "active" };
-        if response.get_optional_child(tag).is_none() {
-            anyhow::bail!("expected <{tag}> in passive-mode response");
-        }
+        required_child(response, tag)?;
         Ok(())
     }
 }
@@ -87,6 +86,7 @@ impl IqSpec for PassiveModeSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wacore_binary::Node;
 
     #[test]
     fn test_passive_mode_spec_passive() {
@@ -136,38 +136,32 @@ mod tests {
         );
     }
 
+    fn result_iq(child_tag: Option<&'static str>) -> Node {
+        let mut iq = NodeBuilder::new("iq").attr("type", "result");
+        if let Some(tag) = child_tag {
+            iq = iq.children([NodeBuilder::new(tag).build()]);
+        }
+        iq.build()
+    }
+
     #[test]
     fn test_passive_mode_spec_parse_response() {
         let spec = PassiveModeSpec::passive();
-        let child = NodeBuilder::new("passive").build();
-        let response = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .children([child])
-            .build();
-
-        let result = spec.parse_response(&response.as_node_ref());
+        let result = spec.parse_response(&result_iq(Some("passive")).as_node_ref());
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_passive_mode_spec_rejects_result_without_mode_child() {
         let spec = PassiveModeSpec::passive();
-        let response = NodeBuilder::new("iq").attr("type", "result").build();
-
-        let result = spec.parse_response(&response.as_node_ref());
+        let result = spec.parse_response(&result_iq(None).as_node_ref());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_passive_mode_spec_rejects_wrong_mode_child() {
         let spec = PassiveModeSpec::passive();
-        let child = NodeBuilder::new("active").build();
-        let response = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .children([child])
-            .build();
-
-        let result = spec.parse_response(&response.as_node_ref());
+        let result = spec.parse_response(&result_iq(Some("active")).as_node_ref());
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Follow-up to #1453, which fixed the V4 accept against a shape-locked IR. This extends the same treatment to every remaining gated success shape in the IQ domain, so no hand-written response parser silently disagrees with the bundle again.

## Scope

- `JoinLinkedGroupIq`: same bare/approval pair as the V4 accept (`JoinLinkedGroupResponseSuccess` childless + `...GroupJoinRequestSuccess` gated on `membership_approval_request`), but the parser required `<linked_group>/<group>` children — copy-pasted from the *query* RPC (`GetLinkedGroup`, whose bundle parser genuinely reads `<linked_group>`), while the join RPC's own success carries no metadata at all (bundle-verified). Bare now joins with the request's subgroup JID; approval stays pending; unknown shapes (unrecognized children and scalar payloads alike) fail loudly instead of reporting `Joined`.
- `JoinLinkedGroupIq::Response` changes `GroupInfoResponse` -> `JoinGroupResult` (breaking for direct `IqSpec` users; the only in-tree caller is `join_subgroup`). `features::join_subgroup` keeps its `Result<GroupMetadata>` signature: a joined result is followed by a metadata query (the only source of metadata), and approval surfaces as a new `CommunityError::MembershipApprovalRequired` variant (additive; the enum is `#[non_exhaustive]`). No extra round trip on any previously working path — the old code errored on every real answer.
- `PassiveModeSpec`: the single-success variants each require their mode child (`<active>`/`<passive>`, bundle-verified pure gates), but the parser returned `Ok(())` unconditionally — and the module doc even showed a bare response. The child is now required via the shared `required_child` helper (uniform missing-tag errors), the doc fixed.
- Codegen: `join_shapes` emitter generalized to a `WANTED` table (AcceptGroupAdd, JoinLinkedGroup, PassiveActive, PassivePassive); lock tests pin all four consts in `groups.rs`/`passive.rs`.
- DRY follow-through (no behavior change): join child tags hoisted to shared consts with both specs delegating to one `parse_join_or_bare` (the error message stays byte-identical — it is matched downstream); shared test fixtures for the new parse tests; `is_success()`/`child_gate()` helpers on the codegen's IR mirror. Lock tests keep wire literals by design.

## Validation

- New parse tests: linked-group bare/approval/unknown; passive accept/reject-bare/reject-wrong-child; V4 unknown-child and scalar-content rejections; three shape-lock tests plus emitter unit tests. Each rejection test proven fail-before against the weakened guard.
- `cargo test -p wacore -p whatspec-codegen`: 1771 pass, 0 fail. `cargo check --workspace`: clean.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo run -p whatspec-codegen -- --check`: clean.
- Not run: full-workspace test and e2e (same scope as #1453).

## Deliberately out of scope

- Newsletter `plaintext`/`reaction` and srvreq gates live in message/notification layers with no corresponding strict parser in `wacore` — audit-only, no behavior to fix.
- Bridge bump carrying #1453 plus this (unblocks removing the baileyrs string-matching shim).