### PR TITLE
fix(message): deduplicate PDO recovery and encrypted retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,7 @@ bytes = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 event-listener = { workspace = true }
 futures = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
 smallvec = { workspace = true }
 hashbrown = { workspace = true }
 hex = { workspace = true }
@@ -330,7 +331,6 @@ hmac = { workspace = true }
 # Raises real SIGINT/SIGTERM at the current process in the shutdown-signal test.
 libc = "0.2"
 metrics-exporter-prometheus = "0.18"
-sha2 = { workspace = true }
 # Parses the crate sources in tests/error_surface.rs. Text scanning silently
 # missed error enums whose doc comments carried unbalanced braces.
 syn = { version = "3.0", features = ["full"] }

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -189,6 +189,9 @@ pub struct CacheConfig {
     /// observed resend window (production logs: median 12s between attempts,
     /// p90 189s, longest plausible resend 285s) and the capacity ~3.6x the
     /// busiest 5-minute burst measured (278 messages). Capacity 0 disables it.
+    /// Capacity counts identities, with up to eight payload digests per identity.
+    /// Further distinct payloads remain deliverable without deduplication.
+    /// The gate does not retain plaintext.
     pub dispatched_messages: CacheEntryConfig,
     /// PDO pending requests (time_to_live). Default: 30s TTL, 200 entries.
     pub pdo_pending_requests: CacheEntryConfig,

--- a/src/client.rs
+++ b/src/client.rs
@@ -465,6 +465,10 @@ pub struct MemoryReport {
     pub undecryptable_dispatched: u64,
     /// Entries in the dispatch-once gate for decrypted messages.
     pub dispatched_messages: u64,
+    /// Payload digests, tokens and aliases retained per dispatch-gate
+    /// identity, on top of the table slots charged above. The identity count
+    /// stays in [`Self::dispatched_messages`].
+    pub dispatched_message_contents: CollectionStats,
     pub pdo_pending_requests: u64,
     pub pdo_requested: u64,
     /// Queued/running history-sync tasks and their logical compressed-payload
@@ -650,7 +654,7 @@ pub struct SubsystemMemory {
 impl MemoryReport {
     /// Common byte-carrying collections used by both totals and `Display`.
     /// Feature-specific collections stay beside their gated report section.
-    fn collections(&self) -> [(&'static str, &CollectionStats); 17] {
+    fn collections(&self) -> [(&'static str, &CollectionStats); 18] {
         [
             ("group_cache:", &self.group_cache),
             ("device_registry_cache:", &self.device_registry_cache),
@@ -666,6 +670,7 @@ impl MemoryReport {
             ("signal_identities:", &self.signal_identities),
             ("signal_sender_keys:", &self.signal_sender_keys),
             ("history_sync_tasks:", &self.history_sync_tasks),
+            ("dispatch_contents:", &self.dispatched_message_contents),
             ("inbound_commit_batch:", &self.inbound_commit_batch),
             ("offline_receipts:", &self.offline_receipt_buffer),
             ("core_event_handlers:", &self.core_event_handlers),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1703,8 +1703,10 @@ pub struct Client {
     /// Dispatch-once gate for a decrypted message. A sender retrying its own
     /// outbox resends one id as fresh ciphertext on a new ratchet iteration,
     /// which decrypts as new traffic, so only message identity can collapse it.
-    pub(crate) dispatched_messages:
-        Cache<wacore::types::message::SenderMessageId, crate::message::MessageDispatch>,
+    pub(crate) dispatched_messages: crate::portable_cache::SyncTtlCache<
+        crate::message::DispatchKey,
+        crate::message::DispatchClaim,
+    >,
 
     /// Lifetime count of resent messages this gate kept from reaching
     /// consumers. Client-level, so it survives reconnects: the sender's retry

--- a/src/client.rs
+++ b/src/client.rs
@@ -1703,7 +1703,8 @@ pub struct Client {
     /// Dispatch-once gate for a decrypted message. A sender retrying its own
     /// outbox resends one id as fresh ciphertext on a new ratchet iteration,
     /// which decrypts as new traffic, so only message identity can collapse it.
-    pub(crate) dispatched_messages: Cache<wacore::types::message::SenderMessageId, ()>,
+    pub(crate) dispatched_messages:
+        Cache<wacore::types::message::SenderMessageId, crate::message::MessageDispatch>,
 
     /// Lifetime count of resent messages this gate kept from reaching
     /// consumers. Client-level, so it survives reconnects: the sender's retry

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -492,6 +492,12 @@ impl Client {
             message_retry_counts: self.message_retry_counts.entry_count_async().await,
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count_async().await,
             dispatched_messages: self.dispatched_messages.entry_count(),
+            dispatched_message_contents: self.dispatched_messages.memory_stats(
+                |key: &crate::message::DispatchKey, claim: &crate::message::DispatchClaim| {
+                    use wacore::stats::HeapSize;
+                    key.heap_bytes() + claim.heap_bytes()
+                },
+            ),
             pdo_pending_requests: self.pdo_pending_requests.entry_count_async().await,
             pdo_requested: self.pdo_requested.entry_count_async().await,
             history_sync_tasks,

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -491,7 +491,7 @@ impl Client {
             dm_devices_memo,
             message_retry_counts: self.message_retry_counts.entry_count_async().await,
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count_async().await,
-            dispatched_messages: self.dispatched_messages.entry_count_async().await,
+            dispatched_messages: self.dispatched_messages.entry_count(),
             pdo_pending_requests: self.pdo_pending_requests.entry_count_async().await,
             pdo_requested: self.pdo_requested.entry_count_async().await,
             history_sync_tasks,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -594,7 +594,10 @@ impl Client {
 
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),
 
-            dispatched_messages: cache_config.dispatched_messages.build_with_ttl(),
+            dispatched_messages: crate::portable_cache::SyncTtlCache::new(
+                cache_config.dispatched_messages.capacity,
+                cache_config.dispatched_messages.timeout,
+            ),
             duplicate_dispatch_suppressed: AtomicU64::new(0),
 
             offline_sync_metrics: Arc::new(OfflineSyncMetrics {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1478,12 +1478,8 @@ impl Client {
         // buffered receipts stay unsent too, because their SKDM/session state
         // may not be durable yet (receipting an SKDM whose sender key only
         // lives in the cache would lose it to a crash with no redelivery).
-        if self
-            .flush_inbound_commits_bounded(Duration::from_secs(5))
-            .await
-        {
-            self.flush_offline_receipts();
-        }
+        self.flush_inbound_commits_bounded(Duration::from_secs(5))
+            .await;
         // Prevent late receipt producers from escaping the drain window.
         self.outbound_flush.close();
         self.outbound_flush
@@ -1562,12 +1558,8 @@ impl Client {
         self.backoff_reset_suppressed.store(true, Ordering::Relaxed);
 
         // Same durable-before-receipts gate as disconnect().
-        if self
-            .flush_inbound_commits_bounded(Duration::from_secs(2))
-            .await
-        {
-            self.flush_offline_receipts();
-        }
+        self.flush_inbound_commits_bounded(Duration::from_secs(2))
+            .await;
         self.outbound_flush.close();
         self.outbound_flush
             .flush(&*self.runtime, Duration::from_secs(2))
@@ -1598,12 +1590,8 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
 
         // Same durable-before-receipts gate as disconnect().
-        if self
-            .flush_inbound_commits_bounded(Duration::from_secs(2))
-            .await
-        {
-            self.flush_offline_receipts();
-        }
+        self.flush_inbound_commits_bounded(Duration::from_secs(2))
+            .await;
         self.outbound_flush.close();
         self.outbound_flush
             .flush(&*self.runtime, Duration::from_secs(2))
@@ -1720,12 +1708,8 @@ impl Client {
         self.pause_state_notifier.notify(usize::MAX);
 
         // Same durable-before-receipts gate as disconnect().
-        if self
-            .flush_inbound_commits_bounded(Duration::from_secs(2))
-            .await
-        {
-            self.flush_offline_receipts();
-        }
+        self.flush_inbound_commits_bounded(Duration::from_secs(2))
+            .await;
         // Everything from here touches connection-scoped shared state, and a
         // `resume()` across the await above can have a replacement installed
         // that has already reopened the outbound scope and reset the

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -401,12 +401,10 @@ impl Client {
     /// so the ordering of flag flip vs. semaphore swap is not observable: any
     /// in-flight worker keeps using its old 1-permit Arc and drains normally;
     /// newly-spawned workers pick up the 64-permit semaphore via
-    /// read_message_semaphore(). The flag flip happens-before the receipt
-    /// drain takes the buffer lock, so late offline receipts either land in
-    /// the flush or observe the flag and send 1:1
-    /// (see try_buffer_offline_receipt).
+    /// read_message_semaphore(). Receipt buffering follows the batcher's drain
+    /// mode, changed under the processing permit, not this later completion flag.
     ///
-    /// `durable`: `Some(true)` flushes the buffered offline receipts;
+    /// `durable`: `Some(true)` already flushed receipts under the drain permit;
     /// `Some(false)` drops them — the tail's durable write failed, its entries
     /// are back in the batcher unacked, and receipting SKDM/session state that
     /// never became durable would trade a redeliverable failure for a
@@ -447,15 +445,11 @@ impl Client {
         if durable != Some(false) {
             self.swap_message_semaphore(64);
         }
-        match durable {
-            Some(true) => self.flush_offline_receipts(),
-            Some(false) => {
-                log::warn!(
-                    "finish_offline_sync: tail commit not durable; dropping buffered offline receipts so the server redelivers"
-                );
-                self.clear_offline_receipt_buffer();
-            }
-            None => {}
+        if let Some(false) = durable {
+            log::warn!(
+                "finish_offline_sync: tail commit not durable; dropping buffered offline receipts so the server redelivers"
+            );
+            self.clear_offline_receipt_buffer();
         }
         self.core.event_bus.dispatch(Event::OfflineSyncCompleted(
             OfflineSyncCompleted::builder().count(count).build(),

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5255,7 +5255,10 @@ async fn cache_maintenance_sweeps_expired_entries() {
     let chat: Jid = "19045550180@s.whatsapp.net".parse().unwrap();
     let key =
         wacore::types::message::SenderMessageId::new(chat.clone(), "3EB0EXPIRING".into(), chat);
-    client.dispatched_messages.insert(key, ()).await;
+    client
+        .dispatched_messages
+        .insert(key, crate::message::MessageDispatch::Decrypted)
+        .await;
     tokio::time::sleep(Duration::from_millis(40)).await;
     assert_eq!(
         client.dispatched_messages.entry_count_async().await,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5253,21 +5253,27 @@ async fn cache_maintenance_sweeps_expired_entries() {
     .await;
 
     let chat: Jid = "19045550180@s.whatsapp.net".parse().unwrap();
-    let key =
-        wacore::types::message::SenderMessageId::new(chat.clone(), "3EB0EXPIRING".into(), chat);
+    let info = Arc::new(crate::types::message::MessageInfo {
+        id: "3EB0EXPIRING".into(),
+        source: crate::types::message::MessageSource {
+            chat: chat.clone(),
+            sender: chat,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
     client
-        .dispatched_messages
-        .insert(key, crate::message::MessageDispatch::Decrypted)
+        .mark_message_dispatched(&info, &wa::Message::default())
         .await;
     tokio::time::sleep(Duration::from_millis(40)).await;
     assert_eq!(
-        client.dispatched_messages.entry_count_async().await,
+        client.dispatched_messages.entry_count(),
         1,
         "a quiet cache keeps its expired entry until swept"
     );
 
     client.run_cache_maintenance().await;
-    assert_eq!(client.dispatched_messages.entry_count_async().await, 0);
+    assert_eq!(client.dispatched_messages.entry_count(), 0);
     assert_eq!(client.memory_report().await.dispatched_messages, 0);
 }
 

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -373,7 +373,7 @@ impl Client {
         self.message_retry_counts.run_pending_tasks().await;
         self.session_recreate_history.run_pending_tasks().await;
         self.undecryptable_dispatched.run_pending_tasks().await;
-        self.dispatched_messages.run_pending_tasks().await;
+        self.dispatched_messages.run_pending_tasks();
         self.pdo_pending_requests.run_pending_tasks().await;
         self.pdo_requested.run_pending_tasks().await;
         self.device_registry_cache.run_pending_tasks().await;

--- a/src/message.rs
+++ b/src/message.rs
@@ -315,6 +315,16 @@ impl DispatchClaim {
             payload.fingerprint == fingerprint
                 && payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED
         }) {
+            // Suppress on a live match, including an in-flight one. The only
+            // way it can still roll back is a concurrent panic: this region
+            // runs no awaits between admission and completion, so cancellation
+            // cannot land inside it. Delivering instead would re-enter a
+            // blocked callback on every overlap and break the progress
+            // contract pinned by
+            // `pdo_retry_blocked_recovery_callback_admits_no_duplicate`.
+            // A rolled-back publication stays observable: its token flips to
+            // INTERRUPTED, which the find above skips, so the next redelivery
+            // after the rollback is admitted fresh.
             if pdo {
                 return true;
             }

--- a/src/message.rs
+++ b/src/message.rs
@@ -311,11 +311,10 @@ impl DispatchClaim {
         hook_committed: bool,
         publication: &mut PublicationGuard,
     ) -> bool {
-        if let Some(payload) = self
-            .payloads
-            .iter_mut()
-            .find(|payload| payload.fingerprint == fingerprint)
-        {
+        if let Some(payload) = self.payloads.iter_mut().find(|payload| {
+            payload.fingerprint == fingerprint
+                && payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED
+        }) {
             if pdo {
                 return true;
             }

--- a/src/message.rs
+++ b/src/message.rs
@@ -231,17 +231,34 @@ const PUBLICATION_PENDING: u8 = 0;
 const PUBLICATION_COMPLETE: u8 = 1;
 const PUBLICATION_INTERRUPTED: u8 = 2;
 
+/// The retained half of a payload's SHA-256.
+///
+/// A digest is only ever compared against the at most
+/// [`MAX_DISPATCH_PAYLOADS`] digests recorded under one message identity, so
+/// what it has to rule out is a second payload for *that* id colliding on 128
+/// bits — a second preimage, not a birthday collision, and unreachable for a
+/// peer that would have to find it. Keeping 32 bytes instead doubled what the
+/// dispatch gate retains per claim, and the gate's table is the largest thing
+/// this feature adds to a client's resident memory.
+pub(crate) type DispatchFingerprint = [u8; 16];
+
 #[derive(Clone)]
 struct DispatchPayload {
-    fingerprint: [u8; 32],
+    fingerprint: DispatchFingerprint,
     state: MessageDispatch,
     publication: Arc<AtomicU8>,
 }
 
+/// Boxed: an alternate identity is evidence a *minority* of claims carry (only
+/// a stanza that spelled both namespaces has one), while the claim itself is
+/// retained for every message id the client dispatches. Inline it cost every
+/// claim a `Jid` whether or not one existed.
+type DispatchAlias = Option<Box<Jid>>;
+
 #[derive(Clone, Default)]
 pub(crate) struct DispatchClaim {
     payloads: smallvec::SmallVec<[DispatchPayload; 1]>,
-    alias: Option<Jid>,
+    alias: DispatchAlias,
 }
 
 #[derive(Default)]
@@ -294,7 +311,7 @@ impl DispatchClaim {
         })
     }
 
-    fn state(&self, fingerprint: &[u8; 32]) -> Option<MessageDispatch> {
+    fn state(&self, fingerprint: &DispatchFingerprint) -> Option<MessageDispatch> {
         self.payloads
             .iter()
             .find(|payload| {
@@ -306,7 +323,7 @@ impl DispatchClaim {
 
     fn admit(
         &mut self,
-        fingerprint: [u8; 32],
+        fingerprint: DispatchFingerprint,
         pdo: bool,
         hook_committed: bool,
         publication: &mut PublicationGuard,
@@ -374,7 +391,7 @@ impl MessageDispatch {
     // stamp the `Message` encode tree once. A second sink type stamps it again
     // (measured +284 KiB .text); see the pinning note on `message_encode_into`.
     #[inline(never)]
-    pub(crate) fn fingerprint(message: &wa::Message) -> [u8; 32] {
+    pub(crate) fn fingerprint(message: &wa::Message) -> DispatchFingerprint {
         FINGERPRINT_SCRATCH.with(|scratch| {
             let mut scratch = scratch.borrow_mut();
             let fingerprint = Self::fingerprint_into(message, &mut scratch);
@@ -387,11 +404,23 @@ impl MessageDispatch {
     }
 
     #[inline(never)]
-    pub(crate) fn fingerprint_into(message: &wa::Message, scratch: &mut Vec<u8>) -> [u8; 32] {
+    pub(crate) fn fingerprint_into(
+        message: &wa::Message,
+        scratch: &mut Vec<u8>,
+    ) -> DispatchFingerprint {
         use sha2::{Digest, Sha256};
         scratch.clear();
         waproto::codec::message_encode_into(message, scratch);
-        Sha256::digest(scratch.as_slice()).into()
+        Self::truncate(Sha256::digest(scratch.as_slice()).into())
+    }
+
+    /// The retained prefix of a full digest, for a caller that already hashed
+    /// the encoded bytes it was writing anyway.
+    pub(crate) fn truncate(digest: [u8; 32]) -> DispatchFingerprint {
+        const LEN: usize = size_of::<DispatchFingerprint>();
+        let mut fingerprint = [0u8; LEN];
+        fingerprint.copy_from_slice(&digest[..LEN]);
+        fingerprint
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -218,6 +218,146 @@ pub(crate) enum MessageDispatch {
     RecoveredCommitted,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct DispatchKey {
+    chat: Jid,
+    id: wacore_binary::MessageId,
+    participant: Option<Jid>,
+    from_me: bool,
+}
+
+const MAX_DISPATCH_PAYLOADS: usize = 8;
+const PUBLICATION_PENDING: u8 = 0;
+const PUBLICATION_COMPLETE: u8 = 1;
+const PUBLICATION_INTERRUPTED: u8 = 2;
+
+#[derive(Clone)]
+struct DispatchPayload {
+    fingerprint: [u8; 32],
+    state: MessageDispatch,
+    publication: Arc<AtomicU8>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct DispatchClaim {
+    payloads: smallvec::SmallVec<[DispatchPayload; 1]>,
+    alias: Option<Jid>,
+}
+
+#[derive(Default)]
+pub(crate) struct PublicationGuard {
+    owner: Option<Arc<AtomicU8>>,
+}
+
+impl PublicationGuard {
+    fn owner(&mut self) -> Arc<AtomicU8> {
+        Arc::clone(
+            self.owner
+                .get_or_insert_with(|| Arc::new(AtomicU8::new(PUBLICATION_PENDING))),
+        )
+    }
+
+    pub(crate) fn complete(mut self) {
+        if let Some(owner) = self.owner.take() {
+            owner.store(PUBLICATION_COMPLETE, Ordering::Release);
+        }
+    }
+}
+
+impl Drop for PublicationGuard {
+    fn drop(&mut self) {
+        if let Some(owner) = &self.owner {
+            // Only slots still carrying this token become invalid. A newer
+            // publisher can replace a pending slot without an ABA rollback.
+            owner.store(PUBLICATION_INTERRUPTED, Ordering::Release);
+        }
+    }
+}
+
+impl DispatchClaim {
+    fn prune(&mut self) {
+        self.payloads.retain(|payload| {
+            payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED
+        });
+    }
+
+    fn has_deliveries(&self) -> bool {
+        self.payloads
+            .iter()
+            .any(|payload| payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED)
+    }
+
+    fn has_recovery(&self) -> bool {
+        self.payloads.iter().any(|payload| {
+            payload.state != MessageDispatch::Decrypted
+                && payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED
+        })
+    }
+
+    fn state(&self, fingerprint: &[u8; 32]) -> Option<MessageDispatch> {
+        self.payloads
+            .iter()
+            .find(|payload| {
+                &payload.fingerprint == fingerprint
+                    && payload.publication.load(Ordering::Acquire) != PUBLICATION_INTERRUPTED
+            })
+            .map(|payload| payload.state)
+    }
+
+    fn admit(
+        &mut self,
+        fingerprint: [u8; 32],
+        pdo: bool,
+        hook_committed: bool,
+        publication: &mut PublicationGuard,
+    ) -> bool {
+        if let Some(payload) = self
+            .payloads
+            .iter_mut()
+            .find(|payload| payload.fingerprint == fingerprint)
+        {
+            if pdo {
+                return true;
+            }
+            if payload.state != MessageDispatch::Decrypted {
+                if hook_committed {
+                    payload.state = MessageDispatch::RecoveredCommitted;
+                }
+                return true;
+            }
+            // Ordinary multipart dispatches and hook replays still fan out.
+            // Keep a completed claim, but let a new publisher own a pending one.
+            if payload.publication.load(Ordering::Acquire) != PUBLICATION_COMPLETE {
+                payload.publication = publication.owner();
+            }
+            return false;
+        }
+        if self.payloads.len() < MAX_DISPATCH_PAYLOADS {
+            self.payloads.push(DispatchPayload {
+                fingerprint,
+                state: if pdo {
+                    MessageDispatch::Recovered
+                } else {
+                    MessageDispatch::Decrypted
+                },
+                publication: publication.owner(),
+            });
+        }
+        // Overflow stays unclaimed, never silently discards another payload.
+        false
+    }
+}
+
+impl MessageDispatch {
+    #[inline(never)]
+    pub(crate) fn fingerprint(message: &wa::Message) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        let mut digest = Sha256::new();
+        waproto::codec::message_encode_chunks(message, &mut |bytes| digest.update(bytes));
+        digest.finalize().into()
+    }
+}
+
 const INBOUND_COMMIT_PENDING: u8 = 0;
 const INBOUND_COMMIT_DURABLE: u8 = 1;
 const INBOUND_COMMIT_DROPPED: u8 = 2;

--- a/src/message.rs
+++ b/src/message.rs
@@ -359,7 +359,11 @@ impl DispatchClaim {
 
 // Rare-path callers (PDO recovery, duplicate probes) share one encode buffer
 // per thread instead of allocating a message-sized `Vec` per call. Borrowed
-// synchronously only, never held across an await.
+// synchronously only, never held across an await. Capacity stays bounded: one
+// huge message must not pin a huge buffer on the worker for the rest of the
+// process.
+const MAX_FINGERPRINT_SCRATCH_BYTES: usize = 64 * 1024;
+
 std::thread_local! {
     static FINGERPRINT_SCRATCH: std::cell::RefCell<Vec<u8>> =
         const { std::cell::RefCell::new(Vec::new()) };
@@ -373,7 +377,12 @@ impl MessageDispatch {
     pub(crate) fn fingerprint(message: &wa::Message) -> [u8; 32] {
         FINGERPRINT_SCRATCH.with(|scratch| {
             let mut scratch = scratch.borrow_mut();
-            Self::fingerprint_into(message, &mut scratch)
+            let fingerprint = Self::fingerprint_into(message, &mut scratch);
+            if scratch.capacity() > MAX_FINGERPRINT_SCRATCH_BYTES {
+                scratch.clear();
+                scratch.shrink_to(MAX_FINGERPRINT_SCRATCH_BYTES);
+            }
+            fingerprint
         })
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -211,6 +211,13 @@ pub(crate) struct PlaintextHandleOutcome {
     skdm_only: bool,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MessageDispatch {
+    Decrypted,
+    Recovered,
+    RecoveredCommitted,
+}
+
 const INBOUND_COMMIT_PENDING: u8 = 0;
 const INBOUND_COMMIT_DURABLE: u8 = 1;
 const INBOUND_COMMIT_DROPPED: u8 = 2;

--- a/src/message.rs
+++ b/src/message.rs
@@ -266,6 +266,14 @@ pub(crate) struct PublicationGuard {
     owner: Option<Arc<AtomicU8>>,
 }
 
+/// Duplicate-probe answer with the plaintext already resolved: dispatch must
+/// reuse it instead of resolving the parent secret a second time. Boxed: the
+/// mismatch path is rare and `wa::Message` is close to a kilobyte.
+pub(crate) enum ProbeOutcome {
+    Suppress,
+    Proceed { decrypted: Option<Box<wa::Message>> },
+}
+
 impl PublicationGuard {
     fn owner(&mut self) -> Arc<AtomicU8> {
         Arc::clone(

--- a/src/message.rs
+++ b/src/message.rs
@@ -348,12 +348,20 @@ impl DispatchClaim {
 }
 
 impl MessageDispatch {
+    // One `Vec<u8>` sink only: `message_to_vec`/`message_encode_into` already
+    // stamp the `Message` encode tree once. A second sink type stamps it again
+    // (measured +284 KiB .text); see the pinning note on `message_encode_into`.
     #[inline(never)]
     pub(crate) fn fingerprint(message: &wa::Message) -> [u8; 32] {
+        Self::fingerprint_into(message, &mut Vec::new())
+    }
+
+    #[inline(never)]
+    pub(crate) fn fingerprint_into(message: &wa::Message, scratch: &mut Vec<u8>) -> [u8; 32] {
         use sha2::{Digest, Sha256};
-        let mut digest = Sha256::new();
-        waproto::codec::message_encode_chunks(message, &mut |bytes| digest.update(bytes));
-        digest.finalize().into()
+        scratch.clear();
+        waproto::codec::message_encode_into(message, scratch);
+        Sha256::digest(scratch.as_slice()).into()
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -394,6 +394,31 @@ std::thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
+impl wacore::stats::HeapSize for DispatchKey {
+    fn heap_bytes(&self) -> usize {
+        self.chat.heap_bytes()
+            + self.id.heap_bytes()
+            + self.participant.as_ref().map_or(0, |p| p.heap_bytes())
+    }
+}
+
+impl wacore::stats::HeapSize for DispatchClaim {
+    /// Heap retained beside the table slot: spilled payloads, one token
+    /// allocation per payload, and the boxed alias. The inline SmallVec slot
+    /// lives in the slot itself and is charged with the table.
+    fn heap_bytes(&self) -> usize {
+        let mut bytes = 0;
+        if self.payloads.len() > 1 {
+            bytes += self.payloads.len() * size_of::<DispatchPayload>();
+        }
+        bytes += self.payloads.len() * size_of::<AtomicU8>();
+        if let Some(alias) = &self.alias {
+            bytes += size_of::<Jid>() + alias.heap_bytes();
+        }
+        bytes
+    }
+}
+
 impl MessageDispatch {
     // One `Vec<u8>` sink only: `message_to_vec`/`message_encode_into` already
     // stamp the `Message` encode tree once. A second sink type stamps it again

--- a/src/message.rs
+++ b/src/message.rs
@@ -402,16 +402,22 @@ impl wacore::stats::HeapSize for DispatchKey {
     }
 }
 
+/// One publication token allocation: the value plus the strong and weak
+/// counts. Allocator rounding above that is not counted, the same floor the
+/// table accounting in `hash_table_bytes` uses.
+const TOKEN_ALLOC_BYTES: usize = 2 * size_of::<usize>() + size_of::<AtomicU8>();
+
 impl wacore::stats::HeapSize for DispatchClaim {
-    /// Heap retained beside the table slot: spilled payloads, one token
-    /// allocation per payload, and the boxed alias. The inline SmallVec slot
-    /// lives in the slot itself and is charged with the table.
+    /// Heap retained beside the table slot: spilled payloads at their
+    /// allocated capacity, one token allocation per payload, and the boxed
+    /// alias. The inline SmallVec slot lives in the slot itself and is
+    /// charged with the table.
     fn heap_bytes(&self) -> usize {
         let mut bytes = 0;
-        if self.payloads.len() > 1 {
-            bytes += self.payloads.len() * size_of::<DispatchPayload>();
+        if self.payloads.spilled() {
+            bytes += self.payloads.capacity() * size_of::<DispatchPayload>();
         }
-        bytes += self.payloads.len() * size_of::<AtomicU8>();
+        bytes += self.payloads.len() * TOKEN_ALLOC_BYTES;
         if let Some(alias) = &self.alias {
             bytes += size_of::<Jid>() + alias.heap_bytes();
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -347,13 +347,24 @@ impl DispatchClaim {
     }
 }
 
+// Rare-path callers (PDO recovery, duplicate probes) share one encode buffer
+// per thread instead of allocating a message-sized `Vec` per call. Borrowed
+// synchronously only, never held across an await.
+std::thread_local! {
+    static FINGERPRINT_SCRATCH: std::cell::RefCell<Vec<u8>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
 impl MessageDispatch {
     // One `Vec<u8>` sink only: `message_to_vec`/`message_encode_into` already
     // stamp the `Message` encode tree once. A second sink type stamps it again
     // (measured +284 KiB .text); see the pinning note on `message_encode_into`.
     #[inline(never)]
     pub(crate) fn fingerprint(message: &wa::Message) -> [u8; 32] {
-        Self::fingerprint_into(message, &mut Vec::new())
+        FINGERPRINT_SCRATCH.with(|scratch| {
+            let mut scratch = scratch.borrow_mut();
+            Self::fingerprint_into(message, &mut scratch)
+        })
     }
 
     #[inline(never)]

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -884,7 +884,7 @@ impl Client {
         // fed can skip re-materializing the batch.
         let mut hook_committed = false;
         let dispatch_gate = self.dispatch_gate_enabled();
-        let mut fingerprints = smallvec::SmallVec::<[Option<[u8; 32]>; 1]>::new();
+        let mut fingerprints = smallvec::SmallVec::<[Option<DispatchFingerprint>; 1]>::new();
         if let Some(hook) = self.inbound_durability_hook() {
             if dispatch_gate {
                 fingerprints.reserve_exact(items.len());
@@ -933,7 +933,9 @@ impl Client {
                             (!crate::features::message_edit::carries_secret_encrypted(
                                 &item.message,
                             ))
-                            .then(|| Sha256::digest(&arena[start..]).into()),
+                            .then(|| {
+                                MessageDispatch::truncate(Sha256::digest(&arena[start..]).into())
+                            }),
                         );
                     }
                 }

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -1045,13 +1045,16 @@ impl Client {
         // admission holds the cache lock; consumer callbacks never own it.
         let mut retained: Option<Vec<InboundMessage>> = None;
         let mut publication = PublicationGuard::default();
+        // One encode buffer for the whole batch: the hook path already hashed
+        // its arena ranges above, this only serves the no-hook path.
+        let mut encode_scratch = Vec::new();
         for (index, item) in items.iter().enumerate() {
             // A later PDO may carry another part under this id. Comparing it
             // without retaining plaintext requires this ordinary digest now.
             let fingerprint = fingerprints.get(index).copied().unwrap_or_else(|| {
                 (dispatch_gate
                     && !crate::features::message_edit::carries_secret_encrypted(&item.message))
-                .then(|| MessageDispatch::fingerprint(&item.message))
+                .then(|| MessageDispatch::fingerprint_into(&item.message, &mut encode_scratch))
             });
             let suppress = self.admit_message_dispatch(
                 &item.info,

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -10,7 +10,6 @@
 
 use super::*;
 use portable_atomic::AtomicU64;
-use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
 use wacore::store::traits::{PendingInboundKey, PendingInboundRow};
 use wacore::types::events::{BatchOrigin, InboundMessage, MessageBatch};
@@ -41,22 +40,6 @@ struct PendingInboundBatch {
     commit_ticket: Option<InboundCommitTicket>,
 }
 
-#[derive(Clone)]
-struct PendingPublication {
-    items: Arc<[InboundMessage]>,
-    arrived: Arc<[InboundMessage]>,
-    origin: BatchOrigin,
-    hook_committed: bool,
-}
-
-#[derive(Clone, Copy)]
-enum PublicationReceipts {
-    Hold,
-    // The caller flushed current Signal state under the processing permit.
-    // This authorization belongs to the call, never to a retained batch.
-    CurrentFlush,
-}
-
 impl PendingInboundBatch {
     fn is_empty(&self) -> bool {
         self.entries.is_empty()
@@ -72,12 +55,6 @@ impl PendingInboundBatch {
 
 pub(crate) struct InboundCommitBatcher {
     state: std::sync::Mutex<BatchState>,
-    // PDO and normal delivery use different lanes. Hold only for publication,
-    // never for backend writes, Signal flushes or consumer durability hooks.
-    pub(crate) dispatch_lock: async_lock::Mutex<()>,
-    // These batches crossed their commit boundary. Their ratchets may already
-    // be persisted, so reconnect reset must retain the unpublished plaintext.
-    publications: std::sync::Mutex<VecDeque<PendingPublication>>,
     #[cfg(test)]
     pub(crate) publication_reached: std::sync::atomic::AtomicBool,
     /// Whether inbound commits accumulate here (offline drain) or commit
@@ -118,8 +95,6 @@ impl Default for InboundCommitBatcher {
     fn default() -> Self {
         Self {
             state: std::sync::Mutex::new(BatchState::default()),
-            dispatch_lock: async_lock::Mutex::new(()),
-            publications: std::sync::Mutex::new(VecDeque::new()),
             #[cfg(test)]
             publication_reached: std::sync::atomic::AtomicBool::new(false),
             active: std::sync::atomic::AtomicBool::new(true),
@@ -135,12 +110,6 @@ impl Default for InboundCommitBatcher {
 }
 
 impl InboundCommitBatcher {
-    fn publications(&self) -> std::sync::MutexGuard<'_, VecDeque<PendingPublication>> {
-        self.publications
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-    }
-
     fn lock(&self) -> std::sync::MutexGuard<'_, BatchState> {
         match self.state.lock() {
             Ok(guard) => guard,
@@ -172,7 +141,7 @@ impl InboundCommitBatcher {
         !self.lock().entries.is_empty()
     }
 
-    /// Entries waiting for commit or publication and their encoded bytes, for
+    /// Entries waiting for commit and their encoded bytes, for
     /// `memory_report()`.
     ///
     /// This is the largest thing one client retains: a drain batch holds
@@ -198,17 +167,7 @@ impl InboundCommitBatcher {
     ///   resident for the session.
     pub(crate) fn pending_stats(&self) -> (usize, usize) {
         let state = self.lock();
-        let publications = self.publications();
-        let unpublished = publications.iter().flat_map(|batch| batch.arrived.iter());
-        unpublished.fold(
-            (state.entries.len(), state.bytes),
-            |(count, bytes), item| {
-                (
-                    count + 1,
-                    bytes + waproto::codec::message_encoded_len(&item.message),
-                )
-            },
-        )
+        (state.entries.len(), state.bytes)
     }
 
     /// Switch to immediate (live) commits. Only the end-of-drain flush (or a
@@ -478,8 +437,6 @@ impl Client {
             return true;
         }
         let was_draining = self.inbound_commit_batch.is_active();
-        self.publish_pending_inbound(PublicationReceipts::Hold)
-            .await;
         let batch = self.inbound_commit_batch.take();
         let durable = if batch.is_empty() {
             // Even with nothing to commit, flush the Signal cache under the
@@ -609,8 +566,6 @@ impl Client {
     ) {
         let settle = async {
             let _permit = self.acquire_message_processing_permit().await;
-            self.publish_pending_inbound(PublicationReceipts::Hold)
-                .await;
             let batch = self.inbound_commit_batch.take();
             let durable = if batch.is_empty() {
                 true
@@ -809,7 +764,7 @@ impl Client {
             waproto::codec::message_encode_into(msg, &mut buf);
             buf
         }
-        type Seen = std::collections::HashMap<wacore::types::message::SenderMessageId, Vec<Kept>>;
+        type Seen = std::collections::HashMap<DispatchKey, Vec<Kept>>;
         fn keep(seen: &mut Seen, item: &InboundMessage) -> bool {
             let kept = seen.entry(Client::dispatch_key(&item.info)).or_default();
             if kept.len() >= MAX_COMPARED_PER_ID {
@@ -928,7 +883,12 @@ impl Client {
         // Rides on the dispatched event so a consumer that the hook already
         // fed can skip re-materializing the batch.
         let mut hook_committed = false;
+        let dispatch_gate = self.dispatch_gate_enabled();
+        let mut fingerprints = smallvec::SmallVec::<[Option<[u8; 32]>; 1]>::new();
         if let Some(hook) = self.inbound_durability_hook() {
+            if dispatch_gate {
+                fingerprints.reserve_exact(items.len());
+            }
             // Key strings live for the whole commit; rows borrow them and the
             // encode arena, so the batch write allocates nothing per row
             // beyond these.
@@ -967,6 +927,15 @@ impl Client {
                     let start = arena.len();
                     waproto::codec::message_encode_into(&item.message, arena);
                     ranges.push(start..arena.len());
+                    if dispatch_gate {
+                        use sha2::{Digest, Sha256};
+                        fingerprints.push(
+                            (!crate::features::message_edit::carries_secret_encrypted(
+                                &item.message,
+                            ))
+                            .then(|| Sha256::digest(&arena[start..]).into()),
+                        );
+                    }
                 }
                 let rows: Vec<PendingInboundRow<'_>> = items
                     .iter()
@@ -1067,95 +1036,48 @@ impl Client {
             }
         }
 
-        self.inbound_commit_batch
-            .publications()
-            .push_back(PendingPublication {
-                items,
-                arrived,
-                origin,
-                hook_committed,
-            });
         reinsert.mark_durable();
-        let receipts = if is_drain {
-            PublicationReceipts::CurrentFlush
-        } else {
-            PublicationReceipts::Hold
-        };
-        self.publish_pending_inbound(receipts).await;
-        true
-    }
-
-    async fn publish_pending_inbound(self: &Arc<Self>, receipts: PublicationReceipts) {
-        if self.inbound_commit_batch.publications().is_empty() {
-            return;
-        }
         #[cfg(test)]
         self.inbound_commit_batch
             .publication_reached
             .store(true, Ordering::Release);
-        let _dispatch_guard = self.inbound_commit_batch.dispatch_lock.lock().await;
-        loop {
-            let Some(PendingPublication {
-                items,
-                arrived,
-                origin,
+        // Admission and dispatch cannot yield after the commit boundary. Only
+        // admission holds the cache lock; consumer callbacks never own it.
+        let mut retained: Option<Vec<InboundMessage>> = None;
+        let mut publication = PublicationGuard::default();
+        for (index, item) in items.iter().enumerate() {
+            // A later PDO may carry another part under this id. Comparing it
+            // without retaining plaintext requires this ordinary digest now.
+            let fingerprint = fingerprints.get(index).copied().unwrap_or_else(|| {
+                (dispatch_gate
+                    && !crate::features::message_edit::carries_secret_encrypted(&item.message))
+                .then(|| MessageDispatch::fingerprint(&item.message))
+            });
+            let suppress = self.admit_message_dispatch(
+                &item.info,
+                false,
+                fingerprint,
                 hook_committed,
-            }) = self.inbound_commit_batch.publications().front().cloned()
-            else {
-                break;
-            };
-            // A PDO may have published while this batch waited for durability.
-            // Ordinary claims must not filter multipart messages or hook replays.
-            let mut retained: Option<Vec<InboundMessage>> = None;
-            for (index, item) in items.iter().enumerate() {
-                let key = Self::dispatch_key(&item.info);
-                let state = self.dispatched_messages.get(&key).await;
-                if matches!(
-                    state,
-                    Some(MessageDispatch::Recovered | MessageDispatch::RecoveredCommitted)
-                ) {
-                    if hook_committed
-                        && state == Some(MessageDispatch::Recovered)
-                        && !crate::features::message_edit::carries_secret_encrypted(&item.message)
-                    {
-                        self.dispatched_messages
-                            .insert(key, MessageDispatch::RecoveredCommitted)
-                            .await;
-                    }
-                    retained.get_or_insert_with(|| items[..index].to_vec());
-                } else if let Some(retained) = &mut retained {
-                    retained.push(item.clone());
-                }
-            }
-            let items = retained.map(Arc::from).unwrap_or(items);
-
-            // Remove only after every pre-publication await. Cancellation before
-            // this point leaves the whole batch available to the next publisher.
-            let published = self
-                .inbound_commit_batch
-                .publications()
-                .pop_front()
-                .expect("publication lock owns the front batch");
-            for _ in 0..published.items.len() - items.len() {
+                &mut publication,
+            );
+            if suppress {
+                retained.get_or_insert_with(|| items[..index].to_vec());
                 self.duplicate_dispatch_suppressed
                     .fetch_add(1, Ordering::Relaxed);
                 wacore::telemetry::recv("duplicate_resend");
+            } else if let Some(retained) = &mut retained {
+                retained.push(item.clone());
             }
-
-            // Acks first (everything durable by now): handle_event runs
-            // synchronously, so a handler that panics or blocks must not be able
-            // to suppress acks for messages the consumer already owns — the
-            // pre-batch at-most-once path acked before dispatching too.
-            for item in arrived.iter() {
-                self.ack_received_message(&item.info);
-            }
-            if matches!(receipts, PublicationReceipts::CurrentFlush) {
-                self.flush_offline_receipts();
-            }
-            if items.is_empty() {
-                continue;
-            }
-            let dispatched = Arc::clone(&items);
+        }
+        let items = retained.map(Arc::from).unwrap_or(items);
+        // Schedule receipts before synchronous consumer code can block or panic.
+        for item in arrived.iter() {
+            self.ack_received_message(&item.info);
+        }
+        if is_drain {
+            self.flush_offline_receipts();
+        }
+        if !items.is_empty() {
             self.core.event_bus.dispatch(Event::Messages(
                 MessageBatch::builder()
                     .messages(items)
@@ -1163,28 +1085,9 @@ impl Client {
                     .hook_committed(hook_committed)
                     .build(),
             ));
-            // Claimed after the dispatch, never between the acks and it: this is the
-            // one suspension point in that span, and a teardown cancelling it there
-            // would leave the batch acked with its event never sent, which for a
-            // consumer without a hook is a lost message. Cancelled here instead, the
-            // claim is simply missing and a resend dispatches twice.
-            for item in dispatched.iter() {
-                // An unresolved secret envelope is a placeholder in the same sense
-                // as an UndecryptableMessage: what reached the consumer is not the
-                // content. Presence, not extractability: a malformed envelope is
-                // just as unreadable to a consumer as an unopenable one, and
-                // `extract_secret_encrypted` returns `None` for both a plain
-                // message and a malformed envelope. Claiming it would suppress the resend that arrives once
-                // the parent secret is known, so leave it unclaimed and take the
-                // duplicate instead. The batch collapse keeps such a resend for a
-                // related reason: it compares content, and the envelope is not the
-                // content.
-                if crate::features::message_edit::carries_secret_encrypted(&item.message) {
-                    continue;
-                }
-                self.mark_message_dispatched(&item.info).await;
-            }
         }
+        publication.complete();
+        true
     }
 }
 

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -10,6 +10,7 @@
 
 use super::*;
 use portable_atomic::AtomicU64;
+use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
 use wacore::store::traits::{PendingInboundKey, PendingInboundRow};
 use wacore::types::events::{BatchOrigin, InboundMessage, MessageBatch};
@@ -40,6 +41,22 @@ struct PendingInboundBatch {
     commit_ticket: Option<InboundCommitTicket>,
 }
 
+#[derive(Clone)]
+struct PendingPublication {
+    items: Arc<[InboundMessage]>,
+    arrived: Arc<[InboundMessage]>,
+    origin: BatchOrigin,
+    hook_committed: bool,
+}
+
+#[derive(Clone, Copy)]
+enum PublicationReceipts {
+    Hold,
+    // The caller flushed current Signal state under the processing permit.
+    // This authorization belongs to the call, never to a retained batch.
+    CurrentFlush,
+}
+
 impl PendingInboundBatch {
     fn is_empty(&self) -> bool {
         self.entries.is_empty()
@@ -55,6 +72,14 @@ impl PendingInboundBatch {
 
 pub(crate) struct InboundCommitBatcher {
     state: std::sync::Mutex<BatchState>,
+    // PDO and normal delivery use different lanes. Hold only for publication,
+    // never for backend writes, Signal flushes or consumer durability hooks.
+    pub(crate) dispatch_lock: async_lock::Mutex<()>,
+    // These batches crossed their commit boundary. Their ratchets may already
+    // be persisted, so reconnect reset must retain the unpublished plaintext.
+    publications: std::sync::Mutex<VecDeque<PendingPublication>>,
+    #[cfg(test)]
+    pub(crate) publication_reached: std::sync::atomic::AtomicBool,
     /// Whether inbound commits accumulate here (offline drain) or commit
     /// immediately (live). Flipped off ONLY by the end-of-drain flush while it
     /// holds the single processing permit, so no stanza can straddle the
@@ -93,6 +118,10 @@ impl Default for InboundCommitBatcher {
     fn default() -> Self {
         Self {
             state: std::sync::Mutex::new(BatchState::default()),
+            dispatch_lock: async_lock::Mutex::new(()),
+            publications: std::sync::Mutex::new(VecDeque::new()),
+            #[cfg(test)]
+            publication_reached: std::sync::atomic::AtomicBool::new(false),
             active: std::sync::atomic::AtomicBool::new(true),
             pending_live: std::sync::atomic::AtomicBool::new(false),
             epoch: AtomicU64::new(0),
@@ -106,6 +135,12 @@ impl Default for InboundCommitBatcher {
 }
 
 impl InboundCommitBatcher {
+    fn publications(&self) -> std::sync::MutexGuard<'_, VecDeque<PendingPublication>> {
+        self.publications
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, BatchState> {
         match self.state.lock() {
             Ok(guard) => guard,
@@ -137,7 +172,7 @@ impl InboundCommitBatcher {
         !self.lock().entries.is_empty()
     }
 
-    /// Accumulated entries and the encoded bytes they account for, for
+    /// Entries waiting for commit or publication and their encoded bytes, for
     /// `memory_report()`.
     ///
     /// This is the largest thing one client retains: a drain batch holds
@@ -163,7 +198,17 @@ impl InboundCommitBatcher {
     ///   resident for the session.
     pub(crate) fn pending_stats(&self) -> (usize, usize) {
         let state = self.lock();
-        (state.entries.len(), state.bytes)
+        let publications = self.publications();
+        let unpublished = publications.iter().flat_map(|batch| batch.arrived.iter());
+        unpublished.fold(
+            (state.entries.len(), state.bytes),
+            |(count, bytes), item| {
+                (
+                    count + 1,
+                    bytes + waproto::codec::message_encoded_len(&item.message),
+                )
+            },
+        )
     }
 
     /// Switch to immediate (live) commits. Only the end-of-drain flush (or a
@@ -433,6 +478,8 @@ impl Client {
             return true;
         }
         let was_draining = self.inbound_commit_batch.is_active();
+        self.publish_pending_inbound(PublicationReceipts::Hold)
+            .await;
         let batch = self.inbound_commit_batch.take();
         let durable = if batch.is_empty() {
             // Even with nothing to commit, flush the Signal cache under the
@@ -465,6 +512,9 @@ impl Client {
             // entries were taken before the reset and its rows are durable.
             return durable;
         }
+        if durable {
+            self.flush_offline_receipts();
+        }
         if deactivate {
             if durable {
                 self.inbound_commit_batch.deactivate();
@@ -495,13 +545,13 @@ impl Client {
     /// permit held and a durable commit just done, so the flip is as raceless
     /// as the normal end-of-drain one.
     pub(crate) fn complete_deferred_live_transition(&self) {
-        self.inbound_commit_batch.deactivate();
-        self.swap_message_semaphore(64);
         // Receipts buffered during the deferred window (SKDM-only stanzas
         // keep buffering while the batcher is active) are safe to send now:
         // the durable flush that triggered this completion persisted their
         // Signal state.
         self.flush_offline_receipts();
+        self.inbound_commit_batch.deactivate();
+        self.swap_message_semaphore(64);
         // Key-share jobs may have observed the earlier failed transition.
         self.offline_sync_notifier.notify(usize::MAX);
         log::info!("Deferred drain-to-live transition completed after a durable flush");
@@ -559,6 +609,8 @@ impl Client {
     ) {
         let settle = async {
             let _permit = self.acquire_message_processing_permit().await;
+            self.publish_pending_inbound(PublicationReceipts::Hold)
+                .await;
             let batch = self.inbound_commit_batch.take();
             let durable = if batch.is_empty() {
                 true
@@ -577,7 +629,10 @@ impl Client {
             // drop with them instead of persisting rowless.
             if durable && !self.inbound_commit_batch.has_entries() {
                 match self.flush_signal_cache().await {
-                    Ok(()) => self.signal_cache.clear_after_flush().await,
+                    Ok(()) => {
+                        self.flush_offline_receipts();
+                        self.signal_cache.clear_after_flush().await;
+                    }
                     // Committed/acked state the server never redelivers: keep
                     // it resident so the next successful flush persists it.
                     // Safe to carry across the reconnect — the teardown
@@ -1010,56 +1065,126 @@ impl Client {
             if is_drain && !self.drain_signal_flush_reporting().await {
                 return false;
             }
-            reinsert.mark_durable();
         }
 
-        // Acks first (everything durable by now): handle_event runs
-        // synchronously, so a handler that panics or blocks must not be able
-        // to suppress acks for messages the consumer already owns — the
-        // pre-batch at-most-once path acked before dispatching too.
-        for item in arrived.iter() {
-            self.ack_received_message(&item.info);
+        self.inbound_commit_batch
+            .publications()
+            .push_back(PendingPublication {
+                items,
+                arrived,
+                origin,
+                hook_committed,
+            });
+        reinsert.mark_durable();
+        let receipts = if is_drain {
+            PublicationReceipts::CurrentFlush
+        } else {
+            PublicationReceipts::Hold
+        };
+        self.publish_pending_inbound(receipts).await;
+        true
+    }
+
+    async fn publish_pending_inbound(self: &Arc<Self>, receipts: PublicationReceipts) {
+        if self.inbound_commit_batch.publications().is_empty() {
+            return;
         }
-        // WA Web `createSnapshot` sends `sendAggregateOfflineReceipts` per
-        // snapshot, not once at drain end. Flush the receipts this batch's acks
-        // just buffered now that the batch is durable: bounds the buffer over a
-        // large backlog and caps redelivery on a mid-drain disconnect to a
-        // single snapshot instead of the whole backlog (a disconnect clears the
-        // buffer, so anything already flushed is not re-sent). Gated on the
-        // durable path — a non-durable batch returned above without acking.
-        if is_drain {
-            self.flush_offline_receipts();
-        }
-        let dispatched = Arc::clone(&items);
-        self.core.event_bus.dispatch(Event::Messages(
-            MessageBatch::builder()
-                .messages(items)
-                .origin(origin)
-                .hook_committed(hook_committed)
-                .build(),
-        ));
-        // Claimed after the dispatch, never between the acks and it: this is the
-        // one suspension point in that span, and a teardown cancelling it there
-        // would leave the batch acked with its event never sent, which for a
-        // consumer without a hook is a lost message. Cancelled here instead, the
-        // claim is simply missing and a resend dispatches twice.
-        for item in dispatched.iter() {
-            // An unresolved secret envelope is a placeholder in the same sense
-            // as an UndecryptableMessage: what reached the consumer is not the
-            // content. Presence, not extractability: a malformed envelope is
-            // just as unreadable to a consumer as an unopenable one, and
-            // `extract_secret_encrypted` returns `None` for both a plain
-            // message and a malformed envelope. Claiming it would suppress the resend that arrives once
-            // the parent secret is known, so leave it unclaimed and take the
-            // duplicate instead. The batch collapse keeps such a resend for a
-            // related reason: it compares content, and the envelope is not the
-            // content.
-            if crate::features::message_edit::carries_secret_encrypted(&item.message) {
+        #[cfg(test)]
+        self.inbound_commit_batch
+            .publication_reached
+            .store(true, Ordering::Release);
+        let _dispatch_guard = self.inbound_commit_batch.dispatch_lock.lock().await;
+        loop {
+            let Some(PendingPublication {
+                items,
+                arrived,
+                origin,
+                hook_committed,
+            }) = self.inbound_commit_batch.publications().front().cloned()
+            else {
+                break;
+            };
+            // A PDO may have published while this batch waited for durability.
+            // Ordinary claims must not filter multipart messages or hook replays.
+            let mut retained: Option<Vec<InboundMessage>> = None;
+            for (index, item) in items.iter().enumerate() {
+                let key = Self::dispatch_key(&item.info);
+                let state = self.dispatched_messages.get(&key).await;
+                if matches!(
+                    state,
+                    Some(MessageDispatch::Recovered | MessageDispatch::RecoveredCommitted)
+                ) {
+                    if hook_committed
+                        && state == Some(MessageDispatch::Recovered)
+                        && !crate::features::message_edit::carries_secret_encrypted(&item.message)
+                    {
+                        self.dispatched_messages
+                            .insert(key, MessageDispatch::RecoveredCommitted)
+                            .await;
+                    }
+                    retained.get_or_insert_with(|| items[..index].to_vec());
+                } else if let Some(retained) = &mut retained {
+                    retained.push(item.clone());
+                }
+            }
+            let items = retained.map(Arc::from).unwrap_or(items);
+
+            // Remove only after every pre-publication await. Cancellation before
+            // this point leaves the whole batch available to the next publisher.
+            let published = self
+                .inbound_commit_batch
+                .publications()
+                .pop_front()
+                .expect("publication lock owns the front batch");
+            for _ in 0..published.items.len() - items.len() {
+                self.duplicate_dispatch_suppressed
+                    .fetch_add(1, Ordering::Relaxed);
+                wacore::telemetry::recv("duplicate_resend");
+            }
+
+            // Acks first (everything durable by now): handle_event runs
+            // synchronously, so a handler that panics or blocks must not be able
+            // to suppress acks for messages the consumer already owns — the
+            // pre-batch at-most-once path acked before dispatching too.
+            for item in arrived.iter() {
+                self.ack_received_message(&item.info);
+            }
+            if matches!(receipts, PublicationReceipts::CurrentFlush) {
+                self.flush_offline_receipts();
+            }
+            if items.is_empty() {
                 continue;
             }
-            self.mark_message_dispatched(&item.info).await;
+            let dispatched = Arc::clone(&items);
+            self.core.event_bus.dispatch(Event::Messages(
+                MessageBatch::builder()
+                    .messages(items)
+                    .origin(origin)
+                    .hook_committed(hook_committed)
+                    .build(),
+            ));
+            // Claimed after the dispatch, never between the acks and it: this is the
+            // one suspension point in that span, and a teardown cancelling it there
+            // would leave the batch acked with its event never sent, which for a
+            // consumer without a hook is a lost message. Cancelled here instead, the
+            // claim is simply missing and a resend dispatches twice.
+            for item in dispatched.iter() {
+                // An unresolved secret envelope is a placeholder in the same sense
+                // as an UndecryptableMessage: what reached the consumer is not the
+                // content. Presence, not extractability: a malformed envelope is
+                // just as unreadable to a consumer as an unopenable one, and
+                // `extract_secret_encrypted` returns `None` for both a plain
+                // message and a malformed envelope. Claiming it would suppress the resend that arrives once
+                // the parent secret is known, so leave it unclaimed and take the
+                // duplicate instead. The batch collapse keeps such a resend for a
+                // related reason: it compares content, and the envelope is not the
+                // content.
+                if crate::features::message_edit::carries_secret_encrypted(&item.message) {
+                    continue;
+                }
+                self.mark_message_dispatched(&item.info).await;
+            }
         }
-        true
     }
 }
 

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -27,10 +27,8 @@ impl Client {
     /// `undecryptable_dispatched` gate is: claiming at the check would claim
     /// for a commit that may still fail. `chat_lanes` serializes incoming
     /// processing per chat and so closes the window for ordinary traffic, but
-    /// two workers for one chat can coexist after a lane eviction. The race
-    /// they leave is a second dispatch of one message, which is the behaviour
-    /// this gate improves on rather than a regression, and it is the safe
-    /// direction: the alternative loses the message.
+    /// PDO recovery arrives on the phone's lane instead. The commit path
+    /// rechecks recovery claims under the shared publication lock.
     pub(crate) async fn message_already_dispatched(&self, info: &Arc<MessageInfo>) -> bool {
         self.dispatched_messages
             .get(&Self::dispatch_key(info))
@@ -54,7 +52,7 @@ impl Client {
     /// consumer, losing the message instead of duplicating it.
     pub(crate) async fn mark_message_dispatched(&self, info: &Arc<MessageInfo>) {
         self.dispatched_messages
-            .insert(Self::dispatch_key(info), ())
+            .insert(Self::dispatch_key(info), MessageDispatch::Decrypted)
             .await;
     }
 

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -21,6 +21,16 @@ impl Client {
     ) -> R {
         let key = Self::dispatch_key(info);
         self.dispatched_messages.with(|cache| {
+            if cache.get(&key).is_some_and(|claim| {
+                claim.prune();
+                claim.payloads.is_empty()
+            }) {
+                // A claim left with no live payloads is absent: every owner
+                // rolled back. Drop the stale key so the alternate-spelling
+                // lookup below still runs instead of treating the empty claim
+                // as authoritative.
+                cache.remove(&key);
+            }
             if let Some(claim) = cache.get(&key) {
                 claim.prune();
                 if !pdo && claim.alias.is_none() {
@@ -111,35 +121,43 @@ impl Client {
         })
     }
 
-    pub(crate) async fn suppress_recovered_or_dispatched(
+    pub(crate) async fn probe_message_dispatch(
         self: &Arc<Self>,
         info: &Arc<MessageInfo>,
         message: &wa::Message,
-    ) -> bool {
+    ) -> ProbeOutcome {
         if !self.dispatch_gate_enabled()
             || !self.with_message_dispatch(info, false, |claim| claim.has_deliveries())
         {
-            return false;
+            return ProbeOutcome::Proceed { decrypted: None };
         }
-        let decrypted;
-        let message = if crate::features::message_edit::carries_secret_encrypted(message) {
-            let Some(inner) = self
+        // A message we cannot materialize compares as its envelope; dispatch
+        // retries the lookup after capturing, so an undecryptable probe must
+        // not suppress.
+        let decrypted = if crate::features::message_edit::carries_secret_encrypted(message) {
+            match self
                 .maybe_decrypt_secret_encrypted_message(message, info)
                 .await
-            else {
-                return false;
-            };
-            decrypted = inner;
-            &decrypted
+            {
+                Some(inner) => Some(inner),
+                None => return ProbeOutcome::Proceed { decrypted: None },
+            }
         } else {
-            message
+            None
         };
-        let fingerprint = MessageDispatch::fingerprint(message);
-        self.with_message_dispatch(info, false, |claim| {
+        let candidate = decrypted.as_ref().map_or(message, |inner| inner);
+        let fingerprint = MessageDispatch::fingerprint(candidate);
+        if self.with_message_dispatch(info, false, |claim| {
             claim.state(&fingerprint).is_some_and(|state| {
                 state != MessageDispatch::Recovered || self.inbound_durability_hook.get().is_none()
             })
-        })
+        }) {
+            ProbeOutcome::Suppress
+        } else {
+            ProbeOutcome::Proceed {
+                decrypted: decrypted.map(Box::new),
+            }
+        }
     }
 
     #[cfg(test)]
@@ -228,6 +246,20 @@ impl Client {
         info: &Arc<MessageInfo>,
         track_commit: bool,
     ) -> InboundCommitState {
+        self.dispatch_parsed_message_with_decrypted(msg, info, track_commit, None)
+            .await
+    }
+
+    /// Same as [`Self::dispatch_parsed_message`], but reuses a plaintext the
+    /// duplicate probe already materialized instead of resolving the parent
+    /// secret a second time.
+    pub(crate) async fn dispatch_parsed_message_with_decrypted(
+        self: &Arc<Self>,
+        msg: wa::Message,
+        info: &Arc<MessageInfo>,
+        track_commit: bool,
+        pre_decrypted: Option<wa::Message>,
+    ) -> InboundCommitState {
         use wacore::proto_helpers::MessageExt;
         wacore::telemetry::recv("decrypted");
         self.stats.record_message_received();
@@ -240,9 +272,13 @@ impl Client {
         // Keep this ordered with dispatch; add-on messages can immediately
         // reference the secret from the stanza just processed.
         self.maybe_capture_inbound_msg_secret(&msg, info).await;
-        let decrypted = self
-            .maybe_decrypt_secret_encrypted_message(&msg, info)
-            .await;
+        let decrypted = match pre_decrypted {
+            Some(inner) => Some(inner),
+            None => {
+                self.maybe_decrypt_secret_encrypted_message(&msg, info)
+                    .await
+            }
+        };
         // A decrypted comment surfaces as its inner body Message, which has no
         // slot for the parent post key; carry the threading link beside it.
         let comment_target = if decrypted.is_some() {

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -13,27 +13,135 @@ fn delivery_receipt_burst_warning(
 }
 
 impl Client {
-    /// Has this message already been dispatched to consumers?
-    ///
-    /// A sender whose network is bad re-runs its own outbox: same message id,
-    /// fresh ciphertext on a new ratchet iteration. Neither ratchet can call
-    /// that a duplicate (`DuplicatedMessage` covers only the byte-identical
-    /// stanza the server replays), so identity is the only thing left that says
-    /// the two deliveries are one message.
-    ///
-    /// Read here and written by [`Self::mark_message_dispatched`] once the
-    /// batch carrying the message becomes observable. Those are two points in
-    /// time, so this cannot be an atomic `get_with` the way the sibling
-    /// `undecryptable_dispatched` gate is: claiming at the check would claim
-    /// for a commit that may still fail. `chat_lanes` serializes incoming
-    /// processing per chat and so closes the window for ordinary traffic, but
-    /// PDO recovery arrives on the phone's lane instead. The commit path
-    /// rechecks recovery claims under the shared publication lock.
+    fn with_message_dispatch<R>(
+        &self,
+        info: &Arc<MessageInfo>,
+        pdo: bool,
+        update: impl FnOnce(&mut DispatchClaim) -> R,
+    ) -> R {
+        let key = Self::dispatch_key(info);
+        self.dispatched_messages.with(|cache| {
+            if let Some(claim) = cache.get(&key) {
+                claim.prune();
+                if !pdo && claim.alias.is_none() {
+                    claim.alias = Self::dispatch_alias(info, &key);
+                }
+                return update(claim);
+            }
+            let mut alias = None;
+            let recovery_key = if pdo {
+                // Only PDO misses scan. Two primaries naming this alternate
+                // are ambiguous, so neither may suppress the recovered event.
+                cache.find_unique_key(|primary, claim| {
+                    if !claim.has_deliveries()
+                        || primary.id != key.id
+                        || primary.from_me != key.from_me
+                    {
+                        return false;
+                    }
+                    match (&primary.participant, &key.participant, &claim.alias) {
+                        (Some(_), Some(participant), Some(alias)) => {
+                            primary.chat == key.chat && participant == alias
+                        }
+                        (None, None, Some(alias)) => &key.chat == alias,
+                        _ => false,
+                    }
+                })
+            } else {
+                alias = Self::dispatch_alias(info, &key);
+                alias.as_ref().and_then(|alternate| {
+                    let alternate_key = DispatchKey {
+                        chat: if key.participant.is_some() {
+                            key.chat.clone()
+                        } else {
+                            alternate.clone()
+                        },
+                        id: key.id.clone(),
+                        participant: key.participant.as_ref().map(|_| alternate.clone()),
+                        from_me: key.from_me,
+                    };
+                    let claim = cache.get(&alternate_key)?;
+                    claim.prune();
+                    let primary = key.participant.as_ref().unwrap_or(&key.chat);
+                    if !claim.has_recovery()
+                        || claim.alias.as_ref().is_some_and(|bound| bound != primary)
+                    {
+                        return None;
+                    }
+                    // Bind only the direct evidence in this stanza. A later
+                    // conflicting primary cannot reuse the PDO claim.
+                    claim.alias.get_or_insert_with(|| primary.clone());
+                    Some(alternate_key)
+                })
+            };
+            if let Some(claim) = recovery_key.as_ref().and_then(|key| cache.get(key)) {
+                claim.prune();
+                return update(claim);
+            }
+            let mut claim = DispatchClaim {
+                alias: alias.or_else(|| Self::dispatch_alias(info, &key)),
+                ..Default::default()
+            };
+            let result = update(&mut claim);
+            if !claim.payloads.is_empty() {
+                cache.insert(key, claim);
+            }
+            result
+        })
+    }
+
+    pub(crate) fn admit_message_dispatch(
+        &self,
+        info: &Arc<MessageInfo>,
+        pdo: bool,
+        fingerprint: Option<[u8; 32]>,
+        hook_committed: bool,
+        publication: &mut PublicationGuard,
+    ) -> bool {
+        let Some(fingerprint) = fingerprint else {
+            return false;
+        };
+        self.with_message_dispatch(info, pdo, |claim| {
+            claim.admit(fingerprint, pdo, hook_committed, publication)
+        })
+    }
+
+    pub(crate) async fn suppress_recovered_or_dispatched(
+        self: &Arc<Self>,
+        info: &Arc<MessageInfo>,
+        message: &wa::Message,
+    ) -> bool {
+        if !self.dispatch_gate_enabled()
+            || !self.with_message_dispatch(info, false, |claim| claim.has_deliveries())
+        {
+            return false;
+        }
+        let decrypted;
+        let message = if crate::features::message_edit::carries_secret_encrypted(message) {
+            let Some(inner) = self
+                .maybe_decrypt_secret_encrypted_message(message, info)
+                .await
+            else {
+                return false;
+            };
+            decrypted = inner;
+            &decrypted
+        } else {
+            message
+        };
+        let fingerprint = MessageDispatch::fingerprint(message);
+        self.with_message_dispatch(info, false, |claim| {
+            claim.state(&fingerprint).is_some_and(|state| {
+                state != MessageDispatch::Recovered || self.inbound_durability_hook.get().is_none()
+            })
+        })
+    }
+
+    #[cfg(test)]
     pub(crate) async fn message_already_dispatched(&self, info: &Arc<MessageInfo>) -> bool {
         self.dispatched_messages
             .get(&Self::dispatch_key(info))
-            .await
-            .is_some()
+            .is_some_and(|claim| claim.has_deliveries())
     }
 
     /// Whether the dispatch-once gate is on. Capacity 0 is its documented off
@@ -43,20 +151,24 @@ impl Client {
         self.dispatched_messages.configured_capacity() != Some(0)
     }
 
-    /// Claim a message id, called where a committed batch is dispatched.
-    ///
-    /// Placing it there rather than at the call site is what makes the offline
-    /// drain claim as well: a deferred batch dispatches later, and a claim
-    /// taken before that could be taken for a batch that never commits, which
-    /// would suppress and ack the redelivery with nothing ever handed to a
-    /// consumer, losing the message instead of duplicating it.
-    pub(crate) async fn mark_message_dispatched(&self, info: &Arc<MessageInfo>) {
-        self.dispatched_messages
-            .insert(Self::dispatch_key(info), MessageDispatch::Decrypted)
-            .await;
+    #[cfg(test)]
+    pub(crate) async fn mark_message_dispatched(
+        &self,
+        info: &Arc<MessageInfo>,
+        message: &wa::Message,
+    ) {
+        let mut publication = PublicationGuard::default();
+        self.admit_message_dispatch(
+            info,
+            false,
+            Some(MessageDispatch::fingerprint(message)),
+            false,
+            &mut publication,
+        );
+        publication.complete();
     }
 
-    /// The message's identity: chat, id, and the sender without its device.
+    /// The message's identity includes direction and, outside DMs, its author.
     ///
     /// Dropping the device matches WA Web, whose `MsgKey` for a group message
     /// takes `participant: asUserWidOrThrow(author)`, a device-less wid. It
@@ -67,12 +179,40 @@ impl Client {
     ///
     /// The PN/LID namespace stays as it arrived, deliberately unresolved, for
     /// the reasons [`Self::dispatch_undecryptable_event`] states at length.
-    pub(crate) fn dispatch_key(info: &Arc<MessageInfo>) -> wacore::types::message::SenderMessageId {
-        wacore::types::message::SenderMessageId::new(
-            info.source.chat.clone(),
-            info.id.clone(),
-            info.source.sender.to_non_ad(),
-        )
+    /// PDO alternate evidence is stored beside the claim, never folded into
+    /// this primary key or followed through another claim.
+    pub(crate) fn dispatch_key(info: &Arc<MessageInfo>) -> DispatchKey {
+        let source = &info.source;
+        let has_participant = source.chat.is_group()
+            || source.chat.is_broadcast_list()
+            || source.chat.is_status_broadcast();
+        DispatchKey {
+            chat: source.chat.clone(),
+            id: info.id.clone(),
+            participant: has_participant.then(|| source.sender.to_non_ad()),
+            from_me: source.is_from_me,
+        }
+    }
+
+    fn dispatch_alias(info: &Arc<MessageInfo>, key: &DispatchKey) -> Option<Jid> {
+        let source = &info.source;
+        let (primary, alternate) = if let Some(participant) = &key.participant {
+            (participant, source.sender_alt.as_ref()?)
+        } else if source.is_from_me {
+            (&key.chat, source.recipient_alt.as_ref()?)
+        } else {
+            let alternate = source.sender_alt.as_ref()?;
+            if source.sender.to_non_ad() != key.chat {
+                return None;
+            }
+            (&key.chat, alternate)
+        };
+        if !(primary.server.is_pn_family() && alternate.server.is_lid_family()
+            || primary.server.is_lid_family() && alternate.server.is_pn_family())
+        {
+            return None;
+        }
+        Some(alternate.to_non_ad())
     }
 
     /// Dispatches a successfully parsed message to the event bus and sends a delivery receipt.

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -24,7 +24,7 @@ impl Client {
             if let Some(claim) = cache.get(&key) {
                 claim.prune();
                 if !pdo && claim.alias.is_none() {
-                    claim.alias = Self::dispatch_alias(info, &key);
+                    claim.alias = Self::dispatch_alias(info, &key).map(Box::new);
                 }
                 return update(claim);
             }
@@ -41,9 +41,9 @@ impl Client {
                     }
                     match (&primary.participant, &key.participant, &claim.alias) {
                         (Some(_), Some(participant), Some(alias)) => {
-                            primary.chat == key.chat && participant == alias
+                            primary.chat == key.chat && participant == &**alias
                         }
-                        (None, None, Some(alias)) => &key.chat == alias,
+                        (None, None, Some(alias)) => key.chat == **alias,
                         _ => false,
                     }
                 })
@@ -64,13 +64,16 @@ impl Client {
                     claim.prune();
                     let primary = key.participant.as_ref().unwrap_or(&key.chat);
                     if !claim.has_recovery()
-                        || claim.alias.as_ref().is_some_and(|bound| bound != primary)
+                        || claim
+                            .alias
+                            .as_ref()
+                            .is_some_and(|bound| &**bound != primary)
                     {
                         return None;
                     }
                     // Bind only the direct evidence in this stanza. A later
                     // conflicting primary cannot reuse the PDO claim.
-                    claim.alias.get_or_insert_with(|| primary.clone());
+                    claim.alias.get_or_insert_with(|| Box::new(primary.clone()));
                     Some(alternate_key)
                 })
             };
@@ -79,7 +82,9 @@ impl Client {
                 return update(claim);
             }
             let mut claim = DispatchClaim {
-                alias: alias.or_else(|| Self::dispatch_alias(info, &key)),
+                alias: alias
+                    .or_else(|| Self::dispatch_alias(info, &key))
+                    .map(Box::new),
                 ..Default::default()
             };
             let result = update(&mut claim);
@@ -94,7 +99,7 @@ impl Client {
         &self,
         info: &Arc<MessageInfo>,
         pdo: bool,
-        fingerprint: Option<[u8; 32]>,
+        fingerprint: Option<DispatchFingerprint>,
         hook_committed: bool,
         publication: &mut PublicationGuard,
     ) -> bool {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1970,7 +1970,15 @@ impl Client {
                 skdm_only: true,
                 ..Default::default()
             })
-        } else if self.message_already_dispatched(info).await {
+        } else if self
+            .dispatched_messages
+            .get(&Self::dispatch_key(info))
+            .await
+            .is_some_and(|state| {
+                // PDO published an event, not a consumer's durable copy.
+                state != MessageDispatch::Recovered || self.inbound_durability_hook.get().is_none()
+            })
+        {
             // The event is a duplicate; the message secret it carries may not
             // be. Capture is write-behind and can drop an entry when its
             // backend is down, and this branch skips `dispatch_parsed_message`,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1970,15 +1970,7 @@ impl Client {
                 skdm_only: true,
                 ..Default::default()
             })
-        } else if self
-            .dispatched_messages
-            .get(&Self::dispatch_key(info))
-            .await
-            .is_some_and(|state| {
-                // PDO published an event, not a consumer's durable copy.
-                state != MessageDispatch::Recovered || self.inbound_durability_hook.get().is_none()
-            })
-        {
+        } else if self.suppress_recovered_or_dispatched(info, &msg).await {
             // The event is a duplicate; the message secret it carries may not
             // be. Capture is write-behind and can drop an entry when its
             // backend is down, and this branch skips `dispatch_parsed_message`,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1970,48 +1970,60 @@ impl Client {
                 skdm_only: true,
                 ..Default::default()
             })
-        } else if self.suppress_recovered_or_dispatched(info, &msg).await {
-            // The event is a duplicate; the message secret it carries may not
-            // be. Capture is write-behind and can drop an entry when its
-            // backend is down, and this branch skips `dispatch_parsed_message`,
-            // which is the only other caller: without this the resend is the
-            // second chance we would have thrown away, and every later
-            // encrypted edit, reaction or comment on that parent stays
-            // unopenable. It is a no-op for a message carrying no secret.
-            self.maybe_capture_inbound_msg_secret(&msg, info).await;
-            // The sender resent a message we already handed to consumers. Ack
-            // it the way the ratchet-level duplicate is acked, so a registered
-            // durability hook still gets its replay instead of a bare ack.
-            // status is acked by the should_ack gate. A hook whose buffered copy
-            // survived replays instead of being acked, which dispatches the
-            // message again: that is the documented at-least-once shape, not a
-            // suppression, so it is not counted as one.
-            let replayed =
-                !info.source.chat.is_status_broadcast() && self.ack_or_replay_to_hook(info).await;
-            if !replayed {
-                self.duplicate_dispatch_suppressed
-                    .fetch_add(1, Ordering::Relaxed);
-                wacore::telemetry::recv("duplicate_resend");
-                log::debug!(
-                    "[msg:{}] already dispatched for this sender; suppressing the resend's event",
-                    info.id
-                );
-            }
-            // The event is a duplicate; the key share is not. Our phone asking
-            // again is what it does when it did not get the keys, so the first
-            // delivery's send having been scheduled is no reason to skip this
-            // one. Sending them twice costs a stanza; not sending them leaves
-            // the requester without app-state keys until it changes request id.
-            if let Some((requester, request)) = app_state_key_share_job {
-                self.schedule_app_state_sync_key_share(requester, request, None);
-            }
-            Ok(PlaintextHandleOutcome {
-                dispatched: true,
-                ..Default::default()
-            })
         } else {
+            // The probe may have already materialized a secret envelope while
+            // fingerprinting; hand it to dispatch instead of resolving the
+            // parent secret a second time.
+            let pre_decrypted = match self.probe_message_dispatch(info, &msg).await {
+                ProbeOutcome::Suppress => {
+                    // The event is a duplicate; the message secret it carries may not
+                    // be. Capture is write-behind and can drop an entry when its
+                    // backend is down, and this branch skips `dispatch_parsed_message`,
+                    // which is the only other caller: without this the resend is the
+                    // second chance we would have thrown away, and every later
+                    // encrypted edit, reaction or comment on that parent stays
+                    // unopenable. It is a no-op for a message carrying no secret.
+                    self.maybe_capture_inbound_msg_secret(&msg, info).await;
+                    // The sender resent a message we already handed to consumers. Ack
+                    // it the way the ratchet-level duplicate is acked, so a registered
+                    // durability hook still gets its replay instead of a bare ack.
+                    // status is acked by the should_ack gate. A hook whose buffered copy
+                    // survived replays instead of being acked, which dispatches the
+                    // message again: that is the documented at-least-once shape, not a
+                    // suppression, so it is not counted as one.
+                    let replayed = !info.source.chat.is_status_broadcast()
+                        && self.ack_or_replay_to_hook(info).await;
+                    if !replayed {
+                        self.duplicate_dispatch_suppressed
+                            .fetch_add(1, Ordering::Relaxed);
+                        wacore::telemetry::recv("duplicate_resend");
+                        log::debug!(
+                            "[msg:{}] already dispatched for this sender; suppressing the resend's event",
+                            info.id
+                        );
+                    }
+                    // The event is a duplicate; the key share is not. Our phone asking
+                    // again is what it does when it did not get the keys, so the first
+                    // delivery's send having been scheduled is no reason to skip this
+                    // one. Sending them twice costs a stanza; not sending them leaves
+                    // the requester without app-state keys until it changes request id.
+                    if let Some((requester, request)) = app_state_key_share_job {
+                        self.schedule_app_state_sync_key_share(requester, request, None);
+                    }
+                    return Ok(PlaintextHandleOutcome {
+                        dispatched: true,
+                        ..Default::default()
+                    });
+                }
+                ProbeOutcome::Proceed { decrypted } => decrypted.map(|boxed| *boxed),
+            };
             let commit_state = self
-                .dispatch_parsed_message(msg, info, app_state_key_share_job.is_some())
+                .dispatch_parsed_message_with_decrypted(
+                    msg,
+                    info,
+                    app_state_key_share_job.is_some(),
+                    pre_decrypted,
+                )
                 .await;
             if let Some((requester, request)) = app_state_key_share_job {
                 match commit_state {

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -9997,9 +9997,9 @@ async fn collect_event<F>(
     collector: Arc<crate::test_utils::TestEventCollector>,
     pred: F,
     timeout_ms: u64,
-) -> Option<Arc<wacore::types::events::Event>>
+) -> Option<Arc<Event>>
 where
-    F: Fn(&wacore::types::events::Event) -> bool,
+    F: Fn(&Event) -> bool,
 {
     let _ = client;
     let mut waited = 0u64;
@@ -14978,6 +14978,702 @@ async fn a_namespace_switch_mid_flight_is_seen_as_a_second_message() {
     );
 }
 
+mod pdo_alias_tests {
+    use super::*;
+    use buffa::Message as _;
+    use wacore::types::events::ChannelEventHandler;
+    use wacore::types::message::MessageSource;
+
+    const ID: &str = "SYNTHETIC_PDO_ALIAS";
+    const PN: &str = "15550001001@s.whatsapp.net";
+    const LID: &str = "777000000000101@lid";
+    const OWN: &str = "15550001002@s.whatsapp.net";
+
+    #[test]
+    fn pdo_alias_fingerprint_does_not_allocate_message_sized_buffer() {
+        let message = wa::Message {
+            conversation: Some("x".repeat(8192)),
+            ..Default::default()
+        };
+        let max = crate::test_alloc::min_max_block(1024, || MessageDispatch::fingerprint(&message));
+        assert!(
+            max <= 1024,
+            "fingerprint allocated a {max}-byte block for an 8192-byte body"
+        );
+    }
+
+    #[test]
+    fn pdo_alias_streaming_fingerprint_matches_wire_encoding() {
+        use sha2::{Digest, Sha256};
+        for message in [
+            wa::Message::default(),
+            wa::Message {
+                conversation: Some("synthetic nested message".into()),
+                location_message: buffa::MessageField::some(wa::message::LocationMessage {
+                    degrees_latitude: Some(1.5),
+                    degrees_longitude: Some(-2.25),
+                    jpeg_thumbnail: Some(vec![0x5A; 8192]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ] {
+            let wire = waproto::codec::message_to_vec(&message);
+            let expected: [u8; 32] = Sha256::digest(&wire).into();
+            assert_eq!(MessageDispatch::fingerprint(&message), expected);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum Shape {
+        Incoming,
+        Outgoing,
+        Group,
+    }
+
+    fn info(shape: Shape) -> Arc<MessageInfo> {
+        let group = matches!(shape, Shape::Group);
+        let outgoing = matches!(shape, Shape::Outgoing);
+        Arc::new(MessageInfo {
+            id: ID.into(),
+            source: MessageSource {
+                chat: if group {
+                    "120363000000000101@g.us"
+                } else {
+                    LID
+                }
+                .parse()
+                .unwrap(),
+                sender: if outgoing { OWN } else { LID }.parse().unwrap(),
+                sender_alt: Some(
+                    if outgoing { "777000000000102@lid" } else { PN }
+                        .parse()
+                        .unwrap(),
+                ),
+                recipient_alt: outgoing.then(|| PN.parse().unwrap()),
+                is_from_me: outgoing,
+                is_group: group,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn response(info: &MessageInfo) -> wa::message::PeerDataOperationRequestResponseMessage {
+        response_with_message(
+            info,
+            wa::Message {
+                conversation: Some("alias payload".into()),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn response_with_message(
+        info: &MessageInfo,
+        message: wa::Message,
+    ) -> wa::message::PeerDataOperationRequestResponseMessage {
+        let web = wa::WebMessageInfo {
+            key: buffa::MessageField::some(wa::MessageKey {
+                id: Some(info.id.to_string()),
+                remote_jid: Some(if info.source.is_group {
+                    info.source.chat.to_string()
+                } else {
+                    PN.into()
+                }),
+                participant: info.source.is_group.then(|| PN.into()),
+                from_me: Some(info.source.is_from_me),
+            }),
+            message: buffa::MessageField::some(message),
+            ..Default::default()
+        };
+        wa::message::PeerDataOperationRequestResponseMessage {
+            peer_data_operation_result: vec![wa::message::peer_data_operation_request_response_message::PeerDataOperationResult {
+                placeholder_message_resend_response: buffa::MessageField::some(
+                    wa::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse {
+                        web_message_info_bytes: Some(web.encode_to_vec()),
+                    }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    async fn retry(client: &Arc<Client>, info: &Arc<MessageInfo>) {
+        retry_message(
+            client,
+            info,
+            &wa::Message {
+                conversation: Some("alias payload".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    }
+
+    async fn retry_message(client: &Arc<Client>, info: &Arc<MessageInfo>, message: &wa::Message) {
+        client
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(message),
+                2,
+                0,
+                Default::default(),
+                info,
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn client() -> (Arc<Client>, async_channel::Receiver<Arc<Event>>) {
+        let client = crate::test_utils::create_test_client().await;
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetId(Some(
+                OWN.parse().unwrap(),
+            )))
+            .await;
+        let (handler, events) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+        (client, events)
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_committed_ordinary_part_keeps_distinct_recovery() {
+        for alias in [false, true] {
+            let (client, events) = client().await;
+            let mut info = info(Shape::Incoming);
+            if !alias {
+                let source = &mut Arc::make_mut(&mut info).source;
+                source.chat = PN.parse().unwrap();
+                source.sender = source.chat.clone();
+                source.sender_alt = None;
+            }
+            retry(&client, &info).await;
+            let response = response_with_message(
+                &info,
+                wa::Message {
+                    conversation: Some("distinct PDO part".into()),
+                    ..Default::default()
+                },
+            );
+            client
+                .handle_pdo_response(&response, &MessageInfo::default())
+                .await;
+            client
+                .handle_pdo_response(&response, &MessageInfo::default())
+                .await;
+            assert_eq!(
+                message_texts_for_id(&events, ID),
+                ["alias payload", "distinct PDO part"]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_unresolved_distinct_part_is_not_suppressed() {
+        let (client, events) = client().await;
+        let info = info(Shape::Incoming);
+        client
+            .handle_pdo_response(&response(&info), &MessageInfo::default())
+            .await;
+        retry_message(
+            &client,
+            &info,
+            &wa::Message {
+                enc_reaction_message: buffa::MessageField::some(Default::default()),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(
+            message_events_for_id(&events, ID),
+            (2, 1),
+            "identity cannot prove an unresolved envelope is the PDO payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_remembers_the_unmatched_ordinary_part() {
+        struct Hook(std::sync::atomic::AtomicUsize);
+        #[async_trait::async_trait]
+        impl crate::types::durability_hook::InboundDurabilityHook for Hook {
+            async fn on_messages(
+                &self,
+                _: Arc<Client>,
+                _: &[wacore::types::events::InboundMessage],
+            ) -> anyhow::Result<()> {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+        for durable in [false, true] {
+            let (client, events) = client().await;
+            let hook = Arc::new(Hook(std::sync::atomic::AtomicUsize::new(0)));
+            if durable {
+                client
+                    .inbound_durability_hook
+                    .set(hook.clone())
+                    .ok()
+                    .unwrap();
+            }
+            let info = info(Shape::Incoming);
+            client
+                .handle_pdo_response(&response(&info), &MessageInfo::default())
+                .await;
+            let part = wa::Message {
+                conversation: Some("ordinary part B".into()),
+                ..Default::default()
+            };
+            retry_message(&client, &info, &part).await;
+            retry_message(&client, &Arc::new((*info).clone()), &part).await;
+            assert_eq!(
+                message_texts_for_id(&events, ID),
+                ["alias payload", "ordinary part B"]
+            );
+            assert_eq!(hook.0.load(Ordering::Relaxed), usize::from(durable));
+        }
+    }
+
+    async fn interrupted_publication(pdo: bool) {
+        use futures::FutureExt as _;
+        struct PanicHandler;
+        impl EventHandler for PanicHandler {
+            fn handle_event(&self, event: Arc<Event>) {
+                assert!(event.as_messages().is_none(), "synthetic subscriber panic");
+            }
+        }
+        let client = crate::test_utils::create_test_client().await;
+        let panicking = client
+            .core
+            .event_bus
+            .subscribe_handler(Arc::new(PanicHandler));
+        let (handler, events) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+        let info = info(Shape::Incoming);
+        let response = response(&info);
+        let interrupted = std::panic::AssertUnwindSafe(async {
+            if pdo {
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+            } else {
+                retry(&client, &info).await;
+            }
+        })
+        .catch_unwind()
+        .await;
+        assert!(interrupted.is_err());
+        assert_eq!(message_events_for_id(&events, ID), (0, 0));
+        assert!(panicking.unsubscribe());
+        if pdo {
+            client
+                .handle_pdo_response(&response, &MessageInfo::default())
+                .await;
+        } else {
+            retry(&client, &Arc::new((*info).clone())).await;
+        }
+        assert_eq!(
+            message_events_for_id(&events, ID),
+            (1, 1),
+            "interrupted fan-out must not suppress delivery to the surviving subscriber"
+        );
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_panic_allows_recovery_redelivery() {
+        interrupted_publication(true).await;
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_panic_allows_ordinary_redelivery() {
+        interrupted_publication(false).await;
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_rollback_preserves_other_and_newer_owners() {
+        let (client, _) = client().await;
+        let info = info(Shape::Incoming);
+        let a = MessageDispatch::fingerprint(&wa::Message {
+            conversation: Some("A".into()),
+            ..Default::default()
+        });
+        let b = MessageDispatch::fingerprint(&wa::Message {
+            conversation: Some("B".into()),
+            ..Default::default()
+        });
+        let mut interrupted = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(&info, false, Some(a), false, &mut interrupted));
+        assert!(!client.admit_message_dispatch(&info, true, Some(b), false, &mut interrupted));
+        let mut newer = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(&info, false, Some(a), false, &mut newer));
+        newer.complete();
+        drop(interrupted);
+        let claim = client
+            .dispatched_messages
+            .get(&Client::dispatch_key(&info))
+            .unwrap();
+        assert!(
+            claim.state(&a) == Some(MessageDispatch::Decrypted),
+            "the later successful publisher owns A"
+        );
+        assert!(
+            claim.state(&b).is_none(),
+            "only the interrupted publisher owned B"
+        );
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_payload_capacity_fails_open() {
+        let (client, events) = client().await;
+        let info = info(Shape::Incoming);
+        let part = |index| wa::Message {
+            conversation: Some(format!("part {index}")),
+            ..Default::default()
+        };
+        for index in 0..=MAX_DISPATCH_PAYLOADS {
+            retry_message(&client, &info, &part(index)).await;
+        }
+        assert_eq!(
+            message_events_for_id(&events, ID).0,
+            MAX_DISPATCH_PAYLOADS + 1
+        );
+        assert_eq!(
+            client
+                .dispatched_messages
+                .get(&Client::dispatch_key(&info))
+                .unwrap()
+                .payloads
+                .len(),
+            MAX_DISPATCH_PAYLOADS
+        );
+        retry_message(&client, &info, &part(0)).await;
+        retry_message(&client, &info, &part(MAX_DISPATCH_PAYLOADS)).await;
+        assert_eq!(
+            message_texts_for_id(&events, ID),
+            [format!("part {MAX_DISPATCH_PAYLOADS}")],
+            "overflow stays deliverable while previously tracked parts stay deduplicated"
+        );
+    }
+
+    async fn arrival_order(recovery_first: bool, queued: bool) {
+        for shape in [Shape::Incoming, Shape::Outgoing, Shape::Group] {
+            for pending in [false, true] {
+                let (client, events) = client().await;
+                let info = info(shape);
+                let response = response(&info);
+                assert!(
+                    client
+                        .lid_pn_cache
+                        .get_phone_number("777000000000101")
+                        .await
+                        .is_none()
+                );
+                if pending {
+                    client
+                        .pdo_pending_requests
+                        .insert(
+                            wacore::types::message::ChatMessageId::new(
+                                if info.source.is_group {
+                                    info.source.chat.clone()
+                                } else {
+                                    PN.parse().unwrap()
+                                },
+                                ID.into(),
+                            ),
+                            crate::pdo::PendingPdoRequest {
+                                message_info: info.clone(),
+                                requested_at: wacore::time::Instant::now(),
+                            },
+                        )
+                        .await;
+                }
+                if queued {
+                    client.inbound_commit_batch.reset();
+                }
+                if recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                retry(&client, &info).await;
+                if !recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                if queued {
+                    assert!(
+                        client
+                            .flush_inbound_commits_under_permit(true, None, None)
+                            .await
+                    );
+                }
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+                assert_eq!(
+                    message_events_for_id(&events, ID),
+                    (1, 1),
+                    "explicit alias must cover the fallback and repeated PDO after pending removal"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_normal_first() {
+        arrival_order(false, false).await;
+    }
+    #[tokio::test]
+    async fn pdo_alias_recovery_first() {
+        arrival_order(true, false).await;
+    }
+    #[tokio::test]
+    async fn pdo_alias_queued_late_filter() {
+        arrival_order(false, true).await;
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_missing_evidence_allows_delivery() {
+        for recovery_first in [false, true] {
+            let (client, events) = client().await;
+            let mut info = info(Shape::Incoming);
+            Arc::make_mut(&mut info).source.sender_alt = None;
+            let response = response(&info);
+            if recovery_first {
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+            }
+            retry(&client, &info).await;
+            if !recovery_first {
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+            }
+            assert_eq!(message_events_for_id(&events, ID), (2, 2));
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_direction_is_part_of_identity() {
+        let (client, events) = client().await;
+        let mut info = info(Shape::Group);
+        Arc::make_mut(&mut info).source.sender = PN.parse().unwrap();
+        let response = response(&info);
+        Arc::make_mut(&mut info).source.is_from_me = true;
+        retry(&client, &info).await;
+        client
+            .handle_pdo_response(&response, &MessageInfo::default())
+            .await;
+        assert_eq!(message_events_for_id(&events, ID), (2, 2));
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_identity_boundaries_fail_open() {
+        for recovery_first in [false, true] {
+            for case in 0..8 {
+                let (client, events) = client().await;
+                let shape = match case {
+                    0..=2 => Shape::Group,
+                    3 | 4 => Shape::Outgoing,
+                    _ => Shape::Incoming,
+                };
+                let mut info = info(shape);
+                let response = response(&info);
+                let info_mut = Arc::make_mut(&mut info);
+                match case {
+                    0 => {
+                        info_mut.source.sender_alt =
+                            Some("15550001003@s.whatsapp.net".parse().unwrap())
+                    }
+                    1 => info_mut.source.chat = "120363000000000103@g.us".parse().unwrap(),
+                    2 => info_mut.id = "DIFFERENT_ID".into(),
+                    3 => {
+                        info_mut.source.recipient_alt = None;
+                        info_mut.source.sender_alt = Some(PN.parse().unwrap());
+                    }
+                    4 => {
+                        info_mut.source.recipient_alt =
+                            Some("15550001003@s.whatsapp.net".parse().unwrap())
+                    }
+                    5 => {
+                        info_mut.source.chat = "15550001001@lid".parse().unwrap();
+                        info_mut.source.sender = info_mut.source.chat.clone();
+                        info_mut.source.sender_alt = None;
+                    }
+                    6 => info_mut.source.sender_alt = Some("777000000000103@lid".parse().unwrap()),
+                    7 => info_mut.source.sender = "777000000000103@lid".parse().unwrap(),
+                    _ => unreachable!(),
+                }
+                if recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                retry(&client, &info).await;
+                if !recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                assert_eq!(
+                    drain_message_events(&events).len(),
+                    2,
+                    "identity boundary case {case}, recovery_first={recovery_first}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_conflicting_primaries_do_not_merge() {
+        for recovery_first in [false, true] {
+            let (client, events) = client().await;
+            let first = info(Shape::Incoming);
+            let mut second = first.clone();
+            let source = &mut Arc::make_mut(&mut second).source;
+            source.chat = "777000000000103@lid".parse().unwrap();
+            source.sender = source.chat.clone();
+            let response = response(&first);
+            if recovery_first {
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+            }
+            retry(&client, &first).await;
+            retry(&client, &second).await;
+            if !recovery_first {
+                client
+                    .handle_pdo_response(&response, &MessageInfo::default())
+                    .await;
+            }
+            assert_eq!(
+                message_events_for_id(&events, ID),
+                if recovery_first { (2, 2) } else { (3, 3) }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_evidence_does_not_merge_ordinary_namespace_switches() {
+        let (client, events) = client().await;
+        let first = info(Shape::Incoming);
+        let mut second = first.clone();
+        let source = &mut Arc::make_mut(&mut second).source;
+        source.chat = PN.parse().unwrap();
+        source.sender = source.chat.clone();
+        source.sender_alt = Some(LID.parse().unwrap());
+        retry(&client, &first).await;
+        retry(&client, &second).await;
+        assert_eq!(message_events_for_id(&events, ID), (2, 2));
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_global_mapping_is_not_evidence() {
+        use crate::lid_pn_cache::{LearningSource, LidPnEntry};
+        for explicit in [false, true] {
+            for recovery_first in [false, true] {
+                let (client, events) = client().await;
+                let mut info = info(Shape::Incoming);
+                if !explicit {
+                    Arc::make_mut(&mut info).source.sender_alt = None;
+                }
+                let mapping = LidPnEntry::new(
+                    "777000000000101",
+                    if explicit {
+                        "15550001003"
+                    } else {
+                        "15550001001"
+                    },
+                    LearningSource::PeerLidMessage,
+                );
+                client.lid_pn_cache.add(&mapping).await;
+                let response = response(&info);
+                if recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                retry(&client, &info).await;
+                if !recovery_first {
+                    client
+                        .handle_pdo_response(&response, &MessageInfo::default())
+                        .await;
+                }
+                assert_eq!(
+                    message_events_for_id(&events, ID),
+                    if explicit { (1, 1) } else { (2, 2) }
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_pending_participant_cannot_override_direction() {
+        let (client, events) = client().await;
+        let mut info = info(Shape::Group);
+        let response = response(&info);
+        Arc::make_mut(&mut info).source.is_from_me = true;
+        client
+            .pdo_pending_requests
+            .insert(
+                wacore::types::message::ChatMessageId::new(info.source.chat.clone(), ID.into()),
+                crate::pdo::PendingPdoRequest {
+                    message_info: info.clone(),
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+        retry(&client, &info).await;
+        client
+            .handle_pdo_response(&response, &MessageInfo::default())
+            .await;
+        assert_eq!(message_events_for_id(&events, ID), (2, 2));
+    }
+
+    #[tokio::test]
+    async fn pdo_alias_hook_promotes_the_original_recovery_claim() {
+        struct Hook(std::sync::atomic::AtomicUsize);
+        #[async_trait::async_trait]
+        impl crate::types::durability_hook::InboundDurabilityHook for Hook {
+            async fn on_messages(
+                &self,
+                _: Arc<Client>,
+                _: &[wacore::types::events::InboundMessage],
+            ) -> anyhow::Result<()> {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+        let (client, events) = client().await;
+        let hook = Arc::new(Hook(std::sync::atomic::AtomicUsize::new(0)));
+        client
+            .inbound_durability_hook
+            .set(hook.clone())
+            .ok()
+            .unwrap();
+        let info = info(Shape::Incoming);
+        let response = response(&info);
+        client
+            .handle_pdo_response(&response, &MessageInfo::default())
+            .await;
+        retry(&client, &info).await;
+        retry(&client, &info).await;
+        client
+            .handle_pdo_response(&response, &MessageInfo::default())
+            .await;
+        assert_eq!(hook.0.load(Ordering::Relaxed), 1);
+        assert_eq!(message_events_for_id(&events, ID), (1, 1));
+        assert_eq!(
+            client.dispatched_messages.entry_count(),
+            1,
+            "hook promotion must not duplicate the authoritative claim under the alternate key"
+        );
+    }
+}
+
 struct PdoRetryFixture {
     client: Arc<Client>,
     transport: Arc<crate::transport::mock::CapturingMockTransport>,
@@ -15417,22 +16113,8 @@ async fn pdo_retry_missing_recovered_content_does_not_claim() {
 #[tokio::test]
 async fn pdo_retry_concurrent_recoveries_share_publication() {
     let fixture = PdoRetryFixture::new().await;
-    let guard = fixture
-        .client
-        .inbound_commit_batch
-        .dispatch_lock
-        .lock()
-        .await;
     let first = fixture.recover();
     let second = fixture.recover();
-    futures::pin_mut!(first, second);
-    assert!(futures::poll!(&mut first).is_pending());
-    assert!(futures::poll!(&mut second).is_pending());
-    assert_eq!(
-        message_events_for_id(&fixture.events, PdoRetryFixture::ID),
-        (0, 0)
-    );
-    drop(guard);
     futures::join!(first, second);
     fixture.retry().await;
     fixture.assert_once();
@@ -15484,6 +16166,152 @@ async fn pdo_retry_batch_keeps_unrelated_messages() {
             .collect::<Vec<_>>(),
         [PdoRetryFixture::ID, "BEFORE_RECOVERED", "AFTER_RECOVERED"]
     );
+}
+
+async fn pdo_retry_distinct_payloads(recover_first: bool) {
+    let fixture = PdoRetryFixture::new().await;
+    fixture.client.inbound_commit_batch.reset();
+    let info = Arc::new(
+        fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap(),
+    );
+    if recover_first {
+        fixture.recover().await;
+    }
+    for text in ["\u{1f980}ping", "distinct multipart body"] {
+        fixture
+            .client
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(&wa::Message {
+                    conversation: Some(text.into()),
+                    ..Default::default()
+                }),
+                2,
+                0,
+                Default::default(),
+                &info,
+            )
+            .await
+            .unwrap();
+    }
+    if !recover_first {
+        fixture.recover().await;
+    }
+    assert!(
+        fixture
+            .client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await
+    );
+    assert_eq!(
+        drain_message_events(&fixture.events).len(),
+        2,
+        "PDO recovered only one payload, not every part sharing its MessageInfo"
+    );
+}
+
+#[tokio::test]
+async fn pdo_retry_late_filter_keeps_distinct_payloads() {
+    pdo_retry_distinct_payloads(false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_early_gate_keeps_distinct_payloads() {
+    pdo_retry_distinct_payloads(true).await;
+}
+
+async fn pdo_retry_callback_progress(recovery: bool) {
+    struct BlockingHandler {
+        id: &'static str,
+        entered: async_channel::Sender<()>,
+        release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+    impl EventHandler for BlockingHandler {
+        fn handle_event(&self, event: Arc<Event>) {
+            if event
+                .as_messages()
+                .is_some_and(|batch| batch.iter().any(|m| m.info.id == self.id))
+            {
+                self.entered.try_send(()).unwrap();
+                self.release.lock().unwrap().recv().unwrap();
+            }
+        }
+    }
+    let fixture = PdoRetryFixture::new().await;
+    let (entered_tx, entered) = async_channel::bounded(1);
+    let (release, release_rx) = std::sync::mpsc::channel();
+    fixture
+        .client
+        .core
+        .event_bus
+        .subscribe_handler(Arc::new(BlockingHandler {
+            id: if recovery {
+                PdoRetryFixture::ID
+            } else {
+                "BLOCKED_CALLBACK"
+            },
+            entered: entered_tx,
+            release: std::sync::Mutex::new(release_rx),
+        }))
+        .detach();
+    let mut info = fixture
+        .client
+        .parse_message_info(fixture.retry.get())
+        .await
+        .unwrap();
+    info.id = "BLOCKED_CALLBACK".into();
+    info.source.chat = "120363000000000072@g.us".parse().unwrap();
+    let client = fixture.client.clone();
+    let response = fixture.response.clone();
+    let phone_info = fixture.phone_info.clone();
+    let blocked = tokio::spawn(async move {
+        if recovery {
+            client.handle_pdo_response(&response, &phone_info).await;
+            return;
+        }
+        client
+            .dispatch_parsed_message(
+                wa::Message {
+                    conversation: Some("blocked".into()),
+                    ..Default::default()
+                },
+                &Arc::new(info),
+                false,
+            )
+            .await;
+    });
+    entered.recv().await.unwrap();
+    let progressed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        fixture.recover().await;
+        fixture.retry().await;
+        fixture
+            .client
+            .teardown_inbound_commits_bounded(std::time::Duration::from_secs(5))
+            .await;
+    })
+    .await
+    .is_ok();
+    release.send(()).unwrap();
+    blocked.await.unwrap();
+    assert!(
+        progressed,
+        "callbacks must not block other publications or inbound teardown"
+    );
+    fixture.assert_once();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pdo_retry_blocked_callback_does_not_block_other_publications() {
+    pdo_retry_callback_progress(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pdo_retry_blocked_recovery_callback_admits_no_duplicate() {
+    pdo_retry_callback_progress(true).await;
 }
 
 #[derive(Default)]
@@ -15560,6 +16388,17 @@ async fn pdo_retry_durability_after_recovery(fail_first: bool) {
         );
     }
     assert!(pending().await.unwrap().is_none());
+    assert!(
+        fixture
+            .client
+            .dispatched_messages
+            .get(&Client::dispatch_key(&info))
+            .is_some_and(|claim| claim
+                .payloads
+                .first()
+                .is_some_and(|payload| payload.state == MessageDispatch::RecoveredCommitted)),
+        "promotion records hook success for the PDO event that was already published"
+    );
     fixture
         .client
         .handle_decrypted_plaintext(
@@ -15594,7 +16433,7 @@ async fn pdo_retry_recovered_event_preserves_failed_hook_replay() {
     pdo_retry_durability_after_recovery(true).await;
 }
 
-async fn pdo_retry_cancel_durable_publication(teardown: bool) {
+async fn pdo_retry_synchronous_durable_publication(teardown: bool) {
     let fixture = PdoRetryFixture::new().await;
     fixture.client.flush_signal_cache().await.unwrap();
     let info = fixture
@@ -15612,29 +16451,29 @@ async fn pdo_retry_cancel_durable_publication(teardown: bool) {
     fixture.client.inbound_commit_batch.reset();
     fixture.client.swap_message_semaphore(1);
     fixture.retry().await;
-    let guard = fixture
-        .client
-        .inbound_commit_batch
-        .dispatch_lock
-        .lock()
-        .await;
     fixture
         .client
         .inbound_commit_batch
         .publication_reached
         .store(false, Ordering::Release);
-    let client = fixture.client.clone();
-    let commit = tokio::spawn(async move {
-        client
-            .flush_inbound_commits_under_permit(false, None, None)
-            .await
-    });
-    crate::test_utils::poll_until("publication after the durable Signal flush", || {
-        fixture
+    let commit = fixture
+        .client
+        .flush_inbound_commits_under_permit(false, None, None);
+    futures::pin_mut!(commit);
+    futures::future::poll_fn(|cx| {
+        let polled = Future::poll(commit.as_mut(), cx);
+        if fixture
             .client
             .inbound_commit_batch
             .publication_reached
             .load(Ordering::Acquire)
+        {
+            assert!(
+                polled.is_ready(),
+                "publication must finish in the poll that completed the Signal flush"
+            );
+        }
+        polled
     })
     .await;
     assert_ne!(
@@ -15648,14 +16487,13 @@ async fn pdo_retry_cancel_durable_publication(teardown: bool) {
     );
     assert_eq!(
         message_events_for_id(&fixture.events, PdoRetryFixture::ID),
-        (0, 0)
+        (1, 1),
+        "a completed Signal flush must not introduce a cancellable wait before publication"
     );
-    commit.abort();
-    assert!(commit.await.unwrap_err().is_cancelled());
     assert_eq!(
         fixture.client.inbound_commit_batch.pending_stats().0,
-        1,
-        "cancellation must retain the unpublished plaintext after its ratchet became durable"
+        0,
+        "publication must not depend on retained in-memory plaintext"
     );
     if teardown {
         fixture
@@ -15665,19 +16503,29 @@ async fn pdo_retry_cancel_durable_publication(teardown: bool) {
         fixture.client.inbound_commit_batch.reset();
         assert_eq!(
             fixture.client.inbound_commit_batch.pending_stats().0,
-            1,
-            "reset cannot discard plaintext whose ratchet was already persisted"
+            0,
+            "reset has no unpublished durable plaintext to discard"
         );
     }
-    drop(guard);
     if teardown {
         fixture.retry().await;
         assert_eq!(
             message_events_for_id(&fixture.events, PdoRetryFixture::ID),
             (0, 0),
-            "the persisted ratchet rejects redelivery; the retained plaintext is the only publication copy"
+            "the persisted ratchet rejects redelivery after the event was published"
         );
-        assert_eq!(fixture.client.inbound_commit_batch.pending_stats().0, 1);
+        assert_eq!(fixture.client.inbound_commit_batch.pending_stats().0, 0);
+        let restarted = crate::test_utils::create_test_client_with_backend(backend.clone()).await;
+        let (handler, events) = wacore::types::events::ChannelEventHandler::new();
+        restarted.core.event_bus.subscribe_handler(handler).detach();
+        restarted
+            .handle_incoming_message(fixture.retry.clone())
+            .await;
+        assert_eq!(
+            message_events_for_id(&events, PdoRetryFixture::ID),
+            (0, 0),
+            "a new Client cannot recover the persisted duplicate; publication must precede teardown"
+        );
     }
     let mut later_info = info;
     later_info.id = "AFTER_CANCEL".into();
@@ -15707,55 +16555,33 @@ async fn pdo_retry_cancel_durable_publication(teardown: bool) {
             .iter()
             .map(|(id, _)| id.as_str())
             .collect::<Vec<_>>(),
-        [PdoRetryFixture::ID, "AFTER_CANCEL"]
+        ["AFTER_CANCEL"]
     );
     assert_eq!(fixture.client.inbound_commit_batch.pending_stats().0, 0);
 }
 
 #[tokio::test]
-async fn pdo_retry_cancel_after_signal_flush_retains_publication() {
-    pdo_retry_cancel_durable_publication(false).await;
+async fn pdo_retry_signal_flush_publishes_without_cancellation_wait() {
+    pdo_retry_synchronous_durable_publication(false).await;
 }
 
 #[tokio::test]
-async fn pdo_retry_teardown_retains_unpublished_durable_plaintext() {
-    pdo_retry_cancel_durable_publication(true).await;
+async fn pdo_retry_teardown_has_no_unpublished_durable_plaintext() {
+    pdo_retry_synchronous_durable_publication(true).await;
 }
 
-async fn pdo_retry_retained_publication_holds_new_skdm_receipt(teardown: bool) {
+async fn pdo_retry_publication_holds_new_skdm_receipt(teardown: bool) {
     let fixture = PdoRetryFixture::new().await;
     fixture.client.flush_signal_cache().await.unwrap();
     fixture.client.inbound_commit_batch.reset();
     fixture.client.swap_message_semaphore(1);
     fixture.retry().await;
-    let guard = fixture
-        .client
-        .inbound_commit_batch
-        .dispatch_lock
-        .lock()
-        .await;
-    fixture
-        .client
-        .inbound_commit_batch
-        .publication_reached
-        .store(false, Ordering::Release);
-    let client = fixture.client.clone();
-    let commit = tokio::spawn(async move {
-        client
-            .flush_inbound_commits_under_permit(false, None, None)
-            .await
-    });
-    crate::test_utils::poll_until("retained publication", || {
+    assert!(
         fixture
             .client
-            .inbound_commit_batch
-            .publication_reached
-            .load(Ordering::Acquire)
-    })
-    .await;
-    commit.abort();
-    assert!(commit.await.unwrap_err().is_cancelled());
-    drop(guard);
+            .flush_inbound_commits_under_permit(false, None, None)
+            .await
+    );
 
     let mut peer = AlicePeer::new("777000000000003:2@lid").await;
     let group: Jid = "120363000000000071@g.us".parse().unwrap();
@@ -15844,7 +16670,7 @@ async fn pdo_retry_retained_publication_holds_new_skdm_receipt(teardown: bool) {
     assert_eq!(
         delivery_receipts_for(&fixture.transport.sent(), SKDM_ID),
         0,
-        "publishing an old durable batch must not receipt a newer unflushed SKDM"
+        "a previous publication must not receipt a newer unflushed SKDM"
     );
     assert_eq!(
         fixture.client.offline_receipt_buffer.lock().unwrap().len(),
@@ -15868,13 +16694,13 @@ async fn pdo_retry_retained_publication_holds_new_skdm_receipt(teardown: bool) {
 }
 
 #[tokio::test]
-async fn pdo_retry_retained_batch_cannot_release_new_skdm_receipt() {
-    pdo_retry_retained_publication_holds_new_skdm_receipt(false).await;
+async fn pdo_retry_previous_batch_cannot_release_new_skdm_receipt() {
+    pdo_retry_publication_holds_new_skdm_receipt(false).await;
 }
 
 #[tokio::test]
 async fn pdo_retry_teardown_cannot_release_new_skdm_receipt() {
-    pdo_retry_retained_publication_holds_new_skdm_receipt(true).await;
+    pdo_retry_publication_holds_new_skdm_receipt(true).await;
 }
 
 #[tokio::test]
@@ -15942,6 +16768,7 @@ async fn pdo_retry_unresolved_hook_copy_must_materialize_before_promotion() {
         reaction_message: buffa::MessageField::some(wa::message::ReactionMessage {
             key: buffa::MessageField::some(target),
             text: Some(text.into()),
+            sender_timestamp_ms: Some(1_700_000_000_000),
             ..Default::default()
         }),
         ..Default::default()
@@ -16029,7 +16856,8 @@ async fn pdo_retry_unresolved_hook_copy_must_materialize_before_promotion() {
     assert_eq!(hook.0.lock().unwrap().len(), 2);
     assert_eq!(
         message_events_for_id(&fixture.events, PdoRetryFixture::ID),
-        (1, 0)
+        (2, 0),
+        "the unresolved envelope stays visible; only its matching materialized copy is suppressed"
     );
 }
 
@@ -16874,7 +17702,7 @@ async fn a_replay_that_fails_to_commit_counts_as_a_suppression() {
         )
         .await
         .expect("buffer a copy");
-    client.mark_message_dispatched(&info).await;
+    client.mark_message_dispatched(&info, &msg).await;
     client
         .inbound_commit_batch
         .fail_commits

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15608,6 +15608,45 @@ mod pdo_alias_tests {
     }
 
     #[tokio::test]
+    async fn pdo_publication_memory_report_counts_payloads_and_alias() {
+        let (client, _) = client().await;
+        let empty = client.memory_report().await.dispatched_message_contents;
+        assert_eq!(empty.entries, 0);
+        assert_eq!(empty.bytes, 0);
+        let info = info(Shape::Incoming);
+        let part = |text: &str| wa::Message {
+            conversation: Some(text.into()),
+            ..Default::default()
+        };
+        let mut first = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(
+            &info,
+            false,
+            Some(MessageDispatch::fingerprint(&part("one"))),
+            false,
+            &mut first,
+        ));
+        first.complete();
+        let one = client.memory_report().await.dispatched_message_contents;
+        assert_eq!(one.entries, 1);
+        let mut second = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(
+            &info,
+            false,
+            Some(MessageDispatch::fingerprint(&part("two"))),
+            false,
+            &mut second,
+        ));
+        second.complete();
+        let two = client.memory_report().await.dispatched_message_contents;
+        assert_eq!(two.entries, 1, "same identity, one entry");
+        assert!(
+            two.bytes > one.bytes,
+            "a second payload and token must add reported bytes"
+        );
+    }
+
+    #[tokio::test]
     async fn pdo_publication_payload_capacity_fails_open() {
         let (client, events) = client().await;
         let info = info(Shape::Incoming);

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14990,20 +14990,23 @@ mod pdo_alias_tests {
     const OWN: &str = "15550001002@s.whatsapp.net";
 
     #[test]
-    fn pdo_alias_fingerprint_does_not_allocate_message_sized_buffer() {
+    fn pdo_alias_fingerprint_reuses_scratch_without_message_sized_blocks() {
         let message = wa::Message {
             conversation: Some("x".repeat(8192)),
             ..Default::default()
         };
-        let max = crate::test_alloc::min_max_block(1024, || MessageDispatch::fingerprint(&message));
+        let mut scratch = Vec::with_capacity(65536);
+        let max = crate::test_alloc::min_max_block(1024, || {
+            MessageDispatch::fingerprint_into(&message, &mut scratch)
+        });
         assert!(
             max <= 1024,
-            "fingerprint allocated a {max}-byte block for an 8192-byte body"
+            "fingerprint allocated a {max}-byte block for an 8192-byte body with a reused buffer"
         );
     }
 
     #[test]
-    fn pdo_alias_streaming_fingerprint_matches_wire_encoding() {
+    fn pdo_alias_fingerprint_matches_wire_encoding() {
         use sha2::{Digest, Sha256};
         for message in [
             wa::Message::default(),
@@ -15021,6 +15024,11 @@ mod pdo_alias_tests {
             let wire = waproto::codec::message_to_vec(&message);
             let expected: [u8; 32] = Sha256::digest(&wire).into();
             assert_eq!(MessageDispatch::fingerprint(&message), expected);
+            let mut scratch = Vec::new();
+            assert_eq!(
+                MessageDispatch::fingerprint_into(&message, &mut scratch),
+                expected
+            );
         }
     }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15324,6 +15324,36 @@ mod pdo_alias_tests {
     }
 
     #[tokio::test]
+    async fn pdo_publication_interrupted_admission_is_treated_as_absent() {
+        let fingerprint = [0xA5; 32];
+        let mut claim = DispatchClaim::default();
+        let mut interrupted = PublicationGuard::default();
+        assert!(!claim.admit(fingerprint, true, false, &mut interrupted));
+        drop(interrupted);
+        let mut live = PublicationGuard::default();
+        assert!(
+            !claim.admit(fingerprint, true, false, &mut live),
+            "an interrupted PDO admission must not suppress redelivery"
+        );
+        live.complete();
+        assert!(
+            claim.state(&fingerprint).is_some(),
+            "redelivery is admitted under the live guard"
+        );
+
+        let mut claim = DispatchClaim::default();
+        let mut interrupted = PublicationGuard::default();
+        assert!(!claim.admit(fingerprint, true, false, &mut interrupted));
+        drop(interrupted);
+        let mut live = PublicationGuard::default();
+        assert!(
+            !claim.admit(fingerprint, false, false, &mut live),
+            "an interrupted recovery must not suppress the ordinary retry"
+        );
+        live.complete();
+    }
+
+    #[tokio::test]
     async fn pdo_publication_payload_capacity_fails_open() {
         let (client, events) = client().await;
         let info = info(Shape::Incoming);

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15005,6 +15005,20 @@ mod pdo_alias_tests {
         );
     }
 
+    /// The gate keeps one claim per message identity for the whole TTL, and the
+    /// cache holds them inline in a single table, so the claim's size is what
+    /// the client's resident memory — and every doubling of that table — scales
+    /// with. The `client_receive` memory rows read that growth allocation
+    /// directly, which is why this is pinned rather than left to drift.
+    #[test]
+    fn pdo_alias_claim_stays_small() {
+        let size = size_of::<DispatchClaim>();
+        assert!(
+            size <= 56,
+            "a dispatch claim grew to {size} bytes; the gate retains one per message identity"
+        );
+    }
+
     #[test]
     fn pdo_alias_fingerprint_reuses_thread_scratch_without_message_sized_blocks() {
         let message = wa::Message {
@@ -15056,7 +15070,12 @@ mod pdo_alias_tests {
         ] {
             let wire = waproto::codec::message_to_vec(&message);
             let expected: [u8; 32] = Sha256::digest(&wire).into();
-            assert_eq!(MessageDispatch::fingerprint(&message), expected);
+            let expected = MessageDispatch::truncate(expected);
+            assert_eq!(
+                MessageDispatch::fingerprint(&message),
+                expected,
+                "the retained digest must be the prefix of the wire digest"
+            );
             let mut scratch = Vec::new();
             assert_eq!(
                 MessageDispatch::fingerprint_into(&message, &mut scratch),
@@ -15366,7 +15385,7 @@ mod pdo_alias_tests {
 
     #[tokio::test]
     async fn pdo_publication_interrupted_admission_is_treated_as_absent() {
-        let fingerprint = [0xA5; 32];
+        let fingerprint = [0xA5; size_of::<DispatchFingerprint>()];
         let mut claim = DispatchClaim::default();
         let mut interrupted = PublicationGuard::default();
         assert!(!claim.admit(fingerprint, true, false, &mut interrupted));
@@ -15400,7 +15419,7 @@ mod pdo_alias_tests {
         // would re-enter a blocked callback on every overlap. The rollback
         // below proves the other half: once the owner drops without
         // completing, the same redelivery is admitted fresh.
-        let fingerprint = [0x3C; 32];
+        let fingerprint = [0x3C; size_of::<DispatchFingerprint>()];
         let mut claim = DispatchClaim::default();
         let mut first = PublicationGuard::default();
         assert!(!claim.admit(fingerprint, true, false, &mut first));

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14978,6 +14978,1138 @@ async fn a_namespace_switch_mid_flight_is_seen_as_a_second_message() {
     );
 }
 
+struct PdoRetryFixture {
+    client: Arc<Client>,
+    transport: Arc<crate::transport::mock::CapturingMockTransport>,
+    events: async_channel::Receiver<Arc<Event>>,
+    failed_group: Arc<OwnedNodeRef>,
+    retry: Arc<OwnedNodeRef>,
+    phone_response: Arc<OwnedNodeRef>,
+    response: wa::message::PeerDataOperationRequestResponseMessage,
+    phone_info: MessageInfo,
+}
+
+impl PdoRetryFixture {
+    const ID: &'static str = "SYNTHETIC_SELF_PING";
+
+    async fn new() -> Self {
+        use buffa::Message as _;
+        use wacore::messages::{MessageUtils, wrap_device_sent};
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("pdo_pairwise_retry").await;
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                "777000000000001:1@lid".parse().unwrap(),
+            )))
+            .await;
+        let group: Jid = "120363000000000071@g.us".parse().unwrap();
+        let mut device = AlicePeer::new("777000000000001:2@lid").await;
+        let (bundle, receiver) = bobs_prekey_bundle(&client).await;
+        device
+            .install_bob_session(&receiver.to_protocol_address(), &bundle)
+            .await;
+        let establish = device
+            .encrypt_text(&receiver.to_protocol_address(), "establish device")
+            .await;
+        process_session_ct(&client, &device.jid, "SYNTHETIC_DEVICE_SETUP", &establish).await;
+        device
+            .sessions
+            .0
+            .get_mut(&receiver.to_protocol_address())
+            .unwrap()
+            .session_state_mut()
+            .unwrap()
+            .clear_unacknowledged_pre_key_message();
+        let message = wa::Message {
+            conversation: Some("\u{1f980}ping".into()),
+            ..Default::default()
+        };
+        device.create_group_skdm(&group).await;
+        let failed_group = group_skmsg_stanza(
+            &group,
+            &device.jid.to_non_ad(),
+            Self::ID,
+            device
+                .encrypt_group_message(&group, &MessageUtils::encode_and_pad(&message))
+                .await,
+        );
+        let ciphertext = device
+            .encrypt(
+                &receiver.to_protocol_address(),
+                &MessageUtils::encode_and_pad(&wrap_device_sent(
+                    message.clone(),
+                    group.to_string(),
+                )),
+            )
+            .await;
+        let payload = enc_payload_from_ciphertext(&ciphertext);
+        assert_eq!(payload.enc_type, EncType::Message);
+        let retry = node_to_arc(
+            NodeBuilder::new("message")
+                .attr("from", group.clone())
+                .attr("participant", device.jid.clone())
+                .attr("id", Self::ID)
+                .attr("t", wacore::time::now_secs().to_string())
+                .attr("type", "text")
+                .attr("addressing_mode", "lid")
+                .children([NodeBuilder::new("enc")
+                    .attr("type", payload.enc_type.as_wire_str())
+                    .attr("v", "2")
+                    .attr("count", "1")
+                    .bytes(payload.ciphertext.to_vec())
+                    .build()])
+                .build(),
+        );
+        let info = Arc::new(client.parse_message_info(retry.get()).await.unwrap());
+        assert!(info.source.is_from_me && info.source.is_group);
+        client
+            .pdo_pending_requests
+            .insert(
+                wacore::types::message::ChatMessageId::new(group.clone(), Self::ID.into()),
+                crate::pdo::PendingPdoRequest {
+                    message_info: info,
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+        let recovered = wa::WebMessageInfo {
+            key: buffa::MessageField::some(wa::MessageKey {
+                remote_jid: Some(group.to_string()),
+                from_me: Some(true),
+                id: Some(Self::ID.into()),
+                participant: Some(device.jid.to_non_ad().to_string()),
+            }),
+            message: buffa::MessageField::some(message),
+            ..Default::default()
+        };
+        let response = wa::message::PeerDataOperationRequestResponseMessage {
+            stanza_id: Some("SYNTHETIC_PDO_REQUEST".into()),
+            peer_data_operation_result: vec![wa::message::peer_data_operation_request_response_message::PeerDataOperationResult {
+                placeholder_message_resend_response: buffa::MessageField::some(
+                    wa::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse {
+                        web_message_info_bytes: Some(recovered.encode_to_vec()),
+                    },
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        client.flush_signal_cache().await.unwrap();
+        let mut phone = AlicePeer::new("777000000000001@lid").await;
+        let (phone_bundle, _) = bobs_prekey_bundle(&client).await;
+        phone
+            .install_bob_session(&receiver.to_protocol_address(), &phone_bundle)
+            .await;
+        let establish = phone
+            .encrypt_text(&receiver.to_protocol_address(), "establish phone")
+            .await;
+        process_session_ct(&client, &phone.jid, "SYNTHETIC_PHONE_SETUP", &establish).await;
+        phone
+            .sessions
+            .0
+            .get_mut(&receiver.to_protocol_address())
+            .unwrap()
+            .session_state_mut()
+            .unwrap()
+            .clear_unacknowledged_pre_key_message();
+        let ciphertext = phone.encrypt(&receiver.to_protocol_address(), &MessageUtils::encode_and_pad(&wa::Message {
+            protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
+                r#type: Some(wa::message::protocol_message::Type::PEER_DATA_OPERATION_REQUEST_RESPONSE_MESSAGE),
+                peer_data_operation_request_response_message: buffa::MessageField::some(response.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })).await;
+        let payload = enc_payload_from_ciphertext(&ciphertext);
+        let phone_response = node_to_arc(
+            NodeBuilder::new("message")
+                .attr("from", phone.jid)
+                .attr("id", "SYNTHETIC_PDO_RESPONSE")
+                .attr("type", "text")
+                .attr("category", "peer")
+                .attr("t", wacore::time::now_secs().to_string())
+                .children([NodeBuilder::new("enc")
+                    .attr("type", payload.enc_type.as_wire_str())
+                    .attr("v", "2")
+                    .bytes(payload.ciphertext.to_vec())
+                    .build()])
+                .build(),
+        );
+        let phone_info = client
+            .parse_message_info(phone_response.get())
+            .await
+            .unwrap();
+        assert!(phone_info.source.is_from_me);
+        let (handler, events) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+        Self {
+            client,
+            transport,
+            events,
+            failed_group,
+            retry,
+            phone_response,
+            response,
+            phone_info,
+        }
+    }
+
+    async fn recover(&self) {
+        self.client
+            .handle_pdo_response(&self.response, &self.phone_info)
+            .await;
+    }
+
+    async fn retry(&self) {
+        self.client
+            .clone()
+            .handle_incoming_message(self.retry.clone())
+            .await;
+    }
+
+    fn assert_once(&self) -> usize {
+        let mut messages = Vec::new();
+        let mut decrypted = 0;
+        while let Ok(event) = self.events.try_recv() {
+            messages.extend(event.messages().filter(|m| m.info.id == Self::ID).cloned());
+            if let Event::DecryptedPayload(payload) = event.as_ref()
+                && payload.info.id == Self::ID
+            {
+                assert_eq!(payload.enc_type, "msg");
+                decrypted += 1;
+            }
+        }
+        assert_eq!(
+            messages.len(),
+            1,
+            "PDO and encrypted own-device retry must deliver one ping"
+        );
+        assert!(messages[0].info.source.is_from_me);
+        assert_eq!(
+            messages[0].message.conversation.as_deref(),
+            Some("\u{1f980}ping")
+        );
+        decrypted
+    }
+}
+
+async fn pdo_retry_ordering(pdo_first: bool, offline: bool) {
+    let fixture = PdoRetryFixture::new().await;
+    let _payloads = fixture.client.acquire_decrypted_payload_forwarding();
+    if offline {
+        fixture.client.inbound_commit_batch.reset();
+    }
+    if pdo_first {
+        fixture.recover().await;
+        fixture.retry().await;
+    } else {
+        fixture.retry().await;
+        fixture.recover().await;
+    }
+    fixture.recover().await;
+    if offline {
+        assert!(
+            fixture
+                .client
+                .flush_inbound_commits_under_permit(true, None, None)
+                .await
+        );
+    }
+    crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+    assert_eq!(
+        fixture.assert_once(),
+        1,
+        "the pairwise retry must still decrypt and advance its session"
+    );
+    assert_eq!(fixture.client.stats().messages_suppressed_duplicate, 2);
+}
+
+#[tokio::test]
+async fn pdo_retry_pdo_first_live() {
+    pdo_retry_ordering(true, false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_retry_first_live() {
+    pdo_retry_ordering(false, false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_pdo_first_offline() {
+    pdo_retry_ordering(true, true).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_retry_first_offline() {
+    pdo_retry_ordering(false, true).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_overlaps_durability_commit() {
+    use crate::types::durability_hook::InboundDurabilityHook;
+    use wacore::types::events::InboundMessage;
+
+    struct PausedHook {
+        entered: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    #[async_trait::async_trait]
+    impl InboundDurabilityHook for PausedHook {
+        async fn on_messages(&self, _: Arc<Client>, _: &[InboundMessage]) -> anyhow::Result<()> {
+            self.entered.send(()).await.unwrap();
+            self.release.recv().await.unwrap();
+            Ok(())
+        }
+    }
+
+    let fixture = PdoRetryFixture::new().await;
+    let (entered_tx, entered) = async_channel::bounded(1);
+    let (release, release_rx) = async_channel::bounded(1);
+    fixture
+        .client
+        .inbound_durability_hook
+        .set(Arc::new(PausedHook {
+            entered: entered_tx,
+            release: release_rx,
+        }))
+        .ok()
+        .unwrap();
+    let client = fixture.client.clone();
+    let retry = fixture.retry.clone();
+    let receiving = tokio::spawn(async move { client.handle_incoming_message(retry).await });
+    tokio::time::timeout(std::time::Duration::from_secs(5), entered.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let info = Arc::new(
+        fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap(),
+    );
+    assert!(
+        !fixture.client.message_already_dispatched(&info).await,
+        "an uncommitted message must not be claimed"
+    );
+    fixture.recover().await;
+    release.send(()).await.unwrap();
+    receiving.await.unwrap();
+    fixture.recover().await;
+    fixture.assert_once();
+}
+
+#[tokio::test]
+async fn pdo_retry_missing_group_key_recovers_on_phone_and_group_lanes() {
+    let fixture = PdoRetryFixture::new().await;
+    let group = fixture
+        .client
+        .parse_message_info(fixture.retry.get())
+        .await
+        .unwrap()
+        .source
+        .chat;
+    let pending_key = wacore::types::message::ChatMessageId::new(group, PdoRetryFixture::ID.into());
+    fixture
+        .client
+        .pdo_pending_requests
+        .remove(&pending_key)
+        .await;
+    fixture
+        .client
+        .clone()
+        .handle_incoming_message(fixture.failed_group.clone())
+        .await;
+    crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+    assert!(
+        fixture
+            .client
+            .pdo_pending_requests
+            .get(&pending_key)
+            .await
+            .is_some(),
+        "decrypt failure must request PDO recovery"
+    );
+    assert_eq!(
+        retry_receipt_key_bundles_for(&fixture.transport.sent(), PdoRetryFixture::ID).len(),
+        1,
+        "decrypt failure must send one retry receipt alongside PDO"
+    );
+
+    for node in [&fixture.phone_response, &fixture.retry] {
+        let from = node.attrs().optional_jid("from").unwrap().to_non_ad();
+        let mut cancelled = false;
+        crate::handlers::message::MessageHandler::handle_inline(
+            fixture.client.clone(),
+            node.clone(),
+            &mut cancelled,
+        )
+        .await;
+        assert!(!cancelled);
+        let lane = fixture.client.chat_lanes.get(&from).await.unwrap();
+        lane.queue_tx.close();
+        crate::test_utils::poll_until("lane processing to finish", || {
+            Arc::strong_count(&lane.enqueue_lock) == 2
+        })
+        .await;
+    }
+    fixture.recover().await;
+    crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+    fixture.assert_once();
+    assert!(
+        fixture
+            .client
+            .pdo_pending_requests
+            .get(&pending_key)
+            .await
+            .is_none(),
+        "recovery must clear the pending request"
+    );
+}
+
+#[tokio::test]
+async fn pdo_retry_failed_commit_does_not_claim_recovery() {
+    let fixture = PdoRetryFixture::new().await;
+    fixture
+        .client
+        .inbound_commit_batch
+        .fail_commits
+        .store(true, Ordering::Release);
+    fixture.retry().await;
+    let info = Arc::new(
+        fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap(),
+    );
+    assert!(!fixture.client.message_already_dispatched(&info).await);
+    fixture.recover().await;
+    fixture.assert_once();
+}
+
+#[tokio::test]
+async fn pdo_retry_missing_recovered_content_does_not_claim() {
+    use buffa::Message as _;
+    let fixture = PdoRetryFixture::new().await;
+    let mut response = fixture.response.clone();
+    let recovered = response.peer_data_operation_result[0]
+        .placeholder_message_resend_response
+        .as_option_mut()
+        .unwrap();
+    let mut web =
+        waproto::codec::web_message_info_decode(recovered.web_message_info_bytes.as_ref().unwrap())
+            .unwrap();
+    web.message.take();
+    recovered.web_message_info_bytes = Some(web.encode_to_vec());
+    fixture
+        .client
+        .handle_pdo_response(&response, &fixture.phone_info)
+        .await;
+    fixture.retry().await;
+    fixture.recover().await;
+    fixture.assert_once();
+}
+
+#[tokio::test]
+async fn pdo_retry_concurrent_recoveries_share_publication() {
+    let fixture = PdoRetryFixture::new().await;
+    let guard = fixture
+        .client
+        .inbound_commit_batch
+        .dispatch_lock
+        .lock()
+        .await;
+    let first = fixture.recover();
+    let second = fixture.recover();
+    futures::pin_mut!(first, second);
+    assert!(futures::poll!(&mut first).is_pending());
+    assert!(futures::poll!(&mut second).is_pending());
+    assert_eq!(
+        message_events_for_id(&fixture.events, PdoRetryFixture::ID),
+        (0, 0)
+    );
+    drop(guard);
+    futures::join!(first, second);
+    fixture.retry().await;
+    fixture.assert_once();
+}
+
+#[tokio::test]
+async fn pdo_retry_batch_keeps_unrelated_messages() {
+    let fixture = PdoRetryFixture::new().await;
+    fixture.client.inbound_commit_batch.reset();
+    for id in ["BEFORE_RECOVERED", PdoRetryFixture::ID, "AFTER_RECOVERED"] {
+        if id == PdoRetryFixture::ID {
+            fixture.retry().await;
+        } else {
+            let mut info = fixture
+                .client
+                .parse_message_info(fixture.retry.get())
+                .await
+                .unwrap();
+            info.id = id.into();
+            fixture
+                .client
+                .handle_decrypted_plaintext(
+                    "msg",
+                    MessageUtils::encode_and_pad(&wa::Message {
+                        conversation: Some(id.into()),
+                        ..Default::default()
+                    }),
+                    2,
+                    0,
+                    Default::default(),
+                    &Arc::new(info),
+                )
+                .await
+                .unwrap();
+        }
+    }
+    fixture.recover().await;
+    assert!(
+        fixture
+            .client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await
+    );
+    let messages = drain_message_events(&fixture.events);
+    assert_eq!(
+        messages
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect::<Vec<_>>(),
+        [PdoRetryFixture::ID, "BEFORE_RECOVERED", "AFTER_RECOVERED"]
+    );
+}
+
+#[derive(Default)]
+struct PdoRetryDurabilityHook {
+    calls: std::sync::atomic::AtomicUsize,
+    fail: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl crate::types::durability_hook::InboundDurabilityHook for PdoRetryDurabilityHook {
+    async fn on_messages(
+        &self,
+        _: Arc<Client>,
+        messages: &[wacore::types::events::InboundMessage],
+    ) -> anyhow::Result<()> {
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].info.id, PdoRetryFixture::ID);
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        anyhow::ensure!(!self.fail.load(Ordering::Relaxed), "synthetic hook failure");
+        Ok(())
+    }
+}
+
+async fn pdo_retry_durability_after_recovery(fail_first: bool) {
+    let fixture = PdoRetryFixture::new().await;
+    let hook = Arc::new(PdoRetryDurabilityHook::default());
+    hook.fail.store(fail_first, Ordering::Relaxed);
+    fixture
+        .client
+        .inbound_durability_hook
+        .set(hook.clone())
+        .ok()
+        .unwrap();
+    fixture.recover().await;
+    assert_eq!(
+        hook.calls.load(Ordering::Relaxed),
+        0,
+        "PDO remains event-only"
+    );
+    fixture.retry().await;
+    crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+    assert_eq!(
+        hook.calls.load(Ordering::Relaxed),
+        1,
+        "an event-only recovery must not bypass the retry's durability hook"
+    );
+    let info = Arc::new(
+        fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap(),
+    );
+    let backend = fixture.client.persistence_manager.backend();
+    let pending = || {
+        backend.get_pending_inbound(
+            "120363000000000071@g.us",
+            "777000000000001:2@lid",
+            PdoRetryFixture::ID,
+        )
+    };
+    if fail_first {
+        assert!(pending().await.unwrap().is_some());
+        assert_eq!(
+            message_acks_for(&fixture.transport.sent(), PdoRetryFixture::ID),
+            0
+        );
+        hook.fail.store(false, Ordering::Relaxed);
+        fixture.retry().await;
+        assert_eq!(
+            hook.calls.load(Ordering::Relaxed),
+            2,
+            "ratchet duplicate must replay the buffered hook failure"
+        );
+    }
+    assert!(pending().await.unwrap().is_none());
+    fixture
+        .client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&wa::Message {
+                conversation: Some("\u{1f980}ping".into()),
+                ..Default::default()
+            }),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        hook.calls.load(Ordering::Relaxed),
+        if fail_first { 2 } else { 1 },
+        "a fresh resend after hook success must not recommit"
+    );
+    fixture.recover().await;
+    fixture.assert_once();
+}
+
+#[tokio::test]
+async fn pdo_retry_recovered_event_still_requires_durable_commit() {
+    pdo_retry_durability_after_recovery(false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_recovered_event_preserves_failed_hook_replay() {
+    pdo_retry_durability_after_recovery(true).await;
+}
+
+async fn pdo_retry_cancel_durable_publication(teardown: bool) {
+    let fixture = PdoRetryFixture::new().await;
+    fixture.client.flush_signal_cache().await.unwrap();
+    let info = fixture
+        .client
+        .parse_message_info(fixture.retry.get())
+        .await
+        .unwrap();
+    let address = info.source.sender.to_protocol_address();
+    let backend = fixture.client.persistence_manager.backend();
+    let before = backend
+        .get_session(address.as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    fixture.client.inbound_commit_batch.reset();
+    fixture.client.swap_message_semaphore(1);
+    fixture.retry().await;
+    let guard = fixture
+        .client
+        .inbound_commit_batch
+        .dispatch_lock
+        .lock()
+        .await;
+    fixture
+        .client
+        .inbound_commit_batch
+        .publication_reached
+        .store(false, Ordering::Release);
+    let client = fixture.client.clone();
+    let commit = tokio::spawn(async move {
+        client
+            .flush_inbound_commits_under_permit(false, None, None)
+            .await
+    });
+    crate::test_utils::poll_until("publication after the durable Signal flush", || {
+        fixture
+            .client
+            .inbound_commit_batch
+            .publication_reached
+            .load(Ordering::Acquire)
+    })
+    .await;
+    assert_ne!(
+        backend
+            .get_session(address.as_str())
+            .await
+            .unwrap()
+            .unwrap(),
+        before,
+        "the received ratchet must already be persisted at cancellation"
+    );
+    assert_eq!(
+        message_events_for_id(&fixture.events, PdoRetryFixture::ID),
+        (0, 0)
+    );
+    commit.abort();
+    assert!(commit.await.unwrap_err().is_cancelled());
+    assert_eq!(
+        fixture.client.inbound_commit_batch.pending_stats().0,
+        1,
+        "cancellation must retain the unpublished plaintext after its ratchet became durable"
+    );
+    if teardown {
+        fixture
+            .client
+            .teardown_inbound_commits_bounded(std::time::Duration::from_millis(1))
+            .await;
+        fixture.client.inbound_commit_batch.reset();
+        assert_eq!(
+            fixture.client.inbound_commit_batch.pending_stats().0,
+            1,
+            "reset cannot discard plaintext whose ratchet was already persisted"
+        );
+    }
+    drop(guard);
+    if teardown {
+        fixture.retry().await;
+        assert_eq!(
+            message_events_for_id(&fixture.events, PdoRetryFixture::ID),
+            (0, 0),
+            "the persisted ratchet rejects redelivery; the retained plaintext is the only publication copy"
+        );
+        assert_eq!(fixture.client.inbound_commit_batch.pending_stats().0, 1);
+    }
+    let mut later_info = info;
+    later_info.id = "AFTER_CANCEL".into();
+    fixture
+        .client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&wa::Message {
+                conversation: Some("later message".into()),
+                ..Default::default()
+            }),
+            2,
+            0,
+            Default::default(),
+            &Arc::new(later_info),
+        )
+        .await
+        .unwrap();
+    assert!(
+        fixture
+            .client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await
+    );
+    assert_eq!(
+        drain_message_events(&fixture.events)
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect::<Vec<_>>(),
+        [PdoRetryFixture::ID, "AFTER_CANCEL"]
+    );
+    assert_eq!(fixture.client.inbound_commit_batch.pending_stats().0, 0);
+}
+
+#[tokio::test]
+async fn pdo_retry_cancel_after_signal_flush_retains_publication() {
+    pdo_retry_cancel_durable_publication(false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_teardown_retains_unpublished_durable_plaintext() {
+    pdo_retry_cancel_durable_publication(true).await;
+}
+
+async fn pdo_retry_retained_publication_holds_new_skdm_receipt(teardown: bool) {
+    let fixture = PdoRetryFixture::new().await;
+    fixture.client.flush_signal_cache().await.unwrap();
+    fixture.client.inbound_commit_batch.reset();
+    fixture.client.swap_message_semaphore(1);
+    fixture.retry().await;
+    let guard = fixture
+        .client
+        .inbound_commit_batch
+        .dispatch_lock
+        .lock()
+        .await;
+    fixture
+        .client
+        .inbound_commit_batch
+        .publication_reached
+        .store(false, Ordering::Release);
+    let client = fixture.client.clone();
+    let commit = tokio::spawn(async move {
+        client
+            .flush_inbound_commits_under_permit(false, None, None)
+            .await
+    });
+    crate::test_utils::poll_until("retained publication", || {
+        fixture
+            .client
+            .inbound_commit_batch
+            .publication_reached
+            .load(Ordering::Acquire)
+    })
+    .await;
+    commit.abort();
+    assert!(commit.await.unwrap_err().is_cancelled());
+    drop(guard);
+
+    let mut peer = AlicePeer::new("777000000000003:2@lid").await;
+    let group: Jid = "120363000000000071@g.us".parse().unwrap();
+    let (bundle, receiver) = bobs_prekey_bundle(&fixture.client).await;
+    peer.install_bob_session(&receiver.to_protocol_address(), &bundle)
+        .await;
+    let skdm = peer.create_group_skdm(&group).await;
+    let ciphertext = peer
+        .encrypt(
+            &receiver.to_protocol_address(),
+            &MessageUtils::encode_and_pad(&wa::Message {
+                sender_key_distribution_message: buffa::MessageField::some(skdm),
+                ..Default::default()
+            }),
+        )
+        .await;
+    let enc = enc_payload_from_ciphertext(&ciphertext);
+    const SKDM_ID: &str = "SYNTHETIC_NEW_SKDM";
+    fixture
+        .client
+        .clone()
+        .handle_incoming_message(node_to_arc(
+            NodeBuilder::new("message")
+                .attr("from", group)
+                .attr("participant", peer.jid)
+                .attr("id", SKDM_ID)
+                .attr("offline", "1")
+                .attr("type", "text")
+                .attr("t", wacore::time::now_secs().to_string())
+                .children([NodeBuilder::new("enc")
+                    .attr("type", enc.enc_type.as_wire_str())
+                    .attr("v", "2")
+                    .bytes(enc.ciphertext.to_vec())
+                    .build()])
+                .build(),
+        ))
+        .await;
+    assert_eq!(
+        fixture.client.offline_receipt_buffer.lock().unwrap().len(),
+        1
+    );
+    // Force teardown through the same failing drain flush rather than its
+    // empty-batch final cache settle.
+    if teardown {
+        let mut info = fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap();
+        info.id = "SYNTHETIC_NEW_CONTENT".into();
+        fixture
+            .client
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(&wa::Message {
+                    conversation: Some("new content".into()),
+                    ..Default::default()
+                }),
+                2,
+                0,
+                Default::default(),
+                &Arc::new(info),
+            )
+            .await
+            .unwrap();
+    }
+    fixture
+        .client
+        .inbound_commit_batch
+        .fail_flushes
+        .store(true, Ordering::Release);
+    if teardown {
+        fixture
+            .client
+            .teardown_inbound_commits_bounded(std::time::Duration::from_secs(5))
+            .await;
+    } else {
+        assert!(
+            !fixture
+                .client
+                .flush_inbound_commits_under_permit(false, None, None)
+                .await
+        );
+    }
+    crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+    assert_eq!(
+        delivery_receipts_for(&fixture.transport.sent(), SKDM_ID),
+        0,
+        "publishing an old durable batch must not receipt a newer unflushed SKDM"
+    );
+    assert_eq!(
+        fixture.client.offline_receipt_buffer.lock().unwrap().len(),
+        1
+    );
+    if !teardown {
+        fixture
+            .client
+            .inbound_commit_batch
+            .fail_flushes
+            .store(false, Ordering::Release);
+        assert!(
+            fixture
+                .client
+                .flush_inbound_commits_under_permit(false, None, None)
+                .await
+        );
+        crate::test_utils::wait_for_outbound_tasks(&fixture.client).await;
+        assert_eq!(delivery_receipts_for(&fixture.transport.sent(), SKDM_ID), 1);
+    }
+}
+
+#[tokio::test]
+async fn pdo_retry_retained_batch_cannot_release_new_skdm_receipt() {
+    pdo_retry_retained_publication_holds_new_skdm_receipt(false).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_teardown_cannot_release_new_skdm_receipt() {
+    pdo_retry_retained_publication_holds_new_skdm_receipt(true).await;
+}
+
+#[tokio::test]
+async fn pdo_retry_unresolved_hook_copy_must_materialize_before_promotion() {
+    use buffa::Message as _;
+    struct RecordingHook(std::sync::Mutex<Vec<Arc<wa::Message>>>);
+    #[async_trait::async_trait]
+    impl crate::types::durability_hook::InboundDurabilityHook for RecordingHook {
+        async fn on_messages(
+            &self,
+            _: Arc<Client>,
+            batch: &[wacore::types::events::InboundMessage],
+        ) -> anyhow::Result<()> {
+            self.0
+                .lock()
+                .unwrap()
+                .extend(batch.iter().map(|item| item.message.clone()));
+            Ok(())
+        }
+    }
+    let fixture = PdoRetryFixture::new().await;
+    let info = Arc::new(
+        fixture
+            .client
+            .parse_message_info(fixture.retry.get())
+            .await
+            .unwrap(),
+    );
+    let parent_author: Jid = "777000000000099@lid".parse().unwrap();
+    let secret = [0x5A; 32];
+    let parent_id = "SYNTHETIC_REACTION_PARENT";
+    let text = "\u{1f44d}";
+    let (payload, iv) = wacore::reaction::encrypt_reaction_with_secret(
+        text,
+        1_700_000_000_000,
+        &secret,
+        parent_id,
+        &parent_author.to_non_ad_string(),
+        &info.source.sender.to_non_ad_string(),
+    )
+    .unwrap();
+    let target = wa::MessageKey {
+        remote_jid: Some(info.source.chat.to_string()),
+        from_me: Some(false),
+        id: Some(parent_id.into()),
+        participant: Some(parent_author.to_string()),
+    };
+    let envelope = wa::Message {
+        enc_reaction_message: buffa::MessageField::some(wa::message::EncReactionMessage {
+            target_message_key: buffa::MessageField::some(target.clone()),
+            enc_payload: Some(payload),
+            enc_iv: Some(iv.to_vec()),
+        }),
+        ..Default::default()
+    };
+    let mut response = fixture.response.clone();
+    let recovered = response.peer_data_operation_result[0]
+        .placeholder_message_resend_response
+        .as_option_mut()
+        .unwrap();
+    let mut web =
+        waproto::codec::web_message_info_decode(recovered.web_message_info_bytes.as_ref().unwrap())
+            .unwrap();
+    web.message = buffa::MessageField::some(wa::Message {
+        reaction_message: buffa::MessageField::some(wa::message::ReactionMessage {
+            key: buffa::MessageField::some(target),
+            text: Some(text.into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    recovered.web_message_info_bytes = Some(web.encode_to_vec());
+    let hook = Arc::new(RecordingHook(std::sync::Mutex::new(Vec::new())));
+    fixture
+        .client
+        .inbound_durability_hook
+        .set(hook.clone())
+        .ok()
+        .unwrap();
+    fixture
+        .client
+        .handle_pdo_response(&response, &fixture.phone_info)
+        .await;
+    fixture
+        .client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&envelope),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .unwrap();
+    assert!(hook.0.lock().unwrap()[0].enc_reaction_message.is_set());
+    fixture
+        .client
+        .persistence_manager
+        .backend()
+        .put_msg_secrets(vec![wacore::store::traits::MsgSecretEntry {
+            chat: info.source.chat.to_non_ad_string().into(),
+            sender: parent_author.to_non_ad_string().into(),
+            msg_id: parent_id.into(),
+            secret,
+            expires_at: 0,
+            message_ts: 0,
+        }])
+        .await
+        .unwrap();
+    fixture
+        .client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&envelope),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .unwrap();
+    {
+        let seen = hook.0.lock().unwrap();
+        assert_eq!(
+            seen.len(),
+            2,
+            "an unresolved hook copy must not suppress the later materialized retry"
+        );
+        assert_eq!(
+            seen[1]
+                .reaction_message
+                .as_option()
+                .unwrap()
+                .text
+                .as_deref(),
+            Some(text)
+        );
+    }
+    fixture
+        .client
+        .handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&envelope),
+            2,
+            0,
+            Default::default(),
+            &info,
+        )
+        .await
+        .unwrap();
+    assert_eq!(hook.0.lock().unwrap().len(), 2);
+    assert_eq!(
+        message_events_for_id(&fixture.events, PdoRetryFixture::ID),
+        (1, 0)
+    );
+}
+
+#[tokio::test]
+async fn pdo_retry_fresh_drain_schedules_receipt_before_synchronous_event() {
+    use wacore::types::events::EventHandler;
+
+    const ID: &str = "SYNTHETIC_RECEIPT_BEFORE_EVENT";
+    struct ObserveReceipt {
+        client: std::sync::Weak<Client>,
+        observed: std::sync::Mutex<Option<(usize, usize)>>,
+    }
+    impl EventHandler for ObserveReceipt {
+        fn handle_event(&self, event: Arc<Event>) {
+            if event.messages().any(|message| message.info.id == ID) {
+                let client = self.client.upgrade().unwrap();
+                *self.observed.lock().unwrap() = Some((
+                    client.offline_receipt_buffer.lock().unwrap().len(),
+                    client.outbound_flush.pending(),
+                ));
+            }
+        }
+    }
+
+    let (client, transport) = capturing_client("receipt_before_sync_event").await;
+    client.inbound_commit_batch.reset();
+    client.swap_message_semaphore(1);
+    let group: Jid = "120363000000000072@g.us".parse().unwrap();
+    let mut peer = joined_group_sender(&client, "777000000000004:2@lid", &group).await;
+    let ciphertext = encrypt_group_text(&mut peer, &group, "synthetic offline text").await;
+    client
+        .clone()
+        .handle_incoming_message(node_to_arc(
+            NodeBuilder::new("message")
+                .attr("from", group)
+                .attr("participant", peer.jid)
+                .attr("id", ID)
+                .attr("offline", "1")
+                .attr("type", "text")
+                .attr("t", wacore::time::now_secs().to_string())
+                .children([NodeBuilder::new("enc")
+                    .attr("type", "skmsg")
+                    .attr("v", "2")
+                    .bytes(ciphertext)
+                    .build()])
+                .build(),
+        ))
+        .await;
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+    let observer = Arc::new(ObserveReceipt {
+        client: Arc::downgrade(&client),
+        observed: std::sync::Mutex::new(None),
+    });
+    client
+        .core
+        .event_bus
+        .subscribe_handler(observer.clone())
+        .detach();
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(false, None, None)
+            .await
+    );
+    let (buffered, scheduled) = observer
+        .observed
+        .lock()
+        .unwrap()
+        .expect("synchronous message callback");
+    assert_eq!(
+        buffered, 0,
+        "the aggregate must leave the receipt buffer before the callback can block or panic"
+    );
+    assert!(
+        scheduled > 0,
+        "the transport task must already be tracked when the callback runs"
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+    assert_eq!(delivery_receipts_for(&transport.sent(), ID), 1);
+}
+
 // --- Resent-message dispatch gate --------------------------------------
 //
 // A sender whose network is bad re-runs its own outbox: same message id, fresh

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15006,6 +15006,20 @@ mod pdo_alias_tests {
     }
 
     #[test]
+    fn pdo_alias_fingerprint_reuses_thread_scratch_without_message_sized_blocks() {
+        let message = wa::Message {
+            conversation: Some("x".repeat(8192)),
+            ..Default::default()
+        };
+        let _ = MessageDispatch::fingerprint(&message);
+        let max = crate::test_alloc::min_max_block(1024, || MessageDispatch::fingerprint(&message));
+        assert!(
+            max <= 1024,
+            "fingerprint allocated a {max}-byte block for an 8192-byte body with a warm buffer"
+        );
+    }
+
+    #[test]
     fn pdo_alias_fingerprint_matches_wire_encoding() {
         use sha2::{Digest, Sha256};
         for message in [

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15020,6 +15020,25 @@ mod pdo_alias_tests {
     }
 
     #[test]
+    fn pdo_alias_fingerprint_thread_scratch_does_not_retain_huge_buffers() {
+        let big = wa::Message {
+            conversation: Some("x".repeat(200_000)),
+            ..Default::default()
+        };
+        let _ = MessageDispatch::fingerprint(&big);
+        let capacity = FINGERPRINT_SCRATCH.with(|scratch| scratch.borrow().capacity());
+        assert!(
+            capacity <= 64 * 1024,
+            "thread scratch retained {capacity} bytes after a huge message"
+        );
+        let small = wa::Message {
+            conversation: Some("ok".into()),
+            ..Default::default()
+        };
+        let _ = MessageDispatch::fingerprint(&small);
+    }
+
+    #[test]
     fn pdo_alias_fingerprint_matches_wire_encoding() {
         use sha2::{Digest, Sha256};
         for message in [

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15376,6 +15376,50 @@ mod pdo_alias_tests {
     }
 
     #[tokio::test]
+    async fn pdo_publication_live_match_suppresses_and_rolled_back_match_delivers() {
+        // Suppress while the owner is live, even in-flight: delivering instead
+        // would re-enter a blocked callback on every overlap. The rollback
+        // below proves the other half: once the owner drops without
+        // completing, the same redelivery is admitted fresh.
+        let fingerprint = [0x3C; 32];
+        let mut claim = DispatchClaim::default();
+        let mut first = PublicationGuard::default();
+        assert!(!claim.admit(fingerprint, true, false, &mut first));
+        let mut concurrent = PublicationGuard::default();
+        assert!(
+            claim.admit(fingerprint, true, false, &mut concurrent),
+            "a live recovery suppresses the concurrent redelivery"
+        );
+        drop(first);
+        let mut after_rollback = PublicationGuard::default();
+        assert!(
+            !claim.admit(fingerprint, true, false, &mut after_rollback),
+            "a rolled-back recovery must not suppress the next redelivery"
+        );
+        after_rollback.complete();
+        let mut late = PublicationGuard::default();
+        assert!(
+            claim.admit(fingerprint, true, false, &mut late),
+            "a completed recovery suppresses the late redelivery"
+        );
+
+        let mut claim = DispatchClaim::default();
+        let mut recovery = PublicationGuard::default();
+        assert!(!claim.admit(fingerprint, true, false, &mut recovery));
+        let mut retry = PublicationGuard::default();
+        assert!(
+            claim.admit(fingerprint, false, false, &mut retry),
+            "a live recovery suppresses the concurrent retry"
+        );
+        drop(recovery);
+        let mut after_rollback = PublicationGuard::default();
+        assert!(
+            !claim.admit(fingerprint, false, false, &mut after_rollback),
+            "a rolled-back recovery must not suppress the next retry"
+        );
+    }
+
+    #[tokio::test]
     async fn pdo_publication_payload_capacity_fails_open() {
         let (client, events) = client().await;
         let info = info(Shape::Incoming);

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -10405,6 +10405,119 @@ async fn secret_encrypted_edit_decrypts_via_resolver_when_store_empty() {
 }
 
 #[tokio::test]
+async fn secret_encrypted_resend_resolves_parent_secret_once() {
+    use crate::cache_config::{CacheConfig, MsgSecretPolicy};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use wacore::messages::MessageUtils;
+
+    struct CountingResolver {
+        chat: String,
+        sender: String,
+        msg_id: String,
+        secret: [u8; 32],
+        calls: AtomicUsize,
+    }
+    #[async_trait::async_trait]
+    impl wacore::msg_secret::OriginalMessageResolver for CountingResolver {
+        async fn resolve_msg_secret(
+            &self,
+            chat: &str,
+            sender: &str,
+            msg_id: &str,
+        ) -> Option<[u8; 32]> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            (chat == self.chat && sender == self.sender && msg_id == self.msg_id)
+                .then_some(self.secret)
+        }
+    }
+
+    let chat = "5511777776666@s.whatsapp.net";
+    let parent_id = "COUNTED_PARENT";
+    let edit_id = "COUNTED_EDIT";
+    let secret = [0x7Au8; 32];
+    let resolver = Arc::new(CountingResolver {
+        chat: chat.to_string(),
+        sender: chat.to_string(),
+        msg_id: parent_id.to_string(),
+        secret,
+        calls: AtomicUsize::new(0),
+    });
+    // Disabled persists nothing, so every decrypt consults the resolver.
+    let cfg = CacheConfig {
+        msg_secret_policy: MsgSecretPolicy::Disabled,
+        original_message_resolver: Some(resolver.clone()),
+        ..Default::default()
+    };
+    let client = crate::test_utils::create_test_client_with_config(
+        "resolver_handoff",
+        Arc::new(MockHttpClient),
+        cfg,
+    )
+    .await;
+    seed_test_pn(&client).await;
+
+    let (handler, events) = wacore::types::events::ChannelEventHandler::new();
+    client.core.event_bus.subscribe_handler(handler).detach();
+
+    let info = Arc::new(MessageInfo {
+        id: edit_id.into(),
+        source: crate::types::message::MessageSource {
+            chat: chat.parse().unwrap(),
+            sender: chat.parse().unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let target_key = wa::MessageKey {
+        remote_jid: Some(chat.to_string()),
+        from_me: Some(false),
+        id: Some(parent_id.to_string()),
+        participant: None,
+    };
+    let mut first_calls = 0;
+    for (index, text) in ["first", "second"].iter().enumerate() {
+        let msg = encrypted_message_edit(
+            target_key.clone(),
+            chat,
+            chat,
+            parent_id,
+            &secret,
+            text,
+            None,
+        );
+        client
+            .clone()
+            .handle_decrypted_plaintext(
+                "msg",
+                MessageUtils::encode_and_pad(&msg),
+                2,
+                0,
+                Default::default(),
+                &info,
+            )
+            .await
+            .unwrap();
+        if index == 0 {
+            first_calls = resolver.calls.load(Ordering::Relaxed);
+            assert!(
+                first_calls > 0,
+                "the first delivery must resolve the parent secret"
+            );
+        }
+    }
+    assert_eq!(
+        resolver.calls.load(Ordering::Relaxed),
+        2 * first_calls,
+        "a mismatched resend must reuse the probe's plaintext instead of resolving again"
+    );
+    assert_eq!(
+        message_events_for_id(&events, edit_id).0,
+        2,
+        "both distinct parts must still dispatch"
+    );
+}
+
+#[tokio::test]
 async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
     let (client, _transport) = capturing_client("secret_edit_chain").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
@@ -15411,6 +15524,43 @@ mod pdo_alias_tests {
             "an interrupted recovery must not suppress the ordinary retry"
         );
         live.complete();
+    }
+
+    #[tokio::test]
+    async fn pdo_publication_pruned_empty_claim_still_resolves_alias() {
+        let (client, _) = client().await;
+        let lid = info(Shape::Incoming);
+        let payload = wa::Message {
+            conversation: Some("alias payload".into()),
+            ..Default::default()
+        };
+        let fingerprint = MessageDispatch::fingerprint(&payload);
+        let mut interrupted = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(
+            &lid,
+            true,
+            Some(fingerprint),
+            false,
+            &mut interrupted
+        ));
+        drop(interrupted);
+        let pn = Arc::new(MessageInfo {
+            id: ID.into(),
+            source: MessageSource {
+                chat: PN.parse().unwrap(),
+                sender: PN.parse().unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut recovery = PublicationGuard::default();
+        assert!(!client.admit_message_dispatch(&pn, true, Some(fingerprint), false, &mut recovery));
+        recovery.complete();
+        let mut late = PublicationGuard::default();
+        assert!(
+            client.admit_message_dispatch(&lid, false, Some(fingerprint), false, &mut late),
+            "a pruned empty claim must not block alias resolution to the completed recovery"
+        );
     }
 
     #[tokio::test]

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -906,6 +906,16 @@ impl Client {
             Some(request_id.to_owned())
         };
 
+        let _dispatch_guard = self.inbound_commit_batch.dispatch_lock.lock().await;
+        if self.message_already_dispatched(&message_info).await {
+            self.duplicate_dispatch_suppressed
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            wacore::telemetry::recv("duplicate_resend");
+            return;
+        }
+        let claim = !crate::features::message_edit::carries_secret_encrypted(&message);
+        let dispatch_key = Self::dispatch_key(&message_info);
+
         info!(
             "Dispatching PDO-recovered message {} from {} via phone (request_id={})",
             message_info.id,
@@ -928,6 +938,11 @@ impl Client {
                     .origin(wacore::types::events::BatchOrigin::Live)
                     .build(),
             ));
+        if claim {
+            self.dispatched_messages
+                .insert(dispatch_key, crate::message::MessageDispatch::Recovered)
+                .await;
+        }
     }
 
     /// Reconstructs a MessageInfo from a WebMessageInfo.

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -837,12 +837,15 @@ impl Client {
         // through to rebuilding from the response, which is the authority on
         // who sent what and is the same path a missing entry already takes.
         let pending = pending.filter(|entry| {
+            if response_from_me != entry.message_info.source.is_from_me {
+                return false;
+            }
             let Some(participant) = response_participant.as_deref() else {
                 // Legitimately absent for a DM and for anything `from_me`, so
                 // the only thing left to agree on is the direction. An incoming
                 // and an outgoing message of one DM can share an id, and both
                 // their responses omit the participant.
-                return response_from_me == entry.message_info.source.is_from_me;
+                return true;
             };
             let Ok(participant) = participant.parse::<Jid>() else {
                 return false;
@@ -906,15 +909,18 @@ impl Client {
             Some(request_id.to_owned())
         };
 
-        let _dispatch_guard = self.inbound_commit_batch.dispatch_lock.lock().await;
-        if self.message_already_dispatched(&message_info).await {
+        let claim = self.dispatch_gate_enabled()
+            && !crate::features::message_edit::carries_secret_encrypted(&message);
+        let fingerprint = claim.then(|| crate::message::MessageDispatch::fingerprint(&message));
+        let mut publication = crate::message::PublicationGuard::default();
+        let suppressed =
+            self.admit_message_dispatch(&message_info, true, fingerprint, false, &mut publication);
+        if suppressed {
             self.duplicate_dispatch_suppressed
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             wacore::telemetry::recv("duplicate_resend");
             return;
         }
-        let claim = !crate::features::message_edit::carries_secret_encrypted(&message);
-        let dispatch_key = Self::dispatch_key(&message_info);
 
         info!(
             "Dispatching PDO-recovered message {} from {} via phone (request_id={})",
@@ -938,11 +944,7 @@ impl Client {
                     .origin(wacore::types::events::BatchOrigin::Live)
                     .build(),
             ));
-        if claim {
-            self.dispatched_messages
-                .insert(dispatch_key, crate::message::MessageDispatch::Recovered)
-                .await;
-        }
+        publication.complete();
     }
 
     /// Reconstructs a MessageInfo from a WebMessageInfo.

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -307,6 +307,10 @@ impl<K: Hash + Eq + Clone, V> SyncTtlGuard<'_, K, V> {
         }
     }
 
+    pub(crate) fn remove(&mut self, key: &K) {
+        self.inner.remove_key(key);
+    }
+
     pub(crate) fn find_unique_key(&self, matches: impl Fn(&K, &V) -> bool) -> Option<K> {
         let mut found = self.inner.iter().filter_map(|(key, entry)| {
             if self

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -266,6 +266,134 @@ struct CacheInner<K, V, S> {
     capacity_eviction_blocks: u64,
 }
 
+/// Synchronous TTL admission for publication paths that cannot yield after commit.
+pub(crate) struct SyncTtlCache<K, V> {
+    inner: std::sync::Mutex<CacheInner<K, V, RandomState>>,
+    capacity: u64,
+    ttl: Option<Duration>,
+}
+
+pub(crate) struct SyncTtlGuard<'a, K, V> {
+    inner: std::sync::MutexGuard<'a, CacheInner<K, V, RandomState>>,
+    capacity: u64,
+    ttl: Option<Duration>,
+    now: Instant,
+}
+
+impl<K: Hash + Eq + Clone, V> SyncTtlGuard<'_, K, V> {
+    pub(crate) fn get(&mut self, key: &K) -> Option<&mut V> {
+        if self.inner.get(key).is_some_and(|entry| {
+            self.ttl
+                .is_some_and(|ttl| self.now.saturating_duration_since(entry.inserted_at) >= ttl)
+        }) {
+            self.inner.remove_key(key);
+        }
+        self.inner.get_mut(key).map(|entry| {
+            entry
+                .referenced
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            &mut entry.value
+        })
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) {
+        if let Some(entry) = self.inner.get_mut(&key) {
+            entry.value = value;
+            entry.inserted_at = self.now;
+            entry.last_accessed_at = self.now;
+        } else if self.capacity != 0 {
+            self.inner
+                .insert_new(key, value, self.now, Some(self.capacity), None);
+        }
+    }
+
+    pub(crate) fn find_unique_key(&self, matches: impl Fn(&K, &V) -> bool) -> Option<K> {
+        let mut found = self.inner.iter().filter_map(|(key, entry)| {
+            if self
+                .ttl
+                .is_some_and(|ttl| self.now.saturating_duration_since(entry.inserted_at) >= ttl)
+                || !matches(key, &entry.value)
+            {
+                None
+            } else {
+                Some((key, entry))
+            }
+        });
+        let first = found.next()?;
+        if found.next().is_some() {
+            return None;
+        }
+        first
+            .1
+            .referenced
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        Some(first.0.clone())
+    }
+}
+
+impl<K: Hash + Eq + Clone, V: Clone> SyncTtlCache<K, V> {
+    pub(crate) fn new(capacity: u64, ttl: Option<Duration>) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(CacheInner::new(true, RandomState::new())),
+            capacity,
+            ttl,
+        }
+    }
+
+    pub(crate) fn configured_capacity(&self) -> Option<u64> {
+        Some(self.capacity)
+    }
+
+    pub(crate) fn with<R>(&self, access: impl FnOnce(&mut SyncTtlGuard<'_, K, V>) -> R) -> R {
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        access(&mut SyncTtlGuard {
+            inner,
+            capacity: self.capacity,
+            ttl: self.ttl,
+            now: Instant::now(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn upsert(&self, key: &K, update: impl FnOnce(Option<&V>) -> Option<V>) {
+        self.with(|cache| {
+            if let Some(value) = update(cache.get(key).as_deref()) {
+                cache.insert(key.clone(), value);
+            }
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(&self, key: &K) -> Option<V> {
+        self.with(|cache| cache.get(key).cloned())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert(&self, key: K, value: V) {
+        self.upsert(&key, |_| Some(value));
+    }
+
+    pub(crate) fn run_pending_tasks(&self) {
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let now = Instant::now();
+        let expired: Vec<_> = inner
+            .iter()
+            .filter(|(_, entry)| {
+                self.ttl
+                    .is_some_and(|ttl| now.saturating_duration_since(entry.inserted_at) >= ttl)
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in expired {
+            inner.remove_key(&key);
+        }
+    }
+
+    pub(crate) fn entry_count(&self) -> u64 {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).len() as u64
+    }
+}
+
 impl<K, V, S> CacheInner<K, V, S>
 where
     K: Hash + Eq + Clone,
@@ -1282,6 +1410,47 @@ impl<K, V, S> Clone for PortableCache<K, V, S> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[test]
+    fn sync_ttl_admission_is_atomic_and_bounded() {
+        let cache = Arc::new(SyncTtlCache::new(2, None));
+        let admitted = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| {
+                    cache.upsert(&1, |entry| {
+                        if entry.is_none() {
+                            admitted.fetch_add(1, Ordering::Relaxed);
+                            Some(1)
+                        } else {
+                            None
+                        }
+                    })
+                });
+            }
+        });
+        assert_eq!(admitted.load(Ordering::Relaxed), 1);
+        for key in 2..10 {
+            cache.insert(key, key);
+            assert_eq!(cache.entry_count(), 2);
+            assert_eq!(cache.get(&key), Some(key));
+        }
+    }
+
+    #[test]
+    fn sync_ttl_expiry_and_disabled_capacity() {
+        let expired = SyncTtlCache::new(2, Some(Duration::ZERO));
+        expired.insert(1, 1);
+        assert_eq!(expired.get(&1), None);
+        expired.insert(2, 2);
+        expired.run_pending_tasks();
+        assert_eq!(expired.entry_count(), 0);
+
+        let disabled = SyncTtlCache::new(0, None);
+        disabled.insert(1, 1);
+        assert_eq!(disabled.get(&1), None);
+        assert_eq!(disabled.entry_count(), 0);
+    }
 
     #[tokio::test]
     async fn pinned_eviction_has_bounded_probe_work() {

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -358,6 +358,27 @@ impl<K: Hash + Eq + Clone, V: Clone> SyncTtlCache<K, V> {
         })
     }
 
+    /// Entry count plus estimated retained bytes: the table the cache itself
+    /// holds, plus `per_entry` summed over the entries, under the single guard
+    /// so the pair is consistent. Mirrors [`Cache::memory_stats`] without the
+    /// async lock.
+    pub(crate) fn memory_stats(
+        &self,
+        mut per_entry: impl FnMut(&K, &V) -> usize,
+    ) -> wacore::stats::CollectionStats {
+        self.with(|cache| {
+            let bytes: usize = cache
+                .inner
+                .iter()
+                .map(|(key, entry)| per_entry(key, &entry.value))
+                .sum();
+            wacore::stats::CollectionStats::new(
+                cache.inner.len() as u64,
+                (bytes + cache.inner.structural_bytes()) as u64,
+            )
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn upsert(&self, key: &K, update: impl FnOnce(Option<&V>) -> Option<V>) {
         self.with(|cache| {

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -856,11 +856,7 @@ impl Client {
         // them before the deferred retry flushes would trade a redeliverable
         // failure for a crash-permanent one. Completion of the deferred
         // transition flushes this buffer (after its durable flush).
-        if self
-            .offline_sync_completed
-            .load(std::sync::atomic::Ordering::Acquire)
-            && !self.inbound_commit_batch.is_active()
-        {
+        if !self.inbound_commit_batch.is_active() {
             return false;
         }
         buffer.push(Arc::clone(info));
@@ -3671,6 +3667,11 @@ mod tests {
         client
             .offline_sync_completed
             .store(false, std::sync::atomic::Ordering::Release);
+        assert!(
+            !client.try_buffer_offline_receipt(&late),
+            "a completed drain must not buffer while its completion event is still pending"
+        );
+        client.inbound_commit_batch.reset();
         let straggler = offline_info(
             "OFF4",
             "5511999990000@s.whatsapp.net",

--- a/tests/report_coverage.rs
+++ b/tests/report_coverage.rs
@@ -673,6 +673,10 @@ fn a_newtype_or_alias_does_not_hide_its_collection() {
         Some("InboundCommitBatcher::Vec"),
         "the offline-drain commit batch is a Vec behind a newtype"
     );
+    assert!(
+        path("SyncTtlCache").is_some(),
+        "the synchronous publication cache must remain visible to the report scanner"
+    );
     assert_eq!(
         path("MsgSecretWriteBuffer").as_deref(),
         Some("MsgSecretWriteBuffer::HashMap"),

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -170,27 +170,6 @@ pub mod codec {
         msg.encode(out);
     }
 
-    /// Stream wire bytes in order without allocating a contiguous output buffer.
-    #[inline(never)]
-    pub fn message_encode_chunks(msg: &whatsapp::Message, consume: &mut dyn FnMut(&[u8])) {
-        struct ChunkSink<'a>(&'a mut dyn FnMut(&[u8]));
-        impl buffa::EncodeSink for ChunkSink<'_> {
-            fn put_u8(&mut self, value: u8) {
-                (self.0)(&[value]);
-            }
-            fn put_slice(&mut self, bytes: &[u8]) {
-                (self.0)(bytes);
-            }
-            fn put_u32_le(&mut self, value: u32) {
-                (self.0)(&value.to_le_bytes());
-            }
-            fn put_u64_le(&mut self, value: u64) {
-                (self.0)(&value.to_le_bytes());
-            }
-        }
-        msg.encode(&mut ChunkSink(consume));
-    }
-
     #[inline(never)]
     pub fn message_to_vec(msg: &whatsapp::Message) -> Vec<u8> {
         msg.encode_to_vec()

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -170,6 +170,27 @@ pub mod codec {
         msg.encode(out);
     }
 
+    /// Stream wire bytes in order without allocating a contiguous output buffer.
+    #[inline(never)]
+    pub fn message_encode_chunks(msg: &whatsapp::Message, consume: &mut dyn FnMut(&[u8])) {
+        struct ChunkSink<'a>(&'a mut dyn FnMut(&[u8]));
+        impl buffa::EncodeSink for ChunkSink<'_> {
+            fn put_u8(&mut self, value: u8) {
+                (self.0)(&[value]);
+            }
+            fn put_slice(&mut self, bytes: &[u8]) {
+                (self.0)(bytes);
+            }
+            fn put_u32_le(&mut self, value: u32) {
+                (self.0)(&value.to_le_bytes());
+            }
+            fn put_u64_le(&mut self, value: u64) {
+                (self.0)(&value.to_le_bytes());
+            }
+        }
+        msg.encode(&mut ChunkSink(consume));
+    }
+
     #[inline(never)]
     pub fn message_to_vec(msg: &whatsapp::Message) -> Vec<u8> {
         msg.encode_to_vec()


### PR DESCRIPTION
## Summary

Prevent phone-assisted PDO recovery and encrypted sender retries from delivering the same logical payload twice.

A production trace showed a group sender-key failure starting both recovery paths. PDO delivered the recovered message first; a pairwise retry with the same message ID, chat and sender decrypted about 650 ms later. The same process invoked its callback twice and created two replies. PDO bypassed the normal delivery cache.

## Evidence and design

Checked the structured whatspec IR first, then captured WhatsApp Web control flow for version `2.3000.1044770897`. `WAWebNonMessageDataRequestHandlerPlaceholderResend` passes recovered content to `WAWebHandleMsgProcess.processMsgs`. Storage and UI processing check logical identity, including after queued work. Fresh Signal encryption is not proof of a new logical message.

- Use synchronous cache admission with no callback under a cache or publication lock. Publication does not add an await after the no-hook Signal commit. No retained-publication queue.
- Track individual payload digests rather than suppressing every payload sharing an identity. Preserve distinct multipart content and later materialization of unresolved secret envelopes. Interrupted admissions are treated as absent so a rolled-back fan-out never suppresses redelivery.
- Suppress on live matches: the admit-to-complete region runs no awaits, so only a concurrent panic can invalidate the decision, while delivering on in-flight matches re-enters blocked callbacks and breaks the progress contract. Post-rollback redelivery is preserved through interruption detection.
- The duplicate probe returns an already-materialized secret envelope to dispatch instead of resolving the parent secret twice. A claim left with no live payloads is dropped so alias resolution still runs.
- Match PDO aliases through explicit immutable stanza evidence, preserving direction and participant. Missing or ambiguous evidence allows delivery. No moving global PN/LID canonicalization or transitive alias matching.
- Roll back admissions owned by interrupted synchronous fan-out, allowing later redelivery without invalidating newer successful owners.
- Keep aggregate receipts tied to the current successful Signal flush and scheduled before synchronous callbacks.
- Report dispatch-gate payload digests, tokens and aliases in the memory report beside the identity count, so the new retention is visible in `total_estimated_bytes`. Spills charge capacity, tokens their full allocation.

No persistent-schema changes, no public API changes, no production identifiers.

## Cost

Payload digests are SHA-256 over the standard `Vec<u8>` wire encoding, truncated to 16 retained bytes. An earlier revision added a streaming sink that stamped a second copy of the `Message` encode tree (+284 KiB .text in waproto); that is deleted and the single existing instantiation is reused. The hook path hashes its arena ranges with no extra encode, the no-hook commit path reuses one scratch buffer per batch, PDO hashing stays on the rare recovery path, and the single-call helper reuses a per-thread buffer capped at 64 KiB resident.

The first payload slot is inline. Each identity retains at most eight digests; further distinct payloads remain deliverable but unclaimed. Publication ownership uses one lazy status-token allocation per fan-out batch needing new admissions. Exact identity lookup is constant-time on average; only PDO misses scan the bounded registry for a unique explicit alias match.

This is not an allocation-free or throughput-improvement claim. Metadata keys still require owned clones, and Buffa size caching may allocate. CodSpeed and binary-size checks run in CI.

## Verification

Initial regressions failed before each fix. Follow-up regressions reproduced blocked callbacks, committed-first and recovery-first multipart losses, untracked second-part resends, alias fallback, interrupted fan-out, post-flush cancellation, the interrupted-admission race, double secret resolution, pruned-alias blocking, and scratch retention before their fixes.

Latest targeted verification on this head:

- 88 selected publication, alias, hook, multipart, cache, secret-resolver and report tests passed, including all 13 `report_coverage` tests.
- The fingerprint equivalence test pins both fingerprint paths to SHA-256 of `message_to_vec`; scratch tests bound allocation blocks and cap resident capacity.
- `cargo clippy -p whatsapp-rust --lib --tests -- -D warnings`, `cargo fmt --all -- --check` and `git diff --check` passed.
- The previous full library run passed 2,005 tests with two existing skips before the review revisions. Heavy workspace/platform suites are left to PR CI.

The earlier CI failures in Build and Test plus Build and Lint were both the structural `report_coverage` assertion finding the added `VecDeque`. Removing that queue fixes the cause; the original expected `InboundCommitBatcher::Vec` assertion remains unchanged. The informational semver failure reports existing generated `waproto` differences against the published release, not changes introduced by this PR.

The CodSpeed bot follow-up `30cf5ad` (16-byte digests, boxed alias, claim-size pin test) is integrated via rebase; the focused suite passes on the combined tree. Its remaining Simulation delta on `dm_receive` is the intrinsic per-message encode plus hash this content dedup requires.

## Limits

The cache remains bounded and nonpersistent. This does not guarantee exactly-once delivery across process restarts, cache expiry, capacity eviction or per-identity payload overflow. Alias dedup requires direct evidence; unknown relationships are not guessed. A late multipart part admitted near TTL end inherits the entry remaining window; expiry duplicates rather than losing. PDO remains event-only.

Tests use fictitious identities and fresh cryptographic state. They verify delivered events, cryptographic state and receipts, not the demo reply flow against a live WhatsApp server. No live deployment was performed. The missing sender chain triggered recovery, but this PR does not establish why that key was originally absent.