### PR TITLE
fix(oracle): model VoIP timestamp calibration callbacks

### DIFF
--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -128,6 +128,63 @@ and `0x01` values. The oracle does not decode camera pixels, parse a live
 laptop SPS, run networking, or replace a browser-to-Android visual retest.
 No proprietary WASM, captured JS, or personal data belongs in the test commit.
 
+## Camera-control execution boundary
+
+`tools/oracle-core/tests/camera_controls.rs` executes the J capture above and
+the S capture for the clock callback.
+These tests require a capture and fail if it is missing. Run them explicitly:
+
+```sh
+WA_WASM_DIR=/path/to/captured-wasm cargo test --release -p oracle-core --test camera_controls -- --ignored --test-threads=1 --nocapture
+```
+
+The first test calls J's clock callback at table slot 7708, function 10363,
+and S's at slot 7923, function 10650. Both capture and body hashes are checked.
+J's encoded-body SHA-256 is
+`5563de8f88fefc7c6f88a08ec53d9d1ff918c62e88b1b33a79d00e07f6122742`.
+It must return advancing millisecond wall time, not the integer `1` that the
+host previously supplied as a supposed capability check.
+
+The captured glue in bundle
+`76b6b49b34591d742f3631ff4141f54a966eb35a60677357f2cdd472c736a161`
+defines S's EM_ASM 1336996 as `Date.now()`. Its other entry, 1337019,
+logs two double-precision timestamp-calibration offsets. J's corresponding
+addresses are 1324292 and 1324315. The clock wrappers and calibration bodies
+were inspected in both binaries. J function 10365 and S function 10652 have
+the same 53-instruction control flow with relocated addresses and type IDs.
+The automatic fingerprint carrier does not match this pair, so this is a
+manual structural comparison, not a claimed successful fingerprint carry.
+J's calibration body hash is
+`85dc769226de44834ac972e7fcea1f4a8e47ab66ffbe72f4aecdb2eaac3570df`.
+The host dispatch remains gated by each capture's data-section hash.
+
+Before the host correction, origination trapped on unsupported EM_ASM 1324315.
+After it, the second test originates a video call through `startVoipCall`,
+observes the real calibration callback, then calls `setCallVideoMute` twice.
+Instrumentation only records function entries and arguments. No guest
+function, return value or call-state field is replaced.
+
+The measured stop calls `call_pause_video` with direction 1 and state 6.
+Resume calls `call_resume_video` with direction 1. The self participant moves
+from Enabled to Stopped and back to Enabled while the peer remains Enabled.
+Camera capture stops once and restarts. The test checks every observed stub
+against its explicit host-boundary list.
+
+**This remains a ringing-call test.** The call stays in Calling, and the peer
+decoder and renderer have never started. Stop returns 70020 because the
+engine refuses to send a video-state stanza in lonely state; resume returns
+zero. Only the original offer reaches the signaling callback. These outcomes
+are asserted rather than counted as successful established-call signaling.
+
+An exploratory synthetic accept reached the message parser but failed device
+JID conversion with 70004. Passing a call wrapper first failed with 70012
+because this entry expects the action node itself. Neither attempt established
+media, and neither is conformance evidence. The remaining required cases are
+an established call with inbound frames surviving local stop/resume, peer
+Stopped with both downgrade conditions, and cancellation during a pending
+video upgrade. Production `stop_video`, source/sink ownership and upgrade
+signaling must not be changed on the strength of this ringing test alone.
+
 ## CI shape
 
 Future fixtures should have one producer command under `cargo xt oracle` that

--- a/tools/oracle-core/src/emscripten.rs
+++ b/tools/oracle-core/src/emscripten.rs
@@ -581,15 +581,16 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
     linker.func_wrap(
         "env",
         "emscripten_asm_const_int",
-        |mut caller: Caller<'_, HostState>, code: i32, _sig: i32, _args: i32| {
-            answer_asm_const(&mut caller, "emscripten_asm_const_int", code)
+        |mut caller: Caller<'_, HostState>, code: i32, sig: i32, args: i32| {
+            answer_asm_const(&mut caller, "emscripten_asm_const_int", code, sig, args)
+                .map(|value| value as i32)
         },
     )?;
     linker.func_wrap(
         "env",
         "emscripten_asm_const_double",
-        |mut caller: Caller<'_, HostState>, code: i32, _sig: i32, _args: i32| {
-            answer_asm_const(&mut caller, "emscripten_asm_const_double", code).map(f64::from)
+        |mut caller: Caller<'_, HostState>, code: i32, sig: i32, args: i32| {
+            answer_asm_const(&mut caller, "emscripten_asm_const_double", code, sig, args)
         },
     )?;
 
@@ -836,7 +837,9 @@ fn answer_asm_const(
     caller: &mut Caller<'_, HostState>,
     symbol: &str,
     code: i32,
-) -> Result<i32, wasmtime::Error> {
+    sig: i32,
+    args: i32,
+) -> Result<f64, wasmtime::Error> {
     crate::state::sync_memory(caller);
     let state = caller.data();
     state.record("env", symbol, vec![code as i64]);
@@ -844,7 +847,7 @@ fn answer_asm_const(
         .read_cstr(code as u32)
         .map_err(|error| wasmtime::Error::msg(format!("read EM_ASM index {code}: {error}")))?;
     if snippet.is_empty() {
-        return answer_em_asm_index(
+        let answer = answer_em_asm_index(
             state.shared.module_data_sha256.get().map(String::as_str),
             code,
         )
@@ -852,23 +855,70 @@ fn answer_asm_const(
             wasmtime::Error::msg(format!(
                 "unsupported EM_ASM index {code} with no embedded source"
             ))
-        });
+        })?;
+        return match answer {
+            AsmConstAnswer::Constant(value) => Ok(f64::from(value)),
+            AsmConstAnswer::WallClock => {
+                if symbol != "emscripten_asm_const_double" {
+                    return Err(wasmtime::Error::msg(
+                        "Date.now requires the double callback",
+                    ));
+                }
+                Ok(EPOCH_MS + state.shared.tick_wall_clock())
+            }
+            AsmConstAnswer::TimestampCalibration => {
+                let signature = state.read_cstr(sig as u32).map_err(|error| {
+                    wasmtime::Error::msg(format!("read timestamp calibration signature: {error}"))
+                })?;
+                if signature != "dd" {
+                    return Err(wasmtime::Error::msg(format!(
+                        "timestamp calibration requires dd, got {signature:?}"
+                    )));
+                }
+                let bytes = state.read(args as u32, 16).map_err(|error| {
+                    wasmtime::Error::msg(format!("read timestamp calibration arguments: {error}"))
+                })?;
+                let old = f64::from_le_bytes(bytes[..8].try_into().expect("eight bytes"));
+                let new = f64::from_le_bytes(bytes[8..].try_into().expect("eight bytes"));
+                state.log(format!(
+                    "voip: [WasmTimestampCalibration] backgrounding detected: skew_old={old:.1}ms, skew_new={new:.1}ms, delta={:.1}ms",
+                    new - old
+                ));
+                Ok(0.0)
+            }
+        };
     }
-    answer_em_asm(&snippet)
+    answer_em_asm(&snippet).map(f64::from)
 }
 
-fn answer_em_asm_index(module_sha256: Option<&str>, code: i32) -> Option<i32> {
+#[derive(Debug, PartialEq, Eq)]
+enum AsmConstAnswer {
+    Constant(i32),
+    WallClock,
+    TimestampCalibration,
+}
+
+fn answer_em_asm_index(module_sha256: Option<&str>, code: i32) -> Option<AsmConstAnswer> {
     match (module_sha256?, code) {
         // COs9e0Kj0ic func 107 calls this once per requested byte. Its locked
         // oracle behavior is a deterministic nonzero byte.
-        ("d463cda148dae98e98b9a811276a5c0b95edea64ffba768820704e0eb15599c7", 50_356) => Some(1),
+        ("d463cda148dae98e98b9a811276a5c0b95edea64ffba768820704e0eb15599c7", 50_356) => {
+            Some(AsmConstAnswer::Constant(1))
+        }
         // COs9e0Kj0ic sodiumInit uses this as hardware concurrency.
-        ("d463cda148dae98e98b9a811276a5c0b95edea64ffba768820704e0eb15599c7", 50_392) => Some(1),
-        // JgwtTQVeWPm and S_ivh1PriOA use the same zero-argument f64 callback
-        // shape at different data addresses during VoIP stack startup; the
-        // locked startup result is truthy.
-        ("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca", 1_324_292) => Some(1),
-        ("2a3d2e9d83b6de3aa2895ce73a2168228b6872ad988232d9c9d7a3e41b50413d", 1_336_996) => Some(1),
+        ("d463cda148dae98e98b9a811276a5c0b95edea64ffba768820704e0eb15599c7", 50_392) => {
+            Some(AsmConstAnswer::Constant(1))
+        }
+        // The captured glue uses Date.now(), not a truthy capability probe.
+        // Its second callback only logs two double-precision clock offsets.
+        ("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca", 1_324_292)
+        | ("2a3d2e9d83b6de3aa2895ce73a2168228b6872ad988232d9c9d7a3e41b50413d", 1_336_996) => {
+            Some(AsmConstAnswer::WallClock)
+        }
+        ("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca", 1_324_315)
+        | ("2a3d2e9d83b6de3aa2895ce73a2168228b6872ad988232d9c9d7a3e41b50413d", 1_337_019) => {
+            Some(AsmConstAnswer::TimestampCalibration)
+        }
         _ => None,
     }
 }
@@ -1194,15 +1244,30 @@ mod tests {
                 Some("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca"),
                 1_324_292
             ),
-            Some(1)
+            Some(AsmConstAnswer::WallClock)
         );
         assert_eq!(answer_em_asm_index(Some("unknown"), 1_324_292), None);
+        assert_eq!(answer_em_asm_index(Some("unknown"), 1_324_315), None);
+        assert_eq!(
+            answer_em_asm_index(
+                Some("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca"),
+                1_324_315
+            ),
+            Some(AsmConstAnswer::TimestampCalibration)
+        );
+        assert_eq!(
+            answer_em_asm_index(
+                Some("4e37a0a11ba95731bb91ec264fa7718fe130c5dc1638e4ac936062cf2f4257ca"),
+                1_337_019
+            ),
+            None
+        );
         assert_eq!(
             answer_em_asm_index(
                 Some("2a3d2e9d83b6de3aa2895ce73a2168228b6872ad988232d9c9d7a3e41b50413d"),
                 1_336_996
             ),
-            Some(1)
+            Some(AsmConstAnswer::WallClock)
         );
     }
 }

--- a/tools/oracle-core/tests/camera_controls.rs
+++ b/tools/oracle-core/tests/camera_controls.rs
@@ -1,0 +1,249 @@
+//! Captured camera controls while ringing, not an established media-call oracle.
+
+use anyhow::{Context, Result};
+use oracle_core::{Runtime, ThreadPolicy, Value, abi, derive::function_body_sha256, patch};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+mod common;
+
+const CAPTURE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+fn capture() -> Result<Vec<u8>> {
+    let bytes = common::capture("JgwtTQVeWPm")?
+        .context("this test requires JgwtTQVeWPm.wasm; set WA_WASM_DIR")?;
+    anyhow::ensure!(hex::encode(Sha256::digest(&bytes)) == CAPTURE_SHA);
+    Ok(bytes)
+}
+
+#[test]
+#[ignore = "requires captured JgwtTQVeWPm and S_ivh1PriOA; missing captures fail"]
+fn captured_date_now_returns_wall_time_not_a_boolean() -> Result<()> {
+    for (id, capture_sha, function, slot, body_sha) in [
+        (
+            "JgwtTQVeWPm",
+            CAPTURE_SHA,
+            10363,
+            7708,
+            "5563de8f88fefc7c6f88a08ec53d9d1ff918c62e88b1b33a79d00e07f6122742",
+        ),
+        (
+            "S_ivh1PriOA",
+            "e55e43babf85e2c0fc76ec65dcb8d47beba0f58b03b135b37a5aaaff7fe70e2f",
+            10650,
+            7923,
+            "3172c2c8addc54ce5ac6f738f98381e86cd8366f4fe4abdc04ed00e8f39a0f7b",
+        ),
+    ] {
+        let bytes =
+            common::capture(id)?.with_context(|| format!("missing {id}; set WA_WASM_DIR"))?;
+        assert_eq!(hex::encode(Sha256::digest(&bytes)), capture_sha);
+        assert_eq!(function_body_sha256(&bytes, function)?, body_sha);
+        assert!(abi::table_slots_of(&bytes, function)?.contains(&slot));
+        let mut runtime = Runtime::instantiate(&bytes)?;
+        runtime.run_ctors()?;
+        let mut previous = oracle_core::emscripten::EPOCH_MS;
+        for _ in 0..3 {
+            let result = runtime.call_table(slot, &[])?;
+            let now = result[0].f64().context("Date.now must return an f64")?;
+            assert!(now > previous, "wall time must advance, got {now}");
+            assert!(now < oracle_core::emscripten::EPOCH_MS + 1000.0);
+            previous = now;
+        }
+        assert!(runtime.stubs_called().is_empty());
+        eprintln!("executed {id} Date.now callback three times: {previous}");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct CallInfo {
+    call_state: u32,
+    video_enabled: bool,
+    participants: Vec<Participant>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Participant {
+    is_self: bool,
+    video_state: u32,
+    video_decode_started: bool,
+    video_render_started: bool,
+}
+
+fn info(runtime: &mut Runtime) -> Result<CallInfo> {
+    runtime.refuel();
+    let value = runtime.call_embind("getCallInfo", &[])?;
+    serde_json::from_str(value.as_str().context("getCallInfo returned no string")?)
+        .context("parsing call info")
+}
+
+#[test]
+#[ignore = "real guest threads and captured JgwtTQVeWPm.wasm; missing captures fail"]
+fn ringing_camera_controls_reach_send_only_pause_and_resume() -> Result<()> {
+    let _serial = common::threaded_guard();
+    let bytes = capture()?;
+    for (index, hash) in [
+        (
+            12431,
+            "cdf5093b715e17e58623cc86b1f3444f3d239710d890ea115ac3596eb6430574",
+        ),
+        (
+            6814,
+            "b0226a3e5240b74a54bc9aa0379457540a21539b422de7cac40a7916800c5b26",
+        ),
+        (
+            12416,
+            "3cc4bb73ee5076ac2a900ac351af414c5e093276eba99f9263d33aaa14d05714",
+        ),
+        (
+            10365,
+            "85dc769226de44834ac972e7fcea1f4a8e47ab66ffbe72f4aecdb2eaac3570df",
+        ),
+    ] {
+        assert_eq!(function_body_sha256(&bytes, index)?, hash);
+    }
+    for (index, anchor) in [
+        (6817, "call_resume_video"),
+        (12433, "call_video_turn_camera_on"),
+    ] {
+        assert!(
+            abi::find_string_refs(&bytes, anchor)?
+                .iter()
+                .any(|s| s.referenced_by.contains(&index))
+        );
+    }
+    let (bytes, _) = patch::instrument(
+        &bytes,
+        &patch::Plan {
+            entry: vec![12431, 12433, 12416],
+            value_entry: vec![
+                (6814, 1),
+                (6814, 2),
+                (6814, 3),
+                (6817, 1),
+                (6817, 2),
+                (6817, 3),
+            ],
+            ..Default::default()
+        },
+    )?;
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.set_thread_policy(ThreadPolicy::Spawn);
+    runtime.set_main_thread_registration(true);
+    runtime.run_ctors()?;
+    runtime.attach_log_ring(4 << 20)?;
+    runtime.shared().watch_markers("env::on_call_event_js_sync");
+    let initialized = runtime.call_embind(
+        "initVoipStack",
+        &[
+            Value::Str("15550002222@c.us".into()),
+            Value::Str("15550002222:0@c.us".into()),
+            Value::Str("99887766554433:0@lid".into()),
+        ],
+    )?;
+    assert_eq!(initialized.as_int(), Some(0));
+    runtime.refuel();
+    let started = runtime.call_embind(
+        "startVoipCall",
+        &[
+            Value::Str("11223344556677@lid".into()),
+            Value::StringList(vec!["11223344556677:0@lid".into()]),
+            Value::Str("0011223344556677".into()),
+            Value::Bool(true),
+            Value::Str("11223344556677@lid".into()),
+            Value::Bool(false),
+            Value::Bytes(vec![0xa5; 32]),
+        ],
+    )?;
+    assert_eq!(started.as_int(), Some(0));
+    assert!(
+        runtime
+            .logs()
+            .iter()
+            .any(|line| line.contains("WasmTimestampCalibration"))
+    );
+
+    for (muted, local_state, expected_status, expected_markers) in [
+        (
+            true,
+            6,
+            70020,
+            [(200000, 0), (200003, 1), (200004, 1), (200005, 6)],
+        ),
+        (
+            false,
+            1,
+            0,
+            [(200001, 0), (200006, 1), (200007, 1), (200008, 6)],
+        ),
+    ] {
+        let before = runtime.shared().markers().len();
+        runtime.refuel();
+        let result = runtime.call_embind("setCallVideoMute", &[Value::Bool(muted)])?;
+        assert_eq!(result.as_int(), Some(expected_status));
+        assert_eq!(&runtime.shared().markers()[before..], &expected_markers);
+        let info = info(&mut runtime)?;
+        assert_eq!(info.call_state, 1, "this oracle covers Calling, not Active");
+        assert!(info.video_enabled);
+        assert_eq!(info.participants.len(), 2);
+        let local = info
+            .participants
+            .iter()
+            .find(|p| p.is_self)
+            .context("no self participant")?;
+        let peer = info
+            .participants
+            .iter()
+            .find(|p| !p.is_self)
+            .context("no peer participant")?;
+        assert_eq!(local.video_state, local_state);
+        assert_eq!(peer.video_state, 1);
+        assert!(!peer.video_decode_started && !peer.video_render_started);
+    }
+    assert!(
+        runtime
+            .engine_log()
+            .iter()
+            .any(|line| line.contains("skip sending video msg in lonely state"))
+    );
+    assert!(!runtime.engine_log_overflowed()?);
+    let signaling = runtime.signaling()?;
+    assert!(!signaling.is_empty(), "origination must emit an offer");
+    for sent in signaling {
+        let node = wacore_binary::marshal::unmarshal_ref(&sent.stanza[1..])?;
+        assert_eq!(
+            node.tag, "offer",
+            "no camera state is signaled while lonely"
+        );
+    }
+    let stubs = runtime.stubs_called();
+    for (symbol, _) in &stubs {
+        assert!(
+            [
+                "env::on_call_event_js_sync",
+                "env::query_browser_audio_processing_status_js_sync",
+                "env::call_start_video_capture_js_sync",
+                "env::call_stop_video_capture_js_sync",
+                "env::emscripten_check_blocking_allowed",
+                "env::get_persistent_directory_path_js",
+            ]
+            .contains(&symbol.as_str()),
+            "unexpected host stub: {symbol}"
+        );
+    }
+    assert!(
+        stubs
+            .iter()
+            .any(|(name, count)| name == "env::call_stop_video_capture_js_sync" && *count == 1)
+    );
+    assert!(
+        stubs
+            .iter()
+            .any(|(name, count)| name == "env::call_start_video_capture_js_sync" && *count == 2)
+    );
+    eprintln!(
+        "executed JgwtTQVeWPm ringing camera stop/resume: direction=1, self=6->1, peer=1; remote decoder never started; stubs={stubs:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fix the oracle host blocker encountered while investigating directional camera teardown. This is a prerequisite tooling fix, not a production camera-stop fix. No client code, CallHandle API, media endpoint ownership, or wire signaling changes.

- Return virtual millisecond wall time for the captured Date.now callback instead of the previous truthy constant.
- Implement the hash-gated timestamp-calibration logging callback, validating its double arguments.
- Add executable capture tests and document exactly which camera transitions remain unproven.

## Executed evidence

Before this change, video origination trapped on unsupported EM_ASM 1324315. With the host correction, the real J module originates a video call and executes camera stop/resume through its own implementations.

The tests verify whole-capture hashes, body hashes or string anchors, and table slots. Instrumentation records entries and arguments only. No guest implementation, return value, or call-state field is replaced.

The clock test executes both JgwtTQVeWPm and S_ivh1PriOA. The camera test executes JgwtTQVeWPm and observes send-only direction 1, local Enabled -> Stopped -> Enabled, and unchanged peer Enabled. Capture stops once and starts twice. All observed host stubs are checked against an explicit list.

This is a ringing call. Its peer decoder and renderer have never started. Camera stop returns 70020 because the engine declines to signal while lonely; resume returns zero. Only the original offer reaches the signaling callback. The test asserts these limitations rather than treating them as established-call success.

## Verification

- `WA_WASM_DIR=/path/to/captures cargo test --release -p oracle-core --test camera_controls -- --ignored --test-threads=1 --nocapture` passed both tests, zero ignored or skipped. Missing captures fail.
- `cargo test --release -p oracle-core --lib` passed 69 tests.
- `cargo test -p whatsapp-rust --features voip-mlow --lib voip::facade::tests::` passed 152 tests, including pending-upgrade stop and timeout coverage.
- `cargo clippy -p oracle-core --all-targets --release -- -D warnings` passed.
- `cargo fmt --all -- --check` passed.
- `cargo machete tools/oracle-core` found no unused dependencies.
- The CI wasm32 release facade build passed with existing unused-qualification warnings in `src/request.rs` and `src/upload.rs`. No browser call test was run.

## Remaining work

The exploratory synthetic accept reached the action parser but failed device JID conversion with 70004. Established inbound-frame survival, resume with a live remote sink, conditional full downgrade when the peer has stopped, and pending-upgrade cancellation still need executed WASM proof before changing production directional media behavior. The new tests deliberately do not claim that proof.