### PR TITLE
perf(cache): flatten slot entry padding

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      toolchain:
+        description: Dated nightly for a main baseline; alternate compilers do not publish graphs
+        required: false
+        type: string
+        default: nightly-2026-06-16
 
 concurrency:
   # head_ref alone could collide across forks; the PR number is unique.
@@ -15,6 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  RUSTUP_TOOLCHAIN: nightly-2026-06-16
   CARGO_TERM_COLOR: always
   PROTOC_VERSION: "3.25.3"
   SCCACHE_GHA_ENABLED: "true"
@@ -32,6 +39,8 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Binary Size (PR)
     runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
     permissions:
       contents: read
       actions: read
@@ -41,7 +50,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-06-16
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
 
       - name: Install tools (protoc, cargo-binstall)
         uses: taiki-e/install-action@v2
@@ -73,20 +82,23 @@ jobs:
       - name: Install ALSA dev headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - name: Measure binary size
-        run: cargo xt ci measure-binary-size --out-dir size-out
+        run: |
+          cargo run --locked --quiet -p whatsapp-xtask -- ci measure-binary-size --out-dir size-out
+          git diff --exit-code
 
       - name: Upload size artifacts
         uses: actions/upload-artifact@v7
         with:
           name: size-metrics
           path: size-out/
+          if-no-files-found: error
           retention-days: 90
 
-      - name: Download baseline from latest main run
+      - name: Download validated PR base measurement
         id: baseline
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo xt ci workflow size-baseline
+        run: cargo run --locked --quiet -p whatsapp-xtask -- ci workflow size-baseline
       # Informational (job summary); the real gate is the report script below.
       # Tolerates the window before the first push run creates the series.
       - name: Compare against gh-pages series
@@ -109,24 +121,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: cargo xt ci workflow size-override
+        run: cargo run --locked --quiet -p whatsapp-xtask -- ci workflow size-override
       # No GH_TOKEN here: the report script is PR-controlled code.
       - name: Generate report and evaluate gate
         env:
           BASE_DIR: ${{ steps.baseline.outputs.dir }}
           ALLOW_SIZE_INCREASE: ${{ steps.override.outputs.allow }}
         run: |
-          cargo xt ci binary-size-report --head size-out --out-dir size-out
-          cargo xt ci workflow append-summary size-out/report.md
+          cargo run --locked --quiet -p whatsapp-xtask -- ci binary-size-report --head size-out --out-dir size-out
+          cargo run --locked --quiet -p whatsapp-xtask -- ci workflow append-summary size-out/report.md
       # Fork PRs run with a read-only token, so they only get the job summary.
       - name: Post sticky PR comment
         if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: cargo xt ci workflow size-comment
+        run: cargo run --locked --quiet -p whatsapp-xtask -- ci workflow size-comment
       - name: Enforce size budget
-        run: cargo xt ci workflow size-gate
+        run: cargo run --locked --quiet -p whatsapp-xtask -- ci workflow size-gate
   binary-size-push:
     # Dispatch only publishes from main so stray branches can't pollute the series.
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -141,7 +153,21 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-06-16
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
+
+      - name: Validate measurement toolchain
+        id: compiler
+        env:
+          REQUESTED_TOOLCHAIN: ${{ inputs.toolchain }}
+          DEFAULT_SIZE_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN }}
+          RUSTC_WRAPPER: ""
+        run: cargo run --locked --quiet -p whatsapp-xtask -- ci workflow size-toolchain
+
+      - name: Install measurement toolchain
+        if: steps.compiler.outputs.toolchain != env.RUSTUP_TOOLCHAIN
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.compiler.outputs.toolchain }}
 
       - name: Install tools (protoc, cargo-binstall)
         uses: taiki-e/install-action@v2
@@ -173,7 +199,11 @@ jobs:
       - name: Install ALSA dev headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - name: Measure binary size
-        run: cargo xt ci measure-binary-size --out-dir size-out
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.compiler.outputs.toolchain }}
+        run: |
+          cargo run --locked --quiet -p whatsapp-xtask -- ci measure-binary-size --out-dir size-out
+          git diff --exit-code
 
       # This artifact is the comparison baseline for PR runs.
       - name: Upload size artifacts
@@ -181,11 +211,13 @@ jobs:
         with:
           name: size-metrics
           path: size-out/
+          if-no-files-found: error
           retention-days: 90
 
       # Post-merge safety net: alerts on the commit when a regression landed
       # despite (or around) the PR gate, e.g. via the size-increase-ok label.
       - name: Store series on gh-pages
+        if: steps.compiler.outputs.publish == 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: "whatsapp-rust binary size"

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -80,7 +80,7 @@ jobs:
 
       # measure_binary_size builds an example, which pulls the cpal dev-dependency (alsa-sys).
       - name: Install ALSA dev headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev unzip
       - name: Measure binary size
         run: |
           cargo run --locked --quiet -p whatsapp-xtask -- ci measure-binary-size --out-dir size-out

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "rtc-shared"
-version = "0.21.0-rc.2"
+version = "0.21.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e90210053b6e2eddf63209c93e52d5181ddc9a4b8d1ff5af9af8cb8d95d97e"
+checksum = "998b045d95d158251842c5146918f3213346ca7724e8c6ac750c37d467dbbcdd"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",

--- a/agent_docs/binary_size_ci.md
+++ b/agent_docs/binary_size_ci.md
@@ -23,12 +23,43 @@ Do NOT switch any metric to rlib size: rlibs carry un-monomorphized generics plu
 
 ## Baseline semantics and pitfalls
 
-- The PR baseline is the `size-metrics` artifact from the **latest successful main run**, not the merge-base. A stale PR can therefore show deltas inherited from main; rebase to clear them.
+- The PR baseline must match the event's `pull_request.base.sha`. The selector searches this repository's Binary Size runs on main, including pushes and manual dispatches. It requires successful measurement and upload in the same job and run attempt, an unexpired artifact from that upload, matching commit metadata, and the same rustc version as the head. Graph publication may fail without invalidating a completed measurement.
+- Missing, expired, malformed or mismatched baselines fail visibly. There is no fallback to older main and no passing gate without a comparison. Run Binary Size on the required main commit, then retry the PR job. A dispatch on a newer main commit cannot supply an older PR's baseline.
 - Metric names are series keys. Renaming one orphans its history in the chart, so keep names stable.
-- Sizes are only comparable under the same pinned toolchain. A `rust-toolchain.toml` bump legitimately moves every metric — expect a gate hit and use the label.
+- Sizes are only comparable under the same pinned toolchain. A toolchain change requires a base measurement with the matching compiler; `size-increase-ok` cannot override missing or incomparable measurements. The selector skips other-compiler candidates at the same base SHA, not metadata or provenance failures.
 - `cargo bloat` exits 0 even on analysis errors; the measure script validates its JSON instead of trusting the exit code.
 - Fork PRs run with a read-only token: they get the job summary and the gate, but no PR comment.
-- Local run: `cargo xt ci measure-binary-size --out-dir size-out` (add `--skip-build` to reuse an existing release build).
+- CI invokes the dispatcher with `cargo run --locked --quiet -p whatsapp-xtask --`. The build, cargo-bloat and cargo-llvm-lines also use `--locked`. Measurement refuses lockfile changes, and CI checks the tracked worktree before uploading. Fix manifest/lock inconsistencies explicitly rather than letting measurement rewrite them and break the subsequent gh-pages checkout.
+- Local measurement uses `cargo run --locked --quiet -p whatsapp-xtask -- ci measure-binary-size --out-dir size-out`. Add `--skip-build` to reuse an existing release build. Reports require `--base <artifact-directory>` or `BASE_DIR`; set `BASE_SHA` to also enforce the expected commit locally.
+
+For a compiler-changing PR, dispatch a matching baseline on main. For example,
+if the PR selects `nightly-2026-07-01`:
+
+```sh
+gh workflow run binary-size.yml --repo oxidezap/whatsapp-rust --ref main -f toolchain=nightly-2026-07-01
+```
+
+Wait for measurement and upload to succeed, then retry the PR job. If the PR's
+base SHA is older than current main, rebase first. The dispatch measures current
+main only, not an arbitrary ref. This workflow support must already be on main.
+
+The optional input defaults to `nightly-2026-06-16`. Only dated nightly identifiers
+are accepted because the build uses nightly-only flags. Input reaches the
+validator through an environment variable, never shell interpolation. Bootstrap
+and tool installation retain the default compiler; the measurement step sets
+`RUSTUP_TOOLCHAIN` to the validated selection for Cargo, cargo-bloat,
+cargo-llvm-lines and `rustc --version`. Metadata records that actual rustc version.
+Alternate-compiler dispatches upload artifacts but skip gh-pages publication, so
+they do not mix compilers in the normal graph series. Pushes and default-compiler
+dispatches retain normal publication.
+
+The stale-baseline failure on PR #1470 illustrates why publication status is not
+measurement status. The parent `47e1b5b41` uploaded valid measurements, then graph
+publication failed on a dirty `Cargo.lock`. The old successful-run selector used
+`2b9a8d799` instead and charged the PR for growth already introduced by group
+resync. Parent and PR artifacts had identical stripped and `.text` sizes. The
+default-feature demo does not enable VoIP, so this says nothing about the size
+cost of a VoIP parser in a VoIP-enabled binary.
 
 ## Per-crate opt-level
 

--- a/agent_docs/binary_size_ci.md
+++ b/agent_docs/binary_size_ci.md
@@ -17,13 +17,14 @@ Do NOT switch any metric to rlib size: rlibs carry un-monomorphized generics plu
 
 ## How regressions are caught
 
-- **PR gate** (`cargo xt ci binary-size-report`): absolute per-PR budget — stripped Δ ≤ 64 KiB, .text Δ ≤ 32 KiB. Absolute instead of percentage because sizes are deterministic for a pinned toolchain and 1% of a multi-MiB binary would hide real regressions. The sticky PR comment shows all deltas plus per-crate top movers.
+- **PR gate**. Run `cargo run --locked --quiet -p whatsapp-xtask -- ci binary-size-report`. The per-PR budgets allow at most 64 KiB of stripped growth and 32 KiB of `.text` growth. A percentage of a multi-MiB binary could hide real regressions. The sticky PR comment shows all deltas and per-crate changes.
 - **Escape hatch**: the `size-increase-ok` label downgrades a failed gate to a warning. Use it for toolchain/dependency bumps and accepted feature costs; the increase still lands in the series.
 - **Post-merge safety net**: the push job stores the series at `dev/binary-size` on gh-pages via github-action-benchmark (`alert-threshold: 102%` comments on the offending commit). Graphs: <https://oxidezap.github.io/whatsapp-rust/dev/binary-size/>.
 
 ## Baseline semantics and pitfalls
 
 - The PR baseline must match the event's `pull_request.base.sha`. The selector searches this repository's Binary Size runs on main, including pushes and manual dispatches. It requires successful measurement and upload in the same job and run attempt, an unexpired artifact from that upload, matching commit metadata, and the same rustc version as the head. Graph publication may fail without invalidating a completed measurement.
+- Artifacts from previous attempts are filtered before checking uniqueness. The selected artifact is downloaded by ID through `gh api`; `unzip` reads only the two fixed JSON members. Older artifacts with the same name cannot replace the validated measurement.
 - Missing, expired, malformed or mismatched baselines fail visibly. There is no fallback to older main and no passing gate without a comparison. Run Binary Size on the required main commit, then retry the PR job. A dispatch on a newer main commit cannot supply an older PR's baseline.
 - Metric names are series keys. Renaming one orphans its history in the chart, so keep names stable.
 - Sizes are only comparable under the same pinned toolchain. A toolchain change requires a base measurement with the matching compiler; `size-increase-ok` cannot override missing or incomparable measurements. The selector skips other-compiler candidates at the same base SHA, not metadata or provenance failures.

--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -130,8 +130,8 @@ No proprietary WASM, captured JS, or personal data belongs in the test commit.
 
 ## Received video orientation proof
 
-`received_frame_rotation_matches_whatsapp_wasm` requires the same captured J
-module and fails if it is unavailable. It calls function 828 at table slot 427
+`received_frame_rotation_matches_whatsapp_wasm` uses the same captured J
+module under the capture-availability policy above. It calls function 828 at table slot 427
 with a synthetic H.264 frame descriptor and records `env::renderVideoFrame_js`.
 The function body hash is
 `6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131`.
@@ -169,7 +169,7 @@ Live Android front/rear switching still requires a device retest.
 `tools/oracle-core/tests/incoming_orientation_probe.rs` feeds synthetic RTP
 packets to J function 4873 at slot 3954, then passes its parsed extension
 object directly to packet-frame constructor 6003 at slot 4331. The host never
-writes `frame+52`. Missing captures fail rather than skip.
+writes `frame+52`. These probes follow the same capture-availability policy.
 
 The executed profile dispatcher uses functions 4922/4923 and frame-info reader
 4911, then getter 4891. This is distinct from the stream-reader function 4913

--- a/agent_docs/voip_media_oracle.md
+++ b/agent_docs/voip_media_oracle.md
@@ -164,6 +164,45 @@ authentication failure, timestamp wrap and reordering, reset, rekey, and SSRC
 replacement. Direct and group engine tests check the signaling fallback.
 Live Android front/rear switching still requires a device retest.
 
+### Incoming extension layout regression
+
+`tools/oracle-core/tests/incoming_orientation_probe.rs` feeds synthetic RTP
+packets to J function 4873 at slot 3954, then passes its parsed extension
+object directly to packet-frame constructor 6003 at slot 4331. The host never
+writes `frame+52`. Missing captures fail rather than skip.
+
+The executed profile dispatcher uses functions 4922/4923 and frame-info reader
+4911, then getter 4891. This is distinct from the stream-reader function 4913
+described above. The tests pin function bodies and compare 3,840 packets across
+all metadata bytes, single IDR and FU-A start/end payload shapes, and five
+layouts. Reordered extensions, frame-info alone and the eight-byte form retain
+metadata just as the complete outgoing layout does. The previous Rust parser
+returned `None` for those layouts, incorrectly activating signaling fallback.
+
+Another 285 cases cover element lengths 1 through 16, padding, unknown ID 15,
+duplicate format precedence and truncated elements. The captured getter prefers
+one-byte-format metadata over three-byte-format metadata over extended metadata;
+the last complete element wins within each format. Truncation stops scanning but
+preserves earlier complete metadata. The malformed-input test disables engine
+logging because the isolated parser does not initialize that logger. No host
+imports are called during these comparisons.
+
+Receive orientation now uses `parse_whatsapp_media_frame_info` after packet
+authentication. The exact outgoing extension set, public header structs and
+optional bandwidth/timing fields are unchanged. No missing field is invented.
+
+The separate passthrough test runs eight packet pairs through constructor 6003,
+H.264 passthrough 12236 and renderer 828. It checks Annex-B bytes and JS rotation
+arguments, but not decoded pixels. Its observed OR aggregation across packet
+metadata is not applied to Rust in this fix. Signaling fallback semantics and
+camera-facing corrections are also unchanged. The live Android extension layout
+has not been captured, so this proves a parser discrepancy, not the cause of the
+reported rear-camera image.
+
+```sh
+WA_WASM_DIR=/path/to/captured-wasm cargo test --release -p oracle-core --test incoming_orientation_probe -- --nocapture
+```
+
 ## Camera-control execution boundary
 
 `tools/oracle-core/tests/camera_controls.rs` executes the J capture above and

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2672,6 +2672,9 @@ mod tests {
         // up to `CLIENTS - 1` over the scaled budget round down into it.
         let bytes_per_client = bytes / CLIENTS as i64;
         let allocs_per_client = allocs / CLIENTS as u64;
+        eprintln!(
+            "fixed structure {bytes_per_client} B {allocs_per_client} allocations; totals={bytes}/{allocs}"
+        );
         assert!(
             bytes <= MAX_BYTES_PER_CLIENT * CLIENTS as i64
                 && allocs <= MAX_ALLOCS_PER_CLIENT * CLIENTS as u64,

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1327,7 +1327,9 @@ impl Client {
                 debug!("Skipping active IQ: connection closed");
                 return;
             }
-            if let Err(e) = client_clone.set_passive(false).await
+            // Release the IQ future before the offline drain instead of retaining
+            // its tracing-expanded storage in this task for the whole backlog.
+            if let Err(e) = Box::pin(client_clone.set_passive(false)).await
                 && !client_clone.is_shutting_down()
             {
                 warn!("Failed to send post-connect active IQ: {e:?}");
@@ -2389,7 +2391,7 @@ mod tests {
     use std::time::Duration;
     use wacore::runtime::{AbortHandle, Runtime};
 
-    /// Records the concrete size of every future handed to the runtime.
+    /// Records the concrete size of every spawned future without polling it.
     ///
     /// `size_of_val` on the unsized `dyn Future` behind the `Pin<Box<_>>` reads
     /// the vtable, so what it reports is exactly the coroutine layout the boxing
@@ -2406,7 +2408,8 @@ mod tests {
                 .lock()
                 .expect("sizes mutex")
                 .push(size_of_val(&*future));
-            self.inner.spawn(future)
+            drop(future);
+            AbortHandle::noop()
         }
 
         fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
@@ -2414,7 +2417,7 @@ mod tests {
                 .lock()
                 .expect("sizes mutex")
                 .push(size_of_val(&*future));
-            self.inner.spawn_detached(future);
+            drop(future);
         }
 
         fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
@@ -2436,10 +2439,9 @@ mod tests {
     /// The post-login task is spawned on every connection and stays parked in
     /// `wait_for_offline_delivery_end` for the whole offline drain, so its
     /// future is resident for minutes on a client with a backlog. Inlining the
-    /// fresh-pairing arm — a branch that runs once per device lifetime — put the
-    /// union of its locals in there and made it 8,224 B; boxing the arm brought
-    /// it to ~1.2 KB. This pins the shape, not the exact number: a future above
-    /// the bound means an arm has been inlined back in.
+    /// fresh-pairing arm made it 8,224 B. The active IQ also needs a box when
+    /// tracing expands its future. Neither belongs in the drain's resident
+    /// storage. This bounds the spawned task, not the temporary boxed work.
     #[tokio::test]
     async fn the_post_login_task_does_not_carry_the_fresh_pairing_arm() {
         const MAX_POST_LOGIN_FUTURE_BYTES: usize = 2048;
@@ -2475,6 +2477,7 @@ mod tests {
             "<success> must spawn the post-login task"
         );
         let largest = spawned.iter().copied().max().unwrap_or(0);
+        eprintln!("post-login spawned={spawned:?}");
         assert!(
             largest < MAX_POST_LOGIN_FUTURE_BYTES,
             "post-login future grew to {largest} B (spawned: {spawned:?}); \

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -989,8 +989,12 @@ impl Client {
 
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         call_id.hash(&mut hasher);
-        let lane = hasher.finish() as usize % self.voip_state().answer_transition_locks.len();
-        self.voip_state().answer_transition_locks[lane].clone()
+        let locks = self
+            .voip_state()
+            .answer_transition_locks
+            .get_or_init(|| std::array::from_fn(|_| Arc::new(async_lock::Mutex::new(()))));
+        let lane = hasher.finish() as usize % locks.len();
+        locks[lane].clone()
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -2240,6 +2244,45 @@ async fn execute_call_service_request<T>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn answer_transition_lanes_are_lazy_and_shared_on_concurrent_first_use() {
+        let client = crate::test_utils::create_test_client().await;
+        assert!(client.voip_state().answer_transition_locks.get().is_none());
+        client.cleanup_connection_state().await;
+        assert!(client.voip_state().answer_transition_locks.get().is_none());
+        let barrier = std::sync::Barrier::new(8);
+        let locks = std::thread::scope(|scope| {
+            let handles = std::array::from_fn::<_, 8, _>(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    client.answer_transition_lock("LAZY-ANSWER")
+                })
+            });
+            handles.map(|handle| handle.join().expect("lane lookup"))
+        });
+        assert!(locks.iter().all(|lock| Arc::ptr_eq(lock, &locks[0])));
+        let guard = locks[0].lock().await;
+        assert!(
+            client
+                .answer_transition_lock("LAZY-ANSWER")
+                .try_lock()
+                .is_none()
+        );
+        drop(guard);
+        assert!(
+            client
+                .answer_transition_lock("LAZY-ANSWER")
+                .try_lock()
+                .is_some()
+        );
+        client.cleanup_connection_state().await;
+        assert!(Arc::ptr_eq(
+            &client.answer_transition_lock("LAZY-ANSWER"),
+            &locks[0]
+        ));
+    }
+
     /// The admission snapshots the report attributes to this subsystem.
     #[cfg(feature = "voip-runtime")]
     async fn pending_link_updates(client: &Client) -> wacore::stats::CollectionStats {

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -35,7 +35,20 @@ const TTI_RENEWAL_DIVISOR: u32 = 16;
 /// rather than repeatedly walking the growing map without finding a victim.
 const GUARDED_EVICTION_PROBES: usize = 64;
 
-struct CacheEntry<V> {
+/// One table slot: the key, its hash, and the entry fields inline.
+///
+/// Flattened from a `Slot { key, hash, entry: CacheEntry }` nest so a narrow
+/// key reuses the entry tail padding: `referenced` (1 byte) plus `key: u32`
+/// pack into one word ahead of `hash`. Field order matters; moving `key` or
+/// `hash` ahead of the 8-byte fields reopens the gap.
+///
+/// The hash is kept so the table can grow without re-hashing every key and so
+/// the FIFO side can address a slot by `(hash, seq)` instead of holding a
+/// second copy of the key. Before this, `order` was a `BTreeMap<u64, K>`: every
+/// entry carried its key twice, and for a `String`, `Jid` or `SenderMessageId`
+/// key that second copy was a second heap allocation held for the entry's
+/// whole lifetime, across every cache the client keeps.
+struct Slot<K, V> {
     value: V,
     // Monotonic instants (not wall-clock) so TTL/TTI are immune to clock jumps,
     // matching moka's timer semantics.
@@ -50,20 +63,8 @@ struct CacheEntry<V> {
     /// on the hit itself needed the write lock, and once every entry was
     /// being moved on every pass a warm read cost three times what it had.
     referenced: portable_atomic::AtomicBool,
-}
-
-/// One table slot: the key, its hash, and the entry.
-///
-/// The hash is kept so the table can grow without re-hashing every key and so
-/// the FIFO side can address a slot by `(hash, seq)` instead of holding a
-/// second copy of the key. Before this, `order` was a `BTreeMap<u64, K>`: every
-/// entry carried its key twice, and for a `String`, `Jid` or `SenderMessageId`
-/// key that second copy was a second heap allocation held for the entry's
-/// whole lifetime, across every cache the client keeps.
-struct Slot<K, V> {
     key: K,
     hash: u64,
-    entry: CacheEntry<V>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -294,30 +295,26 @@ where
         self.table.len()
     }
 
-    fn get<Q>(&self, key: &Q) -> Option<&CacheEntry<V>>
+    fn get<Q>(&self, key: &Q) -> Option<&Slot<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.hash_of(key);
-        self.table
-            .find(hash, |slot| slot.key.borrow() == key)
-            .map(|slot| &slot.entry)
+        self.table.find(hash, |slot| slot.key.borrow() == key)
     }
 
-    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut CacheEntry<V>>
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Slot<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let hash = self.hash_of(key);
-        self.table
-            .find_mut(hash, |slot| slot.key.borrow() == key)
-            .map(|slot| &mut slot.entry)
+        self.table.find_mut(hash, |slot| slot.key.borrow() == key)
     }
 
-    fn iter(&self) -> impl Iterator<Item = (&K, &CacheEntry<V>)> {
-        self.table.iter().map(|slot| (&slot.key, &slot.entry))
+    fn iter(&self) -> impl Iterator<Item = (&K, &Slot<K, V>)> {
+        self.table.iter().map(|slot| (&slot.key, slot))
     }
 
     /// Bytes the table and the eviction order themselves hold, on top of the
@@ -344,7 +341,7 @@ where
     /// Borrowed removal: the `order` side is keyed by the entry's own `seq`,
     /// so nothing here ever needs an owned `K`, and callers with a `&str` or
     /// `&Jid` need not clone the key just to delete it.
-    fn remove_key<Q>(&mut self, key: &Q) -> Option<CacheEntry<V>>
+    fn remove_key<Q>(&mut self, key: &Q) -> Option<Slot<K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -355,14 +352,14 @@ where
             .find_entry(hash, |slot| slot.key.borrow() == key)
             .ok()?
             .remove();
-        self.order.remove(&slot.entry.seq);
-        Some(slot.entry)
+        self.order.remove(&slot.seq);
+        Some(slot)
     }
 
     /// Remove the slot the FIFO side named by `(hash, seq)`.
     fn remove_by_seq(&mut self, hash: u64, seq: u64) -> bool {
         self.table
-            .find_entry(hash, |slot| slot.entry.seq == seq)
+            .find_entry(hash, |slot| slot.seq == seq)
             .ok()
             .map(|occupied| occupied.remove())
             .is_some()
@@ -390,30 +387,26 @@ where
         while self.table.len() as u64 >= cap && remaining != 0 {
             let table = &mut self.table;
             let mut probe = |op| match op {
-                ClockOp::Classify { seq, hash } => {
-                    match table.find(hash, |slot| slot.entry.seq == seq) {
-                        None => ClockVerdict::Skip,
-                        Some(slot)
-                            if evict_guard
-                                .is_some_and(|is_evictable| !is_evictable(&slot.entry.value)) =>
-                        {
-                            ClockVerdict::Skip
-                        }
-                        Some(slot)
-                            if slot
-                                .entry
-                                .referenced
-                                .swap(false, std::sync::atomic::Ordering::Relaxed) =>
-                        {
-                            ClockVerdict::SecondChance
-                        }
-                        Some(_) => ClockVerdict::Victim,
+                ClockOp::Classify { seq, hash } => match table.find(hash, |slot| slot.seq == seq) {
+                    None => ClockVerdict::Skip,
+                    Some(slot)
+                        if evict_guard.is_some_and(|is_evictable| !is_evictable(&slot.value)) =>
+                    {
+                        ClockVerdict::Skip
                     }
-                }
+                    Some(slot)
+                        if slot
+                            .referenced
+                            .swap(false, std::sync::atomic::Ordering::Relaxed) =>
+                    {
+                        ClockVerdict::SecondChance
+                    }
+                    Some(_) => ClockVerdict::Victim,
+                },
                 ClockOp::Reseq { seq, hash, fresh } => {
-                    match table.find_mut(hash, |slot| slot.entry.seq == seq) {
+                    match table.find_mut(hash, |slot| slot.seq == seq) {
                         Some(slot) => {
-                            slot.entry.seq = fresh;
+                            slot.seq = fresh;
                             ClockVerdict::Victim
                         }
                         None => ClockVerdict::Skip,
@@ -474,15 +467,13 @@ where
         self.table.insert_unique(
             hash,
             Slot {
+                value,
+                inserted_at: now,
+                last_accessed_at: now,
+                seq,
+                referenced: portable_atomic::AtomicBool::new(false),
                 key,
                 hash,
-                entry: CacheEntry {
-                    value,
-                    inserted_at: now,
-                    last_accessed_at: now,
-                    seq,
-                    referenced: portable_atomic::AtomicBool::new(false),
-                },
             },
             |slot| slot.hash,
         );
@@ -491,7 +482,7 @@ where
     /// Drop expired entries and the FIFO records that named them. Driven by
     /// `order`, which every cache that expires by time maintains (see
     /// `PortableCacheBuilder::build`), so the walk itself is [`expiry_walk`].
-    fn retain_unexpired(&mut self, mut is_expired: impl FnMut(&CacheEntry<V>) -> bool) {
+    fn retain_unexpired(&mut self, mut is_expired: impl FnMut(&Slot<K, V>) -> bool) {
         debug_assert!(
             self.track_order,
             "a cache that expires by time tracks order; the sweep walks it"
@@ -499,8 +490,8 @@ where
         let table = &self.table;
         let expired = expiry_walk(&self.order, &mut |seq, hash| {
             table
-                .find(hash, |slot| slot.entry.seq == seq)
-                .is_some_and(|slot| is_expired(&slot.entry))
+                .find(hash, |slot| slot.seq == seq)
+                .is_some_and(&mut is_expired)
         });
         for (seq, hash) in expired {
             self.order.remove(&seq);
@@ -837,7 +828,7 @@ where
         }
     }
 
-    fn is_expired(&self, entry: &CacheEntry<V>, now: Instant) -> bool {
+    fn is_expired(&self, entry: &Slot<K, V>, now: Instant) -> bool {
         if let Some(ttl) = self.ttl
             && now.saturating_duration_since(entry.inserted_at) >= ttl
         {
@@ -854,7 +845,7 @@ where
     /// Whether `entry`'s access stamp has aged past [`TTI_RENEWAL_DIVISOR`]'s
     /// tolerance and is worth pushing forward under the write lock. A cache
     /// without TTI never renews.
-    fn needs_tti_renewal(&self, entry: &CacheEntry<V>, now: Instant) -> bool {
+    fn needs_tti_renewal(&self, entry: &Slot<K, V>, now: Instant) -> bool {
         self.tti.is_some_and(|tti| {
             now.saturating_duration_since(entry.last_accessed_at) >= tti / TTI_RENEWAL_DIVISOR
         })
@@ -1701,12 +1692,14 @@ mod tests {
             .build();
 
         let inserted = Instant::ZERO + Duration::from_secs(1_000);
-        let entry = CacheEntry {
+        let entry = Slot {
             value: 1,
             inserted_at: inserted,
             last_accessed_at: inserted,
             seq: 0,
             referenced: portable_atomic::AtomicBool::new(false),
+            key: String::new(),
+            hash: 0,
         };
 
         assert!(!cache.is_expired(&entry, inserted + tti - Duration::from_nanos(1)));
@@ -1735,12 +1728,14 @@ mod tests {
             .build();
 
         let stamped = Instant::ZERO + Duration::from_secs(1_000);
-        let entry = CacheEntry {
+        let entry = Slot {
             value: 1,
             inserted_at: stamped,
             last_accessed_at: stamped,
             seq: 0,
             referenced: portable_atomic::AtomicBool::new(false),
+            key: String::new(),
+            hash: 0,
         };
 
         assert!(!cache.needs_tti_renewal(&entry, stamped));
@@ -1776,12 +1771,14 @@ mod tests {
         // elapsed, so the recorded stamp lags it by (almost) a full window.
         let stamped = Instant::ZERO + Duration::from_secs(1_000);
         let real_access = stamped + tolerance - Duration::from_nanos(1);
-        let entry = CacheEntry {
+        let entry = Slot {
             value: 1,
             inserted_at: stamped,
             last_accessed_at: stamped,
             seq: 0,
             referenced: portable_atomic::AtomicBool::new(false),
+            key: String::new(),
+            hash: 0,
         };
 
         // Never late: gone by `real_access + tti` at the very latest.
@@ -2595,5 +2592,19 @@ mod tests {
         assert_eq!((a, b), (1, 2));
         assert_eq!(cache.get("a").await, Some(1));
         assert_eq!(cache.get("b").await, Some(2));
+    }
+
+    /// The flattened slot packs the 4-byte contact-hash key into the entry
+    /// tail padding, so `Slot<u32, Arc<str>>` is one word smaller than the
+    /// nested `Slot { key, hash, entry }` it replaces. Wide keys already
+    /// align, so the dispatched slot keeps its size.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn flattened_slot_reuses_entry_tail_padding() {
+        assert_eq!(size_of::<Slot<u32, Arc<str>>>(), 56);
+        assert_eq!(
+            size_of::<Slot<wacore::types::message::SenderMessageId, ()>>(),
+            128
+        );
     }
 }

--- a/src/voip/state.rs
+++ b/src/voip/state.rs
@@ -107,7 +107,10 @@ pub(crate) struct VoipState {
     /// Serializes incoming-answer registration with generation-aware teardown. A failed answer
     /// holds its call-id lane until `<terminate>` has been written, so a same-call-id re-offer
     /// cannot become current in the removal-before-send window.
-    pub(crate) answer_transition_locks: [Arc<Mutex<()>>; ANSWER_TRANSITION_LANES],
+    /// Allocate the lanes only on first use; clients that never answer a call
+    /// need none. Once initialized, lane identity survives every reconnect.
+    pub(crate) answer_transition_locks:
+        std::sync::OnceLock<[Arc<Mutex<()>>; ANSWER_TRANSITION_LANES]>,
     /// Outgoing calls awaiting their relay. The initiator's relay is not in the offer; it arrives
     /// from the server AFTER it, so each `voip().call()` parks the material needed to spawn the
     /// engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id arrives.
@@ -132,7 +135,7 @@ impl Default for VoipState {
             call_registry: Arc::new(wacore::voip::CallRegistry::new()),
             pending_call_link_joins: Arc::new(std::sync::Mutex::new(Default::default())),
             pending_call_link_join_lane: Mutex::new(()),
-            answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
+            answer_transition_locks: std::sync::OnceLock::new(),
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
             relay_transport_provider: std::sync::Mutex::new(None),
         }

--- a/tools/oracle-core/tests/incoming_orientation_probe.rs
+++ b/tools/oracle-core/tests/incoming_orientation_probe.rs
@@ -8,7 +8,10 @@ mod common;
 
 #[test]
 fn incoming_rtp_metadata_to_frame_descriptor() -> anyhow::Result<()> {
-    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
+        eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
     for (index, slot, anchor, hash) in [
         (
             4873,
@@ -153,7 +156,10 @@ fn incoming_rtp_metadata_to_frame_descriptor() -> anyhow::Result<()> {
 
 #[test]
 fn incoming_frame_info_element_boundaries() -> anyhow::Result<()> {
-    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
+        eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
     for (index, hash) in [
         (
             4923,
@@ -299,7 +305,10 @@ fn incoming_frame_info_element_boundaries() -> anyhow::Result<()> {
 
 #[test]
 fn incoming_packets_through_h264_passthrough_to_renderer() -> anyhow::Result<()> {
-    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    let Some(bytes) = common::capture("JgwtTQVeWPm")? else {
+        eprintln!("skipping: JgwtTQVeWPm unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
     assert!(
         abi::find_string_refs(&bytes, "h26x_passthrough_codec_decode")?
             .iter()

--- a/tools/oracle-core/tests/incoming_orientation_probe.rs
+++ b/tools/oracle-core/tests/incoming_orientation_probe.rs
@@ -1,0 +1,462 @@
+//! Incoming wire metadata through the captured parser, packet constructor and H.264 passthrough.
+
+use oracle_core::{Runtime, abi, derive::function_body_sha256};
+use wacore::voip::rtp::parse_whatsapp_media_frame_info;
+use wasmtime::Val;
+
+mod common;
+
+#[test]
+fn incoming_rtp_metadata_to_frame_descriptor() -> anyhow::Result<()> {
+    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    for (index, slot, anchor, hash) in [
+        (
+            4873,
+            3954,
+            "EXT_HDR: payload offset",
+            "198c51630bcec7240cbb6472423831f89d6c1ad3676d477032030e624ea07c3b",
+        ),
+        (
+            6003,
+            4331,
+            "Unsupported codec for jbuf",
+            "415de384a70490b5b0b75c37aee0ff2abc447c1a2fb4cdb96bec5588ffb5d045",
+        ),
+    ] {
+        assert!(
+            abi::find_string_refs(&bytes, anchor)?
+                .iter()
+                .any(|entry| entry.referenced_by.contains(&index))
+        );
+        assert!(abi::table_slots_of(&bytes, index)?.contains(&slot));
+        assert_eq!(function_body_sha256(&bytes, index)?, hash);
+    }
+    let _serial = common::threaded_guard();
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.run_ctors()?;
+    let packet = runtime.write_bytes(&[0; 64])?;
+    let extensions = runtime.write_bytes(&[0; 136])?;
+    let frame = runtime.write_bytes(&[0; 336])?;
+    let stream = runtime.write_bytes(&[0; 13000])?;
+    let context = runtime.write_bytes(&[0; 16])?;
+    let status = runtime.write_bytes(&[0; 8])?;
+    let clock = runtime.write_bytes(&[0; 8])?;
+    let mut cases = 0;
+    for layout in ["full", "reordered", "frame-only", "eight-byte", "absent"] {
+        let mut rust_present = 0;
+        for info in 0..=255u8 {
+            for (payload, marker, key) in [
+                (&[0x65, 0x88][..], true, true),
+                (&[0x7c, 0x85, 0x88][..], false, true),
+                (&[0x7c, 0x45, 0x88][..], true, true),
+            ] {
+                let extension = match layout {
+                    "full" => vec![0x30, info, 0x51, 0, 1, 0x61, 0, 0, 0x91, 0, 1, 0],
+                    "reordered" => vec![0x51, 0, 1, 0x30, info, 0x61, 0, 0, 0x91, 0, 1, 0],
+                    "frame-only" => vec![0x30, info, 0, 0],
+                    "eight-byte" => vec![0x37, info, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                    "absent" => vec![0; 4],
+                    _ => unreachable!(),
+                };
+                let mut wire = vec![
+                    0x90,
+                    97 | (u8::from(marker) << 7),
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0xde,
+                    0xbe,
+                    0,
+                    (extension.len() / 4) as u8,
+                ];
+                wire.extend_from_slice(&extension);
+                let payload_offset = wire.len();
+                wire.extend_from_slice(payload);
+                runtime.write_bytes_at(packet, &wire)?;
+                runtime.write_bytes_at(extensions, &[0; 136])?;
+                runtime.shared().clear_trace();
+                runtime.refuel();
+                let result = runtime.call_table(
+                    3954,
+                    &[
+                        Val::I32(packet as i32),
+                        Val::I64(wire.len() as i64),
+                        Val::I32(extensions as i32),
+                    ],
+                )?;
+                assert_eq!(result[0].i32(), Some(0), "parser info={info:#04x}");
+                let rust = parse_whatsapp_media_frame_info(&wire);
+                rust_present += usize::from(rust.is_some());
+                if let Some(rust) = rust {
+                    assert_eq!(rust, info);
+                }
+                runtime.call_table(
+                    4331,
+                    &[
+                        Val::I32(frame as i32),
+                        Val::I32(stream as i32),
+                        Val::I32(context as i32),
+                        Val::I32((packet + payload_offset as u32) as i32),
+                        Val::I32(payload.len() as i32),
+                        Val::I32(status as i32),
+                        Val::I32(packet as i32),
+                        Val::I32(extensions as i32),
+                        Val::I32(97),
+                        Val::I32(clock as i32),
+                    ],
+                )?;
+                let actual = runtime.read_u32_at(frame + 52)?;
+                let expected = if layout == "absent" {
+                    0
+                } else {
+                    0x800 | u32::from(info)
+                };
+                let expected = (expected & !8) | (u32::from(key) << 3) | (u32::from(marker) << 12);
+                assert_eq!(
+                    actual, expected,
+                    "layout={layout}, info={info:#04x}, payload={payload:?}"
+                );
+                assert_eq!(
+                    rust.map(|info| info & !8),
+                    (actual & 0x800 != 0).then_some(actual as u8 & !8),
+                    "Rust/WASM metadata except normalized keyframe bit, layout={layout}, info={info:#04x}"
+                );
+                assert!(
+                    runtime.stubs_called().is_empty(),
+                    "{:?}",
+                    runtime.stubs_called()
+                );
+                assert!(
+                    runtime.shared().hot_calls().is_empty(),
+                    "{:?}",
+                    runtime.shared().hot_calls()
+                );
+                cases += 1;
+            }
+        }
+        eprintln!(
+            "layout={layout}: WASM processed 768 packets; Rust recognized frame-info on {rust_present}"
+        );
+    }
+    eprintln!(
+        "executed actual RTP extension dispatcher -> frame constructor for {cases} wire packets"
+    );
+    Ok(())
+}
+
+#[test]
+fn incoming_frame_info_element_boundaries() -> anyhow::Result<()> {
+    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    for (index, hash) in [
+        (
+            4923,
+            "19f7062204d914d74aa7c8e116af86e674d836c7106eb36ef96747c4987c09fd",
+        ),
+        (
+            4911,
+            "a83fda9022ea210689475a6dbcc671b5606992ffb278a62269af958c1ca7dcee",
+        ),
+        (
+            4891,
+            "7bfbce4785f9aa5a291f9d8e5711079248f324889ca284659b1e2176b0f8de0f",
+        ),
+    ] {
+        assert_eq!(function_body_sha256(&bytes, index)?, hash);
+    }
+    let _serial = common::threaded_guard();
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.run_ctors()?;
+    // Malformed packets log through an engine logger that this isolated test does not initialize.
+    runtime.set_engine_log_level(0)?;
+    let packet = runtime.write_bytes(&[0; 128])?;
+    let extensions = runtime.write_bytes(&[0; 136])?;
+    let frame = runtime.write_bytes(&[0; 336])?;
+    let stream = runtime.write_bytes(&[0; 13000])?;
+    let context = runtime.write_bytes(&[0; 16])?;
+    let status = runtime.write_bytes(&[0; 8])?;
+    let clock = runtime.write_bytes(&[0; 8])?;
+    let mut cases = vec![
+        ("padding", vec![0, 0x0f, 0x30, 3]),
+        ("unknown-before", vec![0xf0, 0xff, 0x30, 3]),
+        ("unknown-after", vec![0x30, 3, 0xf0, 0xff]),
+        ("duplicate-short", vec![0x30, 1, 0x30, 3]),
+        ("duplicate-short-reverse", vec![0x30, 3, 0x30, 1]),
+        (
+            "short-then-long",
+            vec![0x30, 1, 0x37, 3, 0, 0, 0, 0, 0, 0, 0],
+        ),
+        (
+            "long-then-short",
+            vec![0x37, 3, 0, 0, 0, 0, 0, 0, 0, 0x30, 1],
+        ),
+        (
+            "three-then-eight",
+            vec![0x32, 1, 0, 0, 0x37, 3, 0, 0, 0, 0, 0, 0, 0],
+        ),
+        (
+            "eight-then-three",
+            vec![0x37, 3, 0, 0, 0, 0, 0, 0, 0, 0x32, 1, 0, 0],
+        ),
+        ("unknown-truncated-before", vec![0xff, 0x30, 3, 0]),
+        ("unknown-truncated-after", vec![0x30, 3, 0xff, 0]),
+        ("frame-truncated-before", vec![0x3f, 3, 0, 0]),
+        ("frame-truncated-after", vec![0x30, 1, 0x3f, 3]),
+    ];
+    for length in 1..=16 {
+        let mut extension = vec![0; length + 1];
+        extension[0] = 0x30 | (length - 1) as u8;
+        extension[1] = 3;
+        cases.push(("length", extension));
+    }
+    for first in 1..=16 {
+        for last in 1..=16 {
+            let mut extension = vec![0; first + last + 2];
+            extension[0] = 0x30 | (first - 1) as u8;
+            extension[1] = 1;
+            extension[first + 1] = 0x30 | (last - 1) as u8;
+            extension[first + 2] = 3;
+            cases.push(("duplicate-lengths", extension));
+        }
+    }
+    let count = cases.len();
+    for (name, mut extension) in cases {
+        let original = extension.clone();
+        extension.resize(extension.len().next_multiple_of(4), 0);
+        let mut wire = vec![
+            0x90,
+            0xe1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0xde,
+            0xbe,
+            0,
+            (extension.len() / 4) as u8,
+        ];
+        wire.extend_from_slice(&extension);
+        let offset = wire.len();
+        wire.extend_from_slice(&[0x61, 0x88]);
+        runtime.write_bytes_at(packet, &wire)?;
+        runtime.write_bytes_at(extensions, &[0; 136])?;
+        runtime.shared().clear_trace();
+        runtime.refuel();
+        let parsed = runtime.call_table(
+            3954,
+            &[
+                Val::I32(packet as i32),
+                Val::I64(wire.len() as i64),
+                Val::I32(extensions as i32),
+            ],
+        )?;
+        assert_eq!(
+            parsed[0].i32(),
+            Some(if name.contains("truncated") { 70004 } else { 0 })
+        );
+        runtime.call_table(
+            4331,
+            &[
+                Val::I32(frame as i32),
+                Val::I32(stream as i32),
+                Val::I32(context as i32),
+                Val::I32((packet + offset as u32) as i32),
+                Val::I32(2),
+                Val::I32(status as i32),
+                Val::I32(packet as i32),
+                Val::I32(extensions as i32),
+                Val::I32(97),
+                Val::I32(clock as i32),
+            ],
+        )?;
+        let actual = runtime.read_u32_at(frame + 52)?;
+        assert_eq!(
+            parse_whatsapp_media_frame_info(&wire),
+            (actual & 0x800 != 0).then_some(actual as u8),
+            "{name} {original:02x?}: parser={:?}",
+            parsed[0].i32()
+        );
+        assert!(runtime.shared().hot_calls().is_empty());
+        assert!(runtime.stubs_called().is_empty());
+    }
+    eprintln!(
+        "compared Rust/WASM metadata for {count} padding, length, duplicate and truncation cases"
+    );
+    Ok(())
+}
+
+#[test]
+fn incoming_packets_through_h264_passthrough_to_renderer() -> anyhow::Result<()> {
+    let bytes = common::capture("JgwtTQVeWPm")?.expect("pinned capture required");
+    assert!(
+        abi::find_string_refs(&bytes, "h26x_passthrough_codec_decode")?
+            .iter()
+            .any(|entry| entry.referenced_by.contains(&12236))
+    );
+    assert!(abi::table_slots_of(&bytes, 12236)?.contains(&8773));
+    assert_eq!(
+        function_body_sha256(&bytes, 12236)?,
+        "3be2b436a962e13f32de54a563ef8347433a6355232c617a03ca4b8e179f5c35"
+    );
+    assert_eq!(
+        function_body_sha256(&bytes, 828)?,
+        "6b4c303d8f48d3adc46ef8ba1c3e8dc0aca0db37193974b53101e1a9071b7131"
+    );
+    let _serial = common::threaded_guard();
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.run_ctors()?;
+    let packets = runtime.write_bytes(&[0; 128])?;
+    let extensions = runtime.write_bytes(&[0; 136])?;
+    let frames = runtime.write_bytes(&[0; 672])?;
+    let stream = runtime.write_bytes(&[0; 13000])?;
+    let context = runtime.write_bytes(&[0; 16])?;
+    let status = runtime.write_bytes(&[0; 8])?;
+    let clock = runtime.write_bytes(&[0; 8])?;
+    let codec = runtime.write_bytes(&[0; 16])?;
+    let decoder = runtime.write_bytes(&[0; 2200])?;
+    let unpacker = runtime.write_bytes(&[0; 64])?;
+    let output = runtime.write_bytes(&[0; 336])?;
+    let buffer = runtime.write_bytes(&[0; 128])?;
+    let pointers = runtime.write_bytes(&[0; 8])?;
+    let list = runtime.write_bytes(&[0; 16])?;
+    let size = runtime.write_bytes(&[3, 0, 0, 0, 2, 0, 0, 0])?;
+    let peer = runtime.write_bytes(&[0; 24])?;
+    for (ptr, value) in [
+        (codec + 8, decoder),
+        (decoder + 1980, 2),
+        (decoder + 872, 875967048),
+        (decoder + 884, 3),
+        (decoder + 888, 2),
+        (decoder + 2144, buffer),
+        (decoder + 2148, buffer + 64),
+        (decoder + 2156, 64),
+        (decoder + 2184, unpacker),
+        (unpacker + 4, 875967048),
+        (list, 2),
+        (list + 4, 2),
+        (list + 8, pointers),
+        (list + 12, 8),
+        (pointers, frames),
+        (pointers + 4, frames + 336),
+    ] {
+        runtime.write_bytes_at(ptr, &value.to_le_bytes())?;
+    }
+    runtime.write_bytes_at(unpacker + 27, &[1])?;
+    for (first, last) in [
+        (Some(1u8), Some(0u8)),
+        (Some(0), Some(1)),
+        (Some(1), Some(2)),
+        (Some(2), Some(1)),
+        (Some(3), Some(1)),
+        (None, Some(3)),
+        (Some(3), None),
+        (None, None),
+    ] {
+        runtime.shared().clear_trace();
+        runtime.refuel();
+        for (index, info) in [first, last].into_iter().enumerate() {
+            let packet = packets + index as u32 * 64;
+            let mut wire = [
+                0x90, 97, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0xde, 0xbe, 0, 1, 0, 0, 0, 0, 0x61, 0x88,
+            ];
+            wire[1] |= (index as u8) << 7;
+            wire[3] += index as u8;
+            if let Some(info) = info {
+                wire[16] = 0x30;
+                wire[17] = info;
+            }
+            runtime.write_bytes_at(packet, &wire)?;
+            runtime.write_bytes_at(extensions, &[0; 136])?;
+            assert_eq!(
+                runtime.call_table(
+                    3954,
+                    &[
+                        Val::I32(packet as i32),
+                        Val::I64(wire.len() as i64),
+                        Val::I32(extensions as i32),
+                    ]
+                )?[0]
+                    .i32(),
+                Some(0)
+            );
+            runtime.call_table(
+                4331,
+                &[
+                    Val::I32((frames + index as u32 * 336) as i32),
+                    Val::I32(stream as i32),
+                    Val::I32(context as i32),
+                    Val::I32((packet + 20) as i32),
+                    Val::I32(2),
+                    Val::I32(status as i32),
+                    Val::I32(packet as i32),
+                    Val::I32(extensions as i32),
+                    Val::I32(97),
+                    Val::I32(clock as i32),
+                ],
+            )?;
+        }
+        assert_eq!(
+            runtime.call_table(
+                8773,
+                &[
+                    Val::I32(codec as i32),
+                    Val::I32(list as i32),
+                    Val::I32(64),
+                    Val::I32(output as i32),
+                ]
+            )?[0]
+                .i32(),
+            Some(0)
+        );
+        let actual = runtime.read_u32_at(output + 52)?;
+        let expected = [first, last]
+            .into_iter()
+            .flatten()
+            .fold(0x1000u32, |acc, info| acc | 0x800 | u32::from(info));
+        assert_eq!(actual, expected);
+        assert_eq!(runtime.read_u32_at(output + 16)?, 12);
+        let data = runtime.read_u32_at(output + 8)?;
+        assert_eq!(
+            runtime.read(data, 12)?,
+            [0, 0, 0, 1, 0x61, 0x88, 0, 0, 0, 1, 0x61, 0x88]
+        );
+        assert!(
+            runtime.shared().hot_calls().is_empty(),
+            "{:?}",
+            runtime.shared().hot_calls()
+        );
+        runtime.call_table(
+            427,
+            &[
+                Val::I32(output as i32),
+                Val::I32(size as i32),
+                Val::I32(peer as i32),
+            ],
+        )?;
+        let calls = runtime.shared().calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].symbol(), "env::renderVideoFrame_js");
+        let orientation = if actual & 0x800 == 0 {
+            0
+        } else {
+            [1, 4, 3, 2][(actual & 3) as usize]
+        };
+        assert_eq!(calls[0].args[5], orientation);
+        eprintln!(
+            "wire {first:?}, {last:?} -> AU info {actual:#x} -> JS orientation {orientation}"
+        );
+    }
+    Ok(())
+}

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 mod ci;
 mod size;
+mod size_baseline;
 mod workflow;
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/tools/xtask/src/size.rs
+++ b/tools/xtask/src/size.rs
@@ -31,6 +31,9 @@ fn command(root: &Path, program: &str, args: &[&str]) -> Command {
     c.args(args)
         .current_dir(root)
         .env("CARGO_PROFILE_RELEASE_STRIP", "false");
+    if program == "cargo" {
+        c.arg("--locked");
+    }
     c
 }
 fn text(root: &Path, program: &str, args: &[&str]) -> Result<String> {
@@ -78,12 +81,13 @@ fn llvm_total(output: &str) -> Result<(i64, i64)> {
     anyhow::bail!("no TOTAL row in cargo llvm-lines output")
 }
 pub fn measure(root: &Path, out: &Path, skip: bool) -> Result<()> {
+    let lock = std::fs::read(root.join("Cargo.lock"))?;
     std::fs::create_dir_all(out)?;
     if !skip {
         run(&mut command(
             root,
             "cargo",
-            &["build", "--release", "--locked", "--example", "demo"],
+            &["build", "--release", "--example", "demo"],
         ))?;
     }
     let target = std::env::var_os("CARGO_TARGET_DIR")
@@ -174,6 +178,10 @@ pub fn measure(root: &Path, out: &Path, skip: bool) -> Result<()> {
         i64::try_from(count)?,
     ));
     let meta = json!({"commit":text(root,"git",&["rev-parse","HEAD"])?.trim(),"rustc":text(root,"rustc",&["--version"])?.trim()});
+    ensure!(
+        std::fs::read(root.join("Cargo.lock"))? == lock,
+        "measurement changed Cargo.lock; refusing inconsistent size artifacts"
+    );
     write_json(&out.join("size-metrics.json"), &metrics)?;
     write_json(&out.join("size-attribution.json"), &bloat)?;
     write_json(&out.join("size-meta.json"), &meta)?;
@@ -225,6 +233,53 @@ fn metrics(directory: &Path) -> Result<Vec<Metric>> {
         &directory.join("size-metrics.json"),
     )?)?)
 }
+fn validate_metrics(metrics: &[Metric]) -> Result<()> {
+    for (name, _) in GATED {
+        let rows: Vec<_> = metrics.iter().filter(|m| m.name == *name).collect();
+        ensure!(
+            rows.len() == 1 && rows[0].unit == "bytes" && rows[0].value > 0,
+            "size metrics require one positive byte measurement for {name}"
+        );
+    }
+    Ok(())
+}
+#[derive(Deserialize)]
+struct Metadata {
+    commit: String,
+    rustc: String,
+}
+#[derive(Debug)]
+pub(super) struct CompilerMismatch;
+impl std::fmt::Display for CompilerMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("baseline and head rustc differ; size measurements are not comparable")
+    }
+}
+impl std::error::Error for CompilerMismatch {}
+fn metadata(directory: &Path) -> Result<Metadata> {
+    let meta: Metadata = serde_json::from_value(read_json(&directory.join("size-meta.json"))?)?;
+    ensure!(
+        meta.commit.len() == 40
+            && meta.commit.bytes().all(|b| b.is_ascii_hexdigit())
+            && !meta.rustc.trim().is_empty(),
+        "invalid size metadata"
+    );
+    Ok(meta)
+}
+pub fn validate_baseline(head: &Path, base: &Path, expected: Option<&str>) -> Result<()> {
+    let head_meta = metadata(head)?;
+    let base_meta = metadata(base)?;
+    ensure!(
+        expected.is_none_or(|sha| sha == base_meta.commit),
+        "baseline commit does not match PR base SHA"
+    );
+    validate_metrics(&metrics(head)?)?;
+    validate_metrics(&metrics(base)?)?;
+    if head_meta.rustc != base_meta.rustc {
+        return Err(CompilerMismatch.into());
+    }
+    Ok(())
+}
 fn movers(head: &Path, base: &Path) -> Result<Vec<String>> {
     let get = |path: &Path| -> Result<BTreeMap<String, i64>> {
         let v = read_json(&path.join("size-attribution.json"))?;
@@ -274,12 +329,8 @@ fn render(
     base: Option<&[Metric]>,
     allow: bool,
 ) -> Result<(Vec<String>, Vec<String>, String)> {
-    for (name, _) in GATED {
-        ensure!(
-            head.iter().any(|m| m.name == *name),
-            "head metrics missing gated row: {name}"
-        );
-    }
+    validate_metrics(head)?;
+    validate_metrics(base.context("a baseline is required to evaluate the size gate")?)?;
     let mut lines = vec![
         "<!-- binary-size-report -->".into(),
         "## 📦 Binary size report".into(),
@@ -343,13 +394,6 @@ fn render(
         ]);
         lines.extend(crate_rows);
         lines.extend(["".into(), "</details>".into()]);
-    } else {
-        lines.extend(["No baseline available yet (no successful run on main); reporting absolute values only.".into(),"".into(),"| Metric | PR |".into(),"|---|---:|".into()]);
-        for m in head {
-            if !m.name.starts_with(".text ") {
-                lines.push(format!("| {} | {} |", m.name, value(m.value, &m.unit)));
-            }
-        }
     }
     let status = if failures.is_empty() {
         "PASS"
@@ -361,18 +405,23 @@ fn render(
     Ok((lines, failures, status.into()))
 }
 pub fn report(head_dir: &Path, base_dir: Option<&Path>, out: &Path) -> Result<()> {
+    write(
+        &out.join("gate.txt"),
+        b"FAIL\nSize comparison has not completed.\n",
+    )?;
+    let base_dir = base_dir.context("a baseline is required to evaluate the size gate")?;
+    validate_baseline(
+        head_dir,
+        base_dir,
+        std::env::var("BASE_SHA").ok().as_deref(),
+    )?;
     let head = metrics(head_dir)?;
-    let meta = read_json(&head_dir.join("size-meta.json"))?;
-    let base = base_dir
-        .filter(|p| p.join("size-metrics.json").exists())
-        .map(metrics)
-        .transpose()?;
-    let base_meta = base_dir.and_then(|p| read_json(&p.join("size-meta.json")).ok());
+    let meta = metadata(head_dir)?;
+    let base = metrics(base_dir)?;
+    let base_meta = metadata(base_dir)?;
     let allow = std::env::var("ALLOW_SIZE_INCREASE").as_deref() == Ok("true");
-    let (mut lines, failures, status) = render(&head, base.as_deref(), allow)?;
-    if let Some(base_dir) = base_dir
-        && base.is_some()
-        && let Ok(rows) = movers(head_dir, base_dir)
+    let (mut lines, failures, status) = render(&head, Some(&base), allow)?;
+    if let Ok(rows) = movers(head_dir, base_dir)
         && !rows.is_empty()
     {
         lines.extend([
@@ -397,13 +446,10 @@ pub fn report(head_dir: &Path, base_dir: Option<&Path>, out: &Path) -> Result<()
         lines.push(String::new());
         lines.push(if allow{"The `size-increase-ok` label is set, so the gate is not enforced for this PR."}else{"If this increase is expected (toolchain or dependency bump, accepted feature cost), add the `size-increase-ok` label and re-run the failed job."}.into());
     }
-    let baseline = base_meta
-        .as_ref()
-        .and_then(|v| v["commit"].as_str())
-        .unwrap_or("n/a");
-    let head = meta["commit"].as_str().context("head commit missing")?;
+    let baseline = base_meta.commit;
+    let head = meta.commit;
     lines.push(String::new());
-    lines.push(format!("Baseline: `{}` (latest main run) · Head: `{}` · [Graphs](https://oxidezap.github.io/whatsapp-rust/dev/binary-size/)",baseline.chars().take(9).collect::<String>(),head.chars().take(9).collect::<String>()));
+    lines.push(format!("Baseline: `{}` · Head: `{}` · [Graphs](https://oxidezap.github.io/whatsapp-rust/dev/binary-size/)",baseline.chars().take(9).collect::<String>(),head.chars().take(9).collect::<String>()));
     write(&out.join("report.md"), (lines.join("\n") + "\n").as_bytes())?;
     let mut gate = vec![status.clone()];
     gate.extend(failures);
@@ -414,6 +460,107 @@ pub fn report(head_dir: &Path, base_dir: Option<&Path>, out: &Path) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn every_measurement_cargo_command_requires_the_lockfile() {
+        for subcommand in ["build", "bloat", "llvm-lines"] {
+            let command = command(Path::new("."), "cargo", &[subcommand, "--release"]);
+            let args: Vec<_> = command.get_args().collect();
+            assert_eq!(args, [subcommand, "--release", "--locked"]);
+        }
+        let workflow = include_str!("../../../.github/workflows/binary-size.yml");
+        let tasks: Vec<_> = workflow
+            .lines()
+            .map(str::trim)
+            .filter(|line| line.contains("whatsapp-xtask"))
+            .collect();
+        assert!(!tasks.is_empty());
+        assert!(
+            tasks
+                .iter()
+                .all(|line| line.contains("cargo run --locked --quiet -p whatsapp-xtask --"))
+        );
+        assert_eq!(workflow.matches("git diff --exit-code").count(), 2);
+    }
+    #[test]
+    fn gate_requires_complete_baseline_even_with_override() {
+        let head = vec![
+            metric("bin size (stripped)", "bytes", 100000),
+            metric("bin .text", "bytes", 50000),
+        ];
+        for allow in [false, true] {
+            assert!(render(&head, None, allow).is_err());
+            assert!(render(&head, Some(&head[..1]), allow).is_err());
+        }
+        for invalid in [
+            metric("bin .text", "lines", 50000),
+            metric("bin .text", "bytes", -1),
+            metric("bin .text", "bytes", 0),
+        ] {
+            assert!(render(&head, Some(&[head[0].clone(), invalid]), true).is_err());
+        }
+        let mut duplicate = head.clone();
+        duplicate.push(head[0].clone());
+        assert!(render(&head, Some(&duplicate), true).is_err());
+    }
+    #[test]
+    fn missing_baseline_cannot_leave_a_previous_passing_gate() {
+        let out = tempfile::tempdir().unwrap();
+        write(&out.path().join("gate.txt"), b"PASS\n").unwrap();
+        assert!(report(out.path(), None, out.path()).is_err());
+        assert!(
+            std::fs::read_to_string(out.path().join("gate.txt"))
+                .unwrap()
+                .starts_with("FAIL\n")
+        );
+    }
+    #[test]
+    fn compiler_mismatch_cannot_leave_a_previous_passing_gate() {
+        let root = tempfile::tempdir().unwrap();
+        let head = root.path().join("head");
+        let base = root.path().join("base");
+        let out = root.path().join("out");
+        for (directory, rustc) in [
+            (&head, "rustc 1.99.0-nightly"),
+            (&base, "rustc 1.98.0-nightly"),
+        ] {
+            write_json(
+                &directory.join("size-meta.json"),
+                &json!({
+                    "commit":"47e1b5b41b63c23b59372828901ea945c8149565", "rustc":rustc
+                }),
+            )
+            .unwrap();
+            write_json(
+                &directory.join("size-metrics.json"),
+                &vec![
+                    metric("bin size (stripped)", "bytes", 100000),
+                    metric("bin .text", "bytes", 50000),
+                ],
+            )
+            .unwrap();
+        }
+        write(&out.join("gate.txt"), b"PASS\n").unwrap();
+        assert!(
+            report(&head, Some(&base), &out)
+                .unwrap_err()
+                .is::<CompilerMismatch>()
+        );
+        assert!(
+            std::fs::read_to_string(out.join("gate.txt"))
+                .unwrap()
+                .starts_with("FAIL\n")
+        );
+        write_json(
+            &base.join("size-meta.json"),
+            &read_json(&head.join("size-meta.json")).unwrap(),
+        )
+        .unwrap();
+        report(&head, Some(&base), &out).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(out.join("gate.txt")).unwrap(),
+            "PASS\n"
+        );
+    }
     #[test]
     fn exact_budget_boundary_and_override_are_preserved() {
         let base = vec![
@@ -427,6 +574,11 @@ mod tests {
         assert_eq!(render(&head, Some(&base), false).unwrap().2, "FAIL");
         assert_eq!(render(&head, Some(&base), true).unwrap().2, "OVERRIDDEN");
         assert!(render(&head[..1], Some(&base), true).is_err());
+        head = base.clone();
+        head[1].value += 32768;
+        assert_eq!(render(&head, Some(&base), false).unwrap().2, "PASS");
+        head[1].value += 1;
+        assert_eq!(render(&head, Some(&base), false).unwrap().2, "FAIL");
     }
     #[test]
     fn parses_tool_outputs_and_refuses_missing_measurements() {

--- a/tools/xtask/src/size_baseline.rs
+++ b/tools/xtask/src/size_baseline.rs
@@ -1,0 +1,469 @@
+use anyhow::{Context, Result, ensure};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct Repository {
+    full_name: String,
+}
+#[derive(Deserialize)]
+struct Run {
+    id: u64,
+    run_attempt: u64,
+    path: String,
+    event: String,
+    status: String,
+    head_branch: String,
+    head_sha: String,
+    repository: Repository,
+    head_repository: Repository,
+}
+#[derive(Deserialize)]
+struct Runs {
+    workflow_runs: Vec<Run>,
+}
+#[derive(Deserialize)]
+struct Step {
+    name: String,
+    number: u64,
+    conclusion: Option<String>,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+}
+#[derive(Deserialize)]
+struct Job {
+    name: String,
+    head_sha: String,
+    status: String,
+    steps: Vec<Step>,
+}
+#[derive(Deserialize)]
+struct Jobs {
+    jobs: Vec<Job>,
+}
+#[derive(Deserialize)]
+struct ArtifactRun {
+    id: u64,
+    head_branch: String,
+    head_sha: String,
+}
+#[derive(Deserialize)]
+struct Artifact {
+    name: String,
+    expired: bool,
+    created_at: String,
+    workflow_run: ArtifactRun,
+}
+#[derive(Deserialize)]
+struct Artifacts {
+    artifacts: Vec<Artifact>,
+}
+
+pub fn download(
+    head: &Path,
+    destination: &Path,
+    repo: &str,
+    sha: &str,
+    mut gh: impl FnMut(&[&str]) -> Result<Vec<u8>>,
+) -> Result<()> {
+    ensure!(
+        !destination.exists(),
+        "baseline directory already exists; refusing stale artifacts"
+    );
+    ensure!(
+        sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit()),
+        "BASE_SHA must be the full PR base commit"
+    );
+    ensure!(
+        repo.split('/').count() == 2
+            && repo.split('/').all(|part| !part.is_empty()
+                && part
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))),
+        "invalid base repository"
+    );
+    let endpoint = format!(
+        "repos/{repo}/actions/workflows/binary-size.yml/runs?branch=main&head_sha={sha}&status=completed&per_page=100"
+    );
+    let pages: Vec<Runs> =
+        serde_json::from_slice(&gh(&["api", "--paginate", "--slurp", &endpoint])?)?;
+    for run in pages.into_iter().flat_map(|page| page.workflow_runs) {
+        if run.path != ".github/workflows/binary-size.yml"
+            || !matches!(run.event.as_str(), "push" | "workflow_dispatch")
+            || run.status != "completed"
+            || run.head_branch != "main"
+            || run.head_sha != sha
+            || run.repository.full_name != repo
+            || run.head_repository.full_name != repo
+        {
+            continue;
+        }
+        let endpoint = format!(
+            "repos/{repo}/actions/runs/{}/attempts/{}/jobs?per_page=100",
+            run.id, run.run_attempt
+        );
+        let pages: Vec<Jobs> =
+            serde_json::from_slice(&gh(&["api", "--paginate", "--slurp", &endpoint])?)?;
+        let upload = pages.iter().flat_map(|page| &page.jobs).find_map(|job| {
+            if job.name != "Binary Size (push)" || job.head_sha != sha || job.status != "completed"
+            {
+                return None;
+            }
+            let measure = job
+                .steps
+                .iter()
+                .find(|step| step.name == "Measure binary size")?;
+            let upload = job
+                .steps
+                .iter()
+                .find(|step| step.name == "Upload size artifacts")?;
+            (measure.conclusion.as_deref() == Some("success")
+                && upload.conclusion.as_deref() == Some("success")
+                && measure.number < upload.number)
+                .then_some(upload)
+        });
+        let Some(upload) = upload else {
+            eprintln!(
+                "Ignoring size run {} without successful measurement and upload",
+                run.id
+            );
+            continue;
+        };
+        let endpoint = format!(
+            "repos/{repo}/actions/runs/{}/artifacts?per_page=100",
+            run.id
+        );
+        let pages: Vec<Artifacts> =
+            serde_json::from_slice(&gh(&["api", "--paginate", "--slurp", &endpoint])?)?;
+        let artifacts: Vec<_> = pages
+            .iter()
+            .flat_map(|page| &page.artifacts)
+            .filter(|artifact| artifact.name == "size-metrics")
+            .collect();
+        let [artifact] = artifacts.as_slice() else {
+            eprintln!(
+                "Ignoring size run {} without one unambiguous size-metrics artifact",
+                run.id
+            );
+            continue;
+        };
+        // Reruns share a run ID. An old attempt's artifact must not borrow the new attempt's status.
+        if artifact.expired
+            || artifact.workflow_run.id != run.id
+            || artifact.workflow_run.head_branch != "main"
+            || artifact.workflow_run.head_sha != sha
+            || !upload
+                .started_at
+                .as_ref()
+                .is_some_and(|start| start <= &artifact.created_at)
+            || !upload
+                .completed_at
+                .as_ref()
+                .is_some_and(|end| &artifact.created_at <= end)
+        {
+            eprintln!(
+                "Ignoring size run {} with expired or inconsistent artifact provenance",
+                run.id
+            );
+            continue;
+        }
+        let parent = destination
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        let temporary = tempfile::tempdir_in(parent)?;
+        gh(&[
+            "run",
+            "download",
+            &run.id.to_string(),
+            "--repo",
+            repo,
+            "--name",
+            "size-metrics",
+            "--dir",
+            temporary
+                .path()
+                .to_str()
+                .context("baseline path encoding")?,
+        ])?;
+        if let Err(error) = super::size::validate_baseline(head, temporary.path(), Some(sha)) {
+            if error.is::<super::size::CompilerMismatch>() {
+                eprintln!(
+                    "Ignoring size run {} measured with a different compiler",
+                    run.id
+                );
+                continue;
+            }
+            return Err(error)
+                .with_context(|| format!("invalid size baseline from run {}", run.id));
+        }
+        std::fs::rename(temporary.path(), destination)?;
+        println!("Validated size baseline {sha} from main run {}", run.id);
+        return Ok(());
+    }
+    anyhow::bail!(
+        "No validated size-metrics artifact for PR base {sha} on {repo} main; run Binary Size on that base commit before retrying. The size gate cannot be skipped."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+    use xtask_support::write_json;
+
+    const SHA: &str = "47e1b5b41b63c23b59372828901ea945c8149565";
+    const OLD: &str = "2b9a8d799ec2da008cc47fbd1c61d8995d652238";
+    const REPO: &str = "example/project";
+
+    struct Fixture {
+        runs: Value,
+        jobs: Value,
+        artifacts: Value,
+        meta: Value,
+        metrics: Value,
+        fail_download: bool,
+    }
+    fn fixture() -> Fixture {
+        let run = json!({
+            "id":42,"run_attempt":2,"path":".github/workflows/binary-size.yml",
+            "event":"push","status":"completed","conclusion":"failure",
+            "head_branch":"main","head_sha":SHA,
+            "repository":{"full_name":REPO},"head_repository":{"full_name":REPO}
+        });
+        let mut old = run.clone();
+        old["id"] = json!(41);
+        old["head_sha"] = json!(OLD);
+        old["conclusion"] = json!("success");
+        Fixture {
+            runs: json!([{"workflow_runs":[old]},{"workflow_runs":[run]}]),
+            jobs: json!([{"jobs":[{
+                "name":"Binary Size (push)","head_sha":SHA,"status":"completed",
+                "steps":[
+                    {"name":"Measure binary size","number":9,"conclusion":"success"},
+                    {"name":"Upload size artifacts","number":10,"conclusion":"success",
+                        "started_at":"2026-09-08T00:33:37Z","completed_at":"2026-09-08T00:33:39Z"},
+                    {"name":"Store series on gh-pages","number":11,"conclusion":"failure"}
+                ]
+            }]}]),
+            artifacts: json!([{"artifacts":[{
+                "name":"size-metrics","expired":false,"created_at":"2026-09-08T00:33:38Z",
+                "workflow_run":{"id":42,"head_branch":"main","head_sha":SHA}
+            }]}]),
+            meta: json!({"commit":SHA,"rustc":"rustc 1.98.0-nightly (01dfd7924 2026-06-15)"}),
+            metrics: json!([
+                {"name":"bin size (stripped)","unit":"bytes","value":11129496},
+                {"name":"bin .text","unit":"bytes","value":8968502}
+            ]),
+            fail_download: false,
+        }
+    }
+    fn exercise(fixture: Fixture) -> (Result<()>, usize) {
+        let root = tempfile::tempdir().unwrap();
+        write_json(
+            &root.path().join("size-out/size-metrics.json"),
+            &self::fixture().metrics,
+        )
+        .unwrap();
+        write_json(
+            &root.path().join("size-out/size-meta.json"),
+            &self::fixture().meta,
+        )
+        .unwrap();
+        let mut downloads = 0;
+        let result = download(
+            &root.path().join("size-out"),
+            &root.path().join("base-out"),
+            REPO,
+            SHA,
+            |args| {
+                if args[0] == "api" {
+                    assert_eq!(&args[..3], &["api", "--paginate", "--slurp"]);
+                    let value = match args[3] {
+                        path if path
+                            == format!(
+                                "repos/{REPO}/actions/workflows/binary-size.yml/runs?branch=main&head_sha={SHA}&status=completed&per_page=100"
+                            ) =>
+                        {
+                            fixture.runs.clone()
+                        }
+                        "repos/example/project/actions/runs/42/attempts/2/jobs?per_page=100"
+                        | "repos/example/project/actions/runs/43/attempts/2/jobs?per_page=100" => {
+                            fixture.jobs.clone()
+                        }
+                        "repos/example/project/actions/runs/42/artifacts?per_page=100" => {
+                            fixture.artifacts.clone()
+                        }
+                        "repos/example/project/actions/runs/43/artifacts?per_page=100" => {
+                            let mut artifacts = fixture.artifacts.clone();
+                            artifacts[0]["artifacts"][0]["workflow_run"]["id"] = json!(43);
+                            artifacts
+                        }
+                        path => panic!("unexpected GitHub query: {path}"),
+                    };
+                    Ok(serde_json::to_vec(&value)?)
+                } else {
+                    assert!(matches!(args[2], "42" | "43"));
+                    assert_eq!(
+                        &args[..8],
+                        &[
+                            "run",
+                            "download",
+                            args[2],
+                            "--repo",
+                            REPO,
+                            "--name",
+                            "size-metrics",
+                            "--dir"
+                        ]
+                    );
+                    downloads += 1;
+                    ensure!(!fixture.fail_download, "GitHub artifact download failed");
+                    let out = Path::new(args[8]);
+                    let mut meta = fixture.meta.clone();
+                    if args[2] == "43" {
+                        meta["rustc"] = json!("different rustc");
+                    }
+                    write_json(&out.join("size-meta.json"), &meta)?;
+                    write_json(&out.join("size-metrics.json"), &fixture.metrics)?;
+                    Ok(Vec::new())
+                }
+            },
+        );
+        assert_eq!(root.path().join("base-out").exists(), result.is_ok());
+        (result, downloads)
+    }
+    #[test]
+    fn exact_base_survives_graph_failure_and_stale_successful_main() {
+        let (result, downloads) = exercise(fixture());
+        result.unwrap();
+        assert_eq!(downloads, 1);
+        let mut f = fixture();
+        f.runs[1]["workflow_runs"][0]["event"] = json!("workflow_dispatch");
+        exercise(f).0.unwrap();
+    }
+    #[test]
+    fn rejects_failed_measurement_upload_and_untrusted_runs_before_download() {
+        for (pointer, value) in [
+            ("/0/jobs/0/steps/0/conclusion", json!("failure")),
+            ("/0/jobs/0/steps/1/conclusion", json!("skipped")),
+            ("/0/jobs/0/steps/1/number", json!(8)),
+            ("/0/jobs/0/head_sha", json!(OLD)),
+        ] {
+            let mut f = fixture();
+            *f.jobs.pointer_mut(pointer).unwrap() = value;
+            let (result, downloads) = exercise(f);
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("gate cannot be skipped")
+            );
+            assert_eq!(downloads, 0);
+        }
+        for (field, value) in [
+            ("event", json!("pull_request")),
+            ("head_branch", json!("feature")),
+            ("head_sha", json!(OLD)),
+            ("path", json!(".github/workflows/other.yml")),
+            ("head_repository", json!({"full_name":"fork/project"})),
+            ("repository", json!({"full_name":"fork/project"})),
+        ] {
+            let mut f = fixture();
+            f.runs[1]["workflow_runs"][0][field] = value;
+            let (result, downloads) = exercise(f);
+            assert!(result.is_err(), "{field}");
+            assert_eq!(downloads, 0);
+        }
+    }
+    #[test]
+    fn rejects_expired_mismatched_and_previous_attempt_artifacts() {
+        for (pointer, value) in [
+            ("/0/artifacts/0/expired", json!(true)),
+            ("/0/artifacts/0/workflow_run/head_sha", json!(OLD)),
+            ("/0/artifacts/0/workflow_run/id", json!(41)),
+            ("/0/artifacts/0/created_at", json!("2026-09-07T00:33:38Z")),
+            ("/0/artifacts", json!([])),
+        ] {
+            let mut f = fixture();
+            *f.artifacts.pointer_mut(pointer).unwrap() = value;
+            let (result, downloads) = exercise(f);
+            assert!(result.is_err(), "{pointer}");
+            assert_eq!(downloads, 0);
+        }
+    }
+    #[test]
+    fn rejects_downloaded_commit_and_compiler_mismatches() {
+        for (field, value) in [("commit", json!(OLD)), ("rustc", json!("different rustc"))] {
+            let mut f = fixture();
+            f.meta[field] = value;
+            let (result, downloads) = exercise(f);
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains(if field == "rustc" {
+                        "gate cannot be skipped"
+                    } else {
+                        "invalid size baseline"
+                    })
+            );
+            assert_eq!(downloads, 1);
+        }
+    }
+    #[test]
+    fn alternate_compiler_dispatch_does_not_hide_matching_main_measurement() {
+        let mut f = fixture();
+        let mut newer = f.runs[1]["workflow_runs"][0].clone();
+        newer["id"] = json!(43);
+        newer["event"] = json!("workflow_dispatch");
+        f.runs[1]["workflow_runs"]
+            .as_array_mut()
+            .unwrap()
+            .insert(0, newer);
+        let (result, downloads) = exercise(f);
+        result.unwrap();
+        assert_eq!(downloads, 2);
+    }
+    #[test]
+    fn unavailable_or_invalid_evidence_is_an_error_not_a_skipped_gate() {
+        let mut f = fixture();
+        f.fail_download = true;
+        assert!(
+            exercise(f)
+                .0
+                .unwrap_err()
+                .to_string()
+                .contains("download failed")
+        );
+        let mut f = fixture();
+        f.runs = json!([{"workflow_runs":[]}]);
+        assert!(
+            exercise(f)
+                .0
+                .unwrap_err()
+                .to_string()
+                .contains("gate cannot be skipped")
+        );
+        let mut f = fixture();
+        f.metrics = json!([]);
+        assert!(exercise(f).0.is_err());
+        let mut f = fixture();
+        f.meta = json!({});
+        assert!(exercise(f).0.is_err());
+        let mut f = fixture();
+        let duplicate = f.artifacts[0]["artifacts"][0].clone();
+        f.artifacts[0]["artifacts"]
+            .as_array_mut()
+            .unwrap()
+            .push(duplicate);
+        assert!(exercise(f).0.is_err());
+        let root = tempfile::tempdir().unwrap();
+        let error = download(root.path(), &root.path().join("base"), REPO, SHA, |_| {
+            anyhow::bail!("GitHub API unavailable")
+        })
+        .unwrap_err();
+        assert_eq!(error.to_string(), "GitHub API unavailable");
+    }
+}

--- a/tools/xtask/src/size_baseline.rs
+++ b/tools/xtask/src/size_baseline.rs
@@ -49,6 +49,7 @@ struct ArtifactRun {
 }
 #[derive(Deserialize)]
 struct Artifact {
+    id: u64,
     name: String,
     expired: bool,
     created_at: String,
@@ -65,6 +66,7 @@ pub fn download(
     repo: &str,
     sha: &str,
     mut gh: impl FnMut(&[&str]) -> Result<Vec<u8>>,
+    mut download_artifact: impl FnMut(u64, &Path) -> Result<()>,
 ) -> Result<()> {
     ensure!(
         !destination.exists(),
@@ -138,55 +140,37 @@ pub fn download(
         let artifacts: Vec<_> = pages
             .iter()
             .flat_map(|page| &page.artifacts)
-            .filter(|artifact| artifact.name == "size-metrics")
+            // Reruns share a run ID. Select this upload before checking uniqueness.
+            .filter(|artifact| {
+                artifact.name == "size-metrics"
+                    && !artifact.expired
+                    && artifact.workflow_run.id == run.id
+                    && artifact.workflow_run.head_branch == "main"
+                    && artifact.workflow_run.head_sha == sha
+                    && upload
+                        .started_at
+                        .as_ref()
+                        .is_some_and(|start| start <= &artifact.created_at)
+                    && upload
+                        .completed_at
+                        .as_ref()
+                        .is_some_and(|end| &artifact.created_at <= end)
+            })
             .collect();
         let [artifact] = artifacts.as_slice() else {
             eprintln!(
-                "Ignoring size run {} without one unambiguous size-metrics artifact",
+                "Ignoring size run {} without one unambiguous current-attempt size-metrics artifact",
                 run.id
             );
             continue;
         };
-        // Reruns share a run ID. An old attempt's artifact must not borrow the new attempt's status.
-        if artifact.expired
-            || artifact.workflow_run.id != run.id
-            || artifact.workflow_run.head_branch != "main"
-            || artifact.workflow_run.head_sha != sha
-            || !upload
-                .started_at
-                .as_ref()
-                .is_some_and(|start| start <= &artifact.created_at)
-            || !upload
-                .completed_at
-                .as_ref()
-                .is_some_and(|end| &artifact.created_at <= end)
-        {
-            eprintln!(
-                "Ignoring size run {} with expired or inconsistent artifact provenance",
-                run.id
-            );
-            continue;
-        }
         let parent = destination
             .parent()
             .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or(Path::new("."));
         std::fs::create_dir_all(parent)?;
         let temporary = tempfile::tempdir_in(parent)?;
-        gh(&[
-            "run",
-            "download",
-            &run.id.to_string(),
-            "--repo",
-            repo,
-            "--name",
-            "size-metrics",
-            "--dir",
-            temporary
-                .path()
-                .to_str()
-                .context("baseline path encoding")?,
-        ])?;
+        download_artifact(artifact.id, temporary.path())?;
         if let Err(error) = super::size::validate_baseline(head, temporary.path(), Some(sha)) {
             if error.is::<super::size::CompilerMismatch>() {
                 eprintln!(
@@ -248,7 +232,7 @@ mod tests {
                 ]
             }]}]),
             artifacts: json!([{"artifacts":[{
-                "name":"size-metrics","expired":false,"created_at":"2026-09-08T00:33:38Z",
+                "id":442,"name":"size-metrics","expired":false,"created_at":"2026-09-08T00:33:38Z",
                 "workflow_run":{"id":42,"head_branch":"main","head_sha":SHA}
             }]}]),
             meta: json!({"commit":SHA,"rustc":"rustc 1.98.0-nightly (01dfd7924 2026-06-15)"}),
@@ -278,57 +262,46 @@ mod tests {
             REPO,
             SHA,
             |args| {
-                if args[0] == "api" {
-                    assert_eq!(&args[..3], &["api", "--paginate", "--slurp"]);
-                    let value = match args[3] {
-                        path if path
-                            == format!(
-                                "repos/{REPO}/actions/workflows/binary-size.yml/runs?branch=main&head_sha={SHA}&status=completed&per_page=100"
-                            ) =>
-                        {
-                            fixture.runs.clone()
-                        }
-                        "repos/example/project/actions/runs/42/attempts/2/jobs?per_page=100"
-                        | "repos/example/project/actions/runs/43/attempts/2/jobs?per_page=100" => {
-                            fixture.jobs.clone()
-                        }
-                        "repos/example/project/actions/runs/42/artifacts?per_page=100" => {
-                            fixture.artifacts.clone()
-                        }
-                        "repos/example/project/actions/runs/43/artifacts?per_page=100" => {
-                            let mut artifacts = fixture.artifacts.clone();
-                            artifacts[0]["artifacts"][0]["workflow_run"]["id"] = json!(43);
-                            artifacts
-                        }
-                        path => panic!("unexpected GitHub query: {path}"),
-                    };
-                    Ok(serde_json::to_vec(&value)?)
-                } else {
-                    assert!(matches!(args[2], "42" | "43"));
-                    assert_eq!(
-                        &args[..8],
-                        &[
-                            "run",
-                            "download",
-                            args[2],
-                            "--repo",
-                            REPO,
-                            "--name",
-                            "size-metrics",
-                            "--dir"
-                        ]
-                    );
-                    downloads += 1;
-                    ensure!(!fixture.fail_download, "GitHub artifact download failed");
-                    let out = Path::new(args[8]);
-                    let mut meta = fixture.meta.clone();
-                    if args[2] == "43" {
-                        meta["rustc"] = json!("different rustc");
+                assert_eq!(&args[..3], &["api", "--paginate", "--slurp"]);
+                let value = match args[3] {
+                    path if path
+                        == format!(
+                            "repos/{REPO}/actions/workflows/binary-size.yml/runs?branch=main&head_sha={SHA}&status=completed&per_page=100"
+                        ) =>
+                    {
+                        fixture.runs.clone()
                     }
-                    write_json(&out.join("size-meta.json"), &meta)?;
-                    write_json(&out.join("size-metrics.json"), &fixture.metrics)?;
-                    Ok(Vec::new())
+                    "repos/example/project/actions/runs/42/attempts/2/jobs?per_page=100"
+                    | "repos/example/project/actions/runs/43/attempts/2/jobs?per_page=100" => {
+                        fixture.jobs.clone()
+                    }
+                    "repos/example/project/actions/runs/42/artifacts?per_page=100" => {
+                        fixture.artifacts.clone()
+                    }
+                    "repos/example/project/actions/runs/43/artifacts?per_page=100" => {
+                        let mut artifacts = fixture.artifacts.clone();
+                        artifacts[0]["artifacts"][0]["workflow_run"]["id"] = json!(43);
+                        artifacts[0]["artifacts"][0]["id"] = json!(443);
+                        artifacts
+                    }
+                    path => panic!("unexpected GitHub query: {path}"),
+                };
+                Ok(serde_json::to_vec(&value)?)
+            },
+            |id, out| {
+                assert!(
+                    matches!(id, 442 | 443),
+                    "download must select the validated artifact ID"
+                );
+                downloads += 1;
+                ensure!(!fixture.fail_download, "GitHub artifact download failed");
+                let mut meta = fixture.meta.clone();
+                if id == 443 {
+                    meta["rustc"] = json!("different rustc");
                 }
+                write_json(&out.join("size-meta.json"), &meta)?;
+                write_json(&out.join("size-metrics.json"), &fixture.metrics)?;
+                Ok(())
             },
         );
         assert_eq!(root.path().join("base-out").exists(), result.is_ok());
@@ -342,6 +315,21 @@ mod tests {
         let mut f = fixture();
         f.runs[1]["workflow_runs"][0]["event"] = json!("workflow_dispatch");
         exercise(f).0.unwrap();
+    }
+
+    #[test]
+    fn current_attempt_artifact_survives_stale_same_name_artifacts() {
+        for stale_first in [false, true] {
+            let mut f = fixture();
+            let mut stale = f.artifacts[0]["artifacts"][0].clone();
+            stale["id"] = json!(441);
+            stale["created_at"] = json!("2026-09-07T00:33:38Z");
+            let artifacts = f.artifacts[0]["artifacts"].as_array_mut().unwrap();
+            artifacts.insert(if stale_first { 0 } else { 1 }, stale);
+            let (result, downloads) = exercise(f);
+            result.unwrap();
+            assert_eq!(downloads, 1);
+        }
     }
     #[test]
     fn rejects_failed_measurement_upload_and_untrusted_runs_before_download() {
@@ -460,9 +448,14 @@ mod tests {
             .push(duplicate);
         assert!(exercise(f).0.is_err());
         let root = tempfile::tempdir().unwrap();
-        let error = download(root.path(), &root.path().join("base"), REPO, SHA, |_| {
-            anyhow::bail!("GitHub API unavailable")
-        })
+        let error = download(
+            root.path(),
+            &root.path().join("base"),
+            REPO,
+            SHA,
+            |_| anyhow::bail!("GitHub API unavailable"),
+            |_, _| panic!("no validated artifact"),
+        )
         .unwrap_err();
         assert_eq!(error.to_string(), "GitHub API unavailable");
     }

--- a/tools/xtask/src/workflow.rs
+++ b/tools/xtask/src/workflow.rs
@@ -31,8 +31,15 @@ pub enum Task {
     ReleaseTag,
     /// Preserve existing release notes, otherwise create the requested GitHub release.
     GithubRelease,
-    /// Download a baseline only from a successful main push.
-    SizeBaseline,
+    /// Validate a main dispatch's compiler before it reaches rustup or the measurement process.
+    SizeToolchain,
+    /// Download the PR base's validated main measurement, independent of graph publication.
+    SizeBaseline {
+        #[arg(long, default_value = "size-out")]
+        head: PathBuf,
+        #[arg(long, default_value = "base-out")]
+        out_dir: PathBuf,
+    },
     /// Query the live size-increase-ok label and emit the override value.
     SizeOverride,
     /// Update the existing sticky size report, or create it if absent.
@@ -81,6 +88,23 @@ fn env(name: &str) -> Result<String> {
 fn version_valid(version: &str) -> bool {
     regex::Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$")
         .is_ok_and(|r| r.is_match(version))
+}
+fn size_toolchain<'a>(
+    event: &str,
+    requested: &'a str,
+    default: &'a str,
+) -> Result<(&'a str, bool)> {
+    let selected = if event == "workflow_dispatch" && !requested.is_empty() {
+        requested
+    } else {
+        default
+    };
+    ensure!(
+        regex::Regex::new(r"\Anightly-[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])\z")?
+            .is_match(selected),
+        "binary size toolchain must be a dated nightly, nightly-YYYY-MM-DD"
+    );
+    Ok((selected, selected == default))
 }
 fn tag() -> Result<String> {
     let tag = env("RELEASE_TAG")?;
@@ -311,48 +335,23 @@ pub fn run_task(root: &Path, task: Task) -> Result<()> {
                 run(&mut c)?;
             }
         }
-        Task::SizeBaseline => {
-            let result = capture(
-                Command::new("gh")
-                    .args([
-                        "run",
-                        "list",
-                        "--workflow",
-                        "binary-size.yml",
-                        "--branch",
-                        "main",
-                        "--event",
-                        "push",
-                        "--status",
-                        "success",
-                        "--limit",
-                        "1",
-                        "--json",
-                        "databaseId",
-                    ])
-                    .current_dir(root),
-            );
-            if let Ok(bytes) = result
-                && let Ok(v) = serde_json::from_slice::<Value>(&bytes.stdout)
-                && let Some(id) = v[0]["databaseId"].as_u64()
-                && quiet(
-                    Command::new("gh")
-                        .args([
-                            "run",
-                            "download",
-                            &id.to_string(),
-                            "--name",
-                            "size-metrics",
-                            "--dir",
-                            "base-out",
-                        ])
-                        .current_dir(root),
-                )?
-            {
-                output("dir", "base-out")?;
-            } else {
-                println!("No baseline artifact available");
-            }
+        Task::SizeToolchain => {
+            let requested = std::env::var("REQUESTED_TOOLCHAIN").unwrap_or_default();
+            let default = env("DEFAULT_SIZE_TOOLCHAIN")?;
+            let (selected, publish) =
+                size_toolchain(&env("GITHUB_EVENT_NAME")?, &requested, &default)?;
+            output("toolchain", selected)?;
+            output("publish", if publish { "true" } else { "false" })?;
+        }
+        Task::SizeBaseline { head, out_dir } => {
+            super::size_baseline::download(
+                &root.join(&head),
+                &root.join(&out_dir),
+                &env("GITHUB_REPOSITORY")?,
+                &env("BASE_SHA")?,
+                |args| Ok(capture(Command::new("gh").args(args).current_dir(root))?.stdout),
+            )?;
+            output("dir", out_dir.to_str().context("baseline path encoding")?)?;
         }
         Task::SizeOverride => {
             let value = github(&format!(
@@ -420,6 +419,57 @@ pub fn run_task(root: &Path, task: Task) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn size_compiler_override_is_dispatch_only_and_does_not_publish() {
+        let default = "nightly-2026-06-16";
+        let alternate = "nightly-2026-07-01";
+        for event in ["push", "pull_request"] {
+            assert_eq!(
+                size_toolchain(event, alternate, default).unwrap(),
+                (default, true)
+            );
+        }
+        for requested in ["", default] {
+            assert_eq!(
+                size_toolchain("workflow_dispatch", requested, default).unwrap(),
+                (default, true)
+            );
+        }
+        assert_eq!(
+            size_toolchain("workflow_dispatch", alternate, default).unwrap(),
+            (alternate, false)
+        );
+        let workflow = include_str!("../../../.github/workflows/binary-size.yml");
+        assert!(workflow.contains(&format!("default: {default}")));
+        assert!(workflow.contains(&format!("RUSTUP_TOOLCHAIN: {default}")));
+        assert!(workflow.contains("REQUESTED_TOOLCHAIN: ${{ inputs.toolchain }}"));
+        assert!(workflow.contains("DEFAULT_SIZE_TOOLCHAIN: ${{ env.RUSTUP_TOOLCHAIN }}"));
+        assert!(workflow.contains("RUSTUP_TOOLCHAIN: ${{ steps.compiler.outputs.toolchain }}"));
+        assert!(workflow.contains("if: steps.compiler.outputs.publish == 'true'"));
+    }
+    #[test]
+    fn size_compiler_input_cannot_supply_flags_paths_or_shell_syntax() {
+        for requested in [
+            "--help",
+            "+nightly-2026-06-16",
+            "nightly",
+            "stable",
+            "../toolchain",
+            "nightly-2026-06-16 --profile complete",
+            "nightly-2026-06-16;id",
+            "$(id)",
+            "nightly-2026-06-16\nRUSTFLAGS=-O",
+            "nightly-2026-06-16\r",
+            "nightly-2026-00-16",
+            "nightly-2026-06-00",
+            "nightly-2026-13-16",
+        ] {
+            assert!(
+                size_toolchain("workflow_dispatch", requested, "nightly-2026-06-16").is_err(),
+                "{requested:?}"
+            );
+        }
+    }
     #[test]
     fn release_preflight_rejects_docker_tag_collisions() {
         assert!(version_valid("0.7.0"));

--- a/tools/xtask/src/workflow.rs
+++ b/tools/xtask/src/workflow.rs
@@ -344,12 +344,35 @@ pub fn run_task(root: &Path, task: Task) -> Result<()> {
             output("publish", if publish { "true" } else { "false" })?;
         }
         Task::SizeBaseline { head, out_dir } => {
+            let repo = env("GITHUB_REPOSITORY")?;
             super::size_baseline::download(
                 &root.join(&head),
                 &root.join(&out_dir),
-                &env("GITHUB_REPOSITORY")?,
+                &repo,
                 &env("BASE_SHA")?,
                 |args| Ok(capture(Command::new("gh").args(args).current_dir(root))?.stdout),
+                |id, out| {
+                    let archive = tempfile::NamedTempFile::new_in(out)?;
+                    let bytes = capture(Command::new("gh").args([
+                        "api",
+                        "--allow-escape-sequences",
+                        &format!("repos/{repo}/actions/artifacts/{id}/zip"),
+                    ]))?
+                    .stdout;
+                    std::fs::write(archive.path(), bytes)?;
+                    // Read only fixed members, never artifact-controlled extraction paths.
+                    for name in ["size-meta.json", "size-metrics.json"] {
+                        let bytes = capture(
+                            Command::new("unzip")
+                                .arg("-p")
+                                .arg(archive.path())
+                                .arg(name),
+                        )?
+                        .stdout;
+                        std::fs::write(out.join(name), bytes)?;
+                    }
+                    Ok(())
+                },
             )?;
             output("dir", out_dir.to_str().context("baseline path encoding")?)?;
         }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -10978,6 +10978,46 @@ mod tests {
     }
 
     #[test]
+    fn inbound_frame_info_only_overrides_signaling_without_other_extensions() {
+        use crate::voip::{e2e_srtp, rtp};
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.set_peer_video_orientation(1);
+        let mut peer = peer_video_pipe();
+        let key: Vec<u8> = (0..32).collect();
+        let keys = e2e_srtp::derive_e2e_keys(&key, &ssrc::format_e2e_srtp_participant_id(PEER_LID))
+            .unwrap();
+        let au = video_au(100);
+        for info in [Some(3u8), Some(0), None] {
+            let packet = peer.protect_video(&au).pop().unwrap();
+            let mut header = parse_rtp_header(&packet).unwrap();
+            let start = rtp::rtp_header_byte_length(&packet).unwrap();
+            header.video_extension = None;
+            header.extension_word = info.map(|info| u32::from_be_bytes([0x30, info, 0, 0]));
+            let mut rewritten = rtp::encode_rtp_header(&header);
+            rewritten.extend_from_slice(&packet[start..packet.len() - WARP_MI_TAG_LEN]);
+            e2e_srtp::append_warp_mi_tag_in_place(
+                &keys.auth_key,
+                &mut rewritten,
+                0,
+                WARP_MI_TAG_LEN,
+            );
+            eng.handle_input(1, Input::RelayPacket(&rewritten));
+            let frames: Vec<_> = drain(&mut eng)
+                .0
+                .into_iter()
+                .filter_map(|output| match output {
+                    Output::VideoPlayout(frame) => Some(frame),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(frames.len(), 1);
+            assert_eq!(frames[0].data, au);
+            assert_eq!(frames[0].orientation, info.unwrap_or(1));
+        }
+    }
+
+    #[test]
     fn inbound_video_rejects_forged_warp_tag() {
         let mut eng = engine(true);
         assert!(eng.enable_video());

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -210,6 +210,7 @@ mod fuzz_tests {
                 let _ = rtp::is_rtp_version2(&b);
                 let _ = rtp::rtp_header_byte_length(&b);
                 let _ = rtp::parse_rtp_header(&b);
+                let _ = rtp::parse_whatsapp_media_frame_info(&b);
                 // RTCP
                 let _ = rtcp::is_rtcp_packet(&b);
                 let _ = rtcp::rtcp_payload_type(&b);

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -227,8 +227,44 @@ pub fn rtp_extension_profile_and_data(data: &[u8]) -> Option<(Option<u16>, &[u8]
     ))
 }
 
-/// Decode the exact WhatsApp video extension set. Other 0xdebe layouts, including audio
-/// piggyback, deliberately return `None`.
+/// Read the frame-info byte independently of the other 0xdebe extensions.
+/// Callers must authenticate the packet and establish its media type before using it.
+/// A truncated element ends the scan without discarding earlier complete metadata.
+pub fn parse_whatsapp_media_frame_info(data: &[u8]) -> Option<u8> {
+    let (Some(WHATSAPP_RTP_EXTENSION_PROFILE), mut extension) =
+        rtp_extension_profile_and_data(data)?
+    else {
+        return None;
+    };
+    let mut info = [None; 3];
+    while let Some((&header, rest)) = extension.split_first() {
+        extension = rest;
+        let id = header >> 4;
+        if id == 0 {
+            continue;
+        }
+        let len = usize::from(header & 0x0f) + 1;
+        let Some((value, rest)) = extension.split_at_checked(len) else {
+            break;
+        };
+        extension = rest;
+        if id == 3 {
+            // Captured rtp_ext readers keep three formats separately; the getter
+            // prefers short, then three-byte, then extended metadata, regardless of order.
+            let format = match len {
+                1..=2 => 0,
+                3..=5 => 1,
+                _ => 2,
+            };
+            info[format] = Some(value[0]);
+        }
+    }
+    info.into_iter().flatten().next()
+}
+
+/// Decode the exact outgoing WhatsApp video extension set. Other 0xdebe layouts,
+/// including audio piggyback, deliberately return `None`. For received frame metadata,
+/// use [`parse_whatsapp_media_frame_info`] without assuming the optional fields exist.
 pub fn parse_whatsapp_video_extension(data: &[u8]) -> Option<VideoRtpExtension> {
     let (Some(profile), extension) = rtp_extension_profile_and_data(data)? else {
         return None;
@@ -702,6 +738,98 @@ mod tests {
         let bytes = encode_rtp_header(&h);
         assert_eq!(rtp_header_byte_length(&bytes), Some(28));
         assert_eq!(parse_rtp_header(&bytes), Some(h));
+    }
+
+    #[test]
+    fn frame_info_is_independent_of_optional_extensions() {
+        for info in 0..=255u8 {
+            for length in 1..=16usize {
+                let mut extension = vec![0; length + 3];
+                extension[..4].copy_from_slice(&[0, 0x0f, 0x30 | (length - 1) as u8, info]);
+                extension.resize(extension.len().next_multiple_of(4), 0);
+                let mut packet = vec![
+                    0x91,
+                    97,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    2,
+                    0xde,
+                    0xbe,
+                    0,
+                    (extension.len() / 4) as u8,
+                ];
+                packet.extend_from_slice(&extension);
+                assert_eq!(parse_whatsapp_media_frame_info(&packet), Some(info));
+                assert_eq!(parse_whatsapp_video_extension(&packet), None);
+                packet[16] = 0xbe;
+                packet[17] = 0xde;
+                assert_eq!(parse_whatsapp_media_frame_info(&packet), None);
+            }
+        }
+    }
+
+    #[test]
+    fn frame_info_padding_duplicates_and_truncation_match_wasm() {
+        for (extension, expected) in [
+            (&[0x30, 0, 0, 0][..], Some(0)),
+            (&[0, 0x0f, 0, 0][..], None),
+            (&[0xf0, 0xff, 0x30, 3][..], Some(3)),
+            (&[0x30, 1, 0x30, 3][..], Some(3)),
+            (&[0x30, 3, 0x30, 1][..], Some(1)),
+            (&[0x30, 1, 0x37, 3, 0, 0, 0, 0, 0, 0, 0, 0][..], Some(1)),
+            (&[0x37, 3, 0, 0, 0, 0, 0, 0, 0, 0x30, 1, 0][..], Some(1)),
+            (&[0x32, 1, 0, 0, 0x35, 3, 0, 0, 0, 0, 0, 0][..], Some(1)),
+            (&[0x30, 3, 0xff, 0][..], Some(3)),
+            (&[0xff, 0x30, 3, 0][..], None),
+            (&[0x30, 1, 0x3f, 3][..], Some(1)),
+            (&[0x3f, 3, 0, 0][..], None),
+            (&[0, 0, 0, 0x30][..], None),
+        ] {
+            let mut packet = vec![
+                0x90,
+                97,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0xde,
+                0xbe,
+                0,
+                (extension.len() / 4) as u8,
+            ];
+            packet.extend_from_slice(extension);
+            assert_eq!(
+                parse_whatsapp_media_frame_info(&packet),
+                expected,
+                "{extension:02x?}"
+            );
+            packet[15] += 1;
+            assert_eq!(
+                parse_whatsapp_media_frame_info(&packet),
+                None,
+                "truncated block"
+            );
+        }
+        for packet in [&[][..], &[0x80; 11], &[0x90; 12], &[0x80; 12], &[0x8f; 12]] {
+            assert_eq!(parse_whatsapp_media_frame_info(packet), None);
+        }
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -1130,7 +1130,7 @@ impl VideoPipeline {
             self.contender_ssrc = None;
         }
         let previous = self.frame_orientation;
-        let rotation = header.video_extension.map(|ext| ext.media_frame_info & 3);
+        let rotation = super::rtp::parse_whatsapp_media_frame_info(packet).map(|info| info & 3);
         match self.frame_orientation {
             Some((timestamp, ref mut orientation)) if timestamp == header.timestamp => {
                 if rotation.is_some() {
@@ -2000,6 +2000,47 @@ mod tests {
                     assert_eq!(
                         completed,
                         [(timestamp, vec![0, 0, 0, 1, 0x65, 0x88, 0x99], expected)]
+                    );
+                } else {
+                    assert!(completed.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn frame_info_only_packets_preserve_authenticated_rotation() {
+        let key = [42u8; 32];
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&key, b, a)).unwrap();
+        for info in 0..=255u8 {
+            for marker in [false, true] {
+                let mut header = tx.rtp.next_video_packet(marker, info);
+                header.video_extension = None;
+                header.extension_word = Some(u32::from_be_bytes([0x30, info, 0, 0]));
+                let payload: &[u8] = if marker {
+                    &[0x7c, 0x45, 0x99]
+                } else {
+                    &[0x7c, 0x85, 0x88]
+                };
+                let packet =
+                    protect_srtp_packet(&tx.send_keys, &header, 0, WARP_MI_TAG_LEN, payload);
+                let held = rx.frame_orientation;
+                let mut forged = packet.clone();
+                forged[17] ^= 3;
+                assert!(rx.unprotect_video_packet(&forged).is_none());
+                assert_eq!(rx.frame_orientation, held);
+                let completed = rx.unprotect_video_packet(&packet).unwrap().1;
+                if marker {
+                    assert_eq!(
+                        completed,
+                        [(
+                            header.timestamp,
+                            vec![0, 0, 0, 1, 0x65, 0x88, 0x99],
+                            Some(info & 3)
+                        )]
                     );
                 } else {
                     assert!(completed.is_empty());


### PR DESCRIPTION
## Summary

The contact hash slot drops from 64 to 56 bytes. A 4,096 bucket table saves 32,768 bytes. The dispatched slot stays at 128 bytes.

## Changes

CacheEntry merged into Slot, so the narrow key reuses the entry tail padding. Helpers now return Slot references and field accesses go straight to the slot. Eviction, expiry and single flight logic is unchanged. No public API changes.

## Validation

cargo fmt check passes. cargo nextest run for portable_cache passes with 49 tests, including the new flatten test. cargo clippy with warnings denied passes.

## Limits

The win applies to narrow keys only. Wide keys already align, so the dispatched path sees no change. Size assertions run on 64 bit only. This overlaps with the contact saving in opt/lid-no-metadata, so do not sum the two. This branch stands alone and needs no other opt branch.

## Base

I did not rebase onto current main. The rebase stopped on unrelated VOIP conflicts, so this branch sits on an older main.