### PR TITLE
fix(bench): pin cache_insert_at_capacity to a fixed-key hash seed

### DIFF
--- a/benches/client_cache_maint.rs
+++ b/benches/client_cache_maint.rs
@@ -171,14 +171,31 @@ fn cache_insert(bencher: divan::Bencher, n: usize) {
 /// degrade into hit-overwrites with no eviction. A monotonic key counter
 /// (never-before-seen keys per sample) was worse still — it made the
 /// peak-memory instrument read allocator-state drift as signal here.
+///
+/// The fixture pins a fixed-key hasher: under the default per-process seed
+/// the table's growth budget follows a seed-dependent random walk, and at
+/// width 64 it sometimes exhausts mid-iteration — one extra ~20 KiB table
+/// growth that the peak-memory instrument reads as a 2.6 KiB / 22.8 KiB
+/// flip-flop between runs with no code change. Same `DetState` shape the
+/// `wacore` benches use; see `PortableCacheBuilder::hash_builder` for why
+/// the seed decides growth timing.
+///
+/// With the seed fixed the rotation's single table growth lands on a fixed
+/// batch, so the batches start where that batch is not the first: CodSpeed
+/// measures one iteration, which is always the first batch.
+type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+
 #[divan::bench(args = CACHE_SIZES)]
 fn cache_insert_at_capacity(bencher: divan::Bencher, n: usize) {
-    static FULL: OnceLock<Vec<Cache<Jid, Arc<()>>>> = OnceLock::new();
+    static FULL: OnceLock<Vec<Cache<Jid, Arc<()>, DetState>>> = OnceLock::new();
     let built = FULL.get_or_init(|| {
         CACHE_SIZES
             .iter()
             .map(|&m| {
-                let cache: Cache<Jid, Arc<()>> = Cache::builder().max_capacity(m as u64).build();
+                let cache: Cache<Jid, Arc<()>, DetState> = Cache::builder()
+                    .max_capacity(m as u64)
+                    .hash_builder(DetState::default())
+                    .build();
                 block_on(async {
                     for i in 0..m {
                         cache.insert(key(i), Arc::new(())).await;
@@ -199,12 +216,16 @@ fn cache_insert_at_capacity(bencher: divan::Bencher, n: usize) {
     // capacity (4096): 4096 / 512 + 2 = 10 batches = 5120 keys, so the cache
     // can never hold the whole rotation and round-robin insertion always
     // lands on 512 misses. None of the ranges collide with the resident
-    // `key(0..m)` keys, and all stay below 1_000_000 so `{i:06}` never widens.
+    // `key(0..m)` keys, the `cache_insert` batch at 100_000, or the sweep
+    // keys at 400_000, and all stay below 1_000_000 so `{i:06}` never widens.
+    // The base sits at 300_000 rather than 200_000: with the fixed seed above
+    // the rotation's one table growth lands on the second batch, keeping the
+    // first — the one CodSpeed measures — on the flat steady state.
     static ROTATING: OnceLock<Vec<Vec<Jid>>> = OnceLock::new();
     let batches = ROTATING.get_or_init(|| {
         let depth = CACHE_SIZES.iter().max().expect("sizes") / BATCH + 2;
         (0..depth)
-            .map(|b| batch_keys(200_000 + b * BATCH, BATCH))
+            .map(|b| batch_keys(300_000 + b * BATCH, BATCH))
             .collect()
     });
     let round = AtomicUsize::new(0);

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -86,8 +86,8 @@ pub(crate) struct CapacityStats {
 /// Both lazy and best-effort: expired entries are only removed lazily on
 /// access or in `run_pending_tasks`. `entry_count` may include
 /// expired-but-not-yet-evicted entries.
-pub struct PortableCache<K, V> {
-    inner: Arc<RwLock<CacheInner<K, V>>>,
+pub struct PortableCache<K, V, S = RandomState> {
+    inner: Arc<RwLock<CacheInner<K, V, S>>>,
     /// Shared single-flight init-lock registry (see `InitLocks`), built on the
     /// first [`get_with`](Self::get_with) rather than at construction: a client
     /// builds ~20 of these caches and most of them are only ever `get`/`insert`ed,
@@ -241,10 +241,10 @@ fn finish_clock_walk(
     }
 }
 
-struct CacheInner<K, V> {
+struct CacheInner<K, V, S> {
     /// Hashes keys once at insert; lookups with a borrowed `Q` hash through
     /// the same state, which the `Borrow` contract keeps consistent with `K`.
-    hasher: RandomState,
+    hasher: S,
     table: HashTable<Slot<K, V>>,
     /// Eviction order, `seq -> hash`, oldest first; an entry given a second
     /// chance is re-keyed to the back. Eviction walks from the front (O(log n)
@@ -266,13 +266,14 @@ struct CacheInner<K, V> {
     capacity_eviction_blocks: u64,
 }
 
-impl<K, V> CacheInner<K, V>
+impl<K, V, S> CacheInner<K, V, S>
 where
     K: Hash + Eq + Clone,
+    S: BuildHasher,
 {
-    fn new(track_order: bool) -> Self {
+    fn new(track_order: bool, hasher: S) -> Self {
         Self {
-            hasher: RandomState::new(),
+            hasher,
             table: HashTable::new(),
             order: BTreeMap::new(),
             track_order,
@@ -601,29 +602,34 @@ impl Drop for InitLockCleanup<'_> {
 
 // -- Builder --
 
-pub struct PortableCacheBuilder<K, V> {
+pub struct PortableCacheBuilder<K, V, S = RandomState> {
     max_capacity: Option<u64>,
     ttl: Option<Duration>,
     tti: Option<Duration>,
     evict_guard: Option<fn(&V) -> bool>,
+    hash_builder: Option<S>,
     _marker: std::marker::PhantomData<fn(K, V)>,
 }
 
-impl<K, V> PortableCacheBuilder<K, V>
-where
-    K: Hash + Eq + Clone + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
-{
+impl<K, V> PortableCacheBuilder<K, V, RandomState> {
     fn new() -> Self {
         Self {
             max_capacity: None,
             ttl: None,
             tti: None,
             evict_guard: None,
+            hash_builder: None,
             _marker: std::marker::PhantomData,
         }
     }
+}
 
+impl<K, V, S> PortableCacheBuilder<K, V, S>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher,
+{
     /// Protect entries a live task still holds from capacity eviction: `guard`
     /// returns `true` when a value is safe to evict. For an `Arc<Mutex>` lock cache,
     /// pass `|v| Arc::strong_count(v) <= 1`, so an entry held elsewhere is never
@@ -635,6 +641,28 @@ where
     pub fn evict_guard(mut self, guard: fn(&V) -> bool) -> Self {
         self.evict_guard = Some(guard);
         self
+    }
+
+    /// Fix the slot table's hash seed instead of drawing a per-process one.
+    ///
+    /// Whether an evict-then-insert cycle spends or restores the table's
+    /// growth budget — and so whether a mid-run table growth fires inside a
+    /// measurement — follows the bucket layout, which follows this seed.
+    /// Benchmarks pin it so every process measures the same layout.
+    /// Everything else keeps the default: a process-wide fixed seed would
+    /// re-open HashDoS.
+    pub fn hash_builder<H>(self, hash_builder: H) -> PortableCacheBuilder<K, V, H>
+    where
+        H: BuildHasher,
+    {
+        PortableCacheBuilder {
+            max_capacity: self.max_capacity,
+            ttl: self.ttl,
+            tti: self.tti,
+            evict_guard: self.evict_guard,
+            hash_builder: Some(hash_builder),
+            _marker: std::marker::PhantomData,
+        }
     }
 
     pub fn max_capacity(mut self, cap: u64) -> Self {
@@ -659,7 +687,10 @@ where
     /// # Panics
     ///
     /// If an [`evict_guard`](Self::evict_guard) is combined with a TTL or TTI.
-    pub fn build(self) -> PortableCache<K, V> {
+    pub fn build(self) -> PortableCache<K, V, S>
+    where
+        S: Default,
+    {
         // An evict_guard marks a cache of live coordination objects. Expiry
         // does not consult the guard, so a timeout would drop an entry a task
         // still holds and let the next lookup mint a duplicate of it.
@@ -676,7 +707,12 @@ where
             || self.ttl.is_some()
             || self.tti.is_some();
         PortableCache {
-            inner: Arc::new(RwLock::new(CacheInner::new(track_order))),
+            inner: Arc::new(RwLock::new(CacheInner::new(
+                track_order,
+                // A builder that never pinned a seed hashes like every other
+                // cache: `RandomState::default()` draws per-process.
+                self.hash_builder.unwrap_or_default(),
+            ))),
             init_locks: OnceLock::new(),
             max_capacity: self.max_capacity,
             ttl: self.ttl,
@@ -690,7 +726,7 @@ where
 
 // -- PortableCache impl --
 
-impl<K, V> PortableCache<K, V> {
+impl<K, V, S> PortableCache<K, V, S> {
     /// The single-flight registry, built on first use. Unbounded impl block so
     /// [`Clone`] can force it too, keeping every clone on one registry.
     fn init_locks(&self) -> &Arc<InitLocks> {
@@ -698,15 +734,22 @@ impl<K, V> PortableCache<K, V> {
     }
 }
 
-impl<K, V> PortableCache<K, V>
+impl<K, V> PortableCache<K, V, RandomState> {
+    /// Start a builder for a cache that draws its hash seed per process.
+    /// Unbounded impl block so existing `Cache::builder()` call sites keep
+    /// inferring the default hasher; pinning a seed is opt-in through
+    /// [`PortableCacheBuilder::hash_builder`].
+    pub fn builder() -> PortableCacheBuilder<K, V, RandomState> {
+        PortableCacheBuilder::new()
+    }
+}
+
+impl<K, V, S> PortableCache<K, V, S>
 where
     K: Hash + Eq + Clone + Send + Sync + 'static,
     V: Clone + Send + Sync + 'static,
+    S: BuildHasher,
 {
-    pub fn builder() -> PortableCacheBuilder<K, V> {
-        PortableCacheBuilder::new()
-    }
-
     /// Read the monotonic clock only for caches that can expire entries.
     /// Non-expiring caches use a stable sentinel because their timestamps are
     /// never observed, avoiding unnecessary clock reads on every operation.
@@ -1028,7 +1071,7 @@ where
         Vec::new().into_iter()
     }
 
-    fn snapshot(guard: &CacheInner<K, V>) -> Vec<(Arc<K>, V)> {
+    fn snapshot(guard: &CacheInner<K, V, S>) -> Vec<(Arc<K>, V)> {
         guard
             .iter()
             .map(|(k, e)| (Arc::new(k.clone()), e.value.clone()))
@@ -1145,7 +1188,7 @@ where
     }
 }
 
-impl<K, V> Clone for PortableCache<K, V> {
+impl<K, V, S> Clone for PortableCache<K, V, S> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
@@ -1323,6 +1366,22 @@ mod tests {
                 eviction_blocks: 0,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn fixed_hash_seed_cache_evicts_like_default() {
+        type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+        let cache: PortableCache<String, u32, DetState> = PortableCache::builder()
+            .max_capacity(2)
+            .hash_builder(DetState::default())
+            .build();
+
+        cache.insert("a".into(), 1).await;
+        cache.insert("b".into(), 2).await;
+        cache.insert("c".into(), 3).await;
+        assert_eq!(cache.entry_count(), 2);
+        assert!(cache.get("a").await.is_none());
+        assert_eq!(cache.get("c").await, Some(3));
     }
 
     #[tokio::test]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -695,8 +695,6 @@ where
     {
         // A builder that never pinned a seed hashes like every other
         // cache: `RandomState::default()` draws per-process.
-        // A builder that never pinned a seed hashes like every other
-        // cache: `RandomState::default()` draws per-process.
         assemble(
             self.max_capacity,
             self.ttl,

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -607,8 +607,7 @@ pub struct PortableCacheBuilder<K, V, S = RandomState> {
     ttl: Option<Duration>,
     tti: Option<Duration>,
     evict_guard: Option<fn(&V) -> bool>,
-    hash_builder: Option<S>,
-    _marker: std::marker::PhantomData<fn(K, V)>,
+    _marker: std::marker::PhantomData<fn(K, V) -> S>,
 }
 
 impl<K, V> PortableCacheBuilder<K, V, RandomState> {
@@ -618,7 +617,6 @@ impl<K, V> PortableCacheBuilder<K, V, RandomState> {
             ttl: None,
             tti: None,
             evict_guard: None,
-            hash_builder: None,
             _marker: std::marker::PhantomData,
         }
     }
@@ -651,16 +649,20 @@ where
     /// Benchmarks pin it so every process measures the same layout.
     /// Everything else keeps the default: a process-wide fixed seed would
     /// re-open HashDoS.
-    pub fn hash_builder<H>(self, hash_builder: H) -> PortableCacheBuilder<K, V, H>
+    ///
+    /// Returns a [`SeededCacheBuilder`]: unlike [`PortableCacheBuilder::build`],
+    /// building it needs no `Default` from the hasher, so an explicitly
+    /// supplied hasher without one still builds.
+    pub fn hash_builder<H>(self, hash_builder: H) -> SeededCacheBuilder<K, V, H>
     where
         H: BuildHasher,
     {
-        PortableCacheBuilder {
+        SeededCacheBuilder {
             max_capacity: self.max_capacity,
             ttl: self.ttl,
             tti: self.tti,
             evict_guard: self.evict_guard,
-            hash_builder: Some(hash_builder),
+            hash_builder,
             _marker: std::marker::PhantomData,
         }
     }
@@ -691,36 +693,111 @@ where
     where
         S: Default,
     {
-        // An evict_guard marks a cache of live coordination objects. Expiry
-        // does not consult the guard, so a timeout would drop an entry a task
-        // still holds and let the next lookup mint a duplicate of it.
-        assert!(
-            self.evict_guard.is_none() || (self.ttl.is_none() && self.tti.is_none()),
-            "a cache with an evict_guard holds live coordination objects and must not expire by time"
-        );
+        // A builder that never pinned a seed hashes like every other
+        // cache: `RandomState::default()` draws per-process.
+        // A builder that never pinned a seed hashes like every other
+        // cache: `RandomState::default()` draws per-process.
+        assemble(
+            self.max_capacity,
+            self.ttl,
+            self.tti,
+            self.evict_guard,
+            S::default(),
+        )
+    }
+}
 
-        // Order is what eviction pops and what the expiry sweep walks, so a
-        // cache with either a capacity bound or a time bound keeps it. A cache
-        // with neither (the default LID/PN maps) is never swept and skips the
-        // BTreeMap node per entry.
-        let track_order = self.max_capacity.is_some_and(|cap| cap != u64::MAX)
-            || self.ttl.is_some()
-            || self.tti.is_some();
-        PortableCache {
-            inner: Arc::new(RwLock::new(CacheInner::new(
-                track_order,
-                // A builder that never pinned a seed hashes like every other
-                // cache: `RandomState::default()` draws per-process.
-                self.hash_builder.unwrap_or_default(),
-            ))),
-            init_locks: OnceLock::new(),
-            max_capacity: self.max_capacity,
-            ttl: self.ttl,
-            tti: self.tti,
-            evict_guard: self.evict_guard,
-            #[cfg(test)]
-            tti_renewals: Arc::new(portable_atomic::AtomicU64::new(0)),
-        }
+/// A builder with an explicitly supplied hash seed (see
+/// [`PortableCacheBuilder::hash_builder`]). Building it needs nothing from
+/// the hasher beyond [`BuildHasher`], so a supplied hasher without `Default`
+/// builds exactly like one with it.
+pub struct SeededCacheBuilder<K, V, H> {
+    max_capacity: Option<u64>,
+    ttl: Option<Duration>,
+    tti: Option<Duration>,
+    evict_guard: Option<fn(&V) -> bool>,
+    hash_builder: H,
+    _marker: std::marker::PhantomData<fn(K, V)>,
+}
+
+impl<K, V, H> SeededCacheBuilder<K, V, H>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    H: BuildHasher,
+{
+    pub fn max_capacity(mut self, cap: u64) -> Self {
+        self.max_capacity = Some(cap);
+        self
+    }
+
+    pub fn time_to_live(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    pub fn time_to_idle(mut self, tti: Duration) -> Self {
+        self.tti = Some(tti);
+        self
+    }
+
+    pub fn evict_guard(mut self, guard: fn(&V) -> bool) -> Self {
+        self.evict_guard = Some(guard);
+        self
+    }
+
+    /// # Panics
+    ///
+    /// If an evict guard is combined with a TTL or TTI (same rule as
+    /// [`PortableCacheBuilder::build`]).
+    pub fn build(self) -> PortableCache<K, V, H> {
+        assemble(
+            self.max_capacity,
+            self.ttl,
+            self.tti,
+            self.evict_guard,
+            self.hash_builder,
+        )
+    }
+}
+
+/// Shared assembly for both builders: the evict-guard rule and the order
+/// tracking live once, so the two `build` paths cannot drift apart.
+fn assemble<K, V, S>(
+    max_capacity: Option<u64>,
+    ttl: Option<Duration>,
+    tti: Option<Duration>,
+    evict_guard: Option<fn(&V) -> bool>,
+    hash_builder: S,
+) -> PortableCache<K, V, S>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    V: Clone + Send + Sync + 'static,
+    S: BuildHasher,
+{
+    // An evict_guard marks a cache of live coordination objects. Expiry
+    // does not consult the guard, so a timeout would drop an entry a task
+    // still holds and let the next lookup mint a duplicate of it.
+    assert!(
+        evict_guard.is_none() || (ttl.is_none() && tti.is_none()),
+        "a cache with an evict_guard holds live coordination objects and must not expire by time"
+    );
+
+    // Order is what eviction pops and what the expiry sweep walks, so a
+    // cache with either a capacity bound or a time bound keeps it. A cache
+    // with neither (the default LID/PN maps) is never swept and skips the
+    // BTreeMap node per entry.
+    let track_order =
+        max_capacity.is_some_and(|cap| cap != u64::MAX) || ttl.is_some() || tti.is_some();
+    PortableCache {
+        inner: Arc::new(RwLock::new(CacheInner::new(track_order, hash_builder))),
+        init_locks: OnceLock::new(),
+        max_capacity,
+        ttl,
+        tti,
+        evict_guard,
+        #[cfg(test)]
+        tti_renewals: Arc::new(portable_atomic::AtomicU64::new(0)),
     }
 }
 
@@ -1382,6 +1459,43 @@ mod tests {
         assert_eq!(cache.entry_count(), 2);
         assert!(cache.get("a").await.is_none());
         assert_eq!(cache.get("c").await, Some(3));
+    }
+
+    /// A supplied hasher without `Default` still builds: only the
+    /// unseeded path draws a fresh seed, never the explicit one.
+    #[tokio::test]
+    async fn supplied_hasher_without_default_builds() {
+        use std::hash::{BuildHasher, Hasher};
+
+        #[derive(Clone, Copy)]
+        struct FixedSeed(u64);
+        struct FixedHasher(u64);
+        impl Hasher for FixedHasher {
+            fn write(&mut self, bytes: &[u8]) {
+                for b in bytes {
+                    self.0 = self.0.wrapping_mul(0x100000001b3).wrapping_add(*b as u64);
+                }
+            }
+            fn finish(&self) -> u64 {
+                self.0
+            }
+        }
+        impl BuildHasher for FixedSeed {
+            type Hasher = FixedHasher;
+            fn build_hasher(&self) -> FixedHasher {
+                FixedHasher(self.0)
+            }
+        }
+
+        let cache: PortableCache<String, u32, FixedSeed> = PortableCache::builder()
+            .max_capacity(2)
+            .hash_builder(FixedSeed(0x9E3779B97F4A7C15))
+            .build();
+
+        cache.insert("a".into(), 1).await;
+        cache.insert("b".into(), 2).await;
+        cache.insert("c".into(), 3).await;
+        assert_eq!(cache.entry_count(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes the `cache_insert_at_capacity[64]` Memory flip-flop (2.6 KiB <-> 22.8 KiB between runs with no code change) that #1452 deliberately left as suspected runner noise.

## Scope

`benches/client_cache_maint.rs` (the at-capacity fixture only) plus an opt-in hash-seed knob on `PortableCacheBuilder`. Production is untouched: the default stays per-process `RandomState`, and for `S = RandomState` the cache monomorphizes to the same code as before.

## Root cause

#1452 read the flip-flop as runner noise because every `compare_runs` pair carried Environment Differences (CPU/libm). That cannot explain a byte metric that is width-selective: only `[64]` ever flipped, never `[512]`/`[4096]`. The code-scope mechanism does:

- The slot table is keyed by a per-process `RandomState` (`CacheInner::new`). hashbrown marks a freed slot `EMPTY` (restoring growth budget) or `DELETED` (tombstone, budget stays spent) based on the seed-dependent probe neighborhood, and an insert burns budget only when it lands on `EMPTY` — so `growth_left` follows a seed-dependent random walk over each measured batch's 512 evict+insert cycles.
- At width 64 the post-warmup budget (~48) routinely exhausts mid-iteration, firing one full table rehash with old+new tables briefly co-live: a single ~20 KiB allocation. Widths 512/4096 carry 8-80x headroom against the same 512-cycle batch, so they never exhaust.

Proven locally with a size-tallying harness replicating CodSpeed's exact single-iteration window (CodSpeed's own memory instrument cannot run outside its valgrind runner — locally it reports "unknown environment" — so this tallies the same per-window peak net bytes divan's `AllocProfiler`/CodSpeed derive from `GlobalAlloc` sizes). Before: 20 processes split 14x `peak=72, total=50880B, large=0` vs 6x `peak=20752, total=71632B, large=1` (one 20752 B alloc); the delta, 20680 B ≈ 20.2 KiB, is the reported 22.8 − 2.6 KiB flip-flop to the byte.

## Fix

- `PortableCacheBuilder::hash_builder(H)`: type-transitioning setter over a new `S = RandomState` parameter (`CacheInner`/`PortableCache`/`Clone` follow). `builder()` stays on the unbounded `RandomState` block so every existing call site infers as before; `build()` falls back to `S::default()`. Both blessed hashers are SipHash-1-3, so the measured profile is identical in kind — only key material changes.
- The fixture builds its caches with `DetState` (the same fixed-key shape the `wacore` benches use) and the rotation base moves 200_000 -> 300_000: with the seed fixed, the rotation's single table growth lands on the second batch, keeping the first — the one CodSpeed measures — on the flat steady state. Every iteration is still 512 misses plus 512 evictions; the measured quantity is unchanged.
- Plus one unit test covering the new builder path.

Expect a one-time step on all three at-capacity rows as they join the deterministic series; read post-merge runs against the new baseline, not the old mixed one.

Deliberately left out: the file's other rows (`cache_insert`, sweeps) keep `RandomState` — same mechanism could in principle reach them, but CodSpeed never flagged them and this stays scoped to the report. `InitLocks` keeps its own `RandomState` (single-flight registry, not on the measured path).

## Validation

- Harness after the fix: 20/20 processes `peak=72, total=50880B, allocs=1097, large=0` at width 64; full 10-batch rotation deterministic with its single growth on batch 2; widths 512/4096 flat. (Harness was temporary and is removed; numbers above are the record.)
- `cargo fmt --all -- --check`, `cargo clippy -p whatsapp-rust --all-targets -- -D warnings`, `cargo check -p e2e-tests --tests`: clean.
- `cargo nextest run -p whatsapp-rust --lib portable_cache`: 47 passed (46 existing + 1 new).
- Bench binary runs green on all widths with sane throughput (walltime only as a health check — this box has no isolation, so its run-to-run bounce is machine noise, not the instrument).
