### PR TITLE
fix(voip): prefer RTP frame rotation over stale device orientation

### DIFF
--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -128,6 +128,42 @@ and `0x01` values. The oracle does not decode camera pixels, parse a live
 laptop SPS, run networking, or replace a browser-to-Android visual retest.
 No proprietary WASM, captured JS, or personal data belongs in the test commit.
 
+## Received video orientation proof
+
+`received_frame_rotation_matches_whatsapp_wasm` requires the same captured J
+module and fails if it is unavailable. It calls function 828 at table slot 427
+with a synthetic H.264 frame descriptor and records `env::renderVideoFrame_js`.
+The function body hash is
+`6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131`.
+All 256 frame-info bytes execute with internal presence bit `0x800` set.
+Low bits `0,1,2,3` yield JS orientation enum `1,4,3,2`; bit `0x08` controls
+the keyframe argument. The other bits do not change orientation at this boundary.
+Payload pointer, byte count, dimensions and format remain unchanged.
+
+In captured bundle
+`561b4bd5677d24a29707db4c05b63edc019b73744b66699fb6bbfd6b361d6c1a`,
+`WAWebVoipVideoRenderer` applies `rotate(Math.PI*(orientation.valueOf()-1)/2)`.
+The resulting clockwise turns are `0,270,180,90` degrees. This agrees with the
+client's existing rotation helper and does not justify camera-facing compensation.
+
+Static inspection of J function 4913, anchored by
+`parse_media_frame_info_header_s`, shows the one-byte extension copied to
+offset 16 with presence recorded in bit `0x08` at offset 4. Function 4891,
+`pjmedia_rtp_ext_get_media_frame_info`, returns that byte with internal presence
+bit `0x800` when requested. These parser functions have not been executed by
+the receive-renderer test. Nor does it execute the intervening decoder pipeline.
+
+Rust previously replaced frame orientation with the last signaling value.
+The engine regression fails before the fix with orientation 2 instead of 0
+for an upright RTP frame. The receive pipeline now retains authenticated RTP
+rotation per AU timestamp, including when one packet completes the previous
+unmarked AU and its own marked AU. Signaling remains a fallback only when
+frame metadata is absent. The synthetic pipeline tests cover all 256 bytes,
+metadata on either end of a fragmented AU, explicit zero versus absence,
+authentication failure, timestamp wrap and reordering, reset, rekey, and SSRC
+replacement. Direct and group engine tests check the signaling fallback.
+Live Android front/rear switching still requires a device retest.
+
 ## Camera-control execution boundary
 
 `tools/oracle-core/tests/camera_controls.rs` executes the J capture above and

--- a/tools/oracle-core/tests/common/mod.rs
+++ b/tools/oracle-core/tests/common/mod.rs
@@ -83,7 +83,8 @@ pub fn capture(id: &str) -> Result<Option<Vec<u8>>> {
         .map(Some)
 }
 
-/// Holds both the per-binary and cross-process engine locks.
+/// Holds both the per-binary and cross-process engine locks, so Wasmtime
+/// engines stay serialised within and across test binaries.
 pub fn threaded_guard() -> (std::sync::MutexGuard<'static, ()>, EngineLock) {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let local = LOCK

--- a/tools/oracle-core/tests/common/mod.rs
+++ b/tools/oracle-core/tests/common/mod.rs
@@ -83,8 +83,9 @@ pub fn capture(id: &str) -> Result<Option<Vec<u8>>> {
         .map(Some)
 }
 
-/// Holds both the per-binary and cross-process engine locks, so Wasmtime
-/// engines stay serialised within and across test binaries.
+/// Holds the per-binary lock and attempts the cross-process engine lock, so
+/// Wasmtime engines stay serialised within a test binary and, while the lock
+/// is held, across binaries. See `engine_lock` for the timeout fall-through.
 pub fn threaded_guard() -> (std::sync::MutexGuard<'static, ()>, EngineLock) {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let local = LOCK

--- a/tools/oracle-core/tests/video_orientation.rs
+++ b/tools/oracle-core/tests/video_orientation.rs
@@ -9,8 +9,10 @@ mod common;
 
 #[test]
 fn received_frame_rotation_matches_whatsapp_wasm() -> anyhow::Result<()> {
-    let bytes = common::capture("JgwtTQVeWPm")?
-        .expect("receive orientation proof requires captured WASM; set WA_WASM_DIR");
+    let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
+        eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
     assert_eq!(
         hex::encode(Sha256::digest(&bytes)),
         "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db"
@@ -20,6 +22,8 @@ fn received_frame_rotation_matches_whatsapp_wasm() -> anyhow::Result<()> {
         "6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131"
     );
     assert!(abi::table_slots_of(&bytes, 828)?.contains(&427));
+    // Serialise Wasmtime engines within and across test binaries.
+    let _serial = common::threaded_guard();
     let mut runtime = Runtime::instantiate(&bytes)?;
     runtime.run_ctors()?;
     let payload = runtime.write_bytes(&[0, 0, 0, 1, 0x65, 0x88])?;
@@ -118,6 +122,8 @@ fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
             ..Default::default()
         },
     )?;
+    // Serialise Wasmtime engines within and across test binaries.
+    let _serial = common::threaded_guard();
     let mut runtime = Runtime::instantiate(&instrumented)?;
     runtime.run_ctors()?;
     runtime.shared().watch_markers("env::on_call_event_js_sync");

--- a/tools/oracle-core/tests/video_orientation.rs
+++ b/tools/oracle-core/tests/video_orientation.rs
@@ -22,7 +22,6 @@ fn received_frame_rotation_matches_whatsapp_wasm() -> anyhow::Result<()> {
         "6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131"
     );
     assert!(abi::table_slots_of(&bytes, 828)?.contains(&427));
-    // Serialise Wasmtime engines within and across test binaries.
     let _serial = common::threaded_guard();
     let mut runtime = Runtime::instantiate(&bytes)?;
     runtime.run_ctors()?;
@@ -122,7 +121,6 @@ fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
             ..Default::default()
         },
     )?;
-    // Serialise Wasmtime engines within and across test binaries.
     let _serial = common::threaded_guard();
     let mut runtime = Runtime::instantiate(&instrumented)?;
     runtime.run_ctors()?;

--- a/tools/oracle-core/tests/video_orientation.rs
+++ b/tools/oracle-core/tests/video_orientation.rs
@@ -8,6 +8,66 @@ use wasmtime::Val;
 mod common;
 
 #[test]
+fn received_frame_rotation_matches_whatsapp_wasm() -> anyhow::Result<()> {
+    let bytes = common::capture("JgwtTQVeWPm")?
+        .expect("receive orientation proof requires captured WASM; set WA_WASM_DIR");
+    assert_eq!(
+        hex::encode(Sha256::digest(&bytes)),
+        "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db"
+    );
+    assert_eq!(
+        function_body_sha256(&bytes, 828)?,
+        "6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131"
+    );
+    assert!(abi::table_slots_of(&bytes, 828)?.contains(&427));
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.run_ctors()?;
+    let payload = runtime.write_bytes(&[0, 0, 0, 1, 0x65, 0x88])?;
+    let frame = runtime.write_bytes(&[0; 80])?;
+    let size = runtime.write_bytes(&[3, 0, 0, 0, 2, 0, 0, 0])?;
+    let peer = runtime.write_bytes(&[0; 24])?;
+    runtime.write_bytes_at(frame + 4, &875967048u32.to_le_bytes())?;
+    runtime.write_bytes_at(frame + 8, &payload.to_le_bytes())?;
+    runtime.write_bytes_at(frame + 16, &6u32.to_le_bytes())?;
+    for info in 0..=255u32 {
+        runtime.write_bytes_at(frame + 52, &(0x800 | info).to_le_bytes())?;
+        runtime.shared().clear_trace();
+        runtime.refuel();
+        runtime.call_table(
+            427,
+            &[
+                Val::I32(frame as i32),
+                Val::I32(size as i32),
+                Val::I32(peer as i32),
+            ],
+        )?;
+        let calls = runtime.shared().calls();
+        assert_eq!(calls.len(), 1, "info={info:#04x}");
+        assert_eq!(calls[0].symbol(), "env::renderVideoFrame_js");
+        assert_eq!(
+            calls[0].args,
+            [
+                i64::from(peer + 8),
+                i64::from(payload),
+                6,
+                3,
+                2,
+                [1, 4, 3, 2][(info & 3) as usize],
+                100,
+                0,
+                i64::from(info & 8 != 0),
+                0,
+            ],
+            "info={info:#04x}"
+        );
+    }
+    eprintln!(
+        "executed JgwtTQVeWPm.wasm receive renderer: 256 metadata bytes; rotation bits 0,1,2,3 -> JS enum 1,4,3,2"
+    );
+    Ok(())
+}
+
+#[test]
 fn upright_video_frame_info_matches_whatsapp_wasm() -> anyhow::Result<()> {
     let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
         eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -3590,14 +3590,14 @@ mod tests {
             eng,
         ));
 
-        // Inbound: the peer AU reassembled to the sink, orientation stamped from the control arm.
+        // RTP frame metadata takes precedence over the signaling fallback.
         let frames: Vec<VideoFrame> = std::iter::from_fn(|| vout_rx.try_recv().ok()).collect();
         assert_eq!(frames.len(), 1, "peer AU must reach video_out exactly once");
         assert_eq!(frames[0].data, peer_au);
         assert!(frames[0].keyframe);
         assert_eq!(
-            frames[0].orientation, 1,
-            "SetOrientation must apply before the inbound AU reassembles"
+            frames[0].orientation, 0,
+            "the upright frame must not inherit the device orientation"
         );
 
         // Outbound: the two legacy AUs retain fixed-stride timestamps, while the two current timed AUs

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -3009,12 +3009,12 @@ impl CallEngine {
                     now,
                     VIDEO_CLOCK_RATE,
                 );
-                for (timestamp, au) in completed {
+                for (timestamp, au, orientation) in completed {
                     let keyframe = au_is_keyframe(&au);
                     self.outbox.push_back(Output::VideoPlayout(VideoFrame {
                         data: au,
                         keyframe,
-                        orientation: self.peer_video_orientation,
+                        orientation: orientation.unwrap_or(self.peer_video_orientation),
                         sender: None,
                         device: None,
                         pid: None,
@@ -3416,12 +3416,14 @@ impl CallEngine {
                 .or_else(|| group.video_orientations.get(&video.user_jid))
                 .copied()
                 .unwrap_or_default();
-            for (timestamp, access_unit) in video.access_units {
+            for ((timestamp, access_unit), frame_orientation) in
+                video.access_units.into_iter().zip(video.orientations)
+            {
                 let keyframe = au_is_keyframe(&access_unit);
                 self.outbox.push_back(Output::VideoPlayout(VideoFrame {
                     data: access_unit,
                     keyframe,
-                    orientation,
+                    orientation: frame_orientation.unwrap_or(orientation),
                     sender: Some(video.user_jid.clone()),
                     device: Some(video.device_jid.clone()),
                     pid: video.pid,
@@ -9118,28 +9120,35 @@ mod tests {
     }
 
     #[test]
-    fn group_video_uses_per_participant_orientation() {
-        let (mut eng, epoch) = group_engine(true);
-        let peer_device = PEER_LID.parse::<Jid>().expect("peer JID");
-        eng.set_participant_video_orientation(peer_device.clone(), 2);
-        let mut peer = group_peer_video(&epoch);
-        let packet = peer
-            .protect_video(&video_au(100))
-            .pop()
-            .expect("one-packet video");
-        eng.handle_input(1, Input::RelayPacket(&packet));
-        let (outputs, _) = drain(&mut eng);
-        let peer_user = Jid::new("222222222222222", Server::Lid);
-        assert!(outputs.iter().any(|output| matches!(
+    fn group_video_frame_metadata_overrides_participant_orientation() {
+        for has_frame_info in [true, false] {
+            let (mut eng, epoch) = group_engine(true);
+            let peer_device = PEER_LID.parse::<Jid>().expect("peer JID");
+            eng.set_participant_video_orientation(peer_device.clone(), 2);
+            let mut peer = group_peer_video(&epoch);
+            let packet = peer
+                .protect_video(&video_au(100))
+                .pop()
+                .expect("one-packet video");
+            let packet = if has_frame_info {
+                packet
+            } else {
+                without_video_frame_info(&packet, &epoch)
+            };
+            eng.handle_input(1, Input::RelayPacket(&packet));
+            let (outputs, _) = drain(&mut eng);
+            let peer_user = Jid::new("222222222222222", Server::Lid);
+            assert!(outputs.iter().any(|output| matches!(
             output,
             Output::VideoPlayout(VideoFrame {
-                orientation: 2,
+                orientation,
                 sender: Some(sender),
                 device: Some(device),
                 pid: Some(2),
                 ..
-            }) if *sender == peer_user && *device == peer_device
+            }) if *sender == peer_user && *device == peer_device && *orientation == if has_frame_info { 0 } else { 2 }
         )));
+        }
     }
 
     #[test]
@@ -10914,12 +10923,58 @@ mod tests {
         assert_eq!(frames.len(), 1, "N packets must reassemble into 1 AU");
         assert_eq!(frames[0].data, au);
         assert!(frames[0].keyframe, "IDR AU must be flagged as keyframe");
-        assert_eq!(frames[0].orientation, 2);
+        assert_eq!(
+            frames[0].orientation, 0,
+            "per-frame RTP rotation overrides stale device orientation"
+        );
         assert_eq!(
             eng.jitter_len(),
             0,
             "video must not leak into the audio jitter buffer"
         );
+    }
+
+    fn without_video_frame_info(packet: &[u8], call_key: &[u8]) -> Vec<u8> {
+        use crate::voip::{e2e_srtp, rtp};
+        let mut header = parse_rtp_header(packet).unwrap();
+        let payload_start = rtp::rtp_header_byte_length(packet).unwrap();
+        header.video_extension = None;
+        let mut result = Vec::new();
+        rtp::encode_rtp_header_into(&header, &mut result);
+        result.extend_from_slice(&packet[payload_start..packet.len() - WARP_MI_TAG_LEN]);
+        let keys =
+            e2e_srtp::derive_e2e_keys(call_key, &ssrc::format_e2e_srtp_participant_id(PEER_LID))
+                .unwrap();
+        e2e_srtp::append_warp_mi_tag_in_place(&keys.auth_key, &mut result, 0, WARP_MI_TAG_LEN);
+        result
+    }
+
+    #[test]
+    fn inbound_video_without_frame_metadata_keeps_signaling_fallback() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.set_peer_video_orientation(3);
+        let mut peer = peer_video_pipe();
+        let key: Vec<u8> = (0..32).collect();
+        for has_frame_info in [true, false, true] {
+            let packet = peer.protect_video(&video_au(100)).pop().unwrap();
+            let packet = if has_frame_info {
+                packet
+            } else {
+                without_video_frame_info(&packet, &key)
+            };
+            eng.handle_input(1, Input::RelayPacket(&packet));
+            let frames: Vec<_> = drain(&mut eng)
+                .0
+                .into_iter()
+                .filter_map(|output| match output {
+                    Output::VideoPlayout(frame) => Some(frame),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(frames.len(), 1);
+            assert_eq!(frames[0].orientation, if has_frame_info { 0 } else { 3 });
+        }
     }
 
     #[test]

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -103,6 +103,7 @@ pub struct ParticipantVideo {
     pub pid: Option<u32>,
     pub header: RtpHeader,
     pub access_units: Vec<(u32, Vec<u8>)>,
+    pub(crate) orientations: Vec<Option<u8>>,
 }
 
 struct ParticipantReceiver {
@@ -465,6 +466,10 @@ impl GroupMediaRegistry {
             return None;
         }
         let (header, access_units) = receiver.video.as_mut()?.unprotect_video_packet(packet)?;
+        let (access_units, orientations) = access_units
+            .into_iter()
+            .map(|(timestamp, data, orientation)| ((timestamp, data), orientation))
+            .unzip();
         Some(ParticipantVideo {
             participant_id,
             user_jid: receiver.user_jid.clone(),
@@ -472,6 +477,7 @@ impl GroupMediaRegistry {
             pid: receiver.pid,
             header,
             access_units,
+            orientations,
         })
     }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -32,7 +32,9 @@ pub struct VideoFrame {
     pub data: Vec<u8>,
     /// The AU carries an IDR/SPS/PPS NAL — safe point to (re)start a decoder.
     pub keyframe: bool,
-    /// Peer device orientation in 90° steps (0..3), from `<video device_orientation>`.
+    /// Frame rotation bits (0..3) from RTP metadata, falling back to
+    /// `<video device_orientation>` when absent. Display turns clockwise are
+    /// respectively 0, 270, 180, and 90 degrees, as verified by the WASM oracle.
     pub orientation: u8,
     /// Group sender identity. Absent on 1:1 video.
     pub sender: Option<Jid>,

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -785,7 +785,7 @@ fn unprotect_srtp_packet(
 /// per media type) and WARP MI tag, but H.264 packetization on top and its own
 /// SSRC/sequencer. One access unit fans out to N RTP packets on send and is
 /// reassembled from them on receive.
-type TimestampedAccessUnit = (u32, Vec<u8>);
+type TimestampedAccessUnit = (u32, Vec<u8>, Option<u8>);
 type VideoPacketResult = (RtpHeader, Vec<TimestampedAccessUnit>);
 
 pub struct VideoPipeline {
@@ -796,6 +796,7 @@ pub struct VideoPipeline {
     send_roc: RocTracker,
     recv_streams: SrtpRecvStreams,
     depacketizer: H264Depacketizer,
+    frame_orientation: Option<(u32, Option<u8>)>,
     /// SSRC whose fragments the depacketizer currently holds, once one has authenticated.
     ///
     /// The receive table tracks several SSRCs so a renumbering peer keeps its own rollover counter
@@ -872,6 +873,7 @@ impl VideoPipeline {
             send_roc: RocTracker::default(),
             recv_streams: SrtpRecvStreams::default(),
             depacketizer: H264Depacketizer::default(),
+            frame_orientation: None,
             depacketizer_ssrc: None,
             retired_ssrcs: Vec::new(),
             contender_ssrc: None,
@@ -1000,6 +1002,7 @@ impl VideoPipeline {
     /// would otherwise be completed by fewer stragglers than it takes to earn.
     pub(crate) fn reset_reassembly(&mut self) {
         self.depacketizer.reset();
+        self.frame_orientation = None;
         self.depacketizer_ssrc = None;
         self.contender_ssrc = None;
         self.packets_since_stream_change = 0;
@@ -1008,6 +1011,7 @@ impl VideoPipeline {
 
     pub(crate) fn reset_depacketizer(&mut self) {
         self.depacketizer.reset();
+        self.frame_orientation = None;
         self.depacketizer_ssrc = None;
         self.retired_ssrcs.clear();
         self.contender_ssrc = None;
@@ -1054,7 +1058,7 @@ impl VideoPipeline {
         (!completed.is_empty()).then_some(
             completed
                 .into_iter()
-                .map(|(_, access_unit)| access_unit)
+                .map(|(_, access_unit, _)| access_unit)
                 .collect(),
         )
     }
@@ -1109,6 +1113,7 @@ impl VideoPipeline {
             }
             if self.depacketizer_ssrc.is_some() {
                 self.depacketizer.reset();
+                self.frame_orientation = None;
             }
             if let Some(left) = self.depacketizer_ssrc {
                 self.retired_ssrcs.retain(|ssrc| *ssrc != left);
@@ -1124,6 +1129,17 @@ impl VideoPipeline {
             self.retired_ssrc_run = 0;
             self.contender_ssrc = None;
         }
+        let previous = self.frame_orientation;
+        let rotation = header.video_extension.map(|ext| ext.media_frame_info & 3);
+        match self.frame_orientation {
+            Some((timestamp, ref mut orientation)) if timestamp == header.timestamp => {
+                if rotation.is_some() {
+                    *orientation = rotation;
+                }
+            }
+            Some((timestamp, _)) if (header.timestamp.wrapping_sub(timestamp) as i32) <= 0 => {}
+            _ => self.frame_orientation = Some((header.timestamp, rotation)),
+        }
         let first = self.depacketizer.push(
             header.sequence_number,
             header.timestamp,
@@ -1131,11 +1147,17 @@ impl VideoPipeline {
             header.marker,
         );
         let mut completed = Vec::with_capacity(if first.is_some() { 2 } else { 0 });
-        if let Some(au) = first {
-            completed.push(au);
-        }
-        while let Some(au) = self.depacketizer.pop_ready() {
-            completed.push(au);
+        // Ready AUs are drained after every push, so at most the previous unmarked
+        // AU and the current AU complete here. Keep each one's own orientation.
+        let mut next = first;
+        while let Some((timestamp, au)) = next {
+            let orientation = self
+                .frame_orientation
+                .filter(|(stamp, _)| *stamp == timestamp)
+                .or_else(|| previous.filter(|(stamp, _)| *stamp == timestamp))
+                .and_then(|(_, orientation)| orientation);
+            completed.push((timestamp, au, orientation));
+            next = self.depacketizer.pop_ready();
         }
         Some((header, completed))
     }
@@ -1893,6 +1915,147 @@ mod tests {
         let mut au = vec![0, 0, 0, 1, 0x65];
         au.extend((0..nal_len).map(|i| (i % 251) as u8));
         au
+    }
+
+    #[test]
+    fn frame_orientation_survives_camera_changes_and_timestamp_boundaries() {
+        let key = [42u8; 32];
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&key, b, a)).unwrap();
+        let mut previous = None;
+        for info in 0..=255u8 {
+            let mut header = tx.rtp.next_video_packet(true, info);
+            header.marker = info % 2 != 0;
+            let packet =
+                protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, &[0x65, 0x88]);
+            let completed = rx.unprotect_video_packet(&packet).unwrap().1;
+            let mut expected = Vec::new();
+            if let Some((stamp, orientation)) = previous.take() {
+                expected.push((stamp, vec![0, 0, 0, 1, 0x65, 0x88], Some(orientation)));
+            }
+            if header.marker {
+                expected.push((
+                    header.timestamp,
+                    vec![0, 0, 0, 1, 0x65, 0x88],
+                    Some(info & 3),
+                ));
+            } else {
+                previous = Some((header.timestamp, info & 3));
+            }
+            assert_eq!(completed, expected, "info={info:#04x}");
+        }
+
+        let mut header = tx.rtp.next_video_packet(true, 3);
+        header.video_extension = None;
+        let packet = protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, &[0x65, 0x88]);
+        assert_eq!(
+            rx.unprotect_video_packet(&packet).unwrap().1[0].2,
+            None,
+            "an absent extension must not inherit the previous camera rotation"
+        );
+    }
+
+    #[test]
+    fn frame_orientation_preserves_presence_across_fragments_and_rejects_forgery() {
+        let key = [42u8; 32];
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&key, b, a)).unwrap();
+        for (index, (first, last, expected)) in [
+            (Some(0), None, Some(0)),
+            (None, Some(3), Some(3)),
+            (Some(1), Some(1), Some(1)),
+            (None, None, None),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let timestamp = index as u32 * 6000;
+            for (marker, info) in [(false, first), (true, last)] {
+                let mut header = tx.rtp.next_video_packet(marker, info.unwrap_or(0));
+                header.timestamp = timestamp;
+                if info.is_none() {
+                    header.video_extension = None;
+                }
+                let payload: &[u8] = if marker {
+                    &[0x7c, 0x45, 0x99]
+                } else {
+                    &[0x7c, 0x85, 0x88]
+                };
+                let packet =
+                    protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, payload);
+                let held = rx.frame_orientation;
+                let mut forged = packet.clone();
+                *forged.last_mut().unwrap() ^= 1;
+                assert!(rx.unprotect_video_packet(&forged).is_none());
+                assert_eq!(
+                    rx.frame_orientation, held,
+                    "forgery cannot change orientation or fall back"
+                );
+                let completed = rx.unprotect_video_packet(&packet).unwrap().1;
+                if marker {
+                    assert_eq!(
+                        completed,
+                        [(timestamp, vec![0, 0, 0, 1, 0x65, 0x88, 0x99], expected)]
+                    );
+                } else {
+                    assert!(completed.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn frame_orientation_follows_wrap_reorder_and_stream_resets() {
+        let key = [42u8; 32];
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&key, b, a)).unwrap();
+        let au = vec![0, 0, 0, 1, 0x65, 0x88];
+        for (timestamp, marker, info, expected) in [
+            (u32::MAX - 5, false, 1, vec![]),
+            (2, false, 3, vec![(u32::MAX - 5, au.clone(), Some(1))]),
+            (u32::MAX - 4, true, 2, vec![]),
+            (
+                3,
+                true,
+                0,
+                vec![(2, au.clone(), Some(3)), (3, au.clone(), Some(0))],
+            ),
+        ] {
+            let mut header = tx.rtp.next_video_packet(marker, info);
+            header.timestamp = timestamp;
+            let packet =
+                protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, &[0x65, 0x88]);
+            assert_eq!(rx.unprotect_video_packet(&packet).unwrap().1, expected);
+        }
+        for reset in 0..4 {
+            let mut header = tx.rtp.next_video_packet(false, 3);
+            let packet =
+                protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, &[0x65, 0x88]);
+            assert!(rx.unprotect_video_packet(&packet).unwrap().1.is_empty());
+            match reset {
+                0 => rx.reset_reassembly(),
+                1 => rx.reset_depacketizer(),
+                2 => assert!(rx.rekey_recv(&key, a)),
+                _ => header.ssrc ^= 0x100,
+            }
+            header.sequence_number += 1;
+            header.marker = true;
+            header.video_extension = None;
+            let packet =
+                protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, &[0x65, 0x88]);
+            assert_eq!(
+                rx.unprotect_video_packet(&packet).unwrap().1,
+                [(header.timestamp, au.clone(), None)],
+                "reset {reset}"
+            );
+            tx.rtp.next_video_packet(true, 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
On receive, the engine stamped every video frame with the last signaling `device_orientation`, ignoring the per-frame rotation in RTP metadata. Switching cameras (front to rear) could therefore leave the picture upside down until signaling caught up.

`VideoPipeline` now retains the authenticated frame rotation per access-unit timestamp and prefers it when emitting `VideoFrame`. Missing metadata keeps the existing signaling fallback, including an explicit orientation of zero. Direct and group playout paths both carry the per-frame value.

## Oracle proof
Executed against the captured `JgwtTQVeWPm.wasm` (SHA-256 `97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db`), receive function 828:

- All 256 frame-info bytes map low bits 0,1,2,3 to JS enum 1,4,3,2, drawn clockwise as 0,270,180,90 degrees.
- Existing 10 outbound orientation/keyframe cases still pass.

No GUI rotation convention changed and no 180-degree compensation was added. The oracle covers the receive-rendering function, not the full RTP-parser-to-decoder pipeline.

## Verification
- `WA_WASM_DIR=... cargo test --release -p oracle-core --test video_orientation`: 2 passed, 0 skipped.
- `cargo test -p wacore --features voip-mlow --lib voip::`: 686 passed, 1 existing ignored.
- `cargo fmt --all -- --check`, `git diff --check`, and wacore Clippy with `-D warnings` pass.

A live Android front/rear retest on the client is still required before calling the reported symptom resolved.