### PR TITLE
fix(bench): drive overlapped burst and read jointly

### DIFF
--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -43,7 +43,7 @@ sha2 = { workspace = true }
 divan = { workspace = true }
 portable-atomic = { workspace = true }
 rand = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Tokio's timer requires a runtime time driver, which the single-agent browser

--- a/storages/sqlite-storage/benches/store_contention.rs
+++ b/storages/sqlite-storage/benches/store_contention.rs
@@ -185,6 +185,12 @@ const BURST_SEEDS: [u8; 2] = [1, 2];
 /// and only then parks on its blocking job. A read on the write queue thus
 /// queues behind the burst, and a read on a reader connection runs beside a
 /// write in progress, whatever the scheduler does with either task.
+///
+/// Both futures are driven together with `join!`, never awaited in sequence:
+/// awaiting the read first would park it on the write permit while the burst
+/// future — the only thing that can release it — sits unpolled behind it, a
+/// deterministic deadlock. `join!` keeps the burst polled while the read
+/// waits, so the measured interleaving is the queued one above on every run.
 fn read_under_write<R>(
     h: &'static Harness,
     rows: &[AppStateMutationMAC],
@@ -194,8 +200,7 @@ fn read_under_write<R>(
         let mut burst = pin!(h.store.put_mutation_macs("regular", 1, rows));
         let finished = poll_fn(|cx| Poll::Ready(burst.as_mut().poll(cx).is_ready())).await;
         assert!(!finished, "the burst finished before the read was issued");
-        let out = read.await;
-        burst.await.expect("write burst");
+        let (out, _) = tokio::join!(read, async { burst.await.expect("write burst") });
         out
     })
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -7063,12 +7063,7 @@ mod read_routing_tests {
         assert_eq!(got.as_deref(), Some(&b"blob"[..]));
     }
 
-    /// The contention bench overlaps one write burst with one write-queue read
-    /// (`benches/store_contention.rs::read_under_write`): the burst is
-    /// first-polled to hold the permit, then both are driven together.
-    /// Driving them in sequence — awaiting the read while the unpolled burst
-    /// holds its permit — deadlocks, and the shard hangs until CI kills it
-    /// with no failing assertion. This pins joint progress with a timeout.
+    /// Ensures a write-queue read completes while a write burst holds the permit.
     #[tokio::test]
     async fn write_queue_read_completes_beside_a_held_burst() {
         use std::future::{Future, poll_fn};

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -7063,6 +7063,39 @@ mod read_routing_tests {
         assert_eq!(got.as_deref(), Some(&b"blob"[..]));
     }
 
+    /// The contention bench overlaps one write burst with one write-queue read
+    /// (`benches/store_contention.rs::read_under_write`): the burst is
+    /// first-polled to hold the permit, then both are driven together.
+    /// Driving them in sequence — awaiting the read while the unpolled burst
+    /// holds its permit — deadlocks, and the shard hangs until CI kills it
+    /// with no failing assertion. This pins joint progress with a timeout.
+    #[tokio::test]
+    async fn write_queue_read_completes_beside_a_held_burst() {
+        use std::future::{Future, poll_fn};
+        use std::pin::pin;
+        use std::task::Poll;
+
+        let db = TempDb::new("held_burst");
+        let store = store_with(1, &db).await;
+        let rows = vec![AppStateMutationMAC {
+            index_mac: vec![0xA1; 32],
+            value_mac: vec![0xC5; 32],
+        }];
+
+        let outcome = tokio::time::timeout(Duration::from_secs(30), async {
+            let mut burst = pin!(store.put_mutation_macs("regular", 1, &rows));
+            let finished = poll_fn(|cx| Poll::Ready(burst.as_mut().poll(cx).is_ready())).await;
+            assert!(!finished, "burst finished before the read was issued");
+            let (read, _) = tokio::join!(store.get_devices("190455501800"), async {
+                burst.await.expect("write burst")
+            });
+            read
+        })
+        .await
+        .expect("read and burst complete together");
+        assert!(outcome.expect("read succeeds").is_none());
+    }
+
     /// `pool_size > 1` with no reader connections is reachable config, and there
     /// the permit no longer implies an exclusive connection: the writers that
     /// check one out directly can commit between a multi-statement read's


### PR DESCRIPTION
The proto-signal shard has been timing out at the 25-minute cap with zero output from `store_contention` — first seen 12:52, then again 19:30. It is a deterministic deadlock in the benchmark choreography, not slowness: reproduced 3/3 locally (native) plus under valgrind, always stuck at the same point with the process parked, not spinning.

## Root cause (proven with temporary tracing, since removed)

`read_under_write` first-polls the write burst (taking the write permit and dispatching its blocking job), then awaits the read and only afterwards the burst:

```rust
let out = read.await;   // parks on the permit the burst frame holds
burst.await...          // would release it — never reached
```

The write-queue read parks on the permit while the only future that can release it sits unpolled behind it. The burst's blocking job completes, but nobody polls it, so nothing ever wakes the read. Reader-pool reads never wait on the permit, which is why only `write_queue_read_under_write` hangs.

Bisected to #1409 (bb5aa3aa3): #1401's background-writer design could not deadlock this way; the deterministic first-poll choreography introduced the await order. Masked ever since by concurrency-cancelled runs and the job timeout.

## Fix

Drive both futures together with `tokio::join!` — the read still queues behind the burst exactly as documented (the first poll plus the assert order it), but the burst stays polled while the read waits, so the measured interleaving is reachable on every run. Same work measured, no new threads, no timeouts in the bench itself (a hang would still hang CI loudly rather than pass).

Also adds `write_queue_read_completes_beside_a_held_burst` next to the existing concurrency tests: the same choreography against a real store, bounded by a 30s timeout so a regression fails with a message instead of hanging the shard. Proven fail-before (sequential awaits fail at exactly 30s), passes after.

Plus `tokio/macros` on the bench dev-dependency for `join!` (bench-only, no prod impact).

## Validation

- Full bench binary 3/3 completions natively (was 3/3 timeout kills); full binary under valgrind completes in ~4min (was 18min+ stuck).
- New regression test fail-before/fail-after proven.
- `sqlite-storage` lib: 112 pass. `cargo fmt --check`, `cargo clippy -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings`: clean.
- Not run: full-workspace test (touches only this bench, its dev-deps, and its regression test).