### PR TITLE
perf(client): inline unshared Arc wrappers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1537,8 +1537,10 @@ pub struct Client {
     pub(crate) stats: Arc<wacore::stats::SessionStats>,
 
     pub(crate) transport: Arc<Mutex<Option<Arc<dyn crate::transport::Transport>>>>,
+    // Inline: `Client` is always behind `Arc`, and the receiver is only ever
+    // used via `&self`, so no independent owner exists.
     pub(crate) transport_events:
-        Arc<Mutex<Option<async_channel::Receiver<crate::transport::TransportEvent>>>>,
+        Mutex<Option<async_channel::Receiver<crate::transport::TransportEvent>>>,
     pub(crate) transport_factory: Arc<dyn crate::transport::TransportFactory>,
     /// Replaced per connection, so not a `OnceLock` — but every critical section
     /// is a clone or a store, so a sync lock makes holding it across an `.await`
@@ -1770,7 +1772,8 @@ pub struct Client {
     /// per collection, matches whatsmeow's single `appStateSyncLock` and WA Web
     /// funnelling all collections through one `CollectionsStateMachine`; sends
     /// are user-paced, so there is nothing to gain from finer granularity.
-    pub(crate) app_state_send_lock: Arc<Mutex<()>>,
+    /// Inline: only ever locked via `&self` on the `Arc`-held `Client`.
+    pub(crate) app_state_send_lock: Mutex<()>,
     pub(crate) initial_keys_synced_notifier: Arc<event_listener::Event>,
     pub(crate) initial_app_state_keys_received: AtomicBool,
 
@@ -1923,8 +1926,9 @@ pub struct Client {
     ///
     /// Copy-on-write behind a sync lock, guarded by `chatstate_handler_count` so
     /// the default (no handler registered) never takes the lock nor builds the
-    /// event that only a handler would read.
-    pub(crate) chatstate_handlers: Arc<std::sync::RwLock<Arc<[ChatStateHandler]>>>,
+    /// event that only a handler would read. The outer lock is inline (`Client`
+    /// is always behind `Arc`); only the inner snapshot is `Arc`-shared.
+    pub(crate) chatstate_handlers: std::sync::RwLock<Arc<[ChatStateHandler]>>,
     pub(crate) chatstate_handler_count: AtomicUsize,
 
     pub(crate) pdo_pending_requests: Cache<ChatMessageId, crate::pdo::PendingPdoRequest>,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -517,7 +517,7 @@ impl Client {
             stats: Arc::new(wacore::stats::SessionStats::new()),
 
             transport: Arc::new(Mutex::new(None)),
-            transport_events: Arc::new(Mutex::new(None)),
+            transport_events: Mutex::new(None),
             transport_factory,
             noise_socket: Arc::new(std::sync::Mutex::new(None)),
 
@@ -620,7 +620,7 @@ impl Client {
             app_state_processor: std::sync::OnceLock::new(),
             app_state_key_requests: Arc::new(Mutex::new(HashMap::new())),
             app_state_syncing: app_state::SyncInFlight::new(),
-            app_state_send_lock: Arc::new(Mutex::new(())),
+            app_state_send_lock: Mutex::new(()),
             initial_keys_synced_notifier: Arc::new(event_listener::Event::new()),
             initial_app_state_keys_received: AtomicBool::new(false),
             prekey_upload_lock: Arc::new(Mutex::new(())),
@@ -664,7 +664,7 @@ impl Client {
             custom_enc_handlers: std::sync::OnceLock::new(),
             inbound_durability_hook: std::sync::OnceLock::new(),
             retry_admission: std::sync::OnceLock::new(),
-            chatstate_handlers: Arc::new(std::sync::RwLock::new(Arc::from([]))),
+            chatstate_handlers: std::sync::RwLock::new(Arc::from([])),
             chatstate_handler_count: AtomicUsize::new(0),
             pdo_pending_requests: cache_config.pdo_pending_requests.build_with_ttl(),
             pdo_requested: cache_config.pdo_requested.build_with_ttl(),

--- a/src/unified_session.rs
+++ b/src/unified_session.rs
@@ -6,17 +6,20 @@
 use async_lock::Mutex;
 use log::debug;
 use portable_atomic::{AtomicI64, AtomicU64};
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use wacore::ib::{IbStanza, UnifiedSession};
 use wacore::protocol::ProtocolNode;
 use wacore_binary::Node;
 
 /// Manager for unified session telemetry.
+///
+/// Fields are held inline rather than behind `Arc`: the manager is not
+/// `Clone`, exposes no field handles, and every op borrows `&self` from the
+/// `Client` (itself always behind `Arc`), so no independent owner exists.
 pub struct UnifiedSessionManager {
-    server_time_offset_ms: Arc<AtomicI64>,
-    last_sent_id: Arc<Mutex<Option<String>>>,
-    sequence: Arc<AtomicU64>,
+    server_time_offset_ms: AtomicI64,
+    last_sent_id: Mutex<Option<String>>,
+    sequence: AtomicU64,
 }
 
 impl Default for UnifiedSessionManager {
@@ -28,9 +31,9 @@ impl Default for UnifiedSessionManager {
 impl UnifiedSessionManager {
     pub fn new() -> Self {
         Self {
-            server_time_offset_ms: Arc::new(AtomicI64::new(0)),
-            last_sent_id: Arc::new(Mutex::new(None)),
-            sequence: Arc::new(AtomicU64::new(0)),
+            server_time_offset_ms: AtomicI64::new(0),
+            last_sent_id: Mutex::new(None),
+            sequence: AtomicU64::new(0),
         }
     }
 
@@ -131,6 +134,17 @@ impl UnifiedSessionManager {
 mod tests {
     use super::*;
     use wacore_binary::builder::NodeBuilder;
+
+    #[test]
+    fn test_manager_fields_are_inline() {
+        // Locks the inline shape: every field lives in the manager itself, so
+        // `new()` performs zero heap allocations. Reintroducing an `Arc`
+        // wrapper changes this sum and fails the test.
+        assert_eq!(
+            size_of::<UnifiedSessionManager>(),
+            size_of::<AtomicI64>() + size_of::<Mutex<Option<String>>>() + size_of::<AtomicU64>()
+        );
+    }
 
     #[test]
     fn test_manager_default() {

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -160,14 +160,16 @@ pub fn default_tls_connector() -> Connector {
 type Sink<S> = SplitSink<WebSocketStream<S>, Message>;
 
 struct WsTransport<S: AsyncRead + AsyncWrite + Unpin + Send + 'static> {
-    sink: Arc<Mutex<Option<Sink<S>>>>,
+    // Inline: every `WsTransport` is owned by the `Arc<dyn Transport>` minted
+    // in `from_websocket`, and `Transport` methods take `&self`.
+    sink: Mutex<Option<Sink<S>>>,
     shutdown_tx: tokio::sync::watch::Sender<bool>,
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin + Send + 'static> WsTransport<S> {
     fn new(sink: Sink<S>, shutdown_tx: tokio::sync::watch::Sender<bool>) -> Self {
         Self {
-            sink: Arc::new(Mutex::new(Some(sink))),
+            sink: Mutex::new(Some(sink)),
             shutdown_tx,
         }
     }


### PR DESCRIPTION
## Summary

Removes heap indirection around locks and atomics that have no independent owner. `UnifiedSessionManager` goes from 3 allocations to 0 (24-byte struct of three `Arc`s becomes a 56-byte struct holding the `AtomicI64`, `Mutex<Option<String>>` and `AtomicU64` inline). Four secondary single-allocation wrappers are inlined the same way: `Client::transport_events`, `Client::app_state_send_lock`, the outer lock of `Client::chatstate_handlers` (the inner snapshot stays `Arc`-shared), and `WsTransport::sink`. All lock and atomic types are unchanged, so synchronization semantics are identical.

This PR is independent: it touches only these unshared wrappers and stacks on nothing.

## Changes

- `src/unified_session.rs`: `UnifiedSessionManager` holds `AtomicI64` / `Mutex<Option<String>>` / `AtomicU64` directly; adds a size-assert test locking the inline shape.
- `src/client.rs`: `transport_events`, `app_state_send_lock` and outer `chatstate_handlers` lose the outer `Arc`.
- `src/client/lifecycle.rs`: constructors build the fields inline.
- `transports/tokio-transport/src/lib.rs`: `WsTransport::sink` loses the outer `Arc`.

## Validation

- `cargo fmt --all -- --check`: clean.
- `cargo nextest run -p whatsapp-rust --lib`: 1988 passed, 2 skipped.
- `cargo nextest run -p whatsapp-rust-tokio-transport --lib`: 12 passed.
- `cargo clippy -p whatsapp-rust -p whatsapp-rust-tokio-transport --all-targets -- -D warnings`: clean.

## Limits

- Parent structs (`Client`, `WsTransport`) grow slightly since the pointed-to state now lives inline; all of them are already heap-allocated behind `Arc`, so this trades one indirection for locality.
- Genuinely shared handles (`transport`, `transport_factory`, the inner chatstate snapshot, per-connection notifiers) are untouched.