### PR TITLE
fix(ci): synchronize SQLite burst test and guard empty evidence uploads

### DIFF
--- a/.github/workflows/mlow-derive.yml
+++ b/.github/workflows/mlow-derive.yml
@@ -40,7 +40,9 @@ jobs:
         if: github.event_name == 'schedule'
         run: cargo xt oracle conformance --slow
       - uses: actions/upload-artifact@v7
-        if: always()
+        # Early failures can precede derivation. Preserve partial evidence on
+        # failure, but a successful gate must still produce uploadable evidence.
+        if: ${{ always() && (success() || hashFiles('.derive-mlow/specs/*.json', '.derive-mlow/wasm/*.log', '.derive-mlow/wasm/*/manifest.json') != '') }}
         with:
           name: voip-conformance-evidence
           path: |

--- a/agent_docs/voip_conformance.md
+++ b/agent_docs/voip_conformance.md
@@ -68,3 +68,9 @@ Expanded derivation specs are generated from committed bases/recipes into
 `.derive-mlow/specs/`, verified against `mlow.lock.json`, and uploaded alongside
 run manifests. The lightweight `cargo xt` dispatcher launches the release
 `whatsapp-oracle-task` worker; neither is linked into the application runtime.
+
+Capture restoration, code generation checks, and oracle tests precede MLOW
+derivation. A failure in those stages can leave no derivation evidence to
+upload. CI skips an empty upload only after an earlier failure, keeping that
+failure visible. It uploads partial evidence when present and still treats
+missing evidence after a successful gate as an error.

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -7063,7 +7063,8 @@ mod read_routing_tests {
         assert_eq!(got.as_deref(), Some(&b"blob"[..]));
     }
 
-    /// Ensures a write-queue read completes while a write burst holds the permit.
+    /// A reader-pool read proceeds beside a held burst; a write-queue read waits
+    /// for that burst's permit and completes once it is released.
     #[tokio::test]
     async fn write_queue_read_completes_beside_a_held_burst() {
         use std::future::{Future, poll_fn};
@@ -7071,24 +7072,51 @@ mod read_routing_tests {
         use std::task::Poll;
 
         let db = TempDb::new("held_burst");
-        let store = store_with(1, &db).await;
+        let mut store = store_with(1, &db).await;
         let rows = vec![AppStateMutationMAC {
             index_mac: vec![0xA1; 32],
             value_mac: vec![0xC5; 32],
         }];
 
-        let outcome = tokio::time::timeout(Duration::from_secs(30), async {
-            let mut burst = pin!(store.put_mutation_macs("regular", 1, &rows));
-            let finished = poll_fn(|cx| Poll::Ready(burst.as_mut().poll(cx).is_ready())).await;
-            assert!(!finished, "the burst finished before the read was issued");
-            let (read, _) = tokio::join!(store.get_devices("190455501800"), async {
-                burst.await.expect("write burst")
-            });
-            read
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        store.commit_barrier = Some({
+            let entered = entered.clone();
+            let release = release.clone();
+            Arc::new(move || {
+                let entered = entered.clone();
+                let release = release.clone();
+                Box::pin(async move {
+                    entered.notify_one();
+                    release.notified().await;
+                    Ok(())
+                })
+            })
+        });
+
+        let (burst, read) = tokio::time::timeout(Duration::from_secs(30), async {
+            tokio::join!(store.put_mutation_macs("regular", 1, &rows), async {
+                entered.notified().await;
+                assert_eq!(store.db_semaphore.available_permits(), 0);
+                assert_eq!(
+                    store
+                        .get_mutation_mac("regular", &rows[0].index_mac)
+                        .await
+                        .unwrap(),
+                    Some(rows[0].value_mac.clone()),
+                    "the reader connection sees the committed batch while its barrier is held"
+                );
+                let mut read = pin!(store.get_devices("190455501800"));
+                let pending = poll_fn(|cx| Poll::Ready(read.as_mut().poll(cx).is_pending())).await;
+                assert!(pending, "a write-queue read must wait for the held permit");
+                release.notify_one();
+                read.await
+            })
         })
         .await
         .expect("read and burst complete together");
-        assert!(outcome.expect("read succeeds").is_none());
+        burst.expect("write burst");
+        assert!(read.expect("read succeeds").is_none());
     }
 
     /// `pool_size > 1` with no reader connections is reachable config, and there


### PR DESCRIPTION
## Summary

Separate follow-up to merged #1463, based on 077cc3fcc. Fix the flaky SQLite overlap test and the secondary empty artifact-upload error. No production storage behavior or client files change.

## SQLite scheduling failure

The failing job was https://github.com/oxidezap/whatsapp-rust/actions/runs/34091539472/job/101645840349. The test assumed that the first poll of put_mutation_macs must return Pending. Its blocking worker can legally finish before the join handle is first polled.

The unmodified test passed 1,000 ordinary local repetitions. A temporary scheduling probe waited for the blocking worker to finish before exposing its join handle. That reproduced the exact assertion, "the burst finished before the read was issued". The repaired test passed under the same forced schedule. The probe was then removed; pool.rs is unchanged.

The test now holds the actual write at its existing commit-barrier hook and waits for an explicit entry notification. While that barrier holds the write permit, it verifies that a reader connection sees the committed mutation batch and that get_devices remains pending on the write queue. It then releases the barrier and requires both operations to finish within the existing timeout. Both futures remain scoped to the test; there is no detached writer or blocking synchronization hook.

## Artifact failure and contract

Full logs for https://github.com/oxidezap/whatsapp-rust/actions/runs/34091536555/job/101645830804 show that capture restoration failed first. Pinned 9Nbh3eMuVjD.wasm and D5pLH9sfOOl.wasm were unavailable. Restoration precedes codegen checks, oracle tests and MLOW derivation, so none of the upload paths existed. The unconditional upload then added a second error.

The upload condition now preserves these cases:

| Earlier steps | Evidence | Upload |
|---|---|---|
| Success | Present | Run |
| Success | Absent | Run and fail with existing if-no-files-found: error |
| Failure or cancellation | Present, including partial output | Run |
| Failure or cancellation | Absent | Skip the redundant upload only |

The original conformance failure still fails the job. Required evidence is not made optional after a successful gate. Capture pins, credentials, artifact paths and derivation validation remain unchanged.

## Validation

```sh
cargo nextest run -p whatsapp-rust-sqlite-storage --lib --retries 0 --build-jobs 4
cargo nextest run -p whatsapp-rust-sqlite-storage --lib -E "test(write_queue_read_completes_beside_a_held_burst)" --stress-count 1000 --retries 0 --status-level fail --final-status-level fail --build-jobs 4
taskset -c 0 cargo nextest run -p whatsapp-rust-sqlite-storage --lib -E "test(read_routing_tests::)" --stress-count 100 --retries 0 -j 8 --status-level fail --final-status-level fail --build-jobs 4
cargo test --locked -p whatsapp-xtask -p xtask-support -j 4
cargo test --release --locked -p whatsapp-oracle-task -j 4
cargo clippy --locked -p whatsapp-rust-sqlite-storage --all-targets -j 4 -- -D warnings
cargo fmt --all -- --check
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck= .github/workflows/mlow-derive.yml
git diff --check
```

- SQLite suite passed all 112 tests.
- Repaired target passed all 1,000 repetitions without retries.
- Scheduler stress passed 100 rounds of all 11 read-routing tests, 1,100 executions, with eight test processes sharing one CPU.
- Native tooling passed 7 tests; oracle tooling passed 10 tests.
- SQLite Clippy, formatting, actionlint and whitespace checks passed.
- A temporary check using @actions/expressions 0.3.61 evaluated the actual workflow condition for six success/failure/cancellation and evidence-present/absent combinations. All passed, and its hashFiles arguments matched the upload paths. No Node dependency was added to the repository.

## Remaining CI limitation

This does not restore the two unavailable historical captures. Their CDN URLs return 404 and the configured fallback archive is private; CI needs an approved mirror or appropriate read access. Full conformance therefore remains blocked at capture restoration, but no longer reports a misleading missing-upload error as well. No check is suppressed and no private artifact is published.