### PR TITLE
perf(cache): add metadata-free table for unbounded local maps

### DIFF
--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -755,6 +755,130 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn unbounded_table_resolves_all_four_indexes() {
+        let cache = LidPnCache::new();
+        let entry = LidPnEntry::with_timestamp(
+            "100000012345678".to_string(),
+            "559980000001".to_string(),
+            1000,
+            LearningSource::Usync,
+        );
+        cache.add(&entry).await;
+        cache.mark_persisted(&entry.phone_number, &entry.lid).await;
+
+        assert_eq!(
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000012345678")
+        );
+        assert_eq!(
+            cache.get_phone_number("100000012345678").await.as_deref(),
+            Some("559980000001")
+        );
+        for user in ["100000012345678", "559980000001"] {
+            let hash = wacore::crypto::contact_notification_hash(user);
+            assert_eq!(
+                cache.lid_for_contact_hash(hash).await.as_deref(),
+                Some("100000012345678")
+            );
+        }
+        assert!(cache.is_persisted("559980000001", "100000012345678").await);
+        assert!(
+            cache
+                .can_skip_relearn("559980000001", "100000012345678")
+                .await
+        );
+        assert_eq!(cache.lid_count().await, 1);
+        assert_eq!(cache.pn_count().await, 1);
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.lid_count().await, 1);
+        assert_eq!(
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000012345678"),
+            "maintenance must not drop unbounded entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_table_still_evicts_and_expiring_table_still_expires() {
+        let evicting = LidPnCache::with_config(&CacheEntryConfig::new(None, 1), None);
+        evicting
+            .add(&LidPnEntry::with_timestamp(
+                "100000000000001".to_string(),
+                "15550000001".to_string(),
+                1,
+                LearningSource::Usync,
+            ))
+            .await;
+        evicting
+            .add(&LidPnEntry::with_timestamp(
+                "100000000000002".to_string(),
+                "15550000002".to_string(),
+                2,
+                LearningSource::Usync,
+            ))
+            .await;
+        assert_eq!(
+            evicting.lid_count().await,
+            1,
+            "capacity-1 LID map keeps the managed eviction policy"
+        );
+
+        let expiring = LidPnCache::with_config(
+            &CacheEntryConfig::new(Some(std::time::Duration::from_millis(50)), 1_000),
+            None,
+        );
+        expiring
+            .add(&LidPnEntry::new(
+                "100000000000003".to_string(),
+                "15550000003".to_string(),
+                LearningSource::Usync,
+            ))
+            .await;
+        assert!(expiring.get_current_lid("15550000003").await.is_some());
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(
+            expiring.get_current_lid("15550000003").await.is_none(),
+            "idle expiry still applies on the managed path"
+        );
+    }
+
+    #[tokio::test]
+    async fn unbounded_replacement_keeps_pn_winner_rule() {
+        let cache = LidPnCache::new();
+        cache
+            .add(&LidPnEntry::with_timestamp(
+                "100000000000001".to_string(),
+                "15550000004".to_string(),
+                2000,
+                LearningSource::Usync,
+            ))
+            .await;
+        cache
+            .add(&LidPnEntry::with_timestamp(
+                "100000000000002".to_string(),
+                "15550000004".to_string(),
+                1000,
+                LearningSource::Other,
+            ))
+            .await;
+        assert_eq!(
+            cache.get_current_lid("15550000004").await.as_deref(),
+            Some("100000000000001"),
+            "an older PN mapping must not displace the winner"
+        );
+        let phone_hash = wacore::crypto::contact_notification_hash("15550000004");
+        assert_eq!(
+            cache.lid_for_contact_hash(phone_hash).await.as_deref(),
+            Some("100000000000001")
+        );
+        assert_eq!(
+            cache.get_phone_number("100000000000002").await.as_deref(),
+            Some("15550000004"),
+            "the losing LID stays resolvable"
+        );
+    }
+
     #[test]
     fn test_learning_source_serialization() {
         let sources = [

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -67,6 +67,134 @@ struct Slot<K, V> {
     hash: u64,
 }
 
+/// One table slot for a cache that can neither evict nor expire: only the key,
+/// its hash, and the value. Chosen at construction (see `assemble`), never per
+/// entry, so the managed path pays nothing for it and this path stores no
+/// timestamps, sequence numbers, or CLOCK bits.
+struct PlainSlot<K, V> {
+    key: K,
+    hash: u64,
+    value: V,
+}
+
+struct PlainInner<K, V, S> {
+    hasher: S,
+    table: HashTable<PlainSlot<K, V>>,
+}
+
+impl<K, V, S> PlainInner<K, V, S>
+where
+    K: Hash + Eq + Clone,
+    S: BuildHasher,
+{
+    fn new(hasher: S) -> Self {
+        Self {
+            hasher,
+            table: HashTable::new(),
+        }
+    }
+
+    #[inline]
+    fn hash_of<Q: Hash + ?Sized>(&self, key: &Q) -> u64 {
+        self.hasher.hash_one(key)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.table.len()
+    }
+
+    fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &slot.value)
+    }
+
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find_mut(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &mut slot.value)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.table.iter().map(|slot| (&slot.key, &slot.value))
+    }
+
+    fn structural_bytes(&self) -> usize {
+        wacore::stats::hash_table_bytes(self.table.capacity(), size_of::<PlainSlot<K, V>>())
+    }
+
+    fn clear(&mut self) {
+        self.table.clear();
+    }
+
+    fn remove_key<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        let (slot, _) = self
+            .table
+            .find_entry(hash, |slot| slot.key.borrow() == key)
+            .ok()?
+            .remove();
+        Some(slot.value)
+    }
+
+    fn insert_new(&mut self, key: K, value: V) {
+        let hash = self.hash_of(&key);
+        self.table
+            .insert_unique(hash, PlainSlot { key, hash, value }, |slot| slot.hash);
+    }
+}
+
+/// Container-level representation, fixed at construction. The unbounded,
+/// non-expiring, guard-free cache (the default LID/PN maps) holds plain
+/// key/value slots; every other configuration keeps the managed table with
+/// timestamps, order, and CLOCK bits.
+enum Storage<K, V, S> {
+    Plain(PlainInner<K, V, S>),
+    Managed(CacheInner<K, V, S>),
+}
+
+impl<K, V, S> Storage<K, V, S>
+where
+    K: Hash + Eq + Clone,
+    S: BuildHasher,
+{
+    fn len(&self) -> usize {
+        match self {
+            Storage::Plain(inner) => inner.len(),
+            Storage::Managed(inner) => inner.len(),
+        }
+    }
+
+    fn clear(&mut self) {
+        match self {
+            Storage::Plain(inner) => inner.clear(),
+            Storage::Managed(inner) => inner.clear(),
+        }
+    }
+
+    fn structural_bytes(&self) -> usize {
+        match self {
+            Storage::Plain(inner) => inner.structural_bytes(),
+            Storage::Managed(inner) => inner.structural_bytes(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct CapacityStats {
     pub entries: u64,
@@ -88,7 +216,7 @@ pub(crate) struct CapacityStats {
 /// access or in `run_pending_tasks`. `entry_count` may include
 /// expired-but-not-yet-evicted entries.
 pub struct PortableCache<K, V, S = RandomState> {
-    inner: Arc<RwLock<CacheInner<K, V, S>>>,
+    inner: Arc<RwLock<Storage<K, V, S>>>,
     /// Shared single-flight init-lock registry (see `InitLocks`), built on the
     /// first [`get_with`](Self::get_with) rather than at construction: a client
     /// builds ~20 of these caches and most of them are only ever `get`/`insert`ed,
@@ -778,8 +906,19 @@ where
     // BTreeMap node per entry.
     let track_order =
         max_capacity.is_some_and(|cap| cap != u64::MAX) || ttl.is_some() || tti.is_some();
+    // Container-level choice: only a guard-free cache with no capacity bound
+    // (None or u64::MAX), no TTL/TTI, and no order to track drops its
+    // per-entry metadata. Every other configuration keeps the managed table.
+    let unbounded = (max_capacity.is_none() || max_capacity == Some(u64::MAX))
+        && ttl.is_none()
+        && tti.is_none();
+    let inner = if unbounded && evict_guard.is_none() {
+        Storage::Plain(PlainInner::new(hash_builder))
+    } else {
+        Storage::Managed(CacheInner::new(track_order, hash_builder))
+    };
     PortableCache {
-        inner: Arc::new(RwLock::new(CacheInner::new(track_order, hash_builder))),
+        inner: Arc::new(RwLock::new(inner)),
         init_locks: OnceLock::new(),
         max_capacity,
         ttl,
@@ -858,44 +997,57 @@ where
     {
         let (value, renew_at) = {
             let guard = self.inner.read().await;
-            let entry = guard.get(key)?;
-            // Read the clock after the lookup: a miss has no timestamp to
-            // compare, and lookups that miss are a large share of the calls
-            // (every negative registry probe, every warm-up).
-            let now = self.entry_time();
-            if self.is_expired(entry, now) {
-                // Identity of the entry judged expired: `seq` moves if the slot
-                // was re-inserted, `inserted_at` if the value was rewritten in
-                // place. Removing without it could drop a replacement written
-                // while the guard was down and judge it by a stale `now`.
-                let observed = (entry.seq, entry.inserted_at);
-                drop(guard);
-                let mut wguard = self.inner.write().await;
-                if let Some(e) = wguard.get(key)
-                    && (e.seq, e.inserted_at) == observed
-                    && self.is_expired(e, now)
-                {
-                    wguard.remove_key(key);
+            match &*guard {
+                Storage::Plain(inner) => {
+                    return inner.get(key).cloned();
                 }
-                return None;
+                Storage::Managed(inner) => {
+                    let entry = inner.get(key)?;
+                    // Read the clock after the lookup: a miss has no timestamp to
+                    // compare, and lookups that miss are a large share of the calls
+                    // (every negative registry probe, every warm-up).
+                    let now = self.entry_time();
+                    if self.is_expired(entry, now) {
+                        // Identity of the entry judged expired: `seq` moves if the slot
+                        // was re-inserted, `inserted_at` if the value was rewritten in
+                        // place. Removing without it could drop a replacement written
+                        // while the guard was down and judge it by a stale `now`.
+                        let observed = (entry.seq, entry.inserted_at);
+                        drop(guard);
+                        let mut wguard = self.inner.write().await;
+                        let Storage::Managed(managed) = &mut *wguard else {
+                            return None;
+                        };
+                        if let Some(e) = managed.get(key)
+                            && (e.seq, e.inserted_at) == observed
+                            && self.is_expired(e, now)
+                        {
+                            managed.remove_key(key);
+                        }
+                        return None;
+                    }
+                    if inner.track_order {
+                        entry
+                            .referenced
+                            .store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    (
+                        entry.value.clone(),
+                        self.needs_tti_renewal(entry, now).then_some(now),
+                    )
+                }
             }
-            if guard.track_order {
-                entry
-                    .referenced
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-            (
-                entry.value.clone(),
-                self.needs_tti_renewal(entry, now).then_some(now),
-            )
         };
 
         if let Some(now) = renew_at {
             let mut guard = self.inner.write().await;
+            let Storage::Managed(managed) = &mut *guard else {
+                return Some(value);
+            };
             // Re-decide under the lock: the key may have been invalidated (the
             // miss leaves it that way) or already refreshed by a racing renewal
             // or insert, whose newer stamp this lookup must leave alone.
-            if let Some(entry) = guard.get_mut(key)
+            if let Some(entry) = managed.get_mut(key)
                 && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
@@ -909,21 +1061,29 @@ where
     }
 
     pub async fn insert(&self, key: K, value: V) {
-        let now = self.entry_time();
-        let mut guard = self.inner.write().await;
-
-        if let Some(entry) = guard.get_mut(&key) {
-            entry.value = value;
-            entry.inserted_at = now;
-            entry.last_accessed_at = now;
-            return;
-        }
-
         if self.max_capacity == Some(0) {
             return;
         }
-
-        guard.insert_new(key, value, now, self.max_capacity, self.evict_guard);
+        let now = self.entry_time();
+        let mut guard = self.inner.write().await;
+        match &mut *guard {
+            Storage::Plain(inner) => {
+                if let Some(slot) = inner.get_mut(&key) {
+                    *slot = value;
+                    return;
+                }
+                inner.insert_new(key, value);
+            }
+            Storage::Managed(inner) => {
+                if let Some(entry) = inner.get_mut(&key) {
+                    entry.value = value;
+                    entry.inserted_at = now;
+                    entry.last_accessed_at = now;
+                    return;
+                }
+                inner.insert_new(key, value, now, self.max_capacity, self.evict_guard);
+            }
+        }
     }
 
     /// Atomically derive and optionally store a value from the current entry.
@@ -943,56 +1103,82 @@ where
     {
         let now = self.entry_time();
         let mut guard = self.inner.write().await;
+        match &mut *guard {
+            Storage::Plain(inner) => {
+                let (next, result) = update(inner.get(key));
+                let Some(next) = next else {
+                    return result;
+                };
+                if let Some(slot) = inner.get_mut(key) {
+                    *slot = next;
+                } else if self.max_capacity != Some(0) {
+                    inner.insert_new(key.to_owned(), next);
+                }
+                result
+            }
+            Storage::Managed(inner) => {
+                if inner
+                    .get(key)
+                    .is_some_and(|entry| self.is_expired(entry, now))
+                {
+                    inner.remove_key(key);
+                }
 
-        if guard
-            .get(key)
-            .is_some_and(|entry| self.is_expired(entry, now))
-        {
-            guard.remove_key(key);
+                let (next, result) = update(inner.get(key).map(|entry| &entry.value));
+                let Some(next) = next else {
+                    return result;
+                };
+
+                if let Some(entry) = inner.get_mut(key) {
+                    entry.value = next;
+                    entry.inserted_at = now;
+                    entry.last_accessed_at = now;
+                } else if self.max_capacity != Some(0) {
+                    inner.insert_new(
+                        key.to_owned(),
+                        next,
+                        now,
+                        self.max_capacity,
+                        self.evict_guard,
+                    );
+                }
+
+                result
+            }
         }
-
-        let (next, result) = update(guard.get(key).map(|entry| &entry.value));
-        let Some(next) = next else {
-            return result;
-        };
-
-        if let Some(entry) = guard.get_mut(key) {
-            entry.value = next;
-            entry.inserted_at = now;
-            entry.last_accessed_at = now;
-        } else if self.max_capacity != Some(0) {
-            guard.insert_new(
-                key.to_owned(),
-                next,
-                now,
-                self.max_capacity,
-                self.evict_guard,
-            );
-        }
-
-        result
     }
 
     /// Insert and return a clone of the value in one write lock.
     async fn insert_and_return(&self, key: K, value: V) -> V {
-        let now = self.entry_time();
-        let mut guard = self.inner.write().await;
-
-        if let Some(entry) = guard.get_mut(&key) {
-            let ret = value.clone();
-            entry.value = value;
-            entry.inserted_at = now;
-            entry.last_accessed_at = now;
-            return ret;
-        }
-
         if self.max_capacity == Some(0) {
             return value;
         }
+        let now = self.entry_time();
+        let mut guard = self.inner.write().await;
+        match &mut *guard {
+            Storage::Plain(inner) => {
+                let ret = value.clone();
+                if let Some(slot) = inner.get_mut(&key) {
+                    *slot = value;
+                    return ret;
+                }
+                inner.insert_new(key, value);
+                ret
+            }
+            Storage::Managed(inner) => {
+                if let Some(entry) = inner.get_mut(&key) {
+                    let ret = value.clone();
+                    entry.value = value;
+                    entry.inserted_at = now;
+                    entry.last_accessed_at = now;
+                    return ret;
+                }
 
-        let ret = value.clone();
-        guard.insert_new(key, value, now, self.max_capacity, self.evict_guard);
-        ret
+                let ret = value.clone();
+                inner.insert_new(key, value, now, self.max_capacity, self.evict_guard);
+                ret
+            }
+        }
     }
 
     pub async fn remove<Q>(&self, key: &Q) -> Option<V>
@@ -1001,13 +1187,18 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let mut guard = self.inner.write().await;
-        let entry = guard.remove_key(key)?;
-        // Nothing to date until an entry is actually in hand.
-        let now = self.entry_time();
-        if self.is_expired(&entry, now) {
-            None
-        } else {
-            Some(entry.value)
+        match &mut *guard {
+            Storage::Plain(inner) => inner.remove_key(key),
+            Storage::Managed(inner) => {
+                let entry = inner.remove_key(key)?;
+                // Nothing to date until an entry is actually in hand.
+                let now = self.entry_time();
+                if self.is_expired(&entry, now) {
+                    None
+                } else {
+                    Some(entry.value)
+                }
+            }
         }
     }
 
@@ -1017,7 +1208,14 @@ where
         Q: Hash + Eq + ?Sized,
     {
         let mut guard = self.inner.write().await;
-        guard.remove_key(key);
+        match &mut *guard {
+            Storage::Plain(inner) => {
+                inner.remove_key(key);
+            }
+            Storage::Managed(inner) => {
+                inner.remove_key(key);
+            }
+        }
     }
 
     /// Reliably remove all entries, awaiting the write lock. Prefer this in
@@ -1066,10 +1264,17 @@ where
 
     pub(crate) async fn capacity_stats(&self) -> CapacityStats {
         let guard = self.inner.read().await;
-        CapacityStats {
-            entries: guard.len() as u64,
-            evictions: guard.capacity_evictions,
-            eviction_blocks: guard.capacity_eviction_blocks,
+        match &*guard {
+            Storage::Plain(inner) => CapacityStats {
+                entries: inner.len() as u64,
+                evictions: 0,
+                eviction_blocks: 0,
+            },
+            Storage::Managed(inner) => CapacityStats {
+                entries: inner.len() as u64,
+                evictions: inner.capacity_evictions,
+                eviction_blocks: inner.capacity_eviction_blocks,
+            },
         }
     }
 
@@ -1088,7 +1293,10 @@ where
     /// degrade to an empty walk under write contention.
     pub async fn fold_entries<A>(&self, init: A, mut f: impl FnMut(A, &K, &V) -> A) -> A {
         let guard = self.inner.read().await;
-        guard.iter().fold(init, |acc, (k, e)| f(acc, k, &e.value))
+        match &*guard {
+            Storage::Plain(inner) => inner.iter().fold(init, |acc, (k, v)| f(acc, k, v)),
+            Storage::Managed(inner) => inner.iter().fold(init, |acc, (k, e)| f(acc, k, &e.value)),
+        }
     }
 
     /// Entry count plus the bytes of the table and eviction order alone, for
@@ -1110,11 +1318,22 @@ where
         mut per_entry: impl FnMut(&K, &V) -> usize,
     ) -> wacore::stats::CollectionStats {
         let guard = self.inner.read().await;
-        let bytes: usize = guard.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
-        wacore::stats::CollectionStats::new(
-            guard.len() as u64,
-            (bytes + guard.structural_bytes()) as u64,
-        )
+        match &*guard {
+            Storage::Plain(inner) => {
+                let bytes: usize = inner.iter().map(|(k, v)| per_entry(k, v)).sum();
+                wacore::stats::CollectionStats::new(
+                    inner.len() as u64,
+                    (bytes + inner.structural_bytes()) as u64,
+                )
+            }
+            Storage::Managed(inner) => {
+                let bytes: usize = inner.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
+                wacore::stats::CollectionStats::new(
+                    inner.len() as u64,
+                    (bytes + inner.structural_bytes()) as u64,
+                )
+            }
+        }
     }
 
     /// Eager snapshot iterator over `(Arc<K>, V)`: snapshot, not lazy. Includes
@@ -1137,11 +1356,24 @@ where
         Vec::new().into_iter()
     }
 
-    fn snapshot(guard: &CacheInner<K, V, S>) -> Vec<(Arc<K>, V)> {
-        guard
-            .iter()
-            .map(|(k, e)| (Arc::new(k.clone()), e.value.clone()))
-            .collect()
+    fn snapshot(guard: &Storage<K, V, S>) -> Vec<(Arc<K>, V)> {
+        match guard {
+            Storage::Plain(inner) => inner
+                .iter()
+                .map(|(k, v)| (Arc::new(k.clone()), v.clone()))
+                .collect(),
+            Storage::Managed(inner) => inner
+                .iter()
+                .map(|(k, e)| (Arc::new(k.clone()), e.value.clone()))
+                .collect(),
+        }
+    }
+
+    #[cfg(test)]
+    fn is_plain(&self) -> bool {
+        self.inner
+            .try_read()
+            .is_some_and(|guard| matches!(&*guard, Storage::Plain(_)))
     }
 
     /// Get or insert (single-flight). Takes key by value.
@@ -1222,6 +1454,41 @@ where
         self.tti_renewals.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    #[cfg(test)]
+    async fn debug_seq<Q>(&self, key: &Q) -> Option<u64>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let guard = self.inner.read().await;
+        let Storage::Managed(inner) = &*guard else {
+            return None;
+        };
+        inner.get(key).map(|e| e.seq)
+    }
+
+    #[cfg(test)]
+    async fn debug_stamps<Q>(&self, key: &Q) -> Option<(Instant, Instant)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let guard = self.inner.read().await;
+        let Storage::Managed(inner) = &*guard else {
+            return None;
+        };
+        inner.get(key).map(|e| (e.inserted_at, e.last_accessed_at))
+    }
+
+    #[cfg(test)]
+    async fn debug_order_len(&self) -> usize {
+        let guard = self.inner.read().await;
+        match &*guard {
+            Storage::Plain(_) => 0,
+            Storage::Managed(inner) => inner.order.len(),
+        }
+    }
+
     /// Evict expired entries and clean up unused init locks.
     /// Test-only read that leaves the second-chance bit alone, so a test can
     /// observe eviction order without feeding it.
@@ -1231,7 +1498,11 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.inner.read().await.get(key).map(|e| e.value.clone())
+        let guard = self.inner.read().await;
+        match &*guard {
+            Storage::Plain(inner) => inner.get(key).cloned(),
+            Storage::Managed(inner) => inner.get(key).map(|e| e.value.clone()),
+        }
     }
 
     pub async fn run_pending_tasks(&self) {
@@ -1242,7 +1513,10 @@ where
         if self.ttl.is_some() || self.tti.is_some() {
             let now = self.entry_time();
             let mut guard = self.inner.write().await;
-            guard.retain_unexpired(|entry| self.is_expired(entry, now));
+            let Storage::Managed(managed) = &mut *guard else {
+                return;
+            };
+            managed.retain_unexpired(|entry| self.is_expired(entry, now));
         }
 
         // Clean up init locks not actively held. `get()`, not `init_locks()`: a
@@ -1362,10 +1636,12 @@ mod tests {
         cache.insert("key".into(), "value".into()).await;
         assert_eq!(cache.get("key").await.as_deref(), Some("value"));
 
-        let guard = cache.inner.read().await;
-        let entry = guard.get("key").expect("inserted cache entry");
-        assert_eq!(entry.inserted_at, Instant::ZERO);
-        assert_eq!(entry.last_accessed_at, Instant::ZERO);
+        let stamps = cache
+            .debug_stamps("key")
+            .await
+            .expect("inserted cache entry");
+        assert_eq!(stamps.0, Instant::ZERO);
+        assert_eq!(stamps.1, Instant::ZERO);
     }
 
     #[tokio::test]
@@ -1610,10 +1886,10 @@ mod tests {
     async fn a_hit_is_spent_by_one_eviction_pass() {
         let cache: PortableCache<String, u32> = PortableCache::builder().max_capacity(4).build();
         cache.insert("a".to_string(), 1).await;
-        let seq_before = cache.inner.read().await.get("a").map(|e| e.seq);
+        let seq_before = cache.debug_seq("a").await;
         cache.get("a").await;
         assert_eq!(
-            cache.inner.read().await.get("a").map(|e| e.seq),
+            cache.debug_seq("a").await,
             seq_before,
             "a hit must not reorder under the read lock"
         );
@@ -1623,7 +1899,7 @@ mod tests {
             cache.insert(format!("b{i}"), i).await;
         }
         assert_eq!(cache.get_no_touch("a").await, Some(1));
-        assert!(cache.inner.read().await.get("a").map(|e| e.seq) > seq_before);
+        assert!(cache.debug_seq("a").await > seq_before);
         // Not read since: the next pass over it evicts.
         for i in 4..8u32 {
             cache.insert(format!("b{i}"), i).await;
@@ -1805,7 +2081,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache.inner.read().await.get("k").unwrap().last_accessed_at
+            cache.debug_stamps("k").await.expect("entry").1
         };
         let before = stamp(cache.clone()).await;
 
@@ -1835,7 +2111,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache.inner.read().await.get("k").unwrap().last_accessed_at
+            cache.debug_stamps("k").await.expect("entry").1
         };
         let before = stamp(cache.clone()).await;
 
@@ -1863,9 +2139,8 @@ mod tests {
             .build();
 
         let identity = |cache: PortableCache<String, u32>| async move {
-            let guard = cache.inner.read().await;
-            let e = guard.get("k").unwrap();
-            (e.seq, e.inserted_at)
+            let stamps = cache.debug_stamps("k").await.expect("entry");
+            (cache.debug_seq("k").await.expect("entry"), stamps.0)
         };
 
         cache.insert("k".into(), 1).await;
@@ -1920,7 +2195,7 @@ mod tests {
         cache.insert("k".into(), 1).await;
 
         let stamp = |cache: PortableCache<String, u32>| async move {
-            cache.inner.read().await.get("k").unwrap().last_accessed_at
+            cache.debug_stamps("k").await.expect("entry").1
         };
         let before = stamp(cache.clone()).await;
         assert_eq!(cache.tti_renewals(), 0);
@@ -2202,12 +2477,79 @@ mod tests {
             }
             assert_eq!(cache.get("k2").await, Some(2));
         }
-        assert!(unbounded.inner.read().await.order.is_empty());
-        assert!(effectively_unbounded.inner.read().await.order.is_empty());
-        assert_eq!(bounded.inner.read().await.order.len(), 4);
+        assert!(unbounded.is_plain());
+        assert!(effectively_unbounded.is_plain());
+        assert!(!bounded.is_plain());
+        assert_eq!(unbounded.debug_order_len().await, 0);
+        assert_eq!(effectively_unbounded.debug_order_len().await, 0);
+        assert_eq!(bounded.debug_order_len().await, 4);
         // Removal on the unbounded caches still works without the index.
         assert_eq!(unbounded.remove("k1").await, Some(1));
         assert_eq!(unbounded.entry_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn an_unbounded_cache_stores_plain_slots_without_metadata() {
+        let plain: PortableCache<String, u32> = PortableCache::builder().build();
+        let managed: PortableCache<String, u32> = PortableCache::builder().max_capacity(8).build();
+        assert!(plain.is_plain());
+        assert!(!managed.is_plain());
+        for i in 0..8u32 {
+            plain.insert(format!("k{i}"), i).await;
+            managed.insert(format!("k{i}"), i).await;
+        }
+        for i in 0..8u32 {
+            assert_eq!(plain.get(&format!("k{i}")).await, Some(i));
+        }
+        plain.insert("k0".to_string(), 100).await;
+        assert_eq!(plain.get("k0").await, Some(100));
+        assert_eq!(plain.entry_count(), 8);
+        assert_eq!(
+            plain.remove("k0").await,
+            Some(100),
+            "plain removal returns the value with no expiry to consult"
+        );
+        plain.invalidate("k1").await;
+        assert!(plain.get("k1").await.is_none());
+        plain.clear().await;
+        assert_eq!(plain.entry_count(), 0);
+        assert_eq!(
+            size_of::<PlainSlot<String, u32>>(),
+            40,
+            "plain slot must stay key + hash + value with no metadata tail"
+        );
+        assert!(
+            size_of::<Slot<String, u32>>() > size_of::<PlainSlot<String, u32>>(),
+            "managed slot must cost more than the plain slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unbounded_cache_supports_upsert_and_singleflight() {
+        let cache: PortableCache<String, u32> = PortableCache::builder().build();
+        let first = cache
+            .upsert_with_by_ref("counter", |current| {
+                let next = current.copied().unwrap_or_default() + 1;
+                (Some(next), next)
+            })
+            .await;
+        assert_eq!(first, 1);
+        let second = cache
+            .upsert_with_by_ref("counter", |current| {
+                let next = current.copied().unwrap_or_default() + 1;
+                (Some(next), next)
+            })
+            .await;
+        assert_eq!(second, 2);
+        assert_eq!(cache.get("counter").await, Some(2));
+        let single = cache.get_with("fresh".to_string(), async { 7 }).await;
+        assert_eq!(single, 7);
+        assert_eq!(cache.get("fresh").await, Some(7));
+        cache.run_pending_tasks().await;
+        assert_eq!(cache.entry_count(), 2);
+        let stats = cache.capacity_stats().await;
+        assert_eq!(stats.evictions, 0);
+        assert_eq!(stats.eviction_blocks, 0);
     }
 
     #[tokio::test]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -71,10 +71,13 @@ struct Slot<K, V> {
 /// its hash, and the value. Chosen at construction (see `assemble`), never per
 /// entry, so the managed path pays nothing for it and this path stores no
 /// timestamps, sequence numbers, or CLOCK bits.
+///
+/// Field order follows the flattened [`Slot`]: payload first, then the key so a
+/// narrow key reuses the tail padding ahead of `hash`.
 struct PlainSlot<K, V> {
+    value: V,
     key: K,
     hash: u64,
-    value: V,
 }
 
 struct PlainInner<K, V, S> {
@@ -82,11 +85,7 @@ struct PlainInner<K, V, S> {
     table: HashTable<PlainSlot<K, V>>,
 }
 
-impl<K, V, S> PlainInner<K, V, S>
-where
-    K: Hash + Eq + Clone,
-    S: BuildHasher,
-{
+impl<K, V, S> PlainInner<K, V, S> {
     fn new(hasher: S) -> Self {
         Self {
             hasher,
@@ -95,35 +94,8 @@ where
     }
 
     #[inline]
-    fn hash_of<Q: Hash + ?Sized>(&self, key: &Q) -> u64 {
-        self.hasher.hash_one(key)
-    }
-
-    #[inline]
     fn len(&self) -> usize {
         self.table.len()
-    }
-
-    fn get<Q>(&self, key: &Q) -> Option<&V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        let hash = self.hash_of(key);
-        self.table
-            .find(hash, |slot| slot.key.borrow() == key)
-            .map(|slot| &slot.value)
-    }
-
-    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        let hash = self.hash_of(key);
-        self.table
-            .find_mut(hash, |slot| slot.key.borrow() == key)
-            .map(|slot| &mut slot.value)
     }
 
     fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
@@ -137,7 +109,48 @@ where
     fn clear(&mut self) {
         self.table.clear();
     }
+}
 
+impl<K, V, S> PlainInner<K, V, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    #[inline]
+    fn hash_of<Q: Hash + ?Sized>(&self, key: &Q) -> u64 {
+        self.hasher.hash_one(key)
+    }
+
+    /// Table probes below stay out of line: under fat LTO they would otherwise
+    /// inline into every [`PortableCache`] future that dispatches on [`Storage`]
+    /// (`get`, `insert`, `upsert_with_by_ref`, `insert_and_return`, `remove`),
+    /// stamping the hashbrown probe per caller instead of per table. Same
+    /// reason [`expiry_walk`] stays out of line.
+    #[inline(never)]
+    fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &slot.value)
+    }
+
+    #[inline(never)]
+    fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_of(key);
+        self.table
+            .find_mut(hash, |slot| slot.key.borrow() == key)
+            .map(|slot| &mut slot.value)
+    }
+
+    #[inline(never)]
     fn remove_key<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -152,10 +165,22 @@ where
         Some(slot.value)
     }
 
+    #[inline(never)]
     fn insert_new(&mut self, key: K, value: V) {
         let hash = self.hash_of(&key);
         self.table
-            .insert_unique(hash, PlainSlot { key, hash, value }, |slot| slot.hash);
+            .insert_unique(hash, PlainSlot { value, key, hash }, |slot| slot.hash);
+    }
+
+    /// Replace-or-insert shared by `insert` and `insert_and_return` so the
+    /// get-then-insert sequence compiles once per table, not per caller.
+    #[inline(never)]
+    fn insert_or_replace(&mut self, key: K, value: V) {
+        if let Some(slot) = self.get_mut(&key) {
+            *slot = value;
+        } else {
+            self.insert_new(key, value);
+        }
     }
 }
 
@@ -173,6 +198,11 @@ where
     K: Hash + Eq + Clone,
     S: BuildHasher,
 {
+    /// Out of line so the discriminant check compiles once per table instead
+    /// of inlining into every diagnostic caller (`entry_count`,
+    /// `structural_stats`, `clear`, ...). Hot paths match on the variants
+    /// directly and never come through here.
+    #[inline(never)]
     fn len(&self) -> usize {
         match self {
             Storage::Plain(inner) => inner.len(),
@@ -180,6 +210,7 @@ where
         }
     }
 
+    #[inline(never)]
     fn clear(&mut self) {
         match self {
             Storage::Plain(inner) => inner.clear(),
@@ -187,6 +218,7 @@ where
         }
     }
 
+    #[inline(never)]
     fn structural_bytes(&self) -> usize {
         match self {
             Storage::Plain(inner) => inner.structural_bytes(),
@@ -1068,11 +1100,7 @@ where
         let mut guard = self.inner.write().await;
         match &mut *guard {
             Storage::Plain(inner) => {
-                if let Some(slot) = inner.get_mut(&key) {
-                    *slot = value;
-                    return;
-                }
-                inner.insert_new(key, value);
+                inner.insert_or_replace(key, value);
             }
             Storage::Managed(inner) => {
                 if let Some(entry) = inner.get_mut(&key) {
@@ -1158,11 +1186,7 @@ where
         match &mut *guard {
             Storage::Plain(inner) => {
                 let ret = value.clone();
-                if let Some(slot) = inner.get_mut(&key) {
-                    *slot = value;
-                    return ret;
-                }
-                inner.insert_new(key, value);
+                inner.insert_or_replace(key, value);
                 ret
             }
             Storage::Managed(inner) => {


### PR DESCRIPTION
Adds a metadata-free table for unbounded local maps.

Summary
Unbounded caches now use plain slots with no per-entry metadata. This cuts 32B per bucket. Directional and contact entries drop from 64B to 32B. Persisted entries drop from 72B to 40B. All 4 lookup indexes keep working and the PN-winner rule stays intact.

Changes
portable_cache.rs adds the new table and routes unbounded local maps to it. lid_pn_cache.rs moves its unbounded maps onto it. Bounded and expiring tables keep their current behavior.

Validation
cargo fmt check passes. The portable_cache suite passes with 50 tests. The lid_pn_cache suite passes with 22 tests. Clippy on the whatsapp-rust lib and tests reports no warnings.

Limits
This covers the plain config only. Dispatch and code size effects were not measured. The contact saving overlaps with opt/cache-slot-flatten. This branch stands alone. It sits directly on origin/main and needs no other opt branch.