### PR TITLE
fix(voip): preserve upright video orientation in RTP metadata

### DIFF
--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -64,6 +64,58 @@ fixture is accepted. Use `oracle inspect`, `oracle callers`, `oracle abi` and a
 marker run to prove pointer/length/sequence/timestamp positions. Put that proof
 beside the future media spec and pin the capture hash through `wasm.lock.json`.
 
+## Outbound video orientation proof
+
+`tools/oracle-core/tests/video_orientation.rs` executes the captured
+`JgwtTQVeWPm.wasm`, rather than a Rust translation of it. The test checks its
+SHA-256 before instrumentation:
+
+```text
+97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db
+```
+
+The artifact is pinned in `tools/oracle-core/wasm.lock.json`. Fetch captures
+with `cargo xt oracle fetch`, or point `WA_WASM_DIR` at an existing verified
+capture directory. From the repository root:
+
+```sh
+WA_WASM_DIR=/path/to/captured-wasm cargo test --release -p oracle-core --test video_orientation -- --nocapture
+cargo test -p wacore --features voip-mlow --lib voip::
+```
+
+An explicit missing or corrupt capture fails. An absent implicit cache may
+print `skipping:`, which is not proof. A successful execution prints
+`executed JgwtTQVeWPm.wasm: 10 orientation/keyframe cases` and reports upright
+delta `0x00` and IDR `0x08`. The pre-fix comparison failed with WASM `[0, 8]`
+against Rust `[1, 9]`.
+
+The entry is table slot 9602, function 13128, anchored by
+`onEncodedVideoDataFromJsForStream: Manager not initialized!`. Its callee
+13065 constructs an encoded frame with internal presence bit `0x800`,
+keyframe bit `0x08`, and rotation in the low two bits. The test provides a
+synthetic manager and encoder port. It uses existing function 4942 as the
+port callback, with a recording-only entry marker to obtain the frame
+pointer. That callback changes only the frame type, not its metadata.
+
+The test reads the constructed frame and separately feeds its low metadata
+byte to the real extension builder, function 4943 at table slot 3681,
+anchored by `media_frame_info_build_header_ext`. It does not execute the
+intervening sender pipeline. All ten cases preserve the supplied 1280x720
+dimensions, payload pointer and payload length. The only stub invoked during
+each case is the recording marker.
+
+The JS enum comes from `WAWebVoipMediaEnums` in bundle
+`561b4bd5677d24a29707db4c05b63edc019b73744b66699fb6bbfd6b361d6c1a`.
+Its `Unknown`, `Normal`, `Rotate90`, `Rotate180`, and `Rotate270` values are
+0 through 4. The WASM maps them to rotation bits 0, 0, 3, 2, and 1. This is
+WhatsApp-specific evidence, not an assumed CVO mapping.
+
+The Rust session regression checks upright metadata on every protected IDR
+and delta fragment. Android receive fixtures retain their captured `0x09`
+and `0x01` values. The oracle does not decode camera pixels, parse a live
+laptop SPS, run networking, or replace a browser-to-Android visual retest.
+No proprietary WASM, captured JS, or personal data belongs in the test commit.
+
 ## CI shape
 
 Future fixtures should have one producer command under `cargo xt oracle` that

--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -93,9 +93,21 @@ The entry is table slot 9602, function 13128, anchored by
 `onEncodedVideoDataFromJsForStream: Manager not initialized!`. Its callee
 13065 constructs an encoded frame with internal presence bit `0x800`,
 keyframe bit `0x08`, and rotation in the low two bits. The test provides a
-synthetic manager and encoder port. It uses existing function 4942 as the
-port callback, with a recording-only entry marker to obtain the frame
-pointer. That callback changes only the frame type, not its metadata.
+synthetic manager and encoder port. It verifies the entry and extension
+builder string anchors and table slots before execution. The substitute
+port callback 4942 has encoded-body SHA-256
+`a92611af6bc97b1593bf3a167e60f7c8512a5731a9c223194b859fc8d02529d4`.
+It writes only the first output word and, with the zeroed synthetic port,
+sets frame type to 1 and returns zero without changing frame metadata.
+
+The caller 13065 has encoded-body SHA-256
+`e95d64415b62bb0b4e0f4c4bb07a96e72eb703d46af8dc6d359522b7f2d0f8ad`.
+Its instruction 1075 calls `invoke_iii` with local 3 as the callback slot,
+local 13 as the port, and local 9 plus 120 as the frame pointer. The marker
+reads local 9 immediately before this call. It does not mark callback entry,
+so another invocation of that callback cannot be mistaken for the encoder
+port call. Both body hashes include local declarations and are checked
+before instrumentation.
 
 The test reads the constructed frame and separately feeds its low metadata
 byte to the real extension builder, function 4943 at table slot 3681,

--- a/tools/oracle-core/Cargo.toml
+++ b/tools/oracle-core/Cargo.toml
@@ -48,4 +48,4 @@ base64 = "0.23.0"
 wacore-binary = { workspace = true }
 wasmtime.workspace = true
 wasm-encoder = { workspace = true }
-wacore = { workspace = true }
+wacore = { workspace = true, features = ["voip"] }

--- a/tools/oracle-core/tests/video_orientation.rs
+++ b/tools/oracle-core/tests/video_orientation.rs
@@ -1,6 +1,6 @@
 //! Encoded browser frame metadata compared with the shipped WhatsApp WASM.
 
-use oracle_core::{Runtime, patch};
+use oracle_core::{Runtime, abi, derive::function_body_sha256, patch};
 use sha2::{Digest, Sha256};
 use wacore::voip::rtp::{VIDEO_MEDIA_FRAME_INFO_DELTA, VIDEO_MEDIA_FRAME_INFO_IDR};
 use wasmtime::Val;
@@ -18,14 +18,43 @@ fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
         "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db"
     );
 
-    // f13128 is anchored by "onEncodedVideoDataFromJsForStream: Manager not
-    // initialized!". It calls f13065, which constructs the encoded pjmedia
-    // frame. Substitute a harmless existing (i32,i32)->i32 callback, f4942,
-    // at the encoder port boundary. It changes only frame.type, not metadata.
+    for (index, hash) in [
+        (
+            4942,
+            "a92611af6bc97b1593bf3a167e60f7c8512a5731a9c223194b859fc8d02529d4",
+        ),
+        (
+            13065,
+            "e95d64415b62bb0b4e0f4c4bb07a96e72eb703d46af8dc6d359522b7f2d0f8ad",
+        ),
+    ] {
+        assert_eq!(function_body_sha256(&bytes, index)?, hash);
+    }
+    for (index, slot, anchor) in [
+        (
+            13128,
+            9602,
+            "onEncodedVideoDataFromJsForStream: Manager not initialized!",
+        ),
+        (4943, 3681, "media_frame_info_build_header_ext"),
+    ] {
+        assert!(
+            abi::find_string_refs(&bytes, anchor)?
+                .iter()
+                .any(|entry| entry.referenced_by.contains(&index))
+        );
+        assert!(abi::table_slots_of(&bytes, index)?.contains(&slot));
+    }
+    assert!(abi::table_slots_of(&bytes, 4942)?.contains(&3680));
+
+    // The pinned f4942 only writes the callback's first output word. With our
+    // zeroed port it writes frame.type=1 and returns zero, leaving metadata intact.
+    // f13065 instruction 1075 calls invoke_iii with (local3, local13, local9+120).
+    // Record local9 there, not at callback entry, to identify this exact call site.
     let (instrumented, _) = patch::instrument(
         &bytes,
         &patch::Plan {
-            value_entry: vec![(4942, 1)],
+            value_at: vec![(13065, 1075, 9, false)],
             ..Default::default()
         },
     )?;
@@ -71,7 +100,9 @@ fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
                 previous_markers + 1,
                 "the encoder port must receive one frame"
             );
-            let frame = u32::try_from(markers[previous_markers].1)?;
+            let frame = u32::try_from(markers[previous_markers].1)?
+                .checked_add(120)
+                .expect("frame pointer");
             let info = runtime.read_u32_at(frame + 52)?;
             assert_eq!(info, 0x800 | (u32::from(keyframe) << 3) | rotation_bits);
             assert_eq!(runtime.read(frame + 72, 4)?, [0, 5, 208, 2]);

--- a/tools/oracle-core/tests/video_orientation.rs
+++ b/tools/oracle-core/tests/video_orientation.rs
@@ -1,0 +1,117 @@
+//! Encoded browser frame metadata compared with the shipped WhatsApp WASM.
+
+use oracle_core::{Runtime, patch};
+use sha2::{Digest, Sha256};
+use wacore::voip::rtp::{VIDEO_MEDIA_FRAME_INFO_DELTA, VIDEO_MEDIA_FRAME_INFO_IDR};
+use wasmtime::Val;
+
+mod common;
+
+#[test]
+fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
+    let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
+        eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
+    assert_eq!(
+        hex::encode(Sha256::digest(&bytes)),
+        "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db"
+    );
+
+    // f13128 is anchored by "onEncodedVideoDataFromJsForStream: Manager not
+    // initialized!". It calls f13065, which constructs the encoded pjmedia
+    // frame. Substitute a harmless existing (i32,i32)->i32 callback, f4942,
+    // at the encoder port boundary. It changes only frame.type, not metadata.
+    let (instrumented, _) = patch::instrument(
+        &bytes,
+        &patch::Plan {
+            value_entry: vec![(4942, 1)],
+            ..Default::default()
+        },
+    )?;
+    let mut runtime = Runtime::instantiate(&instrumented)?;
+    runtime.run_ctors()?;
+    runtime.shared().watch_markers("env::on_call_event_js_sync");
+    let manager = runtime.write_bytes(&[1])?;
+    runtime.write_bytes_at(1_722_176, &manager.to_le_bytes())?;
+    let mut port_bytes = [0u8; 112];
+    port_bytes[108..112].copy_from_slice(&3680u32.to_le_bytes());
+    let port = runtime.write_bytes(&port_bytes)?;
+    runtime.write_bytes_at(1_719_056, &port.to_le_bytes())?;
+    let payload = runtime.write_bytes(&[0, 0, 0, 1, 0x65, 0x88])?;
+    let extender = runtime.write_bytes(&[0; 24])?;
+    let output = runtime.write_bytes(&[0; 8])?;
+    let mut upright = Vec::new();
+
+    // WAWebVoipMediaEnums in bundle 561b4bd5677d24a29707db4c05b63edc019b73744b66699fb6bbfd6b361d6c1a
+    // defines Unknown=0, Normal=1, Rotate90=2, Rotate180=3, Rotate270=4.
+    for keyframe in [false, true] {
+        for (orientation, rotation_bits) in [(0, 0), (1, 0), (2, 3), (3, 2), (4, 1)] {
+            runtime.shared().clear_trace();
+            let previous_markers = runtime.shared().markers().len();
+            runtime.refuel();
+            let result = runtime.call_table(
+                9602,
+                &[
+                    Val::I32(0),
+                    Val::I32(payload as i32),
+                    Val::I32(6),
+                    Val::I32(1280),
+                    Val::I32(720),
+                    Val::F64(1.0f64.to_bits()),
+                    Val::I32(i32::from(keyframe)),
+                    Val::F64(1.0f64.to_bits()),
+                    Val::I32(orientation),
+                ],
+            )?;
+            assert_eq!(result[0].i32(), Some(0));
+            let markers = runtime.shared().markers();
+            assert_eq!(
+                markers.len(),
+                previous_markers + 1,
+                "the encoder port must receive one frame"
+            );
+            let frame = u32::try_from(markers[previous_markers].1)?;
+            let info = runtime.read_u32_at(frame + 52)?;
+            assert_eq!(info, 0x800 | (u32::from(keyframe) << 3) | rotation_bits);
+            assert_eq!(runtime.read(frame + 72, 4)?, [0, 5, 208, 2]);
+            assert_eq!(runtime.read_u32_at(frame + 8)?, payload);
+            assert_eq!(runtime.read_u32_at(frame + 16)?, 6);
+
+            // f4943, anchored by "media_frame_info_build_header_ext", copies
+            // the low byte to extension 3. Presence is internal bit 0x800.
+            runtime.write_bytes_at(extender + 4, &[info as u8])?;
+            let built = runtime.call_table(
+                3681,
+                &[
+                    Val::I32(extender as i32),
+                    Val::I32(0),
+                    Val::I32(output as i32),
+                    Val::I32(1),
+                    Val::I32(0),
+                ],
+            )?;
+            assert_eq!(built[0].i32(), Some(0));
+            let wire = runtime.read(output, 1)?[0];
+            assert_eq!(wire, (u8::from(keyframe) << 3) | rotation_bits as u8);
+            if orientation == 1 {
+                upright.push(wire);
+            }
+            assert_eq!(
+                runtime.stubs_called(),
+                vec![("env::on_call_event_js_sync".into(), 1)]
+            );
+        }
+    }
+    assert_eq!(
+        upright,
+        [VIDEO_MEDIA_FRAME_INFO_DELTA, VIDEO_MEDIA_FRAME_INFO_IDR],
+        "Rust must not add a quarter turn to upright browser frames"
+    );
+    eprintln!(
+        "executed JgwtTQVeWPm.wasm: 10 orientation/keyframe cases; \
+         upright delta=0x{:02x}, IDR=0x{:02x}; dimensions and payload identity preserved",
+        upright[0], upright[1]
+    );
+    Ok(())
+}

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -626,7 +626,7 @@ impl SendBatch {
             .first()
             .and_then(|packet| parse_rtp_header(packet))
             .and_then(|header| header.video_extension)
-            .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_IDR);
+            .is_some_and(|extension| extension.media_frame_info & VIDEO_MEDIA_FRAME_INFO_IDR != 0);
         Self {
             bytes: packets.iter().map(Bytes::len).sum(),
             packets: packets.into(),
@@ -3775,6 +3775,23 @@ mod tests {
                 .iter()
                 .all(|batch| batch.kind != SendBatchKind::Video || batch.started)
         );
+    }
+
+    #[test]
+    fn video_batch_keyframe_classification_ignores_rotation() {
+        use crate::voip::rtp::{VideoRtpStream, encode_rtp_header};
+
+        let mut stream = VideoRtpStream::new(0x1122_3344, 4500).unwrap();
+        for rotation in 0..=3 {
+            for keyframe in [false, true] {
+                let info = rotation | if keyframe { 0x08 } else { 0 };
+                let header = stream.next_video_packet(true, info);
+                let packet = Bytes::from(encode_rtp_header(&header));
+                let batch = SendBatch::video(vec![packet.clone()]);
+                assert_eq!(batch.video_keyframe, keyframe, "frame info {info:#04x}");
+                assert_eq!(batch.packets.front(), Some(&packet));
+            }
+        }
     }
 
     #[test]

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -29,10 +29,12 @@ pub const RTP_FIXED_HEADER_LEN: usize = 12;
 pub const WHATSAPP_RTP_HEADER_SIZE: usize = 16;
 pub const WHATSAPP_RTP_HEADER_DTX_SIZE: usize = 20;
 pub const WHATSAPP_VIDEO_RTP_HEADER_SIZE: usize = 28;
-/// WhatsApp frame-present and keyframe flags carried by an IDR access unit.
-pub const VIDEO_MEDIA_FRAME_INFO_IDR: u8 = 0x09;
-/// WhatsApp frame-present flag carried by a dependent H.264 access unit.
-pub const VIDEO_MEDIA_FRAME_INFO_DELTA: u8 = 0x01;
+/// WhatsApp keyframe flag for an upright IDR access unit. The low two bits are
+/// rotation, not presence. Captured WASM uses internal bit 0x800 for presence;
+/// its one-byte RTP extension omits that bit. See the oracle's video_orientation test.
+pub const VIDEO_MEDIA_FRAME_INFO_IDR: u8 = 0x08;
+/// Upright dependent H.264 access unit, with no keyframe or rotation bits.
+pub const VIDEO_MEDIA_FRAME_INFO_DELTA: u8 = 0x00;
 pub const WHATSAPP_RTP_EXTENSION_DTX_WORD: u32 = 0x3001_0000;
 const RTP_VERSION: u8 = 2;
 const SRTP_AUTH_TAG_LEN: usize = 10;
@@ -714,7 +716,7 @@ mod tests {
                 0x00, 0x00, 0x00, 0x00, // timestamp
                 0x11, 0x22, 0x33, 0x44, // SSRC
                 0xde, 0xbe, 0x00, 0x03, // WARP profile, three words
-                0x30, 0x09, // ID 3: one-byte encoded-frame flags (keyframe | IDR)
+                0x30, 0x08, // ID 3: keyframe, zero rotation
                 0x51, 0x00, 0x00, // ID 5: two-byte initial bandwidth
                 0x61, 0x00, 0x00, // ID 6: two-byte short timestamp offset
                 0x91, 0x00, 0x00, // ID 9: two-byte transport sequence
@@ -776,7 +778,7 @@ mod tests {
                 ssrc: 0x9b19_59f0,
                 extension_word: None,
                 video_extension: Some(VideoRtpExtension {
-                    media_frame_info: VIDEO_MEDIA_FRAME_INFO_DELTA,
+                    media_frame_info: 0x01,
                     initial_bandwidth: 0,
                     short_offset: 36,
                     transport_sequence: 0x0a6a,

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -2290,7 +2290,7 @@ mod tests {
         assert_eq!(
             header.video_extension.unwrap().media_frame_info,
             VIDEO_MEDIA_FRAME_INFO_IDR,
-            "an IDR AU carries WhatsApp's keyframe and IDR bits"
+            "an IDR AU carries WhatsApp's keyframe bit without rotation"
         );
 
         // Pin the send keystream to the SELF lid (same inversion guard as audio).
@@ -2308,7 +2308,7 @@ mod tests {
     }
 
     #[test]
-    fn video_frame_info_is_constant_across_every_au_fragment() {
+    fn upright_video_frame_info_is_constant_across_every_au_fragment() {
         let call_key: Vec<u8> = (0u8..32).collect();
         let mut pipe = VideoPipeline::new(&video_params(
             &call_key,
@@ -2323,7 +2323,7 @@ mod tests {
         assert!(idr_packets.iter().all(|packet| {
             parse_rtp_header(packet)
                 .and_then(|header| header.video_extension)
-                .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_IDR)
+                .is_some_and(|extension| extension.media_frame_info == 0x08)
         }));
 
         let mut delta = vec![0, 0, 0, 1, 0x41];
@@ -2333,7 +2333,7 @@ mod tests {
         assert!(delta_packets.iter().all(|packet| {
             parse_rtp_header(packet)
                 .and_then(|header| header.video_extension)
-                .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_DELTA)
+                .is_some_and(|extension| extension.media_frame_info == 0x00)
         }));
     }
 


### PR DESCRIPTION
## Summary

Fix outbound video that is upright in browser self-preview but rotated by a quarter turn on receiving Android. The sender incorrectly treated bit 0 of WhatsApp video frame info as a frame-present flag. The captured WhatsApp WASM uses the low two bits for rotation and internal bit 0x800 for presence.

- Emit upright delta/IDR frame info as 0x00/0x08 instead of 0x01/0x09.
- Keep Android receive fixture bytes unchanged.
- Check literal upright metadata on every protected video fragment.
- Add a real-WASM differential test and reproducibility notes in agent_docs/voip_media_oracle.md. No proprietary artifacts or PII are added.

## Executed oracle proof

Artifact JgwtTQVeWPm.wasm, already pinned in tools/oracle-core/wasm.lock.json, with SHA-256:

```text
97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db
```

Ran against the existing capture cache, without skipping:

```sh
WA_WASM_DIR=/home/jlucaso/projects/unwasm/.cache/oracle-wasm-legacy cargo test --release -p oracle-core --test video_orientation -j 4 -- --nocapture
```

```text
executed JgwtTQVeWPm.wasm: 10 orientation/keyframe cases; upright delta=0x00, IDR=0x08; dimensions and payload identity preserved
test upright_video_frame_info_matches_whatsapp_wasm ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
```

Before the fix, the same differential comparison failed with WASM [0, 8] versus Rust [1, 9]. The test executes the captured frame-construction path and separately executes its extension builder. It checks all five WhatsApp orientation enum values with both keyframe states, unchanged supplied 1280x720 dimensions, and payload identity. The only stub invoked in each case is the recording marker. This does not assume standard CVO semantics.

The test substitutes a synthetic manager and encoder port, and manually transfers the constructed metadata byte to the real extension builder. It does not execute the intervening sender pipeline or a full call. Function anchors, table slots and the JS bundle hash are documented beside the test.

## Validation

```sh
cargo test -p wacore --features voip-mlow --lib voip:: -j 4
cargo clippy -p oracle-core --all-targets --release -j 4 -- -D warnings
cargo clippy -p wacore --features voip-mlow --lib --tests -j 4 -- -D warnings
cargo fmt --all -- --check
git diff --check
```

Debug VoIP tests passed with 681 passed, 0 failed and 1 existing diagnostic ignored. This includes both-way video routing, video backpressure/keyframe recovery, Android RTP fixtures and the group-audio debug-assertion test that failed when previously run in release mode. Both Clippy commands, formatting and whitespace checks passed.

## Remaining verification

A live browser-to-Android visual retest is still needed. The oracle does not decode laptop camera pixels or parse a live SPS. Capture, signaling and client code are unchanged. The client can consume this remote branch before merge, keeping every whatsapp-rust crate on the same Git source and branch.