### PR TITLE
feat(transport): race dual chat dials with WA Web semantics

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,5 +1,8 @@
 // Re-export transport types from wacore
-pub use wacore::net::{DisconnectReason, Transport, TransportEvent, TransportFactory};
+pub use wacore::net::{
+    DisconnectReason, RacingTransportFactory, Transport, TransportEvent, TransportFactory,
+    WHATSAPP_WEB_WS_URL_FALLBACK, WHATSAPP_WEB_WS_URLS, with_edge_routing_param,
+};
 
 #[cfg(feature = "tokio-transport")]
 pub use whatsapp_rust_tokio_transport::{

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -154,9 +154,9 @@ pub trait TransportFactory: crate::sync_marker::MaybeSendSync {
     /// Creates a new transport and returns it, along with a stream of events.
     ///
     /// Dropping the returned future must abort the dial without leaking an
-    /// open transport: [`RacingTransportFactory`] cancels the loser by
-    /// dropping it, which is only clean when a half-open dial leaves no
-    /// socket behind.
+    /// open transport: [`RacingTransportFactory`] drops a still-dialling loser
+    /// (aborting it) and closes an already-open one in background, so a
+    /// half-open dial must leave no socket behind when dropped.
     async fn create_transport(
         &self,
     ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>;
@@ -170,46 +170,75 @@ pub trait TransportFactory: crate::sync_marker::MaybeSendSync {
 /// does this return an error (the one that completed last, as WA Web rejects
 /// with the failure that completes the set).
 ///
+/// The winner never waits for the loser: [`Transport::disconnect`] carries no
+/// completion bound (a valid transport may stall it forever), so an
+/// already-open loser is closed on `runtime` via [`Runtime::spawn_detached`]
+/// while the winner is returned immediately. Its event channel is dropped
+/// with it, so the loser's close never surfaces as a `DisconnectReason`.
+///
 /// No handshake runs here, so at most one socket ever reaches Noise: this
-/// returns a single transport and the caller handshakes exactly it. No task is
-/// spawned and no executor primitive is used beyond `futures` combinators, so
-/// this stays portable (wasm32/ESP32) and dropping the race future aborts both
-/// dials with no socket to close.
+/// returns a single transport and the caller handshakes exactly it. The race
+/// itself uses only `futures` combinators, so this stays portable
+/// (wasm32/ESP32); dropping the race future aborts both dials with no socket
+/// to close.
 ///
 /// Inner factories keep their own contracts: TLS session resumption stays
 /// inside each factory's connector, `Origin` stays each factory's, and custom
 /// strategies built on `from_websocket` compose by wrapping the factories.
+///
+/// [`Runtime::spawn_detached`]: crate::runtime::Runtime::spawn_detached
 pub struct RacingTransportFactory {
     primary: Arc<dyn TransportFactory>,
     secondary: Arc<dyn TransportFactory>,
+    runtime: Arc<dyn crate::runtime::Runtime>,
 }
 
 impl RacingTransportFactory {
     /// Races `primary` against `secondary`; the first success wins regardless
     /// of order, so pass the preferred endpoint first only as a tiebreak hint.
     /// For chat parity this is one factory per [`WHATSAPP_WEB_WS_URLS`] entry.
-    pub fn new(primary: Arc<dyn TransportFactory>, secondary: Arc<dyn TransportFactory>) -> Self {
-        Self { primary, secondary }
+    /// `runtime` runs the loser's background close; the winner is returned
+    /// without waiting for it.
+    pub fn new(
+        primary: Arc<dyn TransportFactory>,
+        secondary: Arc<dyn TransportFactory>,
+        runtime: Arc<dyn crate::runtime::Runtime>,
+    ) -> Self {
+        Self {
+            primary,
+            secondary,
+            runtime,
+        }
     }
 }
 
 type TransportDial =
     Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>;
 
-/// Settles a dial that lost the race: an already-open loser is closed cleanly
-/// and its late failure suppressed; a still-pending loser is left for the
-/// caller to drop, which aborts the dial per [`TransportFactory`]'s contract.
-async fn settle_loser<F>(winner: TransportDial, loser: F) -> TransportDial
+/// Settles a dial that lost the race: an already-open loser is closed in
+/// background and its late failure suppressed; a still-pending loser is left
+/// for the caller to drop, which aborts the dial per [`TransportFactory`]'s
+/// contract. Never awaits the loser, so a stalled close cannot delay a usable
+/// winner.
+fn settle_loser<F>(
+    winner: TransportDial,
+    loser: F,
+    runtime: &Arc<dyn crate::runtime::Runtime>,
+) -> TransportDial
 where
     F: Future<Output = TransportDial>,
 {
     use futures::future::FutureExt as _;
 
-    let winner = winner?;
-    if let Some(Ok((loser_transport, _))) = loser.now_or_never() {
-        loser_transport.disconnect().await;
+    if winner.is_ok()
+        && let Some(Ok((loser_transport, _))) = loser.now_or_never()
+    {
+        let runtime = Arc::clone(runtime);
+        runtime.spawn_detached(Box::pin(async move {
+            loser_transport.disconnect().await;
+        }));
     }
-    Ok(winner)
+    winner
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -226,14 +255,14 @@ impl TransportFactory for RacingTransportFactory {
         match select(primary_fut, secondary_fut).await {
             Either::Left((first, second_fut)) => {
                 if first.is_ok() {
-                    settle_loser(first, second_fut).await
+                    settle_loser(first, second_fut, &self.runtime)
                 } else {
                     second_fut.await
                 }
             }
             Either::Right((second, first_fut)) => {
                 if second.is_ok() {
-                    settle_loser(second, first_fut).await
+                    settle_loser(second, first_fut, &self.runtime)
                 } else {
                     first_fut.await
                 }
@@ -419,14 +448,50 @@ mod tests {
     }
 }
 
-/// Race and `?ED=` tests. The implementation uses only `futures` combinators,
-/// so it is portable; the tests below use Tokio timers purely as controllable
-/// latency/failure scripts for the mock dials.
+/// Race and `?ED=` tests. The race itself uses only `futures` combinators plus
+/// a `Runtime` for the loser's background close, so it stays portable; the
+/// tests below use Tokio timers purely as controllable latency/failure scripts
+/// for the mock dials.
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod racing_tests {
     use super::*;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+
+    struct TestRuntime;
+
+    #[async_trait::async_trait]
+    impl crate::runtime::Runtime for TestRuntime {
+        fn spawn(
+            &self,
+            future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+        ) -> crate::runtime::AbortHandle {
+            let handle = tokio::spawn(future);
+            crate::runtime::AbortHandle::new(move || handle.abort())
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(tokio::time::sleep(duration))
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(async move {
+                let _ = tokio::task::spawn_blocking(f).await;
+            })
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            None
+        }
+    }
+
+    fn test_runtime() -> Arc<dyn crate::runtime::Runtime> {
+        Arc::new(TestRuntime)
+    }
 
     struct DialCounters {
         started: AtomicUsize,
@@ -460,6 +525,7 @@ mod racing_tests {
 
     struct MockDialTransport {
         counters: Arc<DialCounters>,
+        stall_disconnect: bool,
     }
 
     #[async_trait::async_trait]
@@ -469,6 +535,11 @@ mod racing_tests {
         }
 
         async fn disconnect(&self) {
+            // Mirrors `StallingMockTransport`: a valid transport may never
+            // finish closing, which is exactly what must not block the winner.
+            if self.stall_disconnect {
+                std::future::pending::<()>().await;
+            }
             self.counters.disconnects.fetch_add(1, Ordering::AcqRel);
         }
     }
@@ -480,6 +551,7 @@ mod racing_tests {
     struct ScriptedDialFactory {
         delay: Option<Duration>,
         fail_with: Option<&'static str>,
+        stall_disconnect: bool,
         counters: Arc<DialCounters>,
     }
 
@@ -503,32 +575,58 @@ mod racing_tests {
             Ok((
                 Arc::new(MockDialTransport {
                     counters: self.counters.clone(),
+                    stall_disconnect: self.stall_disconnect,
                 }),
                 rx,
             ))
         }
     }
 
-    fn scripted(
+    fn scripted_full(
         delay_ms: Option<u64>,
         fail_with: Option<&'static str>,
+        stall_disconnect: bool,
     ) -> (ScriptedDialFactory, Arc<DialCounters>) {
         let counters = Arc::new(DialCounters::zero());
         (
             ScriptedDialFactory {
                 delay: delay_ms.map(Duration::from_millis),
                 fail_with,
+                stall_disconnect,
                 counters: counters.clone(),
             },
             counters,
         )
     }
 
+    fn scripted(
+        delay_ms: Option<u64>,
+        fail_with: Option<&'static str>,
+    ) -> (ScriptedDialFactory, Arc<DialCounters>) {
+        scripted_full(delay_ms, fail_with, false)
+    }
+
     fn race(
         primary: ScriptedDialFactory,
         secondary: ScriptedDialFactory,
     ) -> RacingTransportFactory {
-        RacingTransportFactory::new(Arc::new(primary), Arc::new(secondary))
+        RacingTransportFactory::new(Arc::new(primary), Arc::new(secondary), test_runtime())
+    }
+
+    /// Background loser closes resolve promptly, but not synchronously: wait
+    /// up to the bound for `disconnects` to reach `want`.
+    async fn await_disconnects(
+        primary_c: &Arc<DialCounters>,
+        secondary_c: &Arc<DialCounters>,
+        want: usize,
+    ) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while primary_c.get(|c| &c.disconnects) + secondary_c.get(|c| &c.disconnects) < want {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("the background loser close runs to completion");
     }
 
     #[tokio::test]
@@ -572,6 +670,9 @@ mod racing_tests {
             2,
             "both dials opened before either could be aborted"
         );
+        // The loser close runs detached: the winner is already returned, so
+        // wait for the background close instead of asserting synchronously.
+        await_disconnects(&primary_c, &secondary_c, 1).await;
         let (p_disc, s_disc) = (
             primary_c.get(|c| &c.disconnects),
             secondary_c.get(|c| &c.disconnects),
@@ -580,6 +681,27 @@ mod racing_tests {
             (p_disc, s_disc) == (0, 1) || (p_disc, s_disc) == (1, 0),
             "exactly the loser is closed, the winner is untouched (got {p_disc}/{s_disc})"
         );
+    }
+
+    #[tokio::test]
+    async fn stalled_loser_close_does_not_block_winner() {
+        // Both dials open instantly and both stall forever on close: whoever
+        // loses, the winner must still be delivered promptly and stay usable.
+        let (primary, _) = scripted_full(None, None, true);
+        let (secondary, _) = scripted_full(None, None, true);
+
+        let (transport, _rx) = tokio::time::timeout(
+            Duration::from_secs(5),
+            race(primary, secondary).create_transport(),
+        )
+        .await
+        .expect("the winner resolves despite the stalled loser close")
+        .expect("one of the instant dials wins");
+
+        transport
+            .send(Bytes::from_static(b"ping"))
+            .await
+            .expect("the delivered winner is usable");
     }
 
     #[tokio::test]

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Default WhatsApp Web websocket endpoint.
 pub const WHATSAPP_WEB_WS_URL: &str = "wss://web.whatsapp.com/ws/chat";
@@ -173,8 +174,10 @@ pub trait TransportFactory: crate::sync_marker::MaybeSendSync {
 /// The winner never waits for the loser: [`Transport::disconnect`] carries no
 /// completion bound (a valid transport may stall it forever), so an
 /// already-open loser is closed on `runtime` via [`Runtime::spawn_detached`]
-/// while the winner is returned immediately. Its event channel is dropped
-/// with it, so the loser's close never surfaces as a `DisconnectReason`.
+/// while the winner is returned immediately. The background close is bounded,
+/// so a stalled loser is dropped and its socket released instead of lingering
+/// detached. Its event channel is dropped with it, so the loser's close never
+/// surfaces as a `DisconnectReason`.
 ///
 /// No handshake runs here, so at most one socket ever reaches Noise: this
 /// returns a single transport and the caller handshakes exactly it. The race
@@ -197,8 +200,6 @@ impl RacingTransportFactory {
     /// Races `primary` against `secondary`; the first success wins regardless
     /// of order, so pass the preferred endpoint first only as a tiebreak hint.
     /// For chat parity this is one factory per [`WHATSAPP_WEB_WS_URLS`] entry.
-    /// `runtime` runs the loser's background close; the winner is returned
-    /// without waiting for it.
     pub fn new(
         primary: Arc<dyn TransportFactory>,
         secondary: Arc<dyn TransportFactory>,
@@ -215,11 +216,20 @@ impl RacingTransportFactory {
 type TransportDial =
     Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>;
 
+/// Bound for the loser's background close.
+///
+/// A stalled close must still release its socket eventually, or repeated races
+/// would accumulate detached tasks retaining dead transports. Well under the
+/// 20s transport timeout, so the cleanup never overlaps the client's own
+/// connect accounting.
+const LOSER_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Settles a dial that lost the race: an already-open loser is closed in
 /// background and its late failure suppressed; a still-pending loser is left
 /// for the caller to drop, which aborts the dial per [`TransportFactory`]'s
 /// contract. Never awaits the loser, so a stalled close cannot delay a usable
-/// winner.
+/// winner; the background close itself is bounded, so a stalled loser is
+/// dropped and its socket released instead of lingering detached forever.
 fn settle_loser<F>(
     winner: TransportDial,
     loser: F,
@@ -233,9 +243,12 @@ where
     if winner.is_ok()
         && let Some(Ok((loser_transport, _))) = loser.now_or_never()
     {
-        let runtime = Arc::clone(runtime);
-        runtime.spawn_detached(Box::pin(async move {
-            loser_transport.disconnect().await;
+        let spawner = Arc::clone(runtime);
+        let timer = Arc::clone(runtime);
+        spawner.spawn_detached(Box::pin(async move {
+            let _ =
+                crate::runtime::timeout(&*timer, LOSER_CLOSE_TIMEOUT, loser_transport.disconnect())
+                    .await;
         }));
     }
     winner
@@ -498,6 +511,7 @@ mod racing_tests {
         live: AtomicUsize,
         opened: AtomicUsize,
         disconnects: AtomicUsize,
+        transports_live: AtomicUsize,
     }
 
     impl DialCounters {
@@ -507,6 +521,7 @@ mod racing_tests {
                 live: AtomicUsize::new(0),
                 opened: AtomicUsize::new(0),
                 disconnects: AtomicUsize::new(0),
+                transports_live: AtomicUsize::new(0),
             }
         }
 
@@ -526,6 +541,12 @@ mod racing_tests {
     struct MockDialTransport {
         counters: Arc<DialCounters>,
         stall_disconnect: bool,
+    }
+
+    impl Drop for MockDialTransport {
+        fn drop(&mut self) {
+            self.counters.transports_live.fetch_sub(1, Ordering::AcqRel);
+        }
     }
 
     #[async_trait::async_trait]
@@ -571,6 +592,7 @@ mod racing_tests {
                 return Err(anyhow::anyhow!("{msg}"));
             }
             self.counters.opened.fetch_add(1, Ordering::AcqRel);
+            self.counters.transports_live.fetch_add(1, Ordering::AcqRel);
             let (_tx, rx) = async_channel::bounded(1);
             Ok((
                 Arc::new(MockDialTransport {
@@ -702,6 +724,41 @@ mod racing_tests {
             .send(Bytes::from_static(b"ping"))
             .await
             .expect("the delivered winner is usable");
+    }
+
+    #[tokio::test]
+    async fn stalled_loser_close_is_bounded_and_releases_its_socket() {
+        // Both dials open instantly and both stall forever on close. The
+        // loser's background close must give up and drop the transport
+        // instead of retaining it detached forever: only the delivered
+        // winner stays alive.
+        let (primary, primary_c) = scripted_full(None, None, true);
+        let (secondary, secondary_c) = scripted_full(None, None, true);
+
+        let (_transport, _rx) = race(primary, secondary)
+            .create_transport()
+            .await
+            .expect("one of the instant dials wins");
+        assert_eq!(
+            primary_c.get(|c| &c.transports_live) + secondary_c.get(|c| &c.transports_live),
+            2,
+            "both dials opened before either could be aborted"
+        );
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while primary_c.get(|c| &c.transports_live) + secondary_c.get(|c| &c.transports_live)
+                > 1
+            {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the stalled loser is dropped after the close bound");
+
+        // Neither close ever completed: the loser's was aborted by the bound,
+        // the winner's was never asked for.
+        assert_eq!(primary_c.get(|c| &c.disconnects), 0);
+        assert_eq!(secondary_c.get(|c| &c.disconnects), 0);
     }
 
     #[tokio::test]

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -38,8 +38,17 @@ pub fn with_edge_routing_param(url: &str, edge_routing_info: Option<&[u8]>) -> S
     }
     use base64::Engine as _;
     let encoded = base64::engine::general_purpose::URL_SAFE.encode(info);
-    let sep = if url.contains('?') { '&' } else { '?' };
-    format!("{url}{sep}ED={encoded}")
+    // The query goes before any `#fragment`: fragment bytes never reach the
+    // server, so an `ED` appended after `#` would lose the routing hint.
+    let (base, fragment) = match url.split_once('#') {
+        Some((base, fragment)) => (base, Some(fragment)),
+        None => (url, None),
+    };
+    let sep = if base.contains('?') { '&' } else { '?' };
+    match fragment {
+        Some(fragment) => format!("{base}{sep}ED={encoded}#{fragment}"),
+        None => format!("{base}{sep}ED={encoded}"),
+    }
 }
 
 /// `Origin` sent to every WhatsApp Web endpoint — the chat socket and the media
@@ -879,6 +888,18 @@ mod racing_tests {
             .decode(encoded)
             .expect("valid base64url");
         assert_eq!(decoded, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn edge_routing_param_goes_before_any_fragment() {
+        assert_eq!(
+            with_edge_routing_param("wss://example.invalid/ws/chat#frag", Some(&[0x01])),
+            "wss://example.invalid/ws/chat?ED=AQ==#frag"
+        );
+        assert_eq!(
+            with_edge_routing_param("wss://example.invalid/ws/chat?x=1#frag", Some(&[0x01])),
+            "wss://example.invalid/ws/chat?x=1&ED=AQ==#frag"
+        );
     }
 
     #[test]

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -2,10 +2,44 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 
 /// Default WhatsApp Web websocket endpoint.
 pub const WHATSAPP_WEB_WS_URL: &str = "wss://web.whatsapp.com/ws/chat";
+
+/// Alternate-port WhatsApp Web websocket endpoint.
+///
+/// WA Web dials this concurrently with [`WHATSAPP_WEB_WS_URL`] (its
+/// `openWebSocketsConcurrently` races `wss://web.whatsapp.com/ws/chat` against
+/// `wss://web.whatsapp.com:5222/ws/chat` and keeps the first `onopen`). A
+/// network that blocks 443 but not 5222, or vice versa, connects through the
+/// survivor, where a single-URL dial fails outright.
+pub const WHATSAPP_WEB_WS_URL_FALLBACK: &str = "wss://web.whatsapp.com:5222/ws/chat";
+
+/// Both chat endpoints WA Web dials, primary first.
+pub const WHATSAPP_WEB_WS_URLS: [&str; 2] = [WHATSAPP_WEB_WS_URL, WHATSAPP_WEB_WS_URL_FALLBACK];
+
+/// Appends WA Web's `?ED=` edge-routing query parameter to a chat URL.
+///
+/// The value is the same `edge_routing_info` the handshake already sends as
+/// the binary `ED` pre-intro, here base64url-encoded exactly like WA Web's
+/// `encodeB64UrlSafe` (URL-safe alphabet, padding kept). Both dial URLs carry
+/// it. Returns `url` unchanged when routing is absent, empty, or oversize, the
+/// same omit rules as `build_handshake_header`: a missing query never fails a
+/// handshake, the pre-intro still carries the bytes.
+pub fn with_edge_routing_param(url: &str, edge_routing_info: Option<&[u8]>) -> String {
+    let Some(info) = edge_routing_info else {
+        return url.to_string();
+    };
+    if info.is_empty() || info.len() > wacore_noise::MAX_EDGE_ROUTING_LEN {
+        return url.to_string();
+    }
+    use base64::Engine as _;
+    let encoded = base64::engine::general_purpose::URL_SAFE.encode(info);
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{sep}ED={encoded}")
+}
 
 /// `Origin` sent to every WhatsApp Web endpoint — the chat socket and the media
 /// hosts alike.
@@ -118,9 +152,94 @@ pub trait Transport: crate::sync_marker::MaybeSendSync {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait TransportFactory: crate::sync_marker::MaybeSendSync {
     /// Creates a new transport and returns it, along with a stream of events.
+    ///
+    /// Dropping the returned future must abort the dial without leaking an
+    /// open transport: [`RacingTransportFactory`] cancels the loser by
+    /// dropping it, which is only clean when a half-open dial leaves no
+    /// socket behind.
     async fn create_transport(
         &self,
     ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>;
+}
+
+/// Dials two endpoints concurrently and keeps the first success, mirroring WA
+/// Web's `openWebSocketsConcurrently`: the winner is returned, a loser that
+/// already opened is closed cleanly via [`Transport::disconnect`], a loser
+/// still dialling is aborted by dropping it, and an individual failure is
+/// suppressed while the other dial is still in flight. Only when both fail
+/// does this return an error (the one that completed last, as WA Web rejects
+/// with the failure that completes the set).
+///
+/// No handshake runs here, so at most one socket ever reaches Noise: this
+/// returns a single transport and the caller handshakes exactly it. No task is
+/// spawned and no executor primitive is used beyond `futures` combinators, so
+/// this stays portable (wasm32/ESP32) and dropping the race future aborts both
+/// dials with no socket to close.
+///
+/// Inner factories keep their own contracts: TLS session resumption stays
+/// inside each factory's connector, `Origin` stays each factory's, and custom
+/// strategies built on `from_websocket` compose by wrapping the factories.
+pub struct RacingTransportFactory {
+    primary: Arc<dyn TransportFactory>,
+    secondary: Arc<dyn TransportFactory>,
+}
+
+impl RacingTransportFactory {
+    /// Races `primary` against `secondary`; the first success wins regardless
+    /// of order, so pass the preferred endpoint first only as a tiebreak hint.
+    /// For chat parity this is one factory per [`WHATSAPP_WEB_WS_URLS`] entry.
+    pub fn new(primary: Arc<dyn TransportFactory>, secondary: Arc<dyn TransportFactory>) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+type TransportDial =
+    Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>;
+
+/// Settles a dial that lost the race: an already-open loser is closed cleanly
+/// and its late failure suppressed; a still-pending loser is left for the
+/// caller to drop, which aborts the dial per [`TransportFactory`]'s contract.
+async fn settle_loser<F>(winner: TransportDial, loser: F) -> TransportDial
+where
+    F: Future<Output = TransportDial>,
+{
+    use futures::future::FutureExt as _;
+
+    let winner = winner?;
+    if let Some(Ok((loser_transport, _))) = loser.now_or_never() {
+        loser_transport.disconnect().await;
+    }
+    Ok(winner)
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl TransportFactory for RacingTransportFactory {
+    async fn create_transport(&self) -> TransportDial {
+        use futures::future::{Either, select};
+        use futures::pin_mut;
+
+        let primary_fut = self.primary.create_transport();
+        let secondary_fut = self.secondary.create_transport();
+        pin_mut!(primary_fut, secondary_fut);
+
+        match select(primary_fut, secondary_fut).await {
+            Either::Left((first, second_fut)) => {
+                if first.is_ok() {
+                    settle_loser(first, second_fut).await
+                } else {
+                    second_fut.await
+                }
+            }
+            Either::Right((second, first_fut)) => {
+                if second.is_ok() {
+                    settle_loser(second, first_fut).await
+                } else {
+                    first_fut.await
+                }
+            }
+        }
+    }
 }
 
 /// A simple structure to represent an HTTP request
@@ -297,5 +416,310 @@ mod tests {
                 "close code {code} must not be treated as a clean shutdown"
             );
         }
+    }
+}
+
+/// Race and `?ED=` tests. The implementation uses only `futures` combinators,
+/// so it is portable; the tests below use Tokio timers purely as controllable
+/// latency/failure scripts for the mock dials.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod racing_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    struct DialCounters {
+        started: AtomicUsize,
+        live: AtomicUsize,
+        opened: AtomicUsize,
+        disconnects: AtomicUsize,
+    }
+
+    impl DialCounters {
+        fn zero() -> Self {
+            Self {
+                started: AtomicUsize::new(0),
+                live: AtomicUsize::new(0),
+                opened: AtomicUsize::new(0),
+                disconnects: AtomicUsize::new(0),
+            }
+        }
+
+        fn get(&self, f: impl Fn(&DialCounters) -> &AtomicUsize) -> usize {
+            f(self).load(Ordering::Acquire)
+        }
+    }
+
+    struct LiveGuard(Arc<DialCounters>);
+
+    impl Drop for LiveGuard {
+        fn drop(&mut self) {
+            self.0.live.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+
+    struct MockDialTransport {
+        counters: Arc<DialCounters>,
+    }
+
+    #[async_trait::async_trait]
+    impl Transport for MockDialTransport {
+        async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {
+            self.counters.disconnects.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    /// A factory whose dial sleeps, then succeeds or fails on script. `None`
+    /// delay answers immediately, which is what makes the simultaneous-open
+    /// path deterministic.
+    #[derive(Clone)]
+    struct ScriptedDialFactory {
+        delay: Option<Duration>,
+        fail_with: Option<&'static str>,
+        counters: Arc<DialCounters>,
+    }
+
+    #[async_trait::async_trait]
+    impl TransportFactory for ScriptedDialFactory {
+        async fn create_transport(
+            &self,
+        ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>
+        {
+            self.counters.started.fetch_add(1, Ordering::AcqRel);
+            self.counters.live.fetch_add(1, Ordering::AcqRel);
+            let _live = LiveGuard(self.counters.clone());
+            if let Some(delay) = self.delay {
+                tokio::time::sleep(delay).await;
+            }
+            if let Some(msg) = self.fail_with {
+                return Err(anyhow::anyhow!("{msg}"));
+            }
+            self.counters.opened.fetch_add(1, Ordering::AcqRel);
+            let (_tx, rx) = async_channel::bounded(1);
+            Ok((
+                Arc::new(MockDialTransport {
+                    counters: self.counters.clone(),
+                }),
+                rx,
+            ))
+        }
+    }
+
+    fn scripted(
+        delay_ms: Option<u64>,
+        fail_with: Option<&'static str>,
+    ) -> (ScriptedDialFactory, Arc<DialCounters>) {
+        let counters = Arc::new(DialCounters::zero());
+        (
+            ScriptedDialFactory {
+                delay: delay_ms.map(Duration::from_millis),
+                fail_with,
+                counters: counters.clone(),
+            },
+            counters,
+        )
+    }
+
+    fn race(
+        primary: ScriptedDialFactory,
+        secondary: ScriptedDialFactory,
+    ) -> RacingTransportFactory {
+        RacingTransportFactory::new(Arc::new(primary), Arc::new(secondary))
+    }
+
+    #[tokio::test]
+    async fn fastest_success_wins_and_loser_dial_is_aborted() {
+        let (primary, primary_c) = scripted(Some(100), None);
+        let (secondary, secondary_c) = scripted(Some(5), None);
+
+        let (_transport, _rx) = race(primary, secondary)
+            .create_transport()
+            .await
+            .expect("the fast dial succeeds");
+
+        assert_eq!(secondary_c.get(|c| &c.opened), 1);
+        assert_eq!(
+            primary_c.get(|c| &c.opened),
+            0,
+            "the slow dial never opened"
+        );
+        assert_eq!(
+            primary_c.get(|c| &c.disconnects),
+            0,
+            "a dial that never opened has no socket to close"
+        );
+        assert_eq!(secondary_c.get(|c| &c.disconnects), 0);
+        assert_eq!(primary_c.get(|c| &c.live), 0);
+        assert_eq!(secondary_c.get(|c| &c.live), 0);
+    }
+
+    #[tokio::test]
+    async fn simultaneous_success_closes_loser_cleanly() {
+        let (primary, primary_c) = scripted(None, None);
+        let (secondary, secondary_c) = scripted(None, None);
+
+        let (_transport, _rx) = race(primary, secondary)
+            .create_transport()
+            .await
+            .expect("one of the instant dials wins");
+
+        assert_eq!(
+            primary_c.get(|c| &c.opened) + secondary_c.get(|c| &c.opened),
+            2,
+            "both dials opened before either could be aborted"
+        );
+        let (p_disc, s_disc) = (
+            primary_c.get(|c| &c.disconnects),
+            secondary_c.get(|c| &c.disconnects),
+        );
+        assert!(
+            (p_disc, s_disc) == (0, 1) || (p_disc, s_disc) == (1, 0),
+            "exactly the loser is closed, the winner is untouched (got {p_disc}/{s_disc})"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_failure_waits_for_second_success() {
+        let (primary, _) = scripted(None, Some("primary refused"));
+        let (secondary, secondary_c) = scripted(Some(10), None);
+
+        race(primary, secondary)
+            .create_transport()
+            .await
+            .expect("the surviving dial wins despite the refusal");
+
+        assert_eq!(secondary_c.get(|c| &c.opened), 1);
+    }
+
+    #[tokio::test]
+    async fn double_failure_returns_the_last_error() {
+        // WA Web rejects with the failure that completes the set.
+        let (primary, _) = scripted(Some(20), Some("boom-primary"));
+        let (secondary, _) = scripted(Some(5), Some("boom-secondary"));
+        let err = race(primary, secondary)
+            .create_transport()
+            .await
+            .err()
+            .expect("both dials fail");
+        assert!(
+            err.to_string().contains("boom-primary"),
+            "the last failure wins, got: {err}"
+        );
+
+        let (primary, _) = scripted(Some(5), Some("boom-primary"));
+        let (secondary, _) = scripted(Some(20), Some("boom-secondary"));
+        let err = race(primary, secondary)
+            .create_transport()
+            .await
+            .err()
+            .expect("both dials fail");
+        assert!(
+            err.to_string().contains("boom-secondary"),
+            "the last failure wins, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_race_leaks_no_socket() {
+        use futures::FutureExt as _;
+
+        let (primary, primary_c) = scripted(Some(100), None);
+        let (secondary, secondary_c) = scripted(Some(100), None);
+        let racing = race(primary, secondary);
+
+        assert!(
+            racing.create_transport().now_or_never().is_none(),
+            "both dials are still in flight after one poll"
+        );
+        assert_eq!(primary_c.get(|c| &c.started), 1);
+        assert_eq!(secondary_c.get(|c| &c.started), 1);
+
+        // The race future (and both dials) dropped here.
+        assert_eq!(primary_c.get(|c| &c.live), 0);
+        assert_eq!(secondary_c.get(|c| &c.live), 0);
+        assert_eq!(primary_c.get(|c| &c.opened), 0);
+        assert_eq!(secondary_c.get(|c| &c.opened), 0);
+        assert_eq!(primary_c.get(|c| &c.disconnects), 0);
+        assert_eq!(secondary_c.get(|c| &c.disconnects), 0);
+    }
+
+    #[tokio::test]
+    async fn winner_closed_immediately_after_win_leaves_no_loser() {
+        let (primary, primary_c) = scripted(Some(50), None);
+        let (secondary, secondary_c) = scripted(Some(5), None);
+
+        let (transport, _rx) = race(primary, secondary)
+            .create_transport()
+            .await
+            .expect("the fast dial succeeds");
+        transport.disconnect().await;
+
+        assert_eq!(secondary_c.get(|c| &c.disconnects), 1);
+        assert_eq!(primary_c.get(|c| &c.opened), 0);
+        assert_eq!(primary_c.get(|c| &c.disconnects), 0);
+        assert_eq!(primary_c.get(|c| &c.live), 0);
+        assert_eq!(secondary_c.get(|c| &c.live), 0);
+    }
+
+    #[test]
+    fn edge_routing_param_absent_or_empty_leaves_url_untouched() {
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, None),
+            WHATSAPP_WEB_WS_URL
+        );
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[])),
+            WHATSAPP_WEB_WS_URL
+        );
+    }
+
+    #[test]
+    fn edge_routing_param_encodes_like_wa_web() {
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0x01, 0x02, 0x03])),
+            format!("{WHATSAPP_WEB_WS_URL}?ED=AQID")
+        );
+        // WA Web's urlSafeBase64 swaps the alphabet but never strips `=`.
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0x01, 0x02])),
+            format!("{WHATSAPP_WEB_WS_URL}?ED=AQI=")
+        );
+        // `+`/`/` become `-`/`_`.
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0xFB, 0xFF])),
+            format!("{WHATSAPP_WEB_WS_URL}?ED=-_8=")
+        );
+        let url = with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0xDE, 0xAD, 0xBE, 0xEF]));
+        let encoded = url.split("?ED=").nth(1).expect("query is present");
+        use base64::Engine as _;
+        let decoded = base64::engine::general_purpose::URL_SAFE
+            .decode(encoded)
+            .expect("valid base64url");
+        assert_eq!(decoded, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn edge_routing_param_oversize_keeps_previous_behavior() {
+        let oversize = vec![0x00u8; wacore_noise::MAX_EDGE_ROUTING_LEN + 1];
+        assert_eq!(
+            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&oversize)),
+            WHATSAPP_WEB_WS_URL
+        );
+    }
+
+    #[test]
+    fn chat_urls_cover_both_wa_web_endpoints() {
+        assert_eq!(
+            WHATSAPP_WEB_WS_URL_FALLBACK,
+            "wss://web.whatsapp.com:5222/ws/chat"
+        );
+        assert_eq!(
+            WHATSAPP_WEB_WS_URLS,
+            [WHATSAPP_WEB_WS_URL, WHATSAPP_WEB_WS_URL_FALLBACK]
+        );
     }
 }


### PR DESCRIPTION
WhatsApp Web opens the chat socket by racing `wss://web.whatsapp.com/ws/chat` against `wss://web.whatsapp.com:5222/ws/chat` (`openWebSocketsConcurrently` in `docs/captured-js/WAWeb/Open/Socket.js`) and tags both URLs with `?ED=<base64url edge routing>`; this repo dialled a single hard-coded URL with no query, so a network blocking either 443 or 5222 fails where WA Web connects through the survivor.

## Change

- `RacingTransportFactory` (`wacore/src/net.rs`): races any two `TransportFactory` dials with first-success-wins semantics. An already-open loser is closed in background on the given `Runtime` via `spawn_detached` — the winner is returned immediately because `Transport::disconnect` carries no completion bound and awaiting it could park a usable transport (review finding, fixed). The background close is itself bounded by a 5s timeout, so a stalled loser is dropped and its socket released instead of lingering detached (review follow-up, fixed). A still-dialling loser is aborted by dropping it; an individual failure is suppressed while the other dial is in flight; both failing returns the last error, matching WA Web's reject-with-the-completing-failure. Returns a single transport, so at most one socket ever reaches Noise. Portable (`futures` + `Runtime` only): no `tokio::` in the core path, wasm32 target covered.
- `WHATSAPP_WEB_WS_URL_FALLBACK` / `WHATSAPP_WEB_WS_URLS`: the exact pair WA Web dials, primary first.
- `with_edge_routing_param`: appends `?ED=` with WA Web's `encodeB64UrlSafe` encoding (URL-safe alphabet, padding kept — `WABase64/UrlSafe.js` only swaps `+/`, never strips `=`), and the same omit rules as the `ED` pre-intro (`build_handshake_header`): absent, empty or oversize routing leaves the URL untouched, so a missing query can never fail a handshake.
- Re-exports in `src/transport.rs`. No changes to the Tokio factory, lifecycle, handshake, framing, reconnect or telemetry: single-dial behavior is unchanged and parity is opt-in by composing two single-URL factories.

## Evidence

- `Socket.js`: URL list, first-`onopen` wins, loser `close(1000, "loser socket")`, `AbortError` suppression, `socketOpener` fibonacci retry. `ChatSocket.js`: `getRoutingInfo()` into `?ED=` plus the binary `ED` pre-intro carrying the same bytes.
- whatsmeow and Baileys both dial a single URL with no `?ED=`, confirming the gap is availability under port blocking (and routing quality for the query), not a handshake failure — the pre-intro already carries the routing bytes on every handshake.

## Validation

- 13 new tests in `wacore/src/net.rs::racing_tests`: fastest-wins with loser abort, simultaneous-open with exactly-one background loser close, stalled loser close still delivering a usable winner, stalled loser dropped after the close bound (only the winner stays alive), refusal-then-success, double failure returning the last error in both orders, cancellation leaking no socket, immediate winner close, and `?ED=` encoding/omit vectors (alphabet swap, kept padding, round-trip, query placement before `#fragment`).
- `cargo nextest run -p wacore --lib`: 1639 pass. `-p whatsapp-rust-tokio-transport`: 8 pass. `-p whatsapp-rust --lib`: 1942 pass. `cargo test --doc -p wacore`: pass.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo check -p wacore --target wasm32-unknown-unknown --features js`: clean (the plain wasm check fails on `getrandom` without the `js` feature — pre-existing, unrelated).
- Not run: e2e (needs the mock-server infrastructure from `agent_docs/e2e_testing.md`).

## Deliberately out of scope

- `?ED=` ships as a helper only: the transport layer does not read device state, so callers apply it when building endpoint URLs. The pre-intro already carries the same bytes on every handshake.
- No change to default wiring: `TokioWebSocketTransportFactory` stays single-URL; lifecycle retry policy untouched.

## Breaking changes

None — additive only (new type, constants, helper, re-exports). No migration needed.
