### PR TITLE
audit(newsletter): lock receive-path leniency against presence gates

### DIFF
--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -917,6 +917,12 @@ pub(crate) fn parse_reaction_counts(node: &NodeRef<'_>) -> Vec<NewsletterReactio
 ///   </message>
 /// </messages>
 /// ```
+///
+/// Deliberately lenient where WA Web discriminates: the bundle gates message
+/// subtypes on `<plaintext>` / `<reaction>` presence, but this parser flattens
+/// every message into one struct without subtype dispatch, so a gate can never
+/// misroute here — absence is `None`, never a rejection. Tightening this
+/// (e.g. requiring `<plaintext>`) would drop messages WA delivers.
 fn parse_newsletter_messages_response(
     response: &NodeRef<'_>,
 ) -> Result<Vec<NewsletterMessage>, NewsletterError> {
@@ -1546,6 +1552,26 @@ mod tests {
         let msgs = parse_newsletter_messages_response(&response.as_node_ref()).unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].message_type, NewsletterMessageType::Text);
+    }
+
+    #[test]
+    fn test_message_without_plaintext_is_kept_with_no_payload() {
+        // The bundle gates subtypes on `<plaintext>` presence, but this parser
+        // does not dispatch on it: a message without payload is kept with
+        // `message: None`, never dropped.
+        let response = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("messages")
+                .children([NodeBuilder::new("message")
+                    .attr("server_id", "42")
+                    .attr("t", "1700000000")
+                    .attr("type", "text")
+                    .build()])
+                .build()])
+            .build();
+
+        let msgs = parse_newsletter_messages_response(&response.as_node_ref()).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].message.is_none());
     }
 
     #[test]

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -1556,9 +1556,6 @@ mod tests {
 
     #[test]
     fn test_message_without_plaintext_is_kept_with_no_payload() {
-        // The bundle gates subtypes on `<plaintext>` presence, but this parser
-        // does not dispatch on it: a message without payload is kept with
-        // `message: None`, never dropped.
         let response = NodeBuilder::new("iq")
             .children([NodeBuilder::new("messages")
                 .children([NodeBuilder::new("message")


### PR DESCRIPTION
Stacked on #1454. Audits every remaining presence gate in the IR (newsletter `plaintext` x12 / `reaction` x4, srvreq `reset_smb_last_qp_prefetch_timestamp`, PSA/QP notifications) against the receive paths in `wacore`/`src`, and locks the deliberate leniency so a future tightening cannot regress delivery.

## Audit result (verified, no parser bug found)

- `parse_newsletter_messages_response` (`src/features/newsletter.rs`): flattens every message into one struct with no subtype dispatch, so the bundle's `<plaintext>`/`<reaction>` gates can never misroute here — absence is `None`, malformed `server_id` skips the message, missing `type` defaults to `Text`. All three were already covered by tests except the no-payload case.
- Live-update handler (`handle_newsletter_notification`) and notification dispatch: total — unknown types (incl. `<notification type=psa>`, for which no handler exists) fall through to subsystem/raw event, never an error. Same for status delivery and QP-surfaces shapes: no strict parser consumes them.
- Cross-checked the strict side too: every `required_child` site in `wacore/src/iq/groups.rs` mirrors a required descent in the IR (verified per-RPC for link/unlink/groups/pictures/reports/membership-action wrappers); the only mismatches were the two join RPCs, fixed in #1453/#1454.

## Change

- Documents the deliberate leniency on the parser (why tightening it would drop messages WA delivers).
- New test: a message without `<plaintext>` is kept with `message: None`, never dropped.

## Validation

- `cargo test -p whatsapp-rust --lib features::newsletter`: 23 pass. `cargo fmt --check`, `cargo clippy -p whatsapp-rust --all-targets -- -D warnings`: clean.
- Not run: wider suites (untouched).

## Future work (grounded in this audit)

- **PSA QP-prefetch (`reset_smb_last_qp_prefetch_timestamp`) and QP-surfaces notifications**: no handlers exist; they ride the raw-event fallback today. Needs a product decision (act on prefetch invalidation vs documented-ignore) plus bundle behavior for what WA does with them — do not invent handling without it.
- **Missing-`type` defaults to `Text` / `server_id`-less messages are skipped**: every IR message variant pins `type` and requires `server_id`, so these paths fire only on malformed stanzas. Revisit only on evidence of real traffic hitting them (log-and-count first, never silent reject).
- **Shape-lock extension to message/srvreq gates**: deferred deliberately — a lock without a parser to check it against is dead weight. If a strict parser ever appears on those paths, pin its shapes the way `join_shapes` does for IQ joins.
- **Downstream**: bridge bump carrying #1453/#1454, then remove the baileyrs string-matching shim.