### PR TITLE
fix(voip): send the engine video capability in 1:1 video offers

### DIFF
--- a/tools/oracle-core/tests/video_offer.rs
+++ b/tools/oracle-core/tests/video_offer.rs
@@ -9,7 +9,7 @@ mod common;
 use anyhow::{Context, Result};
 use oracle_core::{Runtime, ThreadPolicy, Value};
 use sha2::{Digest, Sha256};
-use wacore::stanza::call::{OfferDeviceKey, OfferParams, build_offer};
+use wacore::stanza::call::{CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, build_offer};
 use wacore_binary::jid::Server;
 use wacore_binary::node::NodeContent;
 use wacore_binary::{Jid, marshal};
@@ -138,7 +138,7 @@ fn video_offer_matches_the_vendor_engine() -> Result<()> {
             enc_type: "pkmsg".to_string(),
         }],
         privacy_token: Some(&[0xa5; 32]),
-        capability: Some(&[0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x53]),
+        capability: Some(&CAPABILITY_VIDEO_OFFER),
         device_identity: None,
         id: Some("1"),
         multi_device: false,
@@ -173,6 +173,26 @@ fn video_offer_matches_the_vendor_engine() -> Result<()> {
             "builder drift on video {name}"
         );
     }
+    let engine_cap = children
+        .iter()
+        .find(|child| child.tag == "capability")
+        .context("engine capability")?;
+    let rust_cap = match &rust_offer.content {
+        Some(NodeContent::Nodes(inner)) => inner
+            .iter()
+            .find(|child| child.tag == "capability")
+            .context("rust capability child")?,
+        _ => anyhow::bail!("rust offer has no children"),
+    };
+    let rust_cap_bytes = match &rust_cap.content {
+        Some(NodeContent::Bytes(bytes)) => bytes.clone(),
+        _ => anyhow::bail!("rust capability has no bytes"),
+    };
+    assert_eq!(
+        Some(rust_cap_bytes.as_slice()),
+        engine_cap.content_bytes(),
+        "builder drift on video offer capability"
+    );
     eprintln!("executed JgwtTQVeWPm.wasm video offer: engine and builder agree on zero screens");
     Ok(())
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -493,10 +493,13 @@ pub const CAPABILITY_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13]
 pub const CAPABILITY_PREACCEPT: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07];
 /// Legacy offer order observed on WhatsApp Web.
 pub const DEFAULT_AUDIO_RATES: &[&str] = &["8000", "16000"];
-/// Capability blob a client places in a VIDEO `<offer>`: byte 5 is `0xfa` (video) vs the audio
-/// `0xbb`. Observed in a real from-start video offer. A video CALLEE preaccepts with [`CAPABILITY_OFFER`]
-/// (`0xbb`), not this.
-pub const CAPABILITY_VIDEO_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13];
+/// Capability blob a client places in a VIDEO `<offer>`, byte-matching the captured J engine driven
+/// with the video flag set (`JgwtTQVeWPm.wasm`, `video_offer_matches_the_vendor_engine`). The `0xfa`
+/// byte 5 seen in one early capture belongs to another platform's offer and must not be sent here:
+/// against Android it left callees answering a call whose video never rendered, while every flow
+/// that renders — our own video preaccepts, audio offers, and the engine's audio and video offers —
+/// stays in the `0xbb` family. A video CALLEE preaccepts with [`CAPABILITY_OFFER`], not this.
+pub const CAPABILITY_VIDEO_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x53];
 
 /// Capability index for `use_mlow_codec_v1`.
 ///
@@ -932,7 +935,7 @@ fn capability_node(blob: &[u8]) -> Node {
 
 /// `<preaccept>`: audio → \[video\] → encopt → capability. `id` is the random call-wrapper id. A video
 /// callee advertises the `<video>` decoder here; the default capability stays the `0xbb`
-/// [`CAPABILITY_OFFER`] blob (the `0xfa` variant is the caller's offer).
+/// [`CAPABILITY_OFFER`] blob (a video offer carries [`CAPABILITY_VIDEO_OFFER`]).
 pub fn build_preaccept(
     call_id: &str,
     to: &Jid,
@@ -2574,7 +2577,7 @@ mod tests {
             video.attrs().optional_string("screen_width").as_deref(),
             Some("0")
         );
-        // A video callee preaccepts with the 0xbb CAPABILITY_OFFER blob, not the 0xfa offer blob.
+        // A video callee preaccepts with the 0xbb CAPABILITY_OFFER blob, not the video offer blob.
         let cap = action.get_optional_child("capability").unwrap();
         assert_eq!(cap.content_bytes().unwrap(), &CAPABILITY_OFFER);
 


### PR DESCRIPTION
1:1 video offers carried capability fa13 while the captured J engine emits bb53 for video=true, confirmed by extending video_offer_matches_the_vendor_engine to compare capability bytes (red: fa13 vs bb53, green after this change). fa13 clears bit 24 that every rendering flow sets: our own video preaccepts, audio offers, and the engine's audio and video offers. Its provenance was an unknown-platform capture; the engine is the reference. Call-link and group video paths inherit the same blob.