### PR TITLE
fix(transport): retain TLS sessions and document reuse contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "rtc-shared"
-version = "0.21.0-rc.2"
+version = "0.21.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e90210053b6e2eddf63209c93e52d5181ddc9a4b8d1ff5af9af8cb8d95d97e"
+checksum = "998b045d95d158251842c5146918f3213346ca7724e8c6ac750c37d467dbbcdd"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
@@ -5755,6 +5755,7 @@ dependencies = [
  "futures-util",
  "http",
  "log",
+ "rcgen",
  "rustls",
  "tokio",
  "tokio-rustls",

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -369,7 +369,7 @@ the reason for measuring against one.
 | --- | ---: | ---: |
 | HTTP: pooled TLS connection from the version fetch | 88 KiB | 0 KiB (#1243) |
 | noise: batch buffer after one 60 KiB frame | 60 KiB, vs 8 KiB small-traffic | 8 KiB (#1246) |
-| transport: retained `ClientConfig` | 14 KiB | 9 KiB (#1245) |
+| transport: retained `ClientConfig`, historical construction probe | 14 KiB | 9 KiB at #1245, not a warm-cache measurement |
 | topology log preallocation | 4 KiB | 0 KiB (#1244) |
 
 **The prekey window is a backend artifact, not a per-session cost.** Building a
@@ -396,10 +396,15 @@ and its in-call transient high-water from 63.1 KB to 42.1 KB — but retained is
 bit-identical at 42,072 B either way, because the final table is the same size.
 Reserving is worth it for the allocator traffic; it will never move the 41 KiB.
 
-**The rustls session cache is 5 KiB, not 44.** A whole retained
-`default_tls_connector()` measures 14.0 KiB; disabling resumption entirely takes
-it to 9.0 KiB, and sizing the store for the one host a factory dials takes it to
-9.4 KiB. The other 9 KiB is the config plus the webpki root store.
+**Historical rustls construction measurements.** At #1245, a retained
+`default_tls_connector()` measured 14.0 KiB; disabling resumption measured
+9.0 KiB, and the eight-ticket budget measured 9.4 KiB. These construction
+probes do not establish the footprint after processing session tickets.
+In rustls 0.23.43, that budget immediately evicts the first server-name entry.
+The corrected sixteen-ticket budget retains one name and its ticket deque;
+its empty and populated footprints have not been remeasured. Count an
+explicitly shared configuration once per owner, not once per socket. The
+transport resource estimate covers connection buffers, not this factory cache.
 
 ### Should a residency probe be permanent?
 

--- a/agent_docs/transport_reuse_audit.md
+++ b/agent_docs/transport_reuse_audit.md
@@ -1,0 +1,155 @@
+# Transport reuse audit
+
+Baseline `47e1b5b41b63c23b59372828901ea945c8149565`, audited on 2026-09-08.
+This audit covers runtime access, ED construction and TLS state ownership.
+
+## Runtime
+
+Keep `whatsapp_rust::TokioRuntime`, `runtime_impl::TokioRuntime` and the prelude
+export behind `tokio-runtime`. A standalone consumer compiled with defaults
+disabled, using `Runtime` and the Tokio transport without importing `Client`.
+SQLite, Diesel, ureq and OS signal handling were absent. The main crate still
+compiled, as did Signal protocol through wacore's unconditional dependency.
+The `signal` feature controls OS signals, not Signal protocol.
+
+Documentation is the chosen change. Moving the adapter into transport would
+make runtime-only users acquire WebSocket/TLS dependencies unless another
+configuration were added. A separate crate could preserve the old exports but
+adds publication and CI responsibilities without removing wacore's Signal
+dependency. No measured extraction benefit justifies either change here.
+
+External probes passed on current-thread and multi-thread Tokio. They covered
+spawn, cancellation on drop, detach, executor shutdown, lazy blocking submission,
+queued and running blocking work, panic handling and timer requirements. Raw
+blocking joins discard panic errors under unwind; the result-returning core
+helper raises a new panic when its oneshot loses the result. Abort-profile
+panics terminate the process. The adapter's yield hook remains a no-op on both
+executor flavors; 1,000 calls did not schedule a queued peer. The docs now state
+that limit rather than claiming multiple workers eliminate cooperative yielding.
+
+The consumer's release build compiled 145 packages including itself. Compared
+with its core/transport-only graph, enabling the existing adapter added
+`whatsapp-rust` and `scopeguard`. Symbol inspection found adapter functions but
+no named Client or Signal functions. That is not proof that all unrelated
+inlined code or anonymous data disappeared. No adapter relocation or linked-size
+improvement is claimed.
+
+## ED
+
+The pinned whatspec IR at `1a441f0329c941fcdb238490a6c604550d8a9939`, WA
+`2.3000.1045368834`, contains routing references but not this socket construction
+flow. The official `.wa-cache` instead identifies WA `2.3000.1044770897`.
+All 504 cached bundle sizes and hashes matched its manifest. Do not attribute
+that older bundle to the newer IR version.
+
+Primary bundle evidence, using content SHA-256 and original bundle lines:
+
+| Content hash | Modules and lines |
+| --- | --- |
+| `4de5ec27b53a202be96d64493441fe6aed113d6e35e5745e61d1f32a3341a30a` | `WABinary` 8, `WABase64` 27 |
+| `e855464a86b395cabf4aa380540a5585565e6e32db1765227c4a3aac5e94a3c7` | `WAFrameSocket` 1379, `WAWebOpenSocket` 1455, `WAWebOpenChatSocket` 1459 |
+
+`WAWebOpenChatSocket` reads stored opaque routing bytes, calls
+`encodeB64UrlSafe` without its padding argument, and gives the resulting string
+to `WAWebOpenSocket`. That module appends `?ED=` to both fixed endpoints for
+non-null strings. Independently, the same raw bytes enter the binary pre-intro:
+
+```text
+45 44 00 01 | three-byte big-endian byte length | routing bytes | WA header
+```
+
+Executed official module factories confirmed the synthetic vectors in
+`edge_routing_param_retains_padding_unlike_captured_wa_web`, including `01` to
+`AQ` and `FB FF` to `-_8`. Prefix-only tests exercised the three-byte length
+boundary without allocating maximum-sized routing payloads.
+
+Keep the existing Rust helper's output contract. It emits padded base64url,
+omits absent, empty or oversized bytes, and appends before fragments without
+validating URLs or replacing existing ED parameters. In contrast, official
+empty ArrayBuffers produce `?ED=` and a zero-length binary pre-intro. Rust's
+binary builder also accepts empty bytes, but oversized routing falls back to
+WA-only, whereas the official binary writer rejects the unrepresentable length.
+These are retained differences, not a claim of complete WA output parity or
+proof that the server rejects padded output.
+
+No general ED decoder or HTTP parsing API is added. No production caller of the
+query helper or request-side ED decoder was found in this repository. Integrators
+own missing versus empty input, malformed base64/padding rejection, one-time
+percent decoding, duplicate rejection and bounded HTTP request parsing. Existing
+base64 engines supply strict padded and unpadded decoding. Bound the request and
+encoded component before decoding, then bound decoded bytes. A 4 KiB request
+policy is not a protocol limit; `0xFFFFFF` comes from binary framing and is not
+a sensible default HTTP budget. A query built externally is not automatically
+synchronized with the device snapshot used later by the Noise handshake.
+
+## TLS
+
+Keep `with_connector` and per-factory defaults. `Connector` is not cloneable;
+its rustls payload clones an `Arc<ClientConfig>`. That config owns the session
+store. Cloning the config itself also shares its Arc-backed store, so it does
+not establish tenant isolation. A full client already retains its factory.
+Transport-only callers recreating factories should construct the connector once
+per intended trust/client-identity/tenant policy and inject payload clones.
+
+Pinned rustls 0.23.43 exposed a separate defect. An eight-ticket budget gives
+its server-name queue capacity one, and insertion evicts when length reaches
+capacity. Public cache probes retained a key-exchange hint in 0/100 fresh caches
+at budget eight and 100/100 at sixteen. Sixteen retains one server name while
+leaving the per-name TLS 1.3 ticket maximum at eight. This minimum sizing fix
+benefits both full clients and standalone transports without global sharing.
+
+Local trusted TLS 1.3 tests observe `Full`, then `Resumed` on repeated dials and
+shared factories with changed synthetic ED queries and ports. Ticket insertion
+events precede reconnects. An independent config/store performs `Full`, and
+returning to the shared config resumes. Config pointer checks establish retention
+within one factory and separation across default factories. These are identity
+observations, not allocator or constructor-call measurements.
+
+Factory tests use IPv4 literals and assert no SNI for IP addresses. A separate
+preconnected loopback test supplies a DNS ServerName to tokio-rustls, observes
+localhost SNI and rejects a different DNS name. Factory tests also reject an
+untrusted root and a trusted certificate lacking the requested IP SAN. Origin
+remains unchanged. Every network phase has a deadline, with no DNS dependency,
+arbitrary sleeps, external connections or verification bypass.
+
+New dials still open new sockets. Session keys use server names, not ED or ports;
+concurrent racing attempts can consume tickets, and server policy determines
+whether they resume. No WhatsApp resumption rate, latency or memory saving is
+claimed. The full URL was removed from the dial debug log to avoid disclosing ED.
+
+## Cost and validation
+
+No runtime move, parsing dependency or new crate. `rcgen` was already locked and
+is now a transport dev dependency; WebSocket server support is enabled only for
+tests. The lockfile also reconciles the baseline's rtc-shared version with the
+existing exact beta.2 manifest pin, required for locked validation. Production
+dependencies and public paths are unchanged. The cache now retains state that
+the broken configuration discarded. Empty and populated heap sizes have not
+been remeasured, and the observability guide marks its old numbers as historical.
+
+Toolchain was rustc `1.98.0-nightly (01dfd7924 2026-06-15)`, with two build jobs.
+
+| Command or check | Result |
+| --- | --- |
+| `cargo fmt --all` | Passed |
+| `cargo clippy --workspace --all-targets -- -D warnings` | Passed |
+| `cargo nextest run --profile ci -p wacore -p whatsapp-rust --lib` | 3,643 passed, three existing skips |
+| `cargo nextest run -p whatsapp-rust-tokio-transport --lib --locked` | 12 passed |
+| Transport stress, 20 iterations without retries | 240 passed |
+| Transport doctests | One passed |
+| Runtime-only main doctest | One passed |
+| Core no-default doctests | Three passed, 11 existing examples ignored |
+| External runtime probes without/with multi-thread support | Four/six passed |
+
+Workflow wasm release builds passed for main without defaults, core with
+`voip,js`, and main with `voip-mlow`, using
+`RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`. Main emitted two existing
+unused-qualification warnings in request/upload code. These are build checks,
+not wasm execution tests. Core normal/build dependencies contain no Tokio.
+
+An initial full-suite failure in
+`online_device_sync_releases_its_dedup_entry` reproduced unchanged in a separate
+baseline worktree on iteration 729/1,000. Its fixed yield loop sometimes ends
+before cleanup. The final rebuilt patch suite passed; the test was not relaxed.
+No E2E infrastructure or live WhatsApp acceptance test was used. Ignored tests
+and unmeasured performance are not passing evidence.

--- a/src/runtime_impl.rs
+++ b/src/runtime_impl.rs
@@ -1,4 +1,4 @@
-/// Tokio-based implementation of [`Runtime`]. Only available on native targets.
+/// Tokio-based implementation of [`wacore::runtime::Runtime`]. Only available on native targets.
 #[cfg(not(target_arch = "wasm32"))]
 mod tokio_impl {
     use std::future::Future;
@@ -8,6 +8,66 @@ mod tokio_impl {
     use async_trait::async_trait;
     use wacore::runtime::{AbortHandle, Runtime};
 
+    /// Adapter for an existing Tokio executor, available with `tokio-runtime`
+    /// on non-wasm32 targets. Does not create or keep an executor alive.
+    ///
+    /// Works with current-thread and multi-thread executors. `spawn` and
+    /// `spawn_detached` use the current executor when called; `sleep` requires
+    /// its timer driver to be enabled when the sleep future is constructed.
+    /// `spawn_blocking` uses the current executor when its future is first polled.
+    ///
+    /// - `spawn` returns an [`AbortHandle`] that requests cancellation on drop.
+    ///   Cancellation does not wait for destruction or preempt a running poll.
+    /// - `spawn_detached` and [`AbortHandle::detach`] let a task outlive its
+    ///   handle's scope, but do not guarantee completion across executor shutdown.
+    /// - `spawn_blocking` submits nothing until polled. Once submitted, dropping
+    ///   its future leaves queued or running work alive. Blocking work runs on
+    ///   separate threads even with a current-thread executor; started work can
+    ///   delay executor shutdown until it finishes.
+    /// - `yield_now` is a no-op returning `None`, with inherited frequency 10,
+    ///   on both executor flavors. It provides no scheduling point or fairness
+    ///   guarantee. Tight loops must arrange their own cooperative yielding;
+    ///   multiple workers do not eliminate that need.
+    ///
+    /// # Panics
+    ///
+    /// Missing Tokio context panics at the call or first poll described above.
+    /// Constructing a sleep also panics if the timer driver is disabled.
+    /// With unwinding and Tokio's default panic policy, async task panics are
+    /// caught by Tokio and not returned by this adapter. `spawn_blocking` also
+    /// discards its join error, so a closure panic resolves as `()`; the panic
+    /// hook still runs. Use [`wacore::runtime::blocking`] to return a closure's
+    /// result; it raises a new panic if the closure fails to deliver that result.
+    /// With `panic = "abort"`, a panic terminates the process instead.
+    ///
+    /// # Example
+    ///
+    /// No `Client` is needed. Disable defaults to omit the bundled storage,
+    /// transport and HTTP adapters; this still compiles the main crate and core.
+    ///
+    /// ```toml
+    /// [dependencies]
+    /// whatsapp-rust = { version = "0.7", default-features = false, features = ["tokio-runtime"] }
+    /// tokio = { version = "1", features = ["rt", "time"] }
+    /// ```
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use whatsapp_rust::{Runtime, TokioRuntime};
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let executor = tokio::runtime::Builder::new_current_thread()
+    ///         .enable_time()
+    ///         .build()?;
+    ///     let runtime = TokioRuntime;
+    ///     executor.block_on(async {
+    ///         runtime.sleep(Duration::from_millis(1)).await;
+    ///         let answer = whatsapp_rust::wacore::runtime::blocking(&runtime, || 6 * 7).await;
+    ///         assert_eq!(answer, 42);
+    ///     });
+    ///     Ok(())
+    /// }
+    /// ```
     pub struct TokioRuntime;
 
     #[async_trait]
@@ -35,8 +95,6 @@ mod tokio_impl {
         }
 
         fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
-            // Multi-threaded runtime: other tasks run on separate threads,
-            // no cooperative yielding needed.
             None
         }
     }

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -34,9 +34,9 @@ wacore = { workspace = true }
 webpki-roots = "1.0.9"
 
 [dev-dependencies]
-# The upgrade-header tests read the request off a local socket. Dev-only, so the
-# release dependency set — and the binary-size gate — are unaffected.
+rcgen = { version = "0.14.10", default-features = false, features = ["crypto", "ring"] }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "time"] }
+tokio-websockets = { version = "0.13.3", features = ["server"] }
 
 [lints]
 workspace = true

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -43,12 +43,10 @@ fn transport_resource_estimate() -> wacore::stats::TransportResourceReport {
 
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
-/// A factory dials one URL, so its resumption store only ever needs one server
-/// name. rustls's default asks for 256 sessions, which it turns into a
-/// preallocated table of `⌈256/8⌉ = 32` server names. Eight is its per-server
-/// ticket maximum, so one slot here is a full slot, not a reduction in what can
-/// be resumed for the host actually dialled.
-const RESUMPTION_TICKETS: usize = 8;
+/// rustls 0.23.43 divides this budget by eight to size its server-name queue,
+/// then evicts when the queue reaches capacity. Two slots retain one name;
+/// one slot immediately evicts it. The per-server TLS 1.3 ticket limit stays eight.
+const RESUMPTION_TICKETS: usize = 16;
 
 /// Applies the single-host resumption sizing to a freshly built config.
 fn size_for_one_host(mut config: rustls::ClientConfig) -> rustls::ClientConfig {
@@ -381,6 +379,35 @@ impl TokioWebSocketTransportFactory {
     /// This is the primary extension point for custom TLS configuration
     /// (e.g. custom CA certificates, client certs). For full proxy support,
     /// implement [`TransportFactory`] directly and use [`from_websocket`].
+    ///
+    /// Repeated dials on one factory retain its default connector. Separate
+    /// factories build separate defaults. To share TLS configuration and session
+    /// storage across factories, clone the rustls payload, not `Connector`:
+    ///
+    /// ```
+    /// use whatsapp_rust_tokio_transport::{
+    ///     Connector, TokioWebSocketTransportFactory, default_tls_connector,
+    /// };
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let Connector::Rustls(tls) = default_tls_connector() else {
+    ///     anyhow::bail!("expected the default rustls connector");
+    /// };
+    /// let primary = TokioWebSocketTransportFactory::new()
+    ///     .with_connector(Connector::Rustls(tls.clone()));
+    /// let secondary = TokioWebSocketTransportFactory::new()
+    ///     .with_url("wss://web.whatsapp.com:5222/ws/chat")
+    ///     .with_connector(Connector::Rustls(tls.clone()));
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The clones share an `Arc<ClientConfig>`, not an open socket. Share only
+    /// within the intended trust, client-identity, and tenant policy. The default
+    /// store holds tickets for one server name; supply your own configuration
+    /// for a larger multi-host cache. Changing a port or ED query does not change
+    /// the server-name key, but resumption still requires processed tickets and
+    /// server acceptance. Certificate validation, SNI, and Origin are unchanged.
     pub fn with_connector(mut self, connector: Connector) -> Self {
         self.connector = Some(connector);
         self
@@ -417,7 +444,7 @@ impl TransportFactory for TokioWebSocketTransportFactory {
                 .map_err(|e| anyhow::anyhow!("Failed to set Origin header: {e}"))?;
         }
 
-        debug!("Dialing {}", self.url);
+        debug!("Dialing WebSocket");
         let (ws, _) = builder
             .connect()
             .await
@@ -485,46 +512,377 @@ mod tests {
         );
     }
 
-    /// Dials a port nothing answers on, bounded so a stack that drops rather
-    /// than refuses cannot hang the suite. The connector is chosen before the
-    /// dial, so whether it fails or times out is irrelevant to these tests.
-    async fn attempt_dial(factory: &TokioWebSocketTransportFactory) {
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            factory.create_transport(),
-        )
-        .await;
+    async fn attempt_dial(factory: &mut TokioWebSocketTransportFactory) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            factory.url = format!("ws://{}/ws/chat", listener.local_addr().unwrap());
+            let server = async { drop(listener.accept().await.unwrap()) };
+            let client = async { assert!(factory.create_transport().await.is_err()) };
+            tokio::join!(server, client);
+        })
+        .await
+        .expect("local dial timed out");
     }
 
-    /// A reconnect must not rebuild the TLS config. Nothing was retained
-    /// before, which is why the resumption store inside it was always empty.
     #[tokio::test]
     async fn the_default_connector_is_retained_across_dials() {
-        let factory = TokioWebSocketTransportFactory::new().with_url("ws://127.0.0.1:1/ws/chat");
+        let mut factory = TokioWebSocketTransportFactory::new();
         assert!(factory.default_connector.get().is_none());
 
-        attempt_dial(&factory).await;
-        assert!(
-            factory.default_connector.get().is_some(),
-            "the first dial built a connector and dropped it"
-        );
+        attempt_dial(&mut factory).await;
+        let config = rustls_config(factory.default_connector.get().unwrap()).clone();
 
-        attempt_dial(&factory).await;
-        assert!(
-            factory.default_connector.get().is_some(),
-            "a second dial must reuse the retained connector"
-        );
+        attempt_dial(&mut factory).await;
+        assert!(Arc::ptr_eq(
+            &config,
+            rustls_config(factory.default_connector.get().unwrap()),
+        ));
+
+        let mut other = TokioWebSocketTransportFactory::new();
+        attempt_dial(&mut other).await;
+        assert!(!Arc::ptr_eq(
+            &config,
+            rustls_config(other.default_connector.get().unwrap()),
+        ));
+    }
+
+    fn rustls_config(connector: &Connector) -> &Arc<rustls::ClientConfig> {
+        match connector {
+            Connector::Rustls(tls) => tls.config(),
+            _ => panic!("expected rustls"),
+        }
+    }
+
+    #[test]
+    fn single_host_session_cache_retains_state() {
+        use rustls::client::ClientSessionStore;
+        let cache = rustls::client::ClientSessionMemoryCache::new(RESUMPTION_TICKETS);
+        let name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        cache.set_kx_hint(name.clone(), rustls::NamedGroup::X25519);
+        assert_eq!(cache.kx_hint(&name), Some(rustls::NamedGroup::X25519));
+    }
+
+    #[derive(Debug)]
+    struct TicketStore {
+        cache: rustls::client::ClientSessionMemoryCache,
+        received: tokio::sync::Semaphore,
+    }
+
+    impl TicketStore {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                cache: rustls::client::ClientSessionMemoryCache::new(RESUMPTION_TICKETS),
+                received: tokio::sync::Semaphore::new(0),
+            })
+        }
+    }
+
+    impl rustls::client::ClientSessionStore for TicketStore {
+        fn set_kx_hint(
+            &self,
+            name: rustls::pki_types::ServerName<'static>,
+            group: rustls::NamedGroup,
+        ) {
+            self.cache.set_kx_hint(name, group);
+        }
+
+        fn kx_hint(&self, name: &rustls::pki_types::ServerName<'_>) -> Option<rustls::NamedGroup> {
+            self.cache.kx_hint(name)
+        }
+
+        fn set_tls12_session(
+            &self,
+            name: rustls::pki_types::ServerName<'static>,
+            value: rustls::client::Tls12ClientSessionValue,
+        ) {
+            self.cache.set_tls12_session(name, value);
+        }
+
+        fn tls12_session(
+            &self,
+            name: &rustls::pki_types::ServerName<'_>,
+        ) -> Option<rustls::client::Tls12ClientSessionValue> {
+            self.cache.tls12_session(name)
+        }
+
+        fn remove_tls12_session(&self, name: &rustls::pki_types::ServerName<'static>) {
+            self.cache.remove_tls12_session(name);
+        }
+
+        fn insert_tls13_ticket(
+            &self,
+            name: rustls::pki_types::ServerName<'static>,
+            value: rustls::client::Tls13ClientSessionValue,
+        ) {
+            self.cache.insert_tls13_ticket(name, value);
+            self.received.add_permits(1);
+        }
+
+        fn take_tls13_ticket(
+            &self,
+            name: &rustls::pki_types::ServerName<'static>,
+        ) -> Option<rustls::client::Tls13ClientSessionValue> {
+            self.cache.take_tls13_ticket(name)
+        }
+    }
+
+    fn tls_server_config(
+        name: &str,
+    ) -> (
+        Arc<rustls::ServerConfig>,
+        rustls::pki_types::CertificateDer<'static>,
+    ) {
+        let rcgen::CertifiedKey { cert, signing_key } =
+            rcgen::generate_simple_self_signed(vec![name.into()]).unwrap();
+        let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![cert.der().clone()],
+            rustls::pki_types::PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+        )
+        .unwrap();
+        config.send_tls13_tickets = 1;
+        (Arc::new(config), cert.der().clone())
+    }
+
+    fn trusted_connector(
+        cert: rustls::pki_types::CertificateDer<'static>,
+        store: &Arc<TicketStore>,
+    ) -> tokio_rustls::TlsConnector {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert).unwrap();
+        let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+        config.resumption = rustls::client::Resumption::store(store.clone());
+        tokio_rustls::TlsConnector::from(Arc::new(config))
+    }
+
+    async fn tls_dial(
+        listener: &tokio::net::TcpListener,
+        server_config: &Arc<rustls::ServerConfig>,
+        factory: &TokioWebSocketTransportFactory,
+        store: &TicketStore,
+        expected_target: &str,
+    ) -> rustls::HandshakeKind {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let server = async {
+                let (tcp, _) = listener.accept().await.unwrap();
+                let tls = tokio_rustls::TlsAcceptor::from(server_config.clone())
+                    .accept(tcp)
+                    .await
+                    .unwrap();
+                assert_eq!(tls.get_ref().1.server_name(), None);
+                let kind = tls.get_ref().1.handshake_kind().unwrap();
+                let (request, mut ws) = tokio_websockets::ServerBuilder::new()
+                    .accept(tls)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    request.uri().path_and_query().unwrap().as_str(),
+                    expected_target
+                );
+                assert_eq!(request.headers()[http::header::ORIGIN], WHATSAPP_WEB_ORIGIN);
+                assert!(ws.next().await.unwrap().unwrap().is_close());
+                kind
+            };
+            let client = async {
+                let (transport, events) = factory.create_transport().await.unwrap();
+                assert!(matches!(
+                    events.recv().await.unwrap(),
+                    TransportEvent::Connected
+                ));
+                // A completed handshake alone does not mean the client has read its ticket.
+                store.received.acquire().await.unwrap().forget();
+                transport.disconnect().await;
+                assert!(matches!(
+                    events.recv().await.unwrap(),
+                    TransportEvent::Disconnected(_)
+                ));
+            };
+            let (kind, ()) = tokio::join!(server, client);
+            kind
+        })
+        .await
+        .expect("local TLS dial timed out")
+    }
+
+    #[tokio::test]
+    async fn shared_factories_retain_tls_sessions_across_ed_and_ports() {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let (server_config, cert) = tls_server_config("127.0.0.1");
+            let first = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let second = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let store = TicketStore::new();
+            let tls = trusted_connector(cert.clone(), &store);
+            let make_factory = |port, target: &str, tls: tokio_rustls::TlsConnector| {
+                TokioWebSocketTransportFactory::new()
+                    .with_url(format!("wss://127.0.0.1:{port}{target}"))
+                    .with_connector(Connector::Rustls(tls))
+            };
+            let a = make_factory(
+                first.local_addr().unwrap().port(),
+                "/ws/chat?ED=AQ==",
+                tls.clone(),
+            );
+            let b = make_factory(
+                second.local_addr().unwrap().port(),
+                "/ws/chat?ED=Ag==",
+                tls.clone(),
+            );
+            assert!(Arc::ptr_eq(
+                rustls_config(a.connector.as_ref().unwrap()),
+                rustls_config(b.connector.as_ref().unwrap())
+            ));
+            assert_eq!(
+                tls_dial(&first, &server_config, &a, &store, "/ws/chat?ED=AQ==").await,
+                rustls::HandshakeKind::Full
+            );
+            assert_eq!(
+                tls_dial(&first, &server_config, &a, &store, "/ws/chat?ED=AQ==").await,
+                rustls::HandshakeKind::Resumed
+            );
+            drop(a);
+            assert_eq!(
+                tls_dial(&second, &server_config, &b, &store, "/ws/chat?ED=Ag==").await,
+                rustls::HandshakeKind::Resumed
+            );
+            assert!(b.default_connector.get().is_none());
+
+            let isolated_store = TicketStore::new();
+            let isolated_tls = trusted_connector(cert, &isolated_store);
+            assert!(!Arc::ptr_eq(tls.config(), isolated_tls.config()));
+            let isolated = make_factory(
+                second.local_addr().unwrap().port(),
+                "/ws/chat?ED=Aw==",
+                isolated_tls,
+            );
+            assert_eq!(
+                tls_dial(
+                    &second,
+                    &server_config,
+                    &isolated,
+                    &isolated_store,
+                    "/ws/chat?ED=Aw=="
+                )
+                .await,
+                rustls::HandshakeKind::Full
+            );
+            assert_eq!(
+                tls_dial(&second, &server_config, &b, &store, "/ws/chat?ED=Ag==").await,
+                rustls::HandshakeKind::Resumed
+            );
+        })
+        .await
+        .expect("shared TLS factory test timed out");
+    }
+
+    #[tokio::test]
+    async fn tls_rejects_untrusted_certificates_and_wrong_server_names() {
+        let (server_config, cert) = tls_server_config("localhost");
+        let unrelated_key = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::new(vec!["unrelated.invalid".into()]).unwrap();
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "Unrelated test root");
+        let unrelated_cert = params.self_signed(&unrelated_key).unwrap().der().clone();
+        for (root, expected_error) in [
+            (unrelated_cert, "UnknownIssuer"),
+            (cert, "certificate not valid for name"),
+        ] {
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let factory = TokioWebSocketTransportFactory::new()
+                    .with_url(format!(
+                        "wss://127.0.0.1:{}/ws/chat",
+                        listener.local_addr().unwrap().port()
+                    ))
+                    .with_connector(Connector::Rustls(trusted_connector(
+                        root,
+                        &TicketStore::new(),
+                    )));
+                let server = async {
+                    let (tcp, _) = listener.accept().await.unwrap();
+                    assert!(
+                        tokio_rustls::TlsAcceptor::from(server_config.clone())
+                            .accept(tcp)
+                            .await
+                            .is_err()
+                    );
+                };
+                let client = async {
+                    let error = match factory.create_transport().await {
+                        Ok(_) => panic!("invalid TLS peer was accepted"),
+                        Err(error) => error,
+                    };
+                    assert!(error.to_string().contains(expected_error), "{error}");
+                };
+                tokio::join!(server, client);
+            })
+            .await
+            .expect("local TLS rejection timed out");
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_rustls_connector_sends_dns_sni_and_checks_hostname() {
+        let (server_config, cert) = tls_server_config("localhost");
+        let connector = trusted_connector(cert, &TicketStore::new());
+        assert!(connector.config().enable_sni);
+        for name in ["localhost", "wrong.invalid"] {
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let addr = listener.local_addr().unwrap();
+                // DNS names go only to rustls, never to the socket resolver or factory.
+                let server = async {
+                    let (tcp, _) = listener.accept().await.unwrap();
+                    tokio_rustls::TlsAcceptor::from(server_config.clone())
+                        .accept(tcp)
+                        .await
+                };
+                let client = async {
+                    let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+                    connector
+                        .connect(rustls::pki_types::ServerName::try_from(name).unwrap(), tcp)
+                        .await
+                };
+                let (server, client) = tokio::join!(server, client);
+                if name == "localhost" {
+                    assert_eq!(server.unwrap().get_ref().1.server_name(), Some(name));
+                    assert!(client.is_ok());
+                } else {
+                    assert!(server.is_err());
+                    let error = match client {
+                        Ok(_) => panic!("wrong DNS name was accepted"),
+                        Err(error) => error,
+                    };
+                    assert!(
+                        error.to_string().contains("certificate not valid for name"),
+                        "{error}"
+                    );
+                }
+            })
+            .await
+            .expect("direct rustls DNS-name test timed out");
+        }
     }
 
     /// The retained default must stay unbuilt when the caller supplied one:
     /// building it anyway would pay for a TLS config nothing ever dials with.
     #[tokio::test]
     async fn a_custom_connector_leaves_the_default_unbuilt() {
-        let factory = TokioWebSocketTransportFactory::new()
-            .with_url("ws://127.0.0.1:1/ws/chat")
-            .with_connector(default_tls_connector());
+        let mut factory =
+            TokioWebSocketTransportFactory::new().with_connector(default_tls_connector());
 
-        attempt_dial(&factory).await;
+        attempt_dial(&mut factory).await;
 
         assert!(
             factory.default_connector.get().is_none(),

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -21,14 +21,23 @@ pub const WHATSAPP_WEB_WS_URL_FALLBACK: &str = "wss://web.whatsapp.com:5222/ws/c
 /// Both chat endpoints WA Web dials, primary first.
 pub const WHATSAPP_WEB_WS_URLS: [&str; 2] = [WHATSAPP_WEB_WS_URL, WHATSAPP_WEB_WS_URL_FALLBACK];
 
-/// Appends WA Web's `?ED=` edge-routing query parameter to a chat URL.
+/// Appends an `ED` edge-routing query parameter to a chat URL.
 ///
-/// The value is the same `edge_routing_info` the handshake already sends as
-/// the binary `ED` pre-intro, here base64url-encoded exactly like WA Web's
-/// `encodeB64UrlSafe` (URL-safe alphabet, padding kept). Both dial URLs carry
-/// it. Returns `url` unchanged when routing is absent, empty, or oversize, the
-/// same omit rules as `build_handshake_header`: a missing query never fails a
-/// handshake, the pre-intro still carries the bytes.
+/// Encodes the raw routing bytes, not the binary pre-intro header. This helper
+/// retains its padded base64url output contract. Captured WA Web instead calls
+/// `encodeB64UrlSafe` without the padding flag and emits unpadded base64url.
+/// Callers must apply this helper to each dial URL; it does not configure dials.
+///
+/// Returns `url` unchanged when routing is absent, empty, or longer than
+/// [`wacore_noise::MAX_EDGE_ROUTING_LEN`], including any existing `ED` parameters.
+/// The binary [`wacore_noise::build_handshake_header`] also omits absent or
+/// oversized routing, but emits a zero-length pre-intro for `Some(&[])`.
+///
+/// This is an append-only string helper, not a URL or request validator. It adds
+/// `?ED=` or `&ED=` before the first `#fragment`, preserving existing query text
+/// and fragments without normalization or percent-decoding. Existing `ED`
+/// parameters are neither replaced nor deduplicated. Request parsing, duplicate
+/// rejection, and HTTP size limits belong to the caller.
 pub fn with_edge_routing_param(url: &str, edge_routing_info: Option<&[u8]>) -> String {
     let Some(info) = edge_routing_info else {
         return url.to_string();
@@ -855,39 +864,76 @@ mod racing_tests {
 
     #[test]
     fn edge_routing_param_absent_or_empty_leaves_url_untouched() {
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, None),
-            WHATSAPP_WEB_WS_URL
-        );
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[])),
-            WHATSAPP_WEB_WS_URL
-        );
+        for url in [
+            WHATSAPP_WEB_WS_URL,
+            "wss://example.invalid/ws/chat?ED=%ZZ&ED=#frag",
+        ] {
+            assert_eq!(with_edge_routing_param(url, None), url);
+            assert_eq!(with_edge_routing_param(url, Some(&[])), url);
+        }
+
+        let (header, used) = wacore_noise::build_handshake_header(Some(&[]));
+        assert!(used);
+        assert_eq!(&header[..7], b"ED\x00\x01\x00\x00\x00");
+        assert_eq!(&header[7..], &wacore_binary::consts::WA_CONN_HEADER);
     }
 
     #[test]
-    fn edge_routing_param_encodes_like_wa_web() {
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0x01, 0x02, 0x03])),
-            format!("{WHATSAPP_WEB_WS_URL}?ED=AQID")
-        );
-        // WA Web's urlSafeBase64 swaps the alphabet but never strips `=`.
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0x01, 0x02])),
-            format!("{WHATSAPP_WEB_WS_URL}?ED=AQI=")
-        );
-        // `+`/`/` become `-`/`_`.
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0xFB, 0xFF])),
-            format!("{WHATSAPP_WEB_WS_URL}?ED=-_8=")
-        );
-        let url = with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&[0xDE, 0xAD, 0xBE, 0xEF]));
-        let encoded = url.split("?ED=").nth(1).expect("query is present");
+    fn edge_routing_param_retains_padding_unlike_captured_wa_web() {
         use base64::Engine as _;
-        let decoded = base64::engine::general_purpose::URL_SAFE
-            .decode(encoded)
-            .expect("valid base64url");
-        assert_eq!(decoded, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+
+        // Synthetic literals verified by executing WABase64 from official WA
+        // 2.3000.1044770897, bundle content SHA-256
+        // 4de5ec27b53a202be96d64493441fe6aed113d6e35e5745e61d1f32a3341a30a.
+        for (bytes, captured_unpadded, retained_padded) in [
+            (&[0x01][..], "AQ", "AQ=="),
+            (&[0x01, 0x02][..], "AQI", "AQI="),
+            (&[0x01, 0x02, 0x03][..], "AQID", "AQID"),
+            (&[0xFB, 0xFF][..], "-_8", "-_8="),
+            (&[0xDE, 0xAD, 0xBE, 0xEF][..], "3q2-7w", "3q2-7w=="),
+        ] {
+            let url = with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(bytes));
+            assert_eq!(url, format!("{WHATSAPP_WEB_WS_URL}?ED={retained_padded}"));
+            let (_, encoded) = url.split_once("?ED=").expect("query is present");
+            assert_eq!(encoded.trim_end_matches('='), captured_unpadded);
+            assert_eq!(URL_SAFE.decode(encoded).expect("valid base64url"), bytes);
+            assert_eq!(
+                URL_SAFE_NO_PAD
+                    .decode(captured_unpadded)
+                    .expect("valid captured base64url"),
+                bytes
+            );
+        }
+    }
+
+    #[test]
+    fn edge_routing_param_appends_without_validating_or_normalizing() {
+        for (url, expected) in [
+            (
+                "wss://example.invalid/ws/chat?x=1",
+                "wss://example.invalid/ws/chat?x=1&ED=AQ==",
+            ),
+            (
+                "wss://example.invalid/ws/chat?ED=old",
+                "wss://example.invalid/ws/chat?ED=old&ED=AQ==",
+            ),
+            (
+                "wss://example.invalid/ws/chat?ED=&ED=%ZZ#frag",
+                "wss://example.invalid/ws/chat?ED=&ED=%ZZ&ED=AQ==#frag",
+            ),
+            (
+                "wss://example.invalid/ws/chat?",
+                "wss://example.invalid/ws/chat?&ED=AQ==",
+            ),
+            (
+                "wss://example.invalid/ws/chat?x=1&",
+                "wss://example.invalid/ws/chat?x=1&&ED=AQ==",
+            ),
+            ("not a URL?%45D=AQ%3D%3D", "not a URL?%45D=AQ%3D%3D&ED=AQ=="),
+        ] {
+            assert_eq!(with_edge_routing_param(url, Some(&[0x01])), expected);
+        }
     }
 
     #[test]
@@ -900,15 +946,25 @@ mod racing_tests {
             with_edge_routing_param("wss://example.invalid/ws/chat?x=1#frag", Some(&[0x01])),
             "wss://example.invalid/ws/chat?x=1&ED=AQ==#frag"
         );
+        assert_eq!(
+            with_edge_routing_param("wss://example.invalid/ws/chat#?ED=old#", Some(&[0x01])),
+            "wss://example.invalid/ws/chat?ED=AQ==#?ED=old#"
+        );
+        assert_eq!(
+            with_edge_routing_param("wss://example.invalid/ws/chat#", Some(&[0x01])),
+            "wss://example.invalid/ws/chat?ED=AQ==#"
+        );
     }
 
     #[test]
     fn edge_routing_param_oversize_keeps_previous_behavior() {
         let oversize = vec![0x00u8; wacore_noise::MAX_EDGE_ROUTING_LEN + 1];
-        assert_eq!(
-            with_edge_routing_param(WHATSAPP_WEB_WS_URL, Some(&oversize)),
-            WHATSAPP_WEB_WS_URL
-        );
+        for url in [
+            WHATSAPP_WEB_WS_URL,
+            "wss://example.invalid/ws/chat?ED=%ZZ&ED=#frag",
+        ] {
+            assert_eq!(with_edge_routing_param(url, Some(&oversize)), url);
+        }
     }
 
     #[test]

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 
 /// A runtime-agnostic abstraction over async executor capabilities.
 ///
-/// On native targets, futures must be `Send` (multi-threaded executors).
+/// On native targets, futures must be `Send`, even on single-threaded executors.
 /// On wasm32, `Send` is dropped (single-threaded).
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
@@ -32,13 +32,12 @@ pub trait Runtime: Send + Sync + 'static {
     /// Cooperatively yield, allowing other tasks and I/O to make progress.
     ///
     /// Use this in tight async loops that process many items to avoid
-    /// starving other work. Returns `None` if yielding is unnecessary
-    /// (e.g. multi-threaded runtimes where other tasks run on separate
-    /// threads), or `Some(future)` that the caller must `.await` to
-    /// actually yield.
+    /// starving other work. Returns `Some(future)` that the caller must `.await`
+    /// to yield, or `None` if the implementation provides no yield at this point.
     ///
-    /// Returning `None` avoids any allocation or async overhead, making
-    /// the call zero-cost on runtimes that don't need cooperative yielding.
+    /// `None` introduces no scheduling point and does not promise fairness.
+    /// Multi-threaded executors also need tasks to return from each poll;
+    /// multiple workers alone do not make cooperative yielding unnecessary.
     fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>>;
 
     /// How often to yield in tight loops (every N items). Defaults to 10.
@@ -64,8 +63,9 @@ pub trait Runtime: Send + Sync + 'static {
 
     /// Cooperatively yield, allowing other tasks and I/O to make progress.
     ///
-    /// Returns `None` if yielding is unnecessary, or `Some(future)` that
-    /// the caller must `.await` to actually yield.
+    /// Returns `Some(future)` that the caller must `.await` to yield, or `None`
+    /// if the implementation provides no yield at this point. `None` introduces
+    /// no scheduling point and does not promise fairness.
     fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()>>>>;
 
     /// How often to yield in tight loops (every N items). Defaults to 10.
@@ -136,9 +136,9 @@ impl AbortHandle {
 
     /// Detach the handle so the task is NOT aborted on drop.
     ///
-    /// The spawned task will run until completion even if the parent scope
-    /// is dropped. Use this for fire-and-forget tasks where cancellation
-    /// is not desired.
+    /// The task may outlive the parent scope. This does not guarantee completion
+    /// across executor shutdown. Use this for fire-and-forget tasks where
+    /// cancellation on handle drop is not desired.
     pub fn detach(self) {
         *self.abort_fn.lock().unwrap_or_else(|e| e.into_inner()) = None;
     }
@@ -303,8 +303,10 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the runtime drops the spawned task before it completes
-/// (e.g. during runtime shutdown).
+/// Panics if the closure panics or the runtime drops the spawned task before
+/// it delivers a result, such as during shutdown. If the runtime catches the
+/// closure's panic, this helper raises a new panic for the missing result
+/// rather than resuming the original panic payload.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn blocking<T: Send + 'static>(
     rt: &dyn Runtime,


### PR DESCRIPTION
## Summary
Fix the single-host rustls cache and document the existing runtime, ED and connector contracts. No new crate or public API.

## Evidence/Design
The pinned rustls 0.23.43 converts an eight-ticket budget to a one-entry server-name queue, then evicts when insertion reaches capacity. Independent probes retained state in 0/100 caches with budget eight and 100/100 with sixteen. The corrected budget retains one name, still allowing eight TLS 1.3 tickets per name.

Queried the pinned whatspec IR first, then executed modules directly from the official .wa-cache bundles for WA 2.3000.1044770897. All 504 bundle hashes and sizes matched the manifest. The official ED query is unpadded; Rust retains its existing padded output. Empty and oversized routing also have documented differences. This is not a claim of complete wire parity or live-server acceptance.

The audit and source hashes are in agent_docs/transport_reuse_audit.md.

## Changes
- Correct the session cache budget and test actual local TLS 1.3 resumption after ticket receipt.
- Test shared factories across ED queries and ports, independent configurations, certificate rejection, IP-name verification and direct rustls DNS SNI.
- Document connector sharing with a compiling public example. No global cache.
- Document the existing Tokio adapter, cancellation, detach, blocking, panic and no-op yield behavior.
- Correct ED documentation and add independent vectors and append-only URL tests without adding HTTP parsing.
- Remove the complete URL from the dial debug log.
- Mark historical TLS memory figures as unmeasured for the corrected warm cache.
- Reconcile the baseline rtc-shared lock entry with the existing beta.2 manifest pin for locked builds.

## Cost
No production dependency, runtime relocation or parsing dependency. rcgen was already locked and is added only as a transport dev dependency; WebSocket server support is test-only. The fixed cache now retains state previously discarded. No memory reduction, latency gain or WhatsApp resumption rate is claimed. Configuration identity tests are not allocator measurements.

## Checked and not changed
Existing runtime exports remain. Core normal/build dependencies remain Tokio-free. Existing ED padding, omission and URL append behavior remain. Request parsing and a 4 KiB HTTP policy stay with integrators. Noise, framing, pairing, reconnect, storage, proxy authentication and the dial race are unchanged. No API breaks or migrations.

## Validation
- cargo fmt --all and workspace all-target clippy with warnings denied passed.
- wacore and whatsapp-rust library suites passed 3,643 tests, with three existing skips.
- Transport passed 12 tests, one doctest and 240 stress executions without retries.
- Runtime-only public doctest and external current-thread/multi-thread probes passed.
- Core no-default doctests passed three examples; 11 existing examples remain ignored.
- Workflow wasm release builds passed for main without defaults, core voip/js and main voip-mlow. Two existing unused-qualification warnings remain in main.
- An initial online_device_sync_releases_its_dedup_entry failure reproduced unchanged on baseline iteration 729/1,000. The final rebuilt patch suite passed; no test was relaxed.
- TLS tests use trusted synthetic certificates, IPv4 loopback, ticket events and deadlines. No arbitrary sleeps, network service or verification bypass.
- No E2E or live WhatsApp acceptance run. Initial audit baseline is 47e1b5b41b63c23b59372828901ea945c8149565.