### PR TITLE
feat(voip): expose ordered peer video events and a real call fixture

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -48,6 +48,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
+      # The host test invokes rustc for WASM cfg checks; do not cross-compile the test itself.
+      - name: Run native fixture cfg probe
+        run: cargo test -p whatsapp-rust --test native_test_support_cfg -- --ignored
       # Mirrors how whatsapp-rust-bridge consumes the crate: lib only (the
       # binary pulls tokio/sqlite), no default features. Guards against code
       # reachable from wasm regressing on tokio/std-only APIs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,8 @@ tracing-pii = ["wacore/tracing-pii", "wacore-binary/tracing-pii"]
 # target, which links the crate from outside, can reach the crate-private send
 # internals it measures. Never enable it in a shipping build.
 bench-harness = ["tokio-runtime", "tokio/rt-multi-thread"]
+# Native integration fixtures only. Never enable in a shipping dependency.
+test-support = ["voip-runtime", "tokio-runtime", "dep:wacore-noise", "wacore-noise/test-util"]
 danger-skip-tls-verify = ["whatsapp-rust-tokio-transport?/danger-skip-tls-verify"]
 default = [
     "sqlite-storage",
@@ -292,6 +294,7 @@ tokio = { workspace = true, features = ["macros", "rt", "sync", "time"], optiona
 tracing = { workspace = true, optional = true }
 wacore = { workspace = true }
 wacore-binary = { workspace = true }
+wacore-noise = { path = "./wacore/noise", version = "0.7.0", optional = true }
 waproto = { workspace = true }
 zeroize = { workspace = true }
 whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true }

--- a/agent_docs/call_test_support.md
+++ b/agent_docs/call_test_support.md
@@ -1,0 +1,143 @@
+# Native call test support
+
+Enable `test-support` only for native development dependencies. The feature is
+off by default and the fixture module does not compile on wasm. It uses the
+existing `InMemoryBackend`, Tokio runtime and Noise certificate test utility.
+It does not import the root `test_utils` module or require SQLite, a WebSocket
+client, HTTP access, or native media transport.
+
+```toml
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+whatsapp-rust = { workspace = true, features = ["test-support"] }
+```
+
+The workspace dependency must already point at a revision containing this
+feature. Use the same git source and branch for the WhatsApp workspace crates;
+do not introduce a second copy just for the fixture.
+
+## Public API
+
+`whatsapp_rust::test_support::CallFixture` is the native fixture.
+
+- `new().await` completes production Noise XX, login and empty offline delivery.
+  It waits on the production readiness notification. There are no readiness
+  stores or setters in the fixture.
+- `client()` returns the real `Arc<Client>`. Use its normal outgoing builder,
+  event subscriptions and `CallHandle` methods.
+- `peer()` names the fictitious recipient. Its primary device 0 and companion
+  device 2 have seeded device records and Signal sessions.
+- `next_offer().await` returns `PendingOffer` at transport entry. Its `stanza()`
+  contains the actual production video advertisement and encrypted per-device
+  destinations. `complete()` releases send completion; `fail()` or dropping it
+  fails the send. None of these operations acknowledges the offer.
+- `inject(Node).await` marshals a stanza and runs production `process_node`,
+  routing and handlers. It returns after handling and synchronous sends, not
+  merely after queueing. A malformed stanza can be ignored by the real handler;
+  returning `Ok` does not certify that the handler accepted its action.
+- `call_snapshot(id)` reads a detached production session snapshot. This can
+  observe winner selection while the outgoing builder is still blocked. It
+  cannot mutate the live registry.
+- `outgoing_stanzas()` returns decoded stanzas in transport-entry order, not a
+  claim that pending sends completed. `events()` returns production event-bus
+  events. Both report observation overflow rather than silently truncating.
+- `shutdown().await` disconnects the real client and joins its reader. Dropping
+  the fixture signals shutdown and lets the reader perform production cleanup.
+
+There is no fabricated `OutgoingReady`, winner setter or event sender. Subscribe
+through `client().subscribe_handler(...)` for callbacks. For the complete inbound
+accept advertisement, hold `client().acquire_raw_node_forwarding()` and inspect
+`Event::RawNode`; `Event::IncomingCall` is the production parsed representation.
+
+## Example
+
+```rust
+use std::sync::Arc;
+use whatsapp_rust::test_support::CallFixture;
+use wacore_binary::builder::NodeBuilder;
+
+# async fn example() -> anyhow::Result<()> {
+let fixture = Arc::new(CallFixture::new().await?);
+let client = fixture.client().clone();
+let peer = fixture.peer().clone();
+let (_mic_tx, mic_rx) = async_channel::bounded::<Vec<i16>>(1);
+let (speaker_tx, _speaker_rx) = async_channel::bounded::<Vec<i16>>(1);
+let (_video_tx, video_rx) = async_channel::bounded::<Vec<u8>>(1);
+let (sink_tx, _sink_rx) = async_channel::bounded::<wacore::voip::VideoFrame>(1);
+let starting = tokio::spawn(async move {
+    client.voip().call(&peer)
+        .audio(mic_rx, speaker_tx)
+        .video(video_rx, sink_tx)
+        .start().await
+});
+
+let offer = fixture.next_offer().await?;
+assert!(!starting.is_finished());
+// Inspect offer.stanza() here. The production send is still pending.
+offer.complete()?;
+let handle = starting.await??;
+assert_eq!(handle.peer_jid(), *fixture.peer());
+
+let winner = fixture.peer().clone().with_device(2);
+fixture.inject(NodeBuilder::new("call")
+    .attr("from", winner.clone())
+    .attr("id", "SYNTHETIC-ACCEPT")
+    .attr("t", "1788840000")
+    .children([NodeBuilder::new("accept")
+        .attr("call-id", handle.call_id())
+        .attr("call-creator", fixture.client().lid().unwrap())
+        .children([
+            NodeBuilder::new("audio").attr("enc", "opus").attr("rate", "16000").build(),
+            NodeBuilder::new("video").attr("dec", "H264").attr("device_orientation", "0").build(),
+        ]).build()])
+    .build()).await?;
+assert_eq!(handle.peer_jid(), winner);
+fixture.shutdown().await?;
+# Ok(())
+# }
+```
+
+For acceptance before the builder returns, keep `PendingOffer` outstanding,
+spawn `inject` separately, and wait until `call_snapshot(id).answering_device`
+shows the handler's selection. Sibling dismissal blocks behind the pending
+offer send. Complete the offer, then await both futures. The external test
+`accept_before_builder_completion_selects_winner_through_handler` demonstrates
+this ordering without a sleep or a readiness setter.
+
+## Coverage boundaries
+
+The synthetic server performs real Noise key agreement and authenticates
+outgoing encrypted frames. Its certificates and ADV identity are synthetic;
+the fixture uses the existing per-client certificate-signature bypass, never
+the production default. Seeded Signal peers are not remote WhatsApp receivers.
+The fixture proves builder/handler behavior, not peer decryption or protocol
+equivalence.
+
+Explicit stanza injection bypasses inbound Noise framing but not the parser or
+handler. The normal reader runs for login IQ replies and the offline marker.
+Only the active-mode IQ gets a successful synthetic response; unsupported IQs
+get an explicit 503. HTTP is refused. Media is dormant because no offer ACK is
+generated; an installed refusing relay provider also prevents accidental real
+networking when native media features are enabled. To test media, install your
+own synthetic `RelayTransportProvider` before injecting a relay-bearing ACK.
+
+The fixture deliberately preserves the base revision's weak direct-call policy.
+An unrung device can become the first winner. A later non-busy sibling reject
+can terminate the winning call. A busy reject leaves the call ringing, and the
+first accept dismisses the other device with `accepted_elsewhere`. A late
+accept does not replace the selected winner. The tests characterize these
+behaviors; they do not declare them secure or add filtering to hide them.
+
+## Verification
+
+```sh
+cargo test -p whatsapp-rust --no-default-features --features test-support --test voip_call_fixture
+cargo clippy -p whatsapp-rust --no-default-features --features test-support --test voip_call_fixture -- -D warnings
+cargo check -p whatsapp-rust --no-default-features --features test-support --lib
+cargo check -p whatsapp-rust --no-default-features --lib
+cargo test -p whatsapp-rust --features voip-mlow,test-support --lib voip::facade::tests
+cargo fmt --all -- --check
+```
+
+The existing CI shareable-feature task includes new features automatically and
+runs both library and integration tests. No workflow-specific allowlist is
+needed for this fixture.

--- a/agent_docs/call_test_support.md
+++ b/agent_docs/call_test_support.md
@@ -6,6 +6,11 @@ existing `InMemoryBackend`, Tokio runtime and Noise certificate test utility.
 It does not import the root `test_utils` module or require SQLite, a WebSocket
 client, HTTP access, or native media transport.
 
+The native target guard also applies when `cfg(test)` is set. The shared
+session helper, its test-utils delegate, and the native caller suites are
+excluded together, so WASM tests cannot pull in blocking session setup through
+the test-only path.
+
 ```toml
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 whatsapp-rust = { workspace = true, features = ["test-support"] }
@@ -42,6 +47,14 @@ do not introduce a second copy just for the fixture.
   events. Both report observation overflow rather than silently truncating.
 - `shutdown().await` disconnects the real client and joins its reader. Dropping
   the fixture signals shutdown and lets the reader perform production cleanup.
+
+Before construction succeeds, an abort-on-drop guard owns the reader. If
+`Client::connect` fails, `new` joins that reader and returns its original typed
+error rather than the readiness channel's closure. Constructor deadlines abort
+and join the reader; cancellation aborts it when the constructor future drops.
+Only successful construction transfers reader ownership to the fixture's
+graceful teardown path. `shutdown` also guards a reader taken out for joining,
+so a cancelled or timed-out join cannot leave it running detached.
 
 There is no fabricated `OutgoingReady`, winner setter or event sender. Subscribe
 through `client().subscribe_handler(...)` for callbacks. For the complete inbound
@@ -191,9 +204,20 @@ cargo clippy -p whatsapp-rust --no-default-features --features test-support --te
 cargo check -p whatsapp-rust --no-default-features --features test-support --lib
 cargo check -p whatsapp-rust --no-default-features --lib
 cargo test -p whatsapp-rust --features voip-mlow,test-support --lib voip::facade::tests
+cargo test -p whatsapp-rust --features test-support --lib test_support::call::tests
+cargo test -p whatsapp-rust --test native_test_support_cfg -- --ignored
 cargo fmt --all -- --check
 ```
 
 The existing CI shareable-feature task includes new features automatically and
 runs both library and integration tests. No workflow-specific allowlist is
 needed for this fixture.
+
+The explicit cfg probe requires an installed `wasm32-unknown-unknown` target.
+It extracts the actual fixture/helper/caller guards with `syn` and compiles
+them with rustc on WASM for all four combinations of test and test-support
+cfgs. A native positive control proves every checked path remains enabled.
+This probe checks exclusion, not the complete root unit-test dependency graph.
+The latter still enables Tokio's `full` dev feature and fails in `mio` on
+`wasm32-unknown-unknown` before the root tests compile. Production WASM checks
+with and without `test-support` do not have that dev-dependency limitation.

--- a/agent_docs/call_test_support.md
+++ b/agent_docs/call_test_support.md
@@ -105,6 +105,62 @@ this ordering without a sleep or a readiness setter.
 
 ## Coverage boundaries
 
+### Ordered peer video events
+
+The production `whatsapp_rust::voip::CallEvent::PeerVideoStateChanged` variant
+is available with `voip-runtime`, including on wasm. It does not require the
+native `test-support` feature. Its fields are:
+
+```text
+source: Jid
+call_creator: Jid
+state: VideoState
+orientation: Option<u8>
+upgrade_token: Option<VideoUpgradeToken>
+```
+
+Consume this variant from one `CallHandle::events()` receiver for all peer
+video states, including upgrade requests, accepts and stops. Pass its token to
+`accept_video` when accepting a request. Do not join a separate global
+`IncomingCall` stream to recover identity or update the same state from that
+stream; the two consumers can run in a different order.
+
+The source-bearing event is published after the existing typed-ACK and state
+commit checks, while holding the existing video-transition lock. Direct calls
+then publish the unchanged legacy `VideoStateChanged` on that same queue with
+identical state, orientation and token. New consumers must ignore the legacy
+companion; existing consumers can keep matching the legacy variant and ignore
+unknown variants. The old variant's fields and token type are unchanged.
+
+`source` is the parsed `participant` when present, otherwise `from`. It is not
+replaced with the stored winning device. `call_creator` is the incoming value,
+not an inference from the matched call ID. Group PN aliases remain PN aliases
+in the event, while the existing orientation path still canonicalizes them for
+the media registry. Groups publish only the new participant-scoped variant,
+with no upgrade token, after the existing post-ACK roster reauthorization.
+They still do not emit call-wide legacy video state or enter direct negotiation.
+
+Neither identity field certifies authorization. The current direct handler can
+apply a sibling's state or a state carrying a different creator, and the event
+reports those inputs faithfully so a consumer can apply its own policy.
+
+The queue keeps its bounded eviction behavior. It is not a lossless history or
+an atomic pair mailbox. Normal handles have room for both variants; a custom
+single-slot core queue retains the legacy event, preserving its old behavior.
+Both JID allocations are included in the existing queue byte accounting.
+
+The fixture regression first failed on the original implementation with four
+states in order but four absent sources. It now checks source B's upgrade
+accept followed by source A's stop, then a request/token from B followed by a
+stop from A. Every direct pair agrees exactly, and the stopped request's token
+is expired. Separate tests cover routed identity, supplied creator, ignored
+states, group aliases, ACK ordering and legacy single-slot behavior.
+
+This changes the in-process event API, not wire signaling, codecs, sender
+matching or authorization. It is not evidence of WhatsApp protocol parity.
+
+### Fixture transport
+
 The synthetic server performs real Noise key agreement and authenticates
 outgoing encrypted frames. Its certificates and ADV identity are synthetic;
 the fixture uses the existing per-client certificate-signature bypass, never

--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -202,7 +202,7 @@ fn log_signal_flush_error(context: &str, id: Option<&str>, e: &SignalMaintenance
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use wacore::store::in_memory::InMemoryBackend;

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -733,6 +733,7 @@ mod tests {
     use wacore_binary::Server;
 
     use crate::lid_pn_cache::LearningSource;
+    #[cfg(not(target_arch = "wasm32"))]
     use crate::test_utils::seed_peer_session;
 
     async fn memory_client() -> (Arc<Client>, Arc<InMemoryBackend>) {
@@ -1293,6 +1294,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn participant_fanout_reuses_durable_session_leases() {
         let (client, backend) = memory_client().await;

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -861,6 +861,19 @@ impl StanzaHandler for CallHandler {
                             // A group participant's `<video>` state describes only that sender.
                             // The authoritative roster owns group media mode; never feed this into
                             // the 1:1 negotiation state machine or tear down the local plane.
+                            if dispatch_call {
+                                registry.send_call_event_if_current(
+                                    call_id,
+                                    generation,
+                                    CallEvent::PeerVideoStateChanged {
+                                        source: sender,
+                                        call_creator: call.action.call_creator().clone(),
+                                        state: *state,
+                                        orientation: *orientation,
+                                        upgrade_token: None,
+                                    },
+                                );
+                            }
                             drop(event_permit);
                             drop(_transition_guard);
                             if dispatch_call {
@@ -995,11 +1008,21 @@ impl StanzaHandler for CallHandler {
                                 );
                             }
                             let event_delivered = event_permit.as_ref().is_some_and(|permit| {
-                                permit.send(CallEvent::VideoStateChanged {
+                                let sourced = permit.send(CallEvent::PeerVideoStateChanged {
+                                    source: routed_call_sender(&call),
+                                    call_creator: call.action.call_creator().clone(),
                                     state: *state,
                                     orientation: *orientation,
                                     upgrade_token,
-                                })
+                                });
+                                // Keep the legacy event last so a custom single-slot queue retains
+                                // its previous behavior. Normal handles have room for both events.
+                                let legacy = permit.send(CallEvent::VideoStateChanged {
+                                    state: *state,
+                                    orientation: *orientation,
+                                    upgrade_token,
+                                });
+                                sourced && legacy
                             });
                             if !event_delivered {
                                 warn!("call: video state event receiver closed after typed ack");
@@ -1560,6 +1583,18 @@ mod tests {
         Jid::new("111111111111111", Server::Lid)
     }
 
+    #[cfg(feature = "voip-runtime")]
+    fn next_legacy_event(
+        events: &async_channel::Receiver<CallEvent>,
+    ) -> Result<CallEvent, async_channel::TryRecvError> {
+        loop {
+            let event = events.try_recv()?;
+            if !matches!(event, CallEvent::PeerVideoStateChanged { .. }) {
+                return Ok(event);
+            }
+        }
+    }
+
     fn offer_stanza() -> wacore_binary::Node {
         NodeBuilder::new("call")
             .attr("from", fake_caller_lid())
@@ -1985,7 +2020,7 @@ mod tests {
         );
         let stanza = NodeBuilder::new("call")
             .attr("from", Jid::new("GROUP-CALL", Server::Call))
-            .attr("participant", participant_pn)
+            .attr("participant", participant_pn.clone())
             .attr("id", "PN-ORIENTATION")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("video")
@@ -2015,8 +2050,13 @@ mod tests {
             "participant signaling must not tear down the local group video plane"
         );
         assert!(
+            matches!(event_rx.try_recv(), Ok(CallEvent::PeerVideoStateChanged {
+            source, call_creator, state: VideoState::Disabled, orientation: Some(3), upgrade_token: None,
+        }) if source == participant_pn && call_creator == fake_caller_lid())
+        );
+        assert!(
             event_rx.try_recv().is_err(),
-            "the 1:1 video event lacks participant identity and must stay unused for group peers"
+            "groups must not emit the call-wide legacy event"
         );
         let controls = std::iter::from_fn(|| control_rx.try_recv().ok()).collect::<Vec<_>>();
         assert!(
@@ -2055,6 +2095,12 @@ mod tests {
                 .await
         );
         let device_controls = std::iter::from_fn(|| control_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(
+            matches!(event_rx.try_recv(), Ok(CallEvent::PeerVideoStateChanged {
+            source, state: VideoState::Disabled, orientation: Some(1), upgrade_token: None, ..
+        }) if source == routed_device)
+        );
+        assert!(event_rx.try_recv().is_err());
         assert!(
             device_controls.iter().any(|control| matches!(
                 control,
@@ -3331,7 +3377,7 @@ mod tests {
             fake_caller_lid(),
             fake_caller_lid(),
         ));
-        let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(1);
+        let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(2);
         let (control_tx, _control_rx) = video_control_channel();
         registry.set_video_channels(
             "CALL-ID-0001",
@@ -3363,6 +3409,12 @@ mod tests {
         };
         assert!(handled);
         assert!(cancelled);
+        assert!(
+            matches!(event_rx.try_recv(), Ok(CallEvent::PeerVideoStateChanged {
+            source, call_creator, state: VideoState::UpgradeRequestV2,
+            upgrade_token: Some(_), ..
+        }) if source == fake_caller_lid() && call_creator == fake_caller_lid())
+        );
         assert!(matches!(
             event_rx.try_recv(),
             Ok(CallEvent::VideoStateChanged { .. })
@@ -3401,7 +3453,7 @@ mod tests {
                 )
                 .await
         );
-        let token = match event_rx.try_recv().expect("upgrade request event") {
+        let token = match next_legacy_event(&event_rx).expect("upgrade request event") {
             CallEvent::VideoStateChanged {
                 state: VideoState::UpgradeRequestV2,
                 upgrade_token: Some(token),
@@ -3423,7 +3475,7 @@ mod tests {
         );
         assert!(!registry.peer_video_request_is_current("CALL-ID-0001", token));
         assert!(matches!(
-            event_rx.try_recv(),
+            next_legacy_event(&event_rx),
             Ok(CallEvent::VideoStateChanged {
                 state: VideoState::Disabled,
                 upgrade_token: None,
@@ -3650,7 +3702,7 @@ mod tests {
                 .await
         );
 
-        let ev = ev_rx.try_recv().expect("event must be forwarded");
+        let ev = next_legacy_event(&ev_rx).expect("event must be forwarded");
         assert!(matches!(
             ev,
             CallEvent::VideoStateChanged {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,5 +408,9 @@ pub mod bench_support;
 #[cfg(test)]
 pub mod test_utils;
 
+#[cfg(any(test, all(feature = "test-support", not(target_arch = "wasm32"))))]
+#[doc(hidden)]
+pub mod test_support;
+
 #[cfg(test)]
 mod reexports_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ pub mod bench_support;
 #[cfg(test)]
 pub mod test_utils;
 
-#[cfg(any(test, all(feature = "test-support", not(target_arch = "wasm32"))))]
+#[cfg(all(not(target_arch = "wasm32"), any(test, feature = "test-support")))]
 #[doc(hidden)]
 pub mod test_support;
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -4621,6 +4621,7 @@ mod tests {
         assert!(client.jids_share_user_identity(&lid, &pn).await.unwrap());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn public_retransmission_recaches_the_supplied_message() {
         let mut config = crate::cache_config::CacheConfig::default();

--- a/src/send/group_repair.rs
+++ b/src/send/group_repair.rs
@@ -697,6 +697,7 @@ mod tests {
         assert!(sent.unchanged_for(&client, "15550000002").await);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn primary_identity_change_is_shared_by_pn_and_lid_aliases() {
         use crate::lid_pn_cache::{LearningSource, LidPnEntry};
@@ -720,6 +721,7 @@ mod tests {
         assert!(sent.unchanged_for(&client, "15550000002").await);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn historical_repair_emits_only_for_a_continuous_account() {
         use crate::store::commands::DeviceCommand;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3265,7 +3265,8 @@ pub(crate) fn dm_stanza_to(recipient_bare: &Jid, to: &Jid) -> Jid {
     }
 }
 
-#[cfg(test)]
+// This suite shares native Tokio/SQLite fixtures and blocking Signal-session setup.
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
@@ -9724,7 +9725,7 @@ mod future_size_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod clock_budget_tests {
     use super::*;
     use crate::store::commands::DeviceCommand;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,10 @@
+//! Opt-in native fixtures. No connection or call readiness flags are exposed.
+#![doc = include_str!("../agent_docs/call_test_support.md")]
+
+mod session;
+pub(crate) use session::seed_peer_session;
+
+#[cfg(all(feature = "test-support", not(target_arch = "wasm32")))]
+mod call;
+#[cfg(all(feature = "test-support", not(target_arch = "wasm32")))]
+pub use call::{CallFixture, PendingOffer};

--- a/src/test_support/call.rs
+++ b/src/test_support/call.rs
@@ -1,0 +1,481 @@
+//! Real client connection and call signaling over a synthetic in-process server.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::oneshot;
+use wacore::handshake::{NoiseCipher, NoiseHandshake};
+use wacore::libsignal::protocol::KeyPair;
+use wacore::store::InMemoryBackend;
+use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+use wacore::types::events::{Event, EventHandler};
+use wacore_binary::consts::{NOISE_PATTERN_XX, WA_CONN_HEADER};
+use wacore_binary::{Jid, Node, OwnedNodeRef, Server, builder::NodeBuilder, marshal};
+
+use crate::Client;
+use crate::client::ClientBuilder;
+use crate::handshake::NoiseCertPolicy;
+use crate::http::{HttpClient, HttpRequest, HttpResponse};
+use crate::runtime_impl::TokioRuntime;
+use crate::store::commands::DeviceCommand;
+use crate::store::persistence_manager::PersistenceManager;
+use crate::transport::{Transport, TransportEvent, TransportFactory};
+use crate::waproto::whatsapp as wa;
+
+const LIMIT: usize = 4096;
+const DEADLINE: Duration = Duration::from_secs(10);
+
+/// An offer observed at transport entry, before its send future completes.
+/// Dropping this value refuses the send. Completing it does not inject an ACK.
+pub struct PendingOffer {
+    node: Node,
+    completion: oneshot::Sender<Result<(), String>>,
+}
+
+impl PendingOffer {
+    /// The actual production offer, including its video advertisement and device destinations.
+    pub fn stanza(&self) -> &Node {
+        &self.node
+    }
+
+    /// Let the production send finish. The real builder can then return its dormant handle.
+    pub fn complete(self) -> Result<()> {
+        self.completion
+            .send(Ok(()))
+            .map_err(|_| anyhow::anyhow!("offer send was cancelled"))
+    }
+
+    /// Fail the production transport send with a synthetic error.
+    pub fn fail(self) -> Result<()> {
+        self.completion
+            .send(Err("fixture refused offer send".into()))
+            .map_err(|_| anyhow::anyhow!("offer send was cancelled"))
+    }
+}
+
+#[derive(Default)]
+struct Events(Mutex<Vec<Arc<Event>>>);
+
+impl EventHandler for Events {
+    fn handle_event(&self, event: Arc<Event>) {
+        let mut events = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        if events.len() <= LIMIT {
+            events.push(event);
+        }
+    }
+}
+
+/// Native, opt-in call fixture with fictitious identities and no network access.
+///
+/// `new` completes production Noise XX, login and the empty offline-delivery phase.
+/// The synthetic server uses the existing per-client certificate-signature bypass.
+/// Calls must be made with `client().voip().call(peer())`, not a fixture readiness setter.
+/// No offer ACK is synthesized, so the resulting handle stays dormant until the test injects one.
+/// Call `shutdown` before dropping the fixture when testing teardown completion.
+pub struct CallFixture {
+    client: Arc<Client>,
+    peer: Jid,
+    transport: Arc<Wire>,
+    offers: async_channel::Receiver<PendingOffer>,
+    events: Arc<Events>,
+    reader: Mutex<Option<tokio::task::JoinHandle<Result<()>>>>,
+}
+
+impl CallFixture {
+    /// Connect a real client to a synthetic server. Requires a running Tokio runtime.
+    pub async fn new() -> Result<Self> {
+        let pm = Arc::new(PersistenceManager::new(Arc::new(InMemoryBackend::new())).await?);
+        let own = Jid::new("111111111111111", Server::Lid).with_device(1);
+        for command in [
+            DeviceCommand::SetId(Some(Jid::new("15550002222", Server::Pn).with_device(1))),
+            DeviceCommand::SetLid(Some(own.clone())),
+            DeviceCommand::SetPushName("Synthetic call fixture".into()),
+            DeviceCommand::SetAccount(Some(wa::ADVSignedDeviceIdentity {
+                details: Some(vec![0; 32]),
+                account_signature_key: Some(vec![0; 32]),
+                account_signature: Some(vec![0; 64]),
+                device_signature: Some(vec![0; 64]),
+            })),
+        ] {
+            pm.process_command(command).await;
+        }
+        let (server_tx, server_rx) = async_channel::bounded(256);
+        let (offer_tx, offers) = async_channel::bounded(16);
+        let transport = Arc::new(Wire {
+            state: Mutex::new(State::Hello),
+            server_tx,
+            server_rx,
+            offers: offer_tx,
+            outgoing: Mutex::new(Vec::new()),
+        });
+        let client = ClientBuilder::new()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(pm)
+            .with_transport_factory(Factory(transport.clone()))
+            .with_http_client(NoHttp)
+            .with_version_override((2, 3000, 0))
+            .with_noise_cert_policy(NoiseCertPolicy::DangerSkipCertChainVerify)
+            .build()
+            .await?
+            .into_client();
+        client.set_relay_transport_provider(Arc::new(NoRelay));
+        let peer = Jid::new("333333333333333", Server::Lid);
+        client
+            .update_device_list(DeviceListRecord {
+                user: Arc::from(peer.user.as_str()),
+                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(2, None)]
+                    .into_boxed_slice(),
+                timestamp: wacore::time::now_utc().timestamp(),
+                phash: None,
+                raw_id: None,
+            })
+            .await?;
+        for device in [0, 2] {
+            super::seed_peer_session(&client, &peer.clone().with_device(device)).await?;
+        }
+        let events = Arc::new(Events::default());
+        client.subscribe_handler(events.clone()).detach();
+        let (connected_tx, connected_rx) = oneshot::channel();
+        let reader = tokio::spawn({
+            let client = client.clone();
+            async move {
+                let connection = client.connect().await?;
+                let _ = connected_tx.send(());
+                connection.read_until_disconnected().await;
+                Ok(())
+            }
+        });
+        let fixture = Self {
+            client,
+            peer,
+            transport,
+            offers,
+            events,
+            reader: Mutex::new(Some(reader)),
+        };
+        tokio::time::timeout(DEADLINE, connected_rx).await??;
+        fixture
+            .inject(NodeBuilder::new("success").attr("lid", own).build())
+            .await?;
+        fixture.client.wait_for_connected(DEADLINE).await?;
+        Ok(fixture)
+    }
+
+    /// The production client. Attach normal event subscriptions or call the normal builder.
+    pub fn client(&self) -> &Arc<Client> {
+        &self.client
+    }
+
+    /// Fictitious peer with seeded primary device 0 and companion device 2.
+    pub fn peer(&self) -> &Jid {
+        &self.peer
+    }
+
+    /// Read the registered production session, including a winner selected before start returns.
+    /// Mutating this detached snapshot cannot change the live call.
+    pub fn call_snapshot(&self, call_id: &str) -> Option<wacore::voip::CallSession> {
+        self.client.call_registry().snapshot(call_id)
+    }
+
+    /// Wait until an actual offer reaches the transport's controlled send boundary.
+    pub async fn next_offer(&self) -> Result<PendingOffer> {
+        Ok(tokio::time::timeout(DEADLINE, self.offers.recv()).await??)
+    }
+
+    /// Marshal and inject a stanza through production `process_node` and its registered handlers.
+    /// Returns after handling, including synchronous sibling dismissal. While an offer send is
+    /// blocked, inject on a separate task if the handler must itself send a stanza.
+    /// This bypasses inbound Noise framing, not parser, routing or winner-selection policy.
+    pub async fn inject(&self, node: Node) -> Result<()> {
+        let packed = marshal(&node)?;
+        let unpacked = wacore_binary::util::unpack(&packed)?;
+        let node = Arc::new(OwnedNodeRef::new(unpacked.into_owned())?);
+        self.client.process_node(node).await;
+        Ok(())
+    }
+
+    /// Decoded outbound stanzas in transport-entry order. A pending offer is not yet completed.
+    pub fn outgoing_stanzas(&self) -> Result<Vec<Node>> {
+        let nodes = self
+            .transport
+            .outgoing
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ensure!(
+            nodes.len() <= LIMIT,
+            "fixture outgoing observation limit exceeded"
+        );
+        Ok(nodes.clone())
+    }
+
+    /// Production event-bus events, including parsed incoming calls. No event injection API exists.
+    pub fn events(&self) -> Result<Vec<Arc<Event>>> {
+        let events = self.events.0.lock().unwrap_or_else(|e| e.into_inner());
+        ensure!(
+            events.len() <= LIMIT,
+            "fixture event observation limit exceeded"
+        );
+        Ok(events.clone())
+    }
+
+    /// End the actual client connection and all registered calls.
+    pub async fn shutdown(&self) -> Result<()> {
+        self.client.disconnect().await;
+        let reader = self.reader.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(reader) = reader {
+            tokio::time::timeout(DEADLINE, reader).await???;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for CallFixture {
+    fn drop(&mut self) {
+        self.client.signal_shutdown_sync();
+        self.transport.server_tx.close();
+        self.offers.close();
+        // Let the production reader run its cleanup; aborting it leaves live call handles behind.
+    }
+}
+
+struct NoHttp;
+#[async_trait]
+impl HttpClient for NoHttp {
+    async fn execute(&self, _: HttpRequest) -> Result<HttpResponse> {
+        anyhow::bail!("call fixture forbids HTTP")
+    }
+}
+
+struct NoRelay;
+#[async_trait]
+impl wacore::voip::RelayTransportProvider for NoRelay {
+    async fn factory(
+        &self,
+        _: &wacore::voip::RelayEndpointParams,
+    ) -> Result<Arc<dyn wacore::voip::RelayTransportFactory>> {
+        anyhow::bail!("call fixture has no media relay; install a synthetic RelayTransportProvider")
+    }
+}
+
+struct Factory(Arc<Wire>);
+#[async_trait]
+impl TransportFactory for Factory {
+    async fn create_transport(
+        &self,
+    ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>)> {
+        Ok((self.0.clone(), self.0.server_rx.clone()))
+    }
+}
+
+enum State {
+    Hello,
+    Finish {
+        noise: Box<NoiseHandshake>,
+        ephemeral: KeyPair,
+    },
+    Established {
+        read: NoiseCipher,
+        write: NoiseCipher,
+        received: u32,
+        sent: u32,
+    },
+    Closed,
+}
+
+struct Wire {
+    state: Mutex<State>,
+    server_tx: async_channel::Sender<TransportEvent>,
+    server_rx: async_channel::Receiver<TransportEvent>,
+    offers: async_channel::Sender<PendingOffer>,
+    outgoing: Mutex<Vec<Node>>,
+}
+
+impl Wire {
+    fn frame(&self, body: &[u8]) -> Result<(Option<Bytes>, Option<Node>)> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        match std::mem::replace(&mut *state, State::Closed) {
+            State::Hello => {
+                let hello = waproto::codec::handshake_message_decode(body)?;
+                let peer: [u8; 32] = hello
+                    .client_hello
+                    .into_option()
+                    .context("client hello")?
+                    .ephemeral
+                    .context("client ephemeral")?
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("ephemeral length"))?;
+                let identity = KeyPair::generate(&mut rand::rng());
+                let ephemeral = KeyPair::generate(&mut rand::rng());
+                let identity_pub: [u8; 32] = identity.public_key.public_key_bytes().try_into()?;
+                let ephemeral_pub = ephemeral.public_key.public_key_bytes();
+                let mut noise = NoiseHandshake::new(NOISE_PATTERN_XX, &WA_CONN_HEADER)?;
+                noise.authenticate(&peer);
+                noise.authenticate(ephemeral_pub);
+                noise.mix_shared_secret(ephemeral.private_key.serialize(), &peer)?;
+                let encrypted_static = noise.encrypt(&identity_pub)?;
+                noise.mix_shared_secret(identity.private_key.serialize(), &peer)?;
+                let payload = noise.encrypt(&wacore_noise::test_util::build_cert_chain_bytes(
+                    &identity_pub,
+                ))?;
+                let response = waproto::codec::handshake_message_to_vec(&wa::HandshakeMessage {
+                    server_hello: buffa::MessageField::some(wa::handshake_message::ServerHello {
+                        ephemeral: Some(ephemeral_pub.to_vec()),
+                        r#static: Some(encrypted_static),
+                        payload: Some(payload),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                });
+                *state = State::Finish {
+                    noise: Box::new(noise),
+                    ephemeral,
+                };
+                Ok((
+                    Some(wacore::framing::encode_frame(&response, None)?.into()),
+                    None,
+                ))
+            }
+            State::Finish {
+                mut noise,
+                ephemeral,
+            } => {
+                let finish = waproto::codec::handshake_message_decode(body)?
+                    .client_finish
+                    .into_option()
+                    .context("client finish")?;
+                let peer: [u8; 32] = noise
+                    .decrypt(&finish.r#static.context("client static")?)?
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("client static length"))?;
+                noise.mix_shared_secret(ephemeral.private_key.serialize(), &peer)?;
+                let _payload = noise.decrypt(&finish.payload.context("client payload")?)?;
+                let (read, write) = noise.finish()?;
+                *state = State::Established {
+                    read,
+                    write,
+                    received: 0,
+                    sent: 0,
+                };
+                Ok((None, None))
+            }
+            State::Established {
+                read,
+                write,
+                received,
+                sent,
+            } => {
+                let mut plain = BytesMut::from(body);
+                read.decrypt_in_place_with_counter(received, &mut plain)?;
+                let unpacked = wacore_binary::util::unpack(&plain)?;
+                let node = OwnedNodeRef::new(unpacked.into_owned())?.get().to_owned();
+                *state = State::Established {
+                    read,
+                    write,
+                    received: received
+                        .checked_add(1)
+                        .context("receive counter exhausted")?,
+                    sent,
+                };
+                Ok((None, Some(node)))
+            }
+            State::Closed => anyhow::bail!("fixture connection closed"),
+        }
+    }
+
+    async fn reply(&self, node: Node) -> Result<()> {
+        let frame = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let State::Established { write, sent, .. } = &mut *state else {
+                anyhow::bail!("fixture handshake not complete");
+            };
+            let encrypted = write.encrypt_with_counter(*sent, &marshal(&node)?)?;
+            *sent = sent.checked_add(1).context("send counter exhausted")?;
+            wacore::framing::encode_frame(&encrypted, None)?
+        };
+        self.server_tx
+            .send(TransportEvent::DataReceived(frame.into()))
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Transport for Wire {
+    async fn send(&self, data: Bytes) -> Result<()> {
+        let hello = matches!(
+            *self.state.lock().unwrap_or_else(|e| e.into_inner()),
+            State::Hello
+        );
+        let mut remaining = if hello {
+            data.strip_prefix(&WA_CONN_HEADER)
+                .context("missing fixture connection header")?
+        } else {
+            &data
+        };
+        while !remaining.is_empty() {
+            ensure!(remaining.len() >= 3, "short fixture frame");
+            let length = (usize::from(remaining[0]) << 16)
+                | (usize::from(remaining[1]) << 8)
+                | usize::from(remaining[2]);
+            ensure!(remaining.len() >= 3 + length, "truncated fixture frame");
+            let (response, node) = self.frame(&remaining[3..3 + length])?;
+            remaining = &remaining[3 + length..];
+            if let Some(response) = response {
+                self.server_tx
+                    .send(TransportEvent::DataReceived(response))
+                    .await?;
+            }
+            let Some(node) = node else {
+                continue;
+            };
+            {
+                let mut outgoing = self.outgoing.lock().unwrap_or_else(|e| e.into_inner());
+                if outgoing.len() <= LIMIT {
+                    outgoing.push(node.clone());
+                }
+                ensure!(
+                    outgoing.len() <= LIMIT,
+                    "fixture outgoing observation limit exceeded"
+                );
+            }
+            let nr = node.as_node_ref();
+            if nr.tag == "call" && nr.get_optional_child("offer").is_some() {
+                let (completion, done) = oneshot::channel();
+                self.offers.send(PendingOffer { node, completion }).await?;
+                done.await
+                    .context("fixture offer was dropped")?
+                    .map_err(anyhow::Error::msg)?;
+            } else if nr.tag == "iq" {
+                let id = nr.attrs().optional_string("id").context("IQ id")?;
+                let active = nr.get_optional_child("active").is_some();
+                let mut reply = NodeBuilder::new("iq")
+                    .attr("id", id.as_ref())
+                    .attr("from", Jid::new("", Server::Pn))
+                    .attr("type", if active { "result" } else { "error" });
+                if !active {
+                    reply = reply.children([NodeBuilder::new("error")
+                        .attr("code", "503")
+                        .attr("text", "unsupported fixture IQ")
+                        .build()]);
+                }
+                self.reply(reply.build()).await?;
+                if active {
+                    self.reply(
+                        NodeBuilder::new("ib")
+                            .children([NodeBuilder::new("offline").attr("count", "0").build()])
+                            .build(),
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn disconnect(&self) {
+        self.server_tx.close();
+    }
+}

--- a/src/test_support/call.rs
+++ b/src/test_support/call.rs
@@ -87,6 +87,10 @@ pub struct CallFixture {
 impl CallFixture {
     /// Connect a real client to a synthetic server. Requires a running Tokio runtime.
     pub async fn new() -> Result<Self> {
+        Self::configured(|builder| builder).await
+    }
+
+    async fn configured(configure: impl FnOnce(ClientBuilder) -> ClientBuilder) -> Result<Self> {
         let pm = Arc::new(PersistenceManager::new(Arc::new(InMemoryBackend::new())).await?);
         let own = Jid::new("111111111111111", Server::Lid).with_device(1);
         for command in [
@@ -111,16 +115,18 @@ impl CallFixture {
             offers: offer_tx,
             outgoing: Mutex::new(Vec::new()),
         });
-        let client = ClientBuilder::new()
-            .with_runtime(TokioRuntime)
-            .with_persistence_manager(pm)
-            .with_transport_factory(Factory(transport.clone()))
-            .with_http_client(NoHttp)
-            .with_version_override((2, 3000, 0))
-            .with_noise_cert_policy(NoiseCertPolicy::DangerSkipCertChainVerify)
-            .build()
-            .await?
-            .into_client();
+        let client = configure(
+            ClientBuilder::new()
+                .with_runtime(TokioRuntime)
+                .with_persistence_manager(pm)
+                .with_transport_factory(Factory(transport.clone()))
+                .with_http_client(NoHttp)
+                .with_version_override((2, 3000, 0))
+                .with_noise_cert_policy(NoiseCertPolicy::DangerSkipCertChainVerify),
+        )
+        .build()
+        .await?
+        .into_client();
         client.set_relay_transport_provider(Arc::new(NoRelay));
         let peer = Jid::new("333333333333333", Server::Lid);
         client
@@ -139,28 +145,57 @@ impl CallFixture {
         let events = Arc::new(Events::default());
         client.subscribe_handler(events.clone()).detach();
         let (connected_tx, connected_rx) = oneshot::channel();
-        let reader = tokio::spawn({
-            let client = client.clone();
-            async move {
-                let connection = client.connect().await?;
-                let _ = connected_tx.send(());
-                connection.read_until_disconnected().await;
-                Ok(())
-            }
-        });
+        let mut reader = scopeguard::guard(
+            tokio::spawn({
+                let client = client.clone();
+                async move {
+                    let connection = client.connect().await?;
+                    let _ = connected_tx.send(());
+                    connection.read_until_disconnected().await;
+                    Ok(())
+                }
+            }),
+            |reader| reader.abort(),
+        );
         let fixture = Self {
             client,
             peer,
             transport,
             offers,
             events,
-            reader: Mutex::new(Some(reader)),
+            reader: Mutex::new(None),
         };
-        tokio::time::timeout(DEADLINE, connected_rx).await??;
-        fixture
-            .inject(NodeBuilder::new("success").attr("lid", own).build())
-            .await?;
-        fixture.client.wait_for_connected(DEADLINE).await?;
+        match tokio::time::timeout(DEADLINE, connected_rx).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                (&mut *reader).await??;
+                anyhow::bail!("fixture connect ended without reporting readiness or an error");
+            }
+            Err(error) => {
+                reader.abort();
+                let _ = (&mut *reader).await;
+                let _ = fixture.shutdown().await;
+                return Err(error.into());
+            }
+        }
+        let ready = async {
+            fixture
+                .inject(NodeBuilder::new("success").attr("lid", own).build())
+                .await?;
+            fixture.client.wait_for_connected(DEADLINE).await?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+        if let Err(error) = ready {
+            reader.abort();
+            let _ = (&mut *reader).await;
+            let _ = fixture.shutdown().await;
+            return Err(error);
+        }
+        // Before publication, cancellation must abort the reader. Afterwards, fixture Drop lets
+        // the reader run production cleanup so existing CallHandles are reaped normally.
+        *fixture.reader.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(scopeguard::ScopeGuard::into_inner(reader));
         Ok(fixture)
     }
 
@@ -226,7 +261,8 @@ impl CallFixture {
         self.client.disconnect().await;
         let reader = self.reader.lock().unwrap_or_else(|e| e.into_inner()).take();
         if let Some(reader) = reader {
-            tokio::time::timeout(DEADLINE, reader).await???;
+            let mut reader = scopeguard::guard(reader, |reader| reader.abort());
+            tokio::time::timeout(DEADLINE, &mut *reader).await???;
         }
         Ok(())
     }
@@ -477,5 +513,114 @@ impl Transport for Wire {
 
     async fn disconnect(&self) {
         self.server_tx.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("synthetic transport connect failure")]
+    struct ConnectFault;
+
+    struct FailingFactory;
+
+    #[async_trait]
+    impl TransportFactory for FailingFactory {
+        async fn create_transport(
+            &self,
+        ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>)> {
+            Err(ConnectFault.into())
+        }
+    }
+
+    #[tokio::test]
+    async fn constructor_preserves_the_real_connect_error() {
+        let error =
+            CallFixture::configured(|builder| builder.with_transport_factory(FailingFactory))
+                .await
+                .err()
+                .expect("the real connect must fail");
+        assert!(
+            matches!(error.downcast_ref::<crate::ConnectError>(),
+            Some(crate::ConnectError::Transport(cause)) if cause.is::<ConnectFault>()),
+            "lost the typed transport cause: {error:#}"
+        );
+    }
+
+    struct StalledFactory {
+        entered: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+        exited: async_channel::Sender<()>,
+        continued: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl TransportFactory for StalledFactory {
+        async fn create_transport(
+            &self,
+        ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>)> {
+            let _exited = scopeguard::guard(self.exited.clone(), |exited| {
+                let _ = exited.try_send(());
+            });
+            self.entered.send(()).await?;
+            self.release.recv().await?;
+            self.continued.fetch_add(1, Ordering::SeqCst);
+            Err(ConnectFault.into())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn constructor_deadline_and_cancellation_do_not_detach_the_connect_task() {
+        for cancel in [false, true] {
+            let (entered_tx, entered_rx) = async_channel::bounded(1);
+            let (release_tx, release_rx) = async_channel::bounded(1);
+            let (exited_tx, exited_rx) = async_channel::bounded(1);
+            let continued = Arc::new(AtomicUsize::new(0));
+            let factory = StalledFactory {
+                entered: entered_tx,
+                release: release_rx,
+                exited: exited_tx,
+                continued: continued.clone(),
+            };
+            let constructor = tokio::spawn(CallFixture::configured(move |builder| {
+                builder.with_transport_factory(factory)
+            }));
+            entered_rx
+                .recv()
+                .await
+                .expect("production Client::connect must enter the factory");
+            if cancel {
+                constructor.abort();
+                assert!(
+                    constructor
+                        .await
+                        .err()
+                        .expect("constructor cancelled")
+                        .is_cancelled()
+                );
+            } else {
+                tokio::time::advance(DEADLINE).await;
+                let error = constructor
+                    .await
+                    .expect("constructor task")
+                    .err()
+                    .expect("fixture deadline must expire before the transport deadline");
+                assert!(error.is::<tokio::time::error::Elapsed>(), "{error:#}");
+            }
+            tokio::time::timeout(Duration::from_millis(1), exited_rx.recv())
+                .await
+                .expect("the connect future must be dropped, not detached")
+                .expect("connect exit notification");
+            let _ = release_tx.try_send(());
+            tokio::time::advance(DEADLINE * 3).await;
+            assert_eq!(
+                continued.load(Ordering::SeqCst),
+                0,
+                "cancelled connect resumed its callback"
+            );
+        }
     }
 }

--- a/src/test_support/session.rs
+++ b/src/test_support/session.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use crate::Client;
+use wacore::libsignal::protocol::{
+    IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
+    process_prekey_bundle,
+};
+use wacore::types::jid::JidExt;
+use wacore_binary::Jid;
+
+pub(crate) async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) -> anyhow::Result<()> {
+    let bundle = tokio::task::spawn_blocking(|| -> Result<PreKeyBundle, SignalProtocolError> {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let receiver = IdentityKeyPair::generate(&mut rng);
+        let spk = KeyPair::generate(&mut rng);
+        let opk = KeyPair::generate(&mut rng);
+        let signature = receiver
+            .private_key()
+            .calculate_signature(&spk.public_key.serialize(), &mut rng)?;
+        PreKeyBundle::new(
+            1,
+            1u32.into(),
+            Some((1u32.into(), opk.public_key)),
+            1u32.into(),
+            spk.public_key,
+            signature,
+            *receiver.identity_key(),
+        )
+    })
+    .await??;
+    let mut adapter = client.signal_adapter();
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    process_prekey_bundle(
+        &peer.to_protocol_address(),
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+        &bundle,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await?;
+    Ok(())
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -331,46 +331,9 @@ pub(crate) async fn create_test_client_with_transport_factory(
 }
 
 pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
-    use wacore::libsignal::protocol::{
-        IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
-        process_prekey_bundle,
-    };
-    use wacore::types::jid::JidExt;
-
-    let bundle = tokio::task::spawn_blocking(|| -> Result<PreKeyBundle, SignalProtocolError> {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let receiver = IdentityKeyPair::generate(&mut rng);
-        let spk = KeyPair::generate(&mut rng);
-        let opk = KeyPair::generate(&mut rng);
-        let signature = receiver
-            .private_key()
-            .calculate_signature(&spk.public_key.serialize(), &mut rng)?;
-        PreKeyBundle::new(
-            1,
-            1u32.into(),
-            Some((1u32.into(), opk.public_key)),
-            1u32.into(),
-            spk.public_key,
-            signature,
-            *receiver.identity_key(),
-        )
-    })
-    .await
-    .expect("bundle task")
-    .expect("bundle");
-
-    let mut adapter = client.signal_adapter();
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-    process_prekey_bundle(
-        &peer.to_protocol_address(),
-        &mut adapter.session_store,
-        &mut adapter.identity_store,
-        &bundle,
-        &mut rng,
-        UsePQRatchet::No,
-    )
-    .await
-    .expect("peer session");
+    crate::test_support::seed_peer_session(client, peer)
+        .await
+        .expect("peer session");
 }
 
 use std::sync::Mutex;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -330,6 +330,7 @@ pub(crate) async fn create_test_client_with_transport_factory(
     client
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
     crate::test_support::seed_peer_session(client, peer)
         .await

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4634,7 +4634,7 @@ impl CallHandle {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use async_trait::async_trait;

--- a/tests/native_test_support_cfg.rs
+++ b/tests/native_test_support_cfg.rs
@@ -1,0 +1,155 @@
+//! Compile the actual fixture-path cfg guards without the root's native-only dev dependency graph.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+fn imported_name(tree: &syn::UseTree, name: &str) -> bool {
+    match tree {
+        syn::UseTree::Path(path) => imported_name(&path.tree, name),
+        syn::UseTree::Name(leaf) => leaf.ident == name,
+        _ => false,
+    }
+}
+
+fn guards(path: &str, names: &[&str]) -> String {
+    let source = std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path)).unwrap();
+    let parsed = syn::parse_file(&source).unwrap();
+    let mut attributes = parsed.attrs;
+    let mut items = parsed.items;
+    for name in names {
+        let item = items
+            .into_iter()
+            .find(|item| match item {
+                syn::Item::Mod(item) => item.ident == name,
+                syn::Item::Fn(item) => item.sig.ident == name,
+                syn::Item::Use(item) => imported_name(&item.tree, name),
+                _ => false,
+            })
+            .unwrap_or_else(|| panic!("missing {path}::{name}"));
+        items = match item {
+            syn::Item::Mod(item) => {
+                attributes.extend(item.attrs);
+                item.content.map_or_else(Vec::new, |(_, items)| items)
+            }
+            syn::Item::Fn(item) => {
+                attributes.extend(item.attrs);
+                Vec::new()
+            }
+            syn::Item::Use(item) => {
+                attributes.extend(item.attrs);
+                Vec::new()
+            }
+            _ => unreachable!(),
+        };
+    }
+    let clauses: Vec<_> = attributes
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg"))
+        .map(|attr| attr.meta.require_list().unwrap().tokens.to_string())
+        .collect();
+    assert!(!clauses.is_empty(), "{path}::{names:?} has no cfg guard");
+    format!("all({})", clauses.join(","))
+}
+
+fn compile(source: &str, wasm: bool, test: bool, feature: bool) -> Output {
+    let mut command = Command::new("rustc");
+    command.args([
+        "--edition=2024",
+        "--crate-name=native_fixture_cfg_probe",
+        "--crate-type=lib",
+        "--emit=metadata",
+        "-o",
+        "-",
+        "-",
+    ]);
+    if wasm {
+        command.args(["--target", "wasm32-unknown-unknown"]);
+    }
+    if test {
+        command.args(["--cfg", "test"]);
+    }
+    if feature {
+        command.args(["--cfg", "feature=\"test-support\""]);
+    }
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rustc");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(source.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+#[ignore = "requires an installed wasm32-unknown-unknown Rust target; checks cfg reachability, not the full WASM test graph"]
+fn native_fixture_paths_are_excluded_even_with_wasm_test_and_feature_cfgs() {
+    let paths: &[(&str, &[&str])] = &[
+        ("src/lib.rs", &["test_support"]),
+        ("src/test_utils.rs", &["seed_peer_session"]),
+        ("src/client/adapters.rs", &["tests"]),
+        ("src/voip/facade.rs", &["tests"]),
+        ("src/features/signal.rs", &["tests", "seed_peer_session"]),
+        (
+            "src/features/signal.rs",
+            &["tests", "participant_fanout_reuses_durable_session_leases"],
+        ),
+        (
+            "src/retry.rs",
+            &[
+                "tests",
+                "public_retransmission_recaches_the_supplied_message",
+            ],
+        ),
+        (
+            "src/send/group_repair.rs",
+            &[
+                "tests",
+                "primary_identity_change_is_shared_by_pn_and_lid_aliases",
+            ],
+        ),
+        (
+            "src/send/group_repair.rs",
+            &[
+                "tests",
+                "historical_repair_emits_only_for_a_continuous_account",
+            ],
+        ),
+        ("src/send/mod.rs", &["tests"]),
+        ("src/send/mod.rs", &["clock_budget_tests"]),
+        ("tests/voip_call_fixture.rs", &[]),
+    ];
+    let mut source = String::from("#![no_std]\n");
+    for (index, (path, names)) in paths.iter().enumerate() {
+        source.push_str(&format!(
+            "#[cfg({})] compile_error!(\"NATIVE_FIXTURE_{index:02}\");\n",
+            guards(path, names)
+        ));
+    }
+    let native = compile(&source, false, true, true);
+    assert!(!native.status.success());
+    let errors = String::from_utf8(native.stderr).unwrap();
+    for index in 0..paths.len() {
+        assert!(
+            errors.contains(&format!("NATIVE_FIXTURE_{index:02}")),
+            "missing native positive control: {errors}"
+        );
+    }
+    for test in [false, true] {
+        for feature in [false, true] {
+            let result = compile(&source, true, test, feature);
+            assert!(
+                result.status.success(),
+                "wasm test={test} feature={feature}: {}",
+                String::from_utf8_lossy(&result.stderr)
+            );
+        }
+    }
+}

--- a/tests/voip_call_fixture.rs
+++ b/tests/voip_call_fixture.rs
@@ -1,0 +1,323 @@
+//! External-consumer coverage of the opt-in fixture and current handler policy.
+#![cfg(all(feature = "test-support", not(target_arch = "wasm32")))]
+
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Duration;
+use wacore::types::events::Event;
+use wacore_binary::{Jid, Node, Server, builder::NodeBuilder};
+use whatsapp_rust::{test_support::CallFixture, voip::CallHandle};
+
+fn start(
+    fixture: &CallFixture,
+) -> tokio::task::JoinHandle<Result<CallHandle, whatsapp_rust::CallError>> {
+    let client = fixture.client().clone();
+    let peer = fixture.peer().clone();
+    tokio::spawn(async move {
+        let (_mic, mic) = async_channel::bounded::<Vec<i16>>(1);
+        let (speaker, _speaker) = async_channel::bounded::<Vec<i16>>(1);
+        let (_video, video) = async_channel::bounded::<Vec<u8>>(1);
+        let (sink, _sink) = async_channel::bounded::<wacore::voip::VideoFrame>(1);
+        client
+            .voip()
+            .call(&peer)
+            .audio(mic, speaker)
+            .video(video, sink)
+            .start()
+            .await
+    })
+}
+
+fn action(
+    fixture: &CallFixture,
+    call_id: &str,
+    from: Jid,
+    tag: &'static str,
+    reason: Option<&str>,
+) -> Node {
+    let mut action = NodeBuilder::new(tag)
+        .attr("call-id", call_id)
+        .attr("call-creator", fixture.client().lid().unwrap());
+    if let Some(reason) = reason {
+        action = action.attr("reason", reason);
+    }
+    if tag == "accept" {
+        action = action.children([
+            NodeBuilder::new("audio")
+                .attr("enc", "opus")
+                .attr("rate", "16000")
+                .build(),
+            NodeBuilder::new("video")
+                .attr("dec", "H264")
+                .attr("device_orientation", "0")
+                .build(),
+        ]);
+    }
+    NodeBuilder::new("call")
+        .attr("from", from)
+        .attr("id", "SYNTHETIC-ACTION")
+        .attr("t", "1788840000")
+        .children([action.build()])
+        .build()
+}
+
+async fn dormant(fixture: &CallFixture) -> Result<CallHandle> {
+    let start = start(fixture);
+    fixture.next_offer().await?.complete()?;
+    Ok(start.await??)
+}
+
+#[tokio::test]
+async fn builder_returns_real_dormant_handle_only_after_offer_completion() -> Result<()> {
+    let fixture = CallFixture::new().await?;
+    assert!(fixture.client().is_connected());
+    assert!(fixture.client().is_logged_in());
+    fixture
+        .client()
+        .wait_for_connected(Duration::from_secs(1))
+        .await?;
+    let start = start(&fixture);
+    let offer = fixture.next_offer().await?;
+    assert!(!start.is_finished());
+    let node = offer.stanza().as_node_ref();
+    let offer_node = node.get_optional_child("offer").unwrap();
+    let id = offer_node
+        .attrs()
+        .optional_string("call-id")
+        .unwrap()
+        .into_owned();
+    let video = offer_node.get_optional_child("video").unwrap();
+    assert_eq!(
+        video.attrs().optional_string("dec").as_deref(),
+        Some("H264")
+    );
+    assert_eq!(
+        video.attrs().optional_string("enc").as_deref(),
+        Some("h.264")
+    );
+    assert!(offer_node.get_optional_child("destination").is_some());
+    offer.complete()?;
+    let handle = start.await??;
+    assert_eq!(handle.call_id(), id);
+    assert_eq!(handle.peer_jid(), *fixture.peer());
+    assert!(
+        handle.events().try_recv().is_err(),
+        "no relay or media readiness was invented"
+    );
+    fixture.shutdown().await?;
+    tokio::time::timeout(Duration::from_secs(1), handle.wait_ended()).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn accept_before_builder_completion_selects_winner_through_handler() -> Result<()> {
+    let fixture = Arc::new(CallFixture::new().await?);
+    let _raw = fixture.client().acquire_raw_node_forwarding();
+    let start = start(&fixture);
+    let offer = fixture.next_offer().await?;
+    let id = offer
+        .stanza()
+        .as_node_ref()
+        .get_optional_child("offer")
+        .unwrap()
+        .attrs()
+        .optional_string("call-id")
+        .unwrap()
+        .into_owned();
+    let winner = fixture.peer().clone().with_device(2);
+    let accept = action(&fixture, &id, winner.clone(), "accept", None);
+    let injection = tokio::spawn({
+        let fixture = fixture.clone();
+        async move { fixture.inject(accept).await }
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while fixture
+            .call_snapshot(&id)
+            .and_then(|session| session.answering_device)
+            .as_ref()
+            != Some(&winner)
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+    assert!(
+        !start.is_finished(),
+        "the handler chose the winner while the offer send remained blocked"
+    );
+    assert!(
+        !injection.is_finished(),
+        "sibling dismissal awaits the blocked transport"
+    );
+    offer.complete()?;
+    let handle = start.await??;
+    injection.await??;
+    assert_eq!(handle.peer_jid(), winner);
+    assert!(
+        fixture.events()?.iter().any(|event| match &**event {
+            Event::RawNode(node) => node
+                .get()
+                .get_optional_child("accept")
+                .and_then(|accept| accept.get_optional_child("video"))
+                .is_some_and(
+                    |video| video.attrs().optional_string("dec").as_deref() == Some("H264")
+                ),
+            _ => false,
+        }),
+        "the real incoming advertisement is available through the standard raw-node lease"
+    );
+    assert!(
+        fixture
+            .events()?
+            .iter()
+            .any(|event| matches!(&**event, Event::IncomingCall(call)
+        if call.action.call_id() == id && call.from == winner))
+    );
+    let dismissals: Vec<_> = fixture
+        .outgoing_stanzas()?
+        .into_iter()
+        .filter(|node| node.as_node_ref().get_optional_child("terminate").is_some())
+        .collect();
+    assert_eq!(dismissals.len(), 1);
+    assert_eq!(
+        dismissals[0].as_node_ref().attrs().jid("to"),
+        fixture.peer().clone().with_device(0)
+    );
+    assert_eq!(
+        dismissals[0]
+            .as_node_ref()
+            .get_optional_child("terminate")
+            .unwrap()
+            .attrs()
+            .optional_string("reason")
+            .as_deref(),
+        Some("accepted_elsewhere")
+    );
+    fixture
+        .inject(action(
+            &fixture,
+            &id,
+            fixture.peer().clone().with_device(0),
+            "accept",
+            None,
+        ))
+        .await?;
+    assert_eq!(
+        handle.peer_jid(),
+        winner,
+        "late accept must not replace first winner"
+    );
+    fixture.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn refused_offer_cleans_up_without_returning_a_handle() -> Result<()> {
+    let fixture = CallFixture::new().await?;
+    let start = start(&fixture);
+    let offer = fixture.next_offer().await?;
+    let id = offer
+        .stanza()
+        .as_node_ref()
+        .get_optional_child("offer")
+        .unwrap()
+        .attrs()
+        .optional_string("call-id")
+        .unwrap()
+        .into_owned();
+    offer.fail()?;
+    assert!(start.await?.is_err());
+    assert!(fixture.call_snapshot(&id).is_none());
+    fixture.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropped_offer_refuses_send_and_dropped_fixture_reaps_a_real_handle() -> Result<()> {
+    let fixture = CallFixture::new().await?;
+    let first = start(&fixture);
+    drop(fixture.next_offer().await?);
+    assert!(first.await?.is_err());
+    fixture.shutdown().await?;
+
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    let client = fixture.client().clone();
+    drop(fixture);
+    tokio::time::timeout(Duration::from_secs(5), handle.wait_ended()).await?;
+    assert!(!client.is_connected());
+    Ok(())
+}
+
+#[tokio::test]
+async fn busy_sibling_keeps_ringing_but_late_nonbusy_reject_currently_ends_winner() -> Result<()> {
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    let sibling = fixture.peer().clone().with_device(0);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            sibling.clone(),
+            "reject",
+            Some("busy"),
+        ))
+        .await?;
+    assert_eq!(handle.peer_jid(), *fixture.peer());
+    assert!(
+        !fixture
+            .outgoing_stanzas()?
+            .iter()
+            .any(|node| node.as_node_ref().get_optional_child("terminate").is_some())
+    );
+    let winner = fixture.peer().clone().with_device(2);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            winner.clone(),
+            "accept",
+            None,
+        ))
+        .await?;
+    assert_eq!(handle.peer_jid(), winner);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            sibling,
+            "reject",
+            Some("declined"),
+        ))
+        .await?;
+    tokio::time::timeout(Duration::from_secs(1), handle.wait_ended()).await?;
+    assert!(
+        handle.announce_video_enabled().await.is_err(),
+        "characterization of current weak rejection policy, not desired security"
+    );
+    fixture.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn current_handler_accepts_an_unrung_device_as_first_winner() -> Result<()> {
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    let uninvited = Jid::new("444444444444444", Server::Lid).with_device(7);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            uninvited.clone(),
+            "accept",
+            None,
+        ))
+        .await?;
+    assert_eq!(
+        handle.peer_jid(),
+        uninvited,
+        "characterize the handler, do not invent authorization in the fixture"
+    );
+    fixture.shutdown().await?;
+    Ok(())
+}

--- a/tests/voip_call_fixture.rs
+++ b/tests/voip_call_fixture.rs
@@ -11,20 +11,28 @@ use whatsapp_rust::{test_support::CallFixture, voip::CallHandle};
 fn start(
     fixture: &CallFixture,
 ) -> tokio::task::JoinHandle<Result<CallHandle, whatsapp_rust::CallError>> {
+    start_with_video(fixture, true)
+}
+
+fn start_with_video(
+    fixture: &CallFixture,
+    video: bool,
+) -> tokio::task::JoinHandle<Result<CallHandle, whatsapp_rust::CallError>> {
     let client = fixture.client().clone();
     let peer = fixture.peer().clone();
     tokio::spawn(async move {
         let (_mic, mic) = async_channel::bounded::<Vec<i16>>(1);
         let (speaker, _speaker) = async_channel::bounded::<Vec<i16>>(1);
-        let (_video, video) = async_channel::bounded::<Vec<u8>>(1);
+        let (_video, video_rx) = async_channel::bounded::<Vec<u8>>(1);
         let (sink, _sink) = async_channel::bounded::<wacore::voip::VideoFrame>(1);
-        client
-            .voip()
-            .call(&peer)
-            .audio(mic, speaker)
-            .video(video, sink)
-            .start()
-            .await
+        let voip = client.voip();
+        let builder = voip.call(&peer).audio(mic, speaker);
+        let builder = if video {
+            builder.video(video_rx, sink)
+        } else {
+            builder
+        };
+        builder.start().await
     })
 }
 
@@ -318,6 +326,203 @@ async fn current_handler_accepts_an_unrung_device_as_first_winner() -> Result<()
         uninvited,
         "characterize the handler, do not invent authorization in the fixture"
     );
+    fixture.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn peer_video_queue_keeps_sender_state_and_upgrade_token_in_order() -> Result<()> {
+    use wacore::types::call::VideoState;
+    use wacore::voip::CallEvent;
+
+    let fixture = CallFixture::new().await?;
+    let starting = start_with_video(&fixture, false);
+    fixture.next_offer().await?.complete()?;
+    let handle = starting.await??;
+    let winner = fixture.peer().clone().with_device(2);
+    let sibling = fixture.peer().clone().with_device(0);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            winner.clone(),
+            "accept",
+            None,
+        ))
+        .await?;
+    let creator = fixture.client().lid().unwrap();
+    let video_stanza = |source: &Jid, state: VideoState, orientation: u8| {
+        NodeBuilder::new("call")
+            .attr("from", source.clone())
+            .attr("id", format!("VIDEO-{}", state.code()))
+            .attr("t", "1788840000")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", handle.call_id())
+                .attr("call-creator", creator.clone())
+                .attr("state", state.code().to_string())
+                .attr("device_orientation", orientation.to_string())
+                .attr("dec", "H264")
+                .build()])
+            .build()
+    };
+    let (_source_tx, source) = async_channel::bounded::<Vec<u8>>(1);
+    let (sink, _sink_rx) = async_channel::bounded::<wacore::voip::VideoFrame>(1);
+    handle.start_video(source.clone(), sink.clone()).await?;
+    fixture
+        .inject(video_stanza(&winner, VideoState::UpgradeAccept, 1))
+        .await?;
+    fixture
+        .inject(video_stanza(&sibling, VideoState::Stopped, 2))
+        .await?;
+    handle.stop_video().await?;
+    fixture
+        .inject(video_stanza(&winner, VideoState::UpgradeRequestV2, 3))
+        .await?;
+    fixture
+        .inject(video_stanza(&sibling, VideoState::Stopped, 0))
+        .await?;
+
+    let events = handle.events();
+    let queued: Vec<_> = std::iter::from_fn(|| events.try_recv().ok()).collect();
+    assert_eq!(
+        queued.len(),
+        8,
+        "one source event and one legacy event per committed direct state"
+    );
+    let observed: Vec<_> = queued
+        .chunks_exact(2)
+        .map(|pair| {
+            let CallEvent::PeerVideoStateChanged {
+                source,
+                call_creator,
+                state,
+                orientation,
+                upgrade_token,
+                ..
+            } = &pair[0]
+            else {
+                panic!("expected source-bearing event, got {:?}", pair[0]);
+            };
+            assert_eq!(call_creator, &creator);
+            assert_eq!(
+                pair[1],
+                CallEvent::VideoStateChanged {
+                    state: *state,
+                    orientation: *orientation,
+                    upgrade_token: *upgrade_token,
+                },
+                "legacy construction remains source-compatible and tokens match exactly"
+            );
+            (source.clone(), *state, *orientation, *upgrade_token)
+        })
+        .collect();
+    assert_eq!(
+        observed.iter().map(|event| event.1).collect::<Vec<_>>(),
+        [
+            VideoState::UpgradeAccept,
+            VideoState::Stopped,
+            VideoState::UpgradeRequestV2,
+            VideoState::Stopped,
+        ]
+    );
+    assert_eq!(
+        observed
+            .iter()
+            .map(|event| event.0.clone())
+            .collect::<Vec<_>>(),
+        [
+            winner.clone(),
+            sibling.clone(),
+            winner.clone(),
+            sibling.clone(),
+        ],
+        "the ordered handle queue must identify each actual sender without consulting the global event bus"
+    );
+    let request = observed[2]
+        .3
+        .expect("the source-bearing request must retain its token");
+    assert_eq!(
+        observed.iter().map(|event| event.2).collect::<Vec<_>>(),
+        [Some(1), Some(2), Some(3), Some(0)]
+    );
+    assert!(
+        observed
+            .iter()
+            .enumerate()
+            .all(|(index, event)| (index == 2) == event.3.is_some())
+    );
+    assert!(matches!(
+        handle.accept_video(request, source, sink).await,
+        Err(whatsapp_rust::CallError::VideoUpgradeExpired)
+    ));
+    assert_eq!(
+        handle.peer_jid(),
+        winner,
+        "metadata must not change current winner policy"
+    );
+    fixture.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn peer_video_metadata_reports_routed_sender_and_supplied_creator_without_new_authorization()
+-> Result<()> {
+    use wacore::types::call::VideoState;
+    use wacore::voip::CallEvent;
+
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    let winner = fixture.peer().clone().with_device(2);
+    fixture
+        .inject(action(
+            &fixture,
+            handle.call_id(),
+            winner.clone(),
+            "accept",
+            None,
+        ))
+        .await?;
+    let source = fixture.peer().clone().with_device(0);
+    let supplied_creator = Jid::new("444444444444444", Server::Lid);
+    let video = |state: VideoState| {
+        NodeBuilder::new("call")
+            .attr("from", winner.clone())
+            .attr("participant", source.clone())
+            .attr("id", "ROUTED-VIDEO")
+            .attr("t", "1788840000")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", handle.call_id())
+                .attr("call-creator", supplied_creator.clone())
+                .attr("state", state.code().to_string())
+                .build()])
+            .build()
+    };
+    fixture.inject(video(VideoState::Stopped)).await?;
+    let events = handle.events();
+    assert_eq!(
+        events.try_recv()?,
+        CallEvent::PeerVideoStateChanged {
+            source: source.clone(),
+            call_creator: supplied_creator.clone(),
+            state: VideoState::Stopped,
+            orientation: None,
+            upgrade_token: None,
+        }
+    );
+    assert_eq!(
+        events.try_recv()?,
+        CallEvent::VideoStateChanged {
+            state: VideoState::Stopped,
+            orientation: None,
+            upgrade_token: None,
+        }
+    );
+    fixture.inject(video(VideoState::Unknown(99))).await?;
+    assert!(
+        events.is_empty(),
+        "an ignored transition must publish neither variant"
+    );
+    assert_eq!(handle.peer_jid(), winner);
     fixture.shutdown().await?;
     Ok(())
 }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -625,11 +625,32 @@ pub enum CallEvent {
     /// Pushed by the signaling handler, not the engine; surfaced here so one event stream carries
     /// the whole call. For an upgrade request, pass `upgrade_token` to `accept_video`; a cancelled
     /// or superseded token cannot attach video endpoints.
+    /// Identity-aware consumers should use `PeerVideoStateChanged` instead and ignore this
+    /// compatibility event, rather than joining this queue with the global incoming-call stream.
     VideoStateChanged {
         state: crate::types::call::VideoState,
         orientation: Option<u8>,
         /// Accepting requires this exact token. `None` means simultaneous local and peer requests
         /// were already resolved by the signaling state machine.
+        upgrade_token: Option<super::VideoUpgradeToken>,
+    },
+    /// A committed peer video-state notification with its signaling identity.
+    ///
+    /// Published on the same handle queue, under the same transition lock, as video-upgrade
+    /// tokens. Direct calls publish this before the matching legacy `VideoStateChanged`;
+    /// consume one variant or the other, not both. Group participants publish only this variant
+    /// and never enter the direct-call upgrade state machine.
+    ///
+    /// `source` is the parsed stanza's `participant`, or `from` when absent, not the stored
+    /// winning device. PN aliases are retained. `call_creator` is also the stanza's value.
+    /// These fields report the existing handler's decision; they do not add authorization.
+    /// Queue pressure retains the existing bounded eviction policy, not lossless delivery of pairs.
+    PeerVideoStateChanged {
+        source: Jid,
+        call_creator: Jid,
+        state: crate::types::call::VideoState,
+        orientation: Option<u8>,
+        /// The same token as the direct-call compatibility event; always `None` for groups.
         upgrade_token: Option<super::VideoUpgradeToken>,
     },
     /// Outbound video needs an IDR before anything can go on the wire, and the
@@ -799,6 +820,11 @@ impl CallEvent {
                         .sum::<usize>()
             }
             Self::MediaSetupFailed(reason) => reason.capacity(),
+            Self::PeerVideoStateChanged {
+                source,
+                call_creator,
+                ..
+            } => source.heap_bytes() + call_creator.heap_bytes(),
             Self::RelayAllocated
             | Self::RelayAllocateFailed(_)
             | Self::RelayAllocateTimedOut

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -5107,6 +5107,44 @@ mod tests {
     }
 
     #[test]
+    fn source_video_events_account_for_both_jids_and_preserve_legacy_at_capacity_one() {
+        use crate::stats::HeapSize;
+
+        for capacity in [1, 2] {
+            let reg = CallRegistry::new();
+            let generation = reg.insert(session("CID"));
+            let (event_tx, event_rx) = async_channel::bounded(capacity);
+            let (ctl_tx, _ctl_rx) = video_control_channel();
+            reg.set_video_channels("CID", generation, event_tx, ctl_tx, Box::new(|| {}));
+            let source = Jid::new("3".repeat(64), Server::Lid);
+            let call_creator = Jid::new("4".repeat(64), Server::Lid);
+            let expected_heap = source.heap_bytes() + call_creator.heap_bytes();
+            let sourced = CallEvent::PeerVideoStateChanged {
+                source,
+                call_creator,
+                state: VideoState::Stopped,
+                orientation: Some(2),
+                upgrade_token: None,
+            };
+            assert_eq!(sourced.heap_bytes(), expected_heap);
+            assert!(expected_heap > 0);
+            let legacy = CallEvent::VideoStateChanged {
+                state: VideoState::Stopped,
+                orientation: Some(2),
+                upgrade_token: None,
+            };
+            let permit = reg.reserve_call_event("CID").unwrap();
+            assert!(permit.send(sourced.clone()));
+            assert!(permit.send(legacy.clone()));
+            if capacity == 2 {
+                assert_eq!(event_rx.try_recv(), Ok(sourced));
+            }
+            assert_eq!(event_rx.try_recv(), Ok(legacy));
+            assert!(event_rx.is_empty());
+        }
+    }
+
+    #[test]
     fn peer_upgrade_tokens_reject_cancel_request_aba() {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("CID"));


### PR DESCRIPTION
## Summary

Add `CallEvent::PeerVideoStateChanged` with `source`, `call_creator`, `state`, `orientation`, and `upgrade_token`. Consumers can now process peer video state and upgrade tokens from one handle queue instead of joining it with the global incoming-call stream.

The fixture regression failed before the event change with four correctly ordered states but no sender metadata. It now verifies B UpgradeAccept, A Stopped, B UpgradeRequestV2 with its token, then A Stopped. The stopped request token is expired, and every direct notification has an identical legacy companion.

This PR also includes the previously published opt-in `test-support` fixture. It uses the production outgoing builder and handler, completes a real in-process Noise handshake and login, and gates actual offer-send completion. It exposes no readiness, winner, or event-injection setters. The fixture remains native-only and outside default features.

## Compatibility

- Keep the existing `VideoStateChanged` fields and `VideoUpgradeToken` unchanged. The enum is non-exhaustive, but the legacy variant itself is not, so adding fields would break consumers.
- Publish the new direct event before its legacy companion under the existing transition lock and post-ACK checks. Consumers should handle one variant, not both.
- Group video notifications carry routed participant identity after the existing roster reauthorization, without a legacy call-wide event or upgrade token. PN aliases remain faithful to the incoming stanza.
- Preserve bounded queue eviction, including legacy behavior in custom single-slot queues. Delivery of pairs is not atomic or lossless under pressure. Account for both JID allocations in the existing byte budget.
- Do not change sender matching, authorization, signaling, codecs, or wire bytes. Tests preserve the current weaknesses around unrung winners, late sibling rejection, and direct video states with a different supplied creator. This is not a claim of WhatsApp protocol parity or a live Android media fix.

## Validation

- `cargo test -p whatsapp-rust --features voip-mlow,test-support --lib --test voip_call_fixture` passed 2,233 library tests and 8 fixture tests; 2 existing library tests ignored.
- `cargo test -p wacore --features voip-mlow --lib` passed 2,352 tests; 2 existing tests ignored.
- The 8 fixture tests also passed with default features disabled.
- Clippy passed with warnings denied for both packages, including their tests.
- The fixture documentation example passed as a doctest; formatting and diff checks passed.
- WASM `cargo check` passed with default features disabled and `voip-mlow`, using the CI getrandom backend flag. It reported unused-qualification warnings in unchanged `src/request.rs` and `src/upload.rs`.

No client application files were changed. Usage and boundaries are documented in `agent_docs/call_test_support.md`.