### PR TITLE
feat(voip): expose the immutable initial call peer

### DIFF
--- a/agent_docs/call_test_support.md
+++ b/agent_docs/call_test_support.md
@@ -31,6 +31,11 @@ do not introduce a second copy just for the fixture.
   event subscriptions and `CallHandle` methods.
 - `peer()` names the fictitious recipient. Its primary device 0 and companion
   device 2 have seeded device records and Signal sessions.
+- `cache_peer_phone(phone).await` adds a memory-only fictitious PN alias and
+  returns its JID. `clear_lid_pn_cache().await` removes cached mappings without
+  ending calls. Clear after `next_offer()` to test identity lookup failure
+  after the builder has resolved the recipient. An unmapped PN is rejected
+  before an offer, even if its device list is cached.
 - `next_offer().await` returns `PendingOffer` at transport entry. Its `stanza()`
   contains the actual production video advertisement and encrypted per-device
   destinations. `complete()` releases send completion; `fail()` or dropping it
@@ -115,6 +120,12 @@ shows the handler's selection. Sibling dismissal blocks behind the pending
 offer send. Complete the offer, then await both futures. The external test
 `accept_before_builder_completion_selects_winner_through_handler` demonstrates
 this ordering without a sleep or a readiness setter.
+
+`CallHandle::initial_peer_jid()` borrows the immutable peer captured during
+handle construction. For a direct outgoing call it is the builder's resolved
+offer target, independent of later cache loss or winner selection. In contrast,
+`peer_jid()` follows the answering device and group promotion for signaling.
+The immutable getter does not change the handler's acceptance policy.
 
 ## Coverage boundaries
 

--- a/src/test_support/call.rs
+++ b/src/test_support/call.rs
@@ -209,6 +209,25 @@ impl CallFixture {
         &self.peer
     }
 
+    /// Cache a fictitious phone alias for the peer without persisting it.
+    /// Clearing the cache then reproduces a missing secondary identity lookup.
+    pub async fn cache_peer_phone(&self, phone: &str) -> Jid {
+        self.client
+            .lid_pn_cache
+            .add(&crate::lid_pn_cache::LidPnEntry::new(
+                self.peer.user.as_str(),
+                phone,
+                crate::lid_pn_cache::LearningSource::Usync,
+            ))
+            .await;
+        Jid::pn(phone)
+    }
+
+    /// Evict identity mappings without changing the connection or registered calls.
+    pub async fn clear_lid_pn_cache(&self) {
+        self.client.lid_pn_cache.clear().await;
+    }
+
     /// Read the registered production session, including a winner selected before start returns.
     /// Mutating this detached snapshot cannot change the live call.
     pub fn call_snapshot(&self, call_id: &str) -> Option<wacore::voip::CallSession> {
@@ -520,6 +539,53 @@ impl Transport for Wire {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn unmapped_phone_is_rejected_before_an_offer() -> Result<()> {
+        let fixture = CallFixture::new().await?;
+        let requested = Jid::pn("15550003333");
+        fixture
+            .client()
+            .update_device_list(DeviceListRecord {
+                user: Arc::from(requested.user.as_str()),
+                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(2, None)]
+                    .into_boxed_slice(),
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await?;
+        assert!(
+            fixture
+                .client()
+                .get_lid_pn_entry(&requested)
+                .await?
+                .is_none()
+        );
+        let (_mic, mic) = async_channel::bounded::<Vec<i16>>(1);
+        let (speaker, _speaker) = async_channel::bounded::<Vec<i16>>(1);
+        let result = fixture
+            .client()
+            .voip()
+            .call(&requested)
+            .audio(mic, speaker)
+            .start()
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::CallError::Media(
+                "no known LID for the PN callee; cannot derive media keys"
+            ))
+        ));
+        assert!(
+            !fixture
+                .outgoing_stanzas()?
+                .iter()
+                .any(|node| node.as_node_ref().get_optional_child("offer").is_some())
+        );
+        fixture.shutdown().await?;
+        Ok(())
+    }
 
     #[derive(Debug, thiserror::Error)]
     #[error("synthetic transport connect failure")]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3778,6 +3778,15 @@ impl CallHandle {
         self.media_stats.snapshot()
     }
 
+    /// The peer captured when this handle was created.
+    ///
+    /// For a direct outgoing call, this is the builder's resolved offer target, not the device
+    /// selected by an inbound accept. It does not change after acceptance, group promotion or
+    /// teardown, and does not consult the identity cache. Use [`Self::peer_jid`] for signaling.
+    pub fn initial_peer_jid(&self) -> &Jid {
+        &self.peer_jid
+    }
+
     /// The peer this call is with, as the `<terminate>` target. For an outgoing call this is the
     /// call-scoped JID after an ad-hoc group promotion, otherwise the callee device that answered
     /// (learned from the inbound `<accept>`) once one has, since direct-call signaling is addressed

--- a/tests/voip_call_fixture.rs
+++ b/tests/voip_call_fixture.rs
@@ -241,6 +241,88 @@ async fn refused_offer_cleans_up_without_returning_a_handle() -> Result<()> {
 }
 
 #[tokio::test]
+async fn initial_peer_survives_phone_cache_loss_and_early_spoofed_winner() -> Result<()> {
+    for spoofed in [false, true] {
+        let fixture = Arc::new(CallFixture::new().await?);
+        let requested = fixture.cache_peer_phone("15550003333").await;
+        let starting = tokio::spawn({
+            let client = fixture.client().clone();
+            let requested = requested.clone();
+            async move {
+                let (_mic, mic) = async_channel::bounded::<Vec<i16>>(1);
+                let (speaker, _speaker) = async_channel::bounded::<Vec<i16>>(1);
+                client
+                    .voip()
+                    .call(&requested)
+                    .audio(mic, speaker)
+                    .start()
+                    .await
+            }
+        });
+        let offer = fixture.next_offer().await?;
+        let node = offer.stanza().as_node_ref();
+        assert_eq!(
+            node.attrs().optional_jid("to"),
+            Some(fixture.peer().clone())
+        );
+        let id = node
+            .get_optional_child("offer")
+            .unwrap()
+            .attrs()
+            .optional_string("call-id")
+            .unwrap()
+            .into_owned();
+        fixture.clear_lid_pn_cache().await;
+        assert!(
+            fixture
+                .client()
+                .get_lid_pn_entry(&requested)
+                .await?
+                .is_none()
+        );
+        let winner = if spoofed {
+            Jid::lid("999999999999999").with_device(2)
+        } else {
+            fixture.peer().clone().with_device(2)
+        };
+        let accept = action(&fixture, &id, winner.clone(), "accept", None);
+        let injection = tokio::spawn({
+            let fixture = fixture.clone();
+            async move { fixture.inject(accept).await }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while fixture
+                .call_snapshot(&id)
+                .and_then(|session| session.answering_device)
+                .as_ref()
+                != Some(&winner)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+        assert!(!starting.is_finished());
+        offer.complete()?;
+        let handle = starting.await??;
+        injection.await??;
+        assert_eq!(handle.peer_jid(), winner);
+        assert_eq!(handle.initial_peer_jid(), fixture.peer());
+        assert_eq!(handle.clone().initial_peer_jid(), fixture.peer());
+        assert!(
+            fixture
+                .client()
+                .get_lid_pn_entry(&requested)
+                .await?
+                .is_none()
+        );
+        assert!(futures::poll!(std::pin::pin!(handle.wait_ended())).is_pending());
+        fixture.shutdown().await?;
+        assert_eq!(handle.initial_peer_jid(), fixture.peer());
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn dropped_offer_refuses_send_and_dropped_fixture_reaps_a_real_handle() -> Result<()> {
     let fixture = CallFixture::new().await?;
     let first = start(&fixture);


### PR DESCRIPTION
Adds `CallHandle::initial_peer_jid(&self) -> &Jid`, borrowing the existing immutable peer field. For direct outgoing calls this is the resolved offer target. Unlike `peer_jid()`, it does not follow the answering device or group promotion and does not consult the identity cache.

This lets a consumer validate accepted media against the intended recipient without rereading a mapping after an offer has already been sent. The existing `peer_jid()` signaling behavior and inbound winner policy remain unchanged.

Based on merged #1472 at `823158d7b6a7519c991b17505ead4cddf902af09`.

Tests use the real CallFixture builder, clear a memory-only PN mapping at the blocked offer-send boundary, and inject either the intended winner or an unrelated first winner before start returns. The immutable getter stays bound to the offer target across cloning and teardown. Two opt-in fixture cache controls support downstream reproduction without changing readiness or winner state. A separate control confirms that an initially unmapped PN is rejected before any offer, even with cached devices.

Verification

- Before the getter, deriving the target from `peer_jid().to_non_ad()` failed on the spoofed winner.
- Downstream client regression failed with `no known LID for outgoing call target` after successful builder completion. Switching to this getter passed all 139 session tests, including 18 acceptance cases.
- 9 upstream fixture integration tests passed.
- 3 fixture unit tests passed.
- 152 facade unit tests passed with `test-support,voip-mlow`. An initial run without `voip-mlow` failed 34 media setup tests with the missing codec feature.
- Targeted Clippy with warnings denied and formatting checks passed.

No client dependency change is included. Full workspace CI and live media interoperability are not claimed.