### PR TITLE
perf(client): retain runtime-only cache config

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -412,9 +412,47 @@ impl Default for CacheConfig {
     }
 }
 
+/// Runtime-retained subset of [`CacheConfig`].
+///
+/// The constructor consumes most settings into live caches; only these fields
+/// are read after construction (lazy group-cache init, recent-message gate,
+/// sent-message sweep, secret policy). Converted once, so `Client` never
+/// holds the full construction config. Only the group-cache store is kept:
+/// the device-registry and LID-PN stores are owned by their live caches after
+/// construction, and keeping another `Arc` here would pin them for no reason.
+#[derive(Clone)]
+pub(crate) struct RuntimeCacheConfig {
+    pub(crate) group_cache: CacheEntryConfig,
+    pub(crate) group_cache_store: Option<Arc<dyn CacheStore>>,
+    pub(crate) recent_messages_enabled: bool,
+    pub(crate) sent_message_ttl_secs: u64,
+    pub(crate) msg_secret_policy: MsgSecretPolicy,
+    pub(crate) msg_secret_retention: MsgSecretRetention,
+    pub(crate) seed_msg_secrets_from_history: bool,
+    pub(crate) original_message_resolver: Option<Arc<dyn OriginalMessageResolver>>,
+    pub(crate) msg_secret_resolver_timeout: Duration,
+}
+
+impl From<&CacheConfig> for RuntimeCacheConfig {
+    fn from(config: &CacheConfig) -> Self {
+        Self {
+            group_cache: config.group_cache.clone(),
+            group_cache_store: config.cache_stores.group_cache.clone(),
+            recent_messages_enabled: config.recent_messages.capacity > 0,
+            sent_message_ttl_secs: config.sent_message_ttl_secs,
+            msg_secret_policy: config.msg_secret_policy,
+            msg_secret_retention: config.msg_secret_retention,
+            seed_msg_secrets_from_history: config.seed_msg_secrets_from_history,
+            original_message_resolver: config.original_message_resolver.clone(),
+            msg_secret_resolver_timeout: config.msg_secret_resolver_timeout,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::size_of;
 
     #[test]
     fn lid_pn_cache_default_is_effectively_unbounded() {
@@ -428,5 +466,55 @@ mod tests {
             u64::MAX,
             "lid_pn_cache must be effectively unbounded; capacity-LRU re-introduces the eviction bug at higher thresholds"
         );
+    }
+
+    #[test]
+    fn runtime_config_is_compact() {
+        assert!(
+            size_of::<RuntimeCacheConfig>() * 2 < size_of::<CacheConfig>(),
+            "runtime config {} B must stay well under construction config {} B",
+            size_of::<RuntimeCacheConfig>(),
+            size_of::<CacheConfig>()
+        );
+        assert!(
+            size_of::<RuntimeCacheConfig>() <= 136,
+            "runtime config grew to {} B (budget 136)",
+            size_of::<RuntimeCacheConfig>()
+        );
+    }
+
+    #[test]
+    fn runtime_conversion_keeps_nondefault_settings() {
+        let cfg = CacheConfig {
+            group_cache: CacheEntryConfig::new(Some(Duration::from_secs(60)), 10),
+            recent_messages: CacheEntryConfig::new(Some(Duration::from_secs(300)), 64),
+            sent_message_ttl_secs: 60,
+            msg_secret_policy: MsgSecretPolicy::Full,
+            msg_secret_retention: MsgSecretRetention {
+                text: Duration::from_secs(7 * 86_400),
+                poll_event: Duration::from_secs(7 * 86_400),
+                bot: Duration::from_secs(7 * 86_400),
+            },
+            seed_msg_secrets_from_history: false,
+            msg_secret_resolver_timeout: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let runtime = RuntimeCacheConfig::from(&cfg);
+        assert_eq!(runtime.group_cache.capacity, 10);
+        assert_eq!(runtime.group_cache.timeout, Some(Duration::from_secs(60)));
+        assert!(runtime.recent_messages_enabled);
+        assert_eq!(runtime.sent_message_ttl_secs, 60);
+        assert_eq!(runtime.msg_secret_policy, MsgSecretPolicy::Full);
+        assert_eq!(
+            runtime.msg_secret_retention.text,
+            Duration::from_secs(7 * 86_400)
+        );
+        assert!(!runtime.seed_msg_secrets_from_history);
+        assert_eq!(runtime.msg_secret_resolver_timeout, Duration::from_secs(1));
+        assert!(runtime.group_cache_store.is_none());
+        assert!(runtime.original_message_resolver.is_none());
+
+        let disabled = CacheConfig::default();
+        assert!(!RuntimeCacheConfig::from(&disabled).recent_messages_enabled);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -374,7 +374,9 @@ pub(crate) type SkdmWarmMemoEntry = (
 use wacore::runtime::timeout as rt_timeout;
 use waproto::whatsapp as wa;
 
+#[cfg(test)]
 use crate::cache_config::CacheConfig;
+use crate::cache_config::RuntimeCacheConfig;
 use crate::socket::{NoiseSocket, SocketError, error::EncryptSendError};
 use crate::sync_task::MajorSyncTask;
 use wacore::runtime::Runtime;
@@ -2034,9 +2036,9 @@ pub struct Client {
     /// Clamped to the protocol-safe range at upload time.
     pub(crate) wanted_pre_key_count: AtomicUsize,
 
-    /// Cache configuration for TTL and capacity of all caches.
+    /// Runtime subset of the construction [`crate::cache_config::CacheConfig`].
     /// Stored for use by lazily-initialized caches (group_cache).
-    pub(crate) cache_config: CacheConfig,
+    pub(crate) cache_config: RuntimeCacheConfig,
 
     /// Weak self-reference for spawning background tasks from `&self` methods.
     /// Initialized after `Arc::new(this)` in the constructor.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -20,7 +20,7 @@ impl Client {
             Arc::new(
                 self.cache_config
                     .group_cache
-                    .build_typed_ttl(self.cache_config.cache_stores.group_cache.clone(), "group"),
+                    .build_typed_ttl(self.cache_config.group_cache_store.clone(), "group"),
             )
         })
     }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1,6 +1,7 @@
 //! Client construction and connection lifecycle: connect, run, reconnect, shutdown.
 
 use super::*;
+use crate::cache_config::CacheConfig;
 use wacore::net::DisconnectReason;
 
 /// Why [`Client::run`] stopped supervising the session.
@@ -483,6 +484,7 @@ impl Client {
         let device_topology = device_topology::DeviceTopology::new();
         let sent_frame_tap = Arc::new(SentFrameTap::new(core.event_bus.clone()));
         let stream_waiter_count = Arc::new(AtomicUsize::new(0));
+        let runtime_cache_config = RuntimeCacheConfig::from(&cache_config);
         let this = Self {
             runtime: runtime.clone(),
             core,
@@ -704,7 +706,7 @@ impl Client {
             ab_props_fetch: AtomicBool::new(true),
             automatic_presence: AtomicBool::new(true),
             wanted_pre_key_count: AtomicUsize::new(crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT),
-            cache_config,
+            cache_config: runtime_cache_config,
             self_weak: std::sync::OnceLock::new(),
             saver_handle: std::sync::OnceLock::new(),
             alloc_meter: std::sync::OnceLock::new(),

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -274,7 +274,7 @@ impl Client {
     /// Look up and consume a message by exact `ChatMessageId` (L1 cache then DB).
     async fn try_take_by_key(&self, key: &ChatMessageId) -> Option<wa::Message> {
         let chat_str = key.chat.to_string();
-        let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
+        let has_l1_cache = self.cache_config.recent_messages_enabled;
 
         // L1 cache check (if capacity > 0)
         if has_l1_cache && let Some(bytes) = self.recent_messages.remove(key).await {
@@ -369,7 +369,7 @@ impl Client {
     /// (capacity 0) or misses; the DB is intentionally not read here so the caller
     /// can fall back to the consuming take + re-add path.
     async fn peek_by_key(&self, key: &ChatMessageId) -> Option<wa::Message> {
-        if self.cache_config.recent_messages.capacity == 0 {
+        if !self.cache_config.recent_messages_enabled {
             return None;
         }
         let bytes = self.recent_messages.get(key).await?;
@@ -415,7 +415,7 @@ impl Client {
         &self,
         key: &ChatMessageId,
     ) -> Option<std::sync::Arc<Vec<u8>>> {
-        if self.cache_config.recent_messages.capacity > 0
+        if self.cache_config.recent_messages_enabled
             && let Some(bytes) = self.recent_messages.get(key).await
         {
             return Some(bytes);
@@ -453,7 +453,7 @@ impl Client {
     ) {
         let shared =
             encoded.unwrap_or_else(|| std::sync::Arc::new(waproto::codec::message_to_vec(msg)));
-        let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
+        let has_l1_cache = self.cache_config.recent_messages_enabled;
 
         if has_l1_cache {
             // L1 cache serves reads immediately; DB write can be backgrounded.
@@ -515,7 +515,7 @@ mod tests {
         runtime.block_on(async {
             for cancel_before_query in [true, false] {
                 let client = create_test_client().await;
-                assert_eq!(client.cache_config.recent_messages.capacity, 0);
+                assert!(!client.cache_config.recent_messages_enabled);
                 let chat: Jid = "120363000000000001@g.us".parse().unwrap();
                 let backend = client.persistence_manager.backend();
                 let payload = b"\x0a\x05hello";

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3569,6 +3569,110 @@ async fn test_custom_cache_config_is_respected() {
 }
 
 #[tokio::test]
+async fn runtime_cache_config_propagates_nondefault_settings() {
+    use crate::cache_config::{CacheEntryConfig, CacheStores, MsgSecretPolicy, MsgSecretRetention};
+    use std::time::Duration;
+
+    struct StubStore;
+    #[async_trait::async_trait]
+    impl crate::cache_store::CacheStore for StubStore {
+        async fn get(&self, _: &str, _: &str) -> Result<Option<Vec<u8>>> {
+            Ok(None)
+        }
+        async fn set(&self, _: &str, _: &str, _: &[u8], _: Option<Duration>) -> Result<()> {
+            Ok(())
+        }
+        async fn delete(&self, _: &str, _: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn clear(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct StubResolver;
+    #[async_trait::async_trait]
+    impl crate::cache_config::OriginalMessageResolver for StubResolver {
+        async fn resolve_msg_secret(&self, _: &str, _: &str, _: &str) -> Option<[u8; 32]> {
+            Some([0xABu8; 32])
+        }
+    }
+
+    let store: Arc<dyn crate::cache_store::CacheStore> = Arc::new(StubStore);
+    let resolver: Arc<dyn crate::cache_config::OriginalMessageResolver> = Arc::new(StubResolver);
+    let config = CacheConfig {
+        group_cache: CacheEntryConfig::new(Some(Duration::from_secs(60)), 10),
+        recent_messages: CacheEntryConfig::new(Some(Duration::from_secs(300)), 64),
+        sent_message_ttl_secs: 60,
+        msg_secret_policy: MsgSecretPolicy::Full,
+        msg_secret_retention: MsgSecretRetention {
+            text: Duration::from_secs(7 * 86_400),
+            poll_event: Duration::from_secs(7 * 86_400),
+            bot: Duration::from_secs(7 * 86_400),
+        },
+        seed_msg_secrets_from_history: false,
+        original_message_resolver: Some(Arc::clone(&resolver)),
+        msg_secret_resolver_timeout: Duration::from_secs(1),
+        cache_stores: CacheStores {
+            group_cache: Some(Arc::clone(&store)),
+            ..Default::default()
+        },
+        ..CacheConfig::default()
+    };
+    let client = crate::test_utils::create_test_client_with_config(
+        "runtime_config_propagates",
+        Arc::new(MockHttpClient),
+        config,
+    )
+    .await;
+
+    assert_eq!(client.cache_config.group_cache.capacity, 10);
+    assert_eq!(
+        client.cache_config.group_cache.timeout,
+        Some(Duration::from_secs(60))
+    );
+    assert!(
+        client.cache_config.group_cache_store.is_some(),
+        "custom group-cache store must be retained for lazy init"
+    );
+    assert!(client.cache_config.recent_messages_enabled);
+    assert_eq!(client.cache_config.sent_message_ttl_secs, 60);
+    assert_eq!(client.cache_config.msg_secret_policy, MsgSecretPolicy::Full);
+    assert_eq!(
+        client.cache_config.msg_secret_retention.text,
+        Duration::from_secs(7 * 86_400)
+    );
+    assert!(!client.cache_config.seed_msg_secrets_from_history);
+    assert!(client.cache_config.original_message_resolver.is_some());
+    assert_eq!(
+        client.cache_config.msg_secret_resolver_timeout,
+        Duration::from_secs(1)
+    );
+    // Lazy init must reuse the retained store, not build a local cache.
+    let _ = client.get_group_cache();
+    assert!(client.group_cache.get().is_some());
+}
+
+#[tokio::test]
+async fn runtime_cache_config_honors_disabled_recent_cache() {
+    let client = crate::test_utils::create_test_client_with_config(
+        "runtime_config_recent_disabled",
+        Arc::new(MockHttpClient),
+        CacheConfig::default(),
+    )
+    .await;
+    assert!(
+        !client.cache_config.recent_messages_enabled,
+        "default capacity 0 must surface as disabled"
+    );
+    let chat: Jid = "120363000000000099@g.us".parse().unwrap();
+    assert!(
+        client.peek_recent_message(&chat, "MISSING").await.is_none(),
+        "disabled L1 must fall through to the DB miss path"
+    );
+}
+
+#[tokio::test]
 async fn held_group_distribution_lane_survives_capacity_pressure() {
     let config = CacheConfig {
         group_distribution_locks_capacity: 1,

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -26,7 +26,7 @@ struct HistorySecretSeedConfig {
 }
 
 impl HistorySecretSeedConfig {
-    fn snapshot(config: &crate::cache_config::CacheConfig) -> Self {
+    fn snapshot(config: &crate::cache_config::RuntimeCacheConfig) -> Self {
         Self {
             enabled: config.seed_msg_secrets_from_history,
             policy: config.msg_secret_policy,


### PR DESCRIPTION
## Summary

Client now keeps RuntimeCacheConfig (136B) instead of the full CacheConfig (456B), which saves 320B per client at the struct level. Builders still accept the full CacheConfig, so no call site changes.

## Changes

Port of the reviewed optimization onto current main. Only these files change.

- src/cache_config.rs
- src/client.rs
- src/client/accessors.rs
- src/client/lifecycle.rs
- src/client/sender_keys.rs
- src/client/tests.rs
- src/history_sync.rs

## Validation

- cargo fmt --all -- --check is clean
- cargo nextest run -p whatsapp-rust --lib passes, 1991 passed and 2 skipped, including nondefault propagation coverage
- cargo clippy -p whatsapp-rust --all-targets -- -D warnings is clean

One full test run showed a single flake in online_device_sync_releases_its_dedup_entry. It passed alone and both full reruns passed with no code change.

## Limits

- Whole Client padding is unmeasured, so the struct level delta is the only size claim here.
- There is no ptr_eq or strong_count drop timing test for the retained config.

This branch is independent of the stale opt/runtime-config worktree. It carries only the 7 optimization files rebased onto origin/main.