### PR TITLE
perf(cache): release dedup table buckets when it empties

### DIFF
--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -1820,7 +1820,15 @@ mod tests {
             shrunk < grown,
             "empty table must release its buckets: {grown} -> {shrunk}"
         );
+        assert_eq!(
+            shrunk, 0,
+            "empty table must release all buckets: {grown} -> {shrunk}"
+        );
         let shrunk_bytes = cache.memory_stats(|_, _| 0).bytes;
+        assert_eq!(
+            shrunk_bytes, 0,
+            "empty table must retain no structural bytes"
+        );
         eprintln!(
             "dedup shrink: {grown} -> {shrunk} buckets, {grown_bytes} -> {shrunk_bytes} structural bytes (cold fill took {cold_fill:?})"
         );

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -1799,7 +1799,7 @@ mod tests {
     fn empty_dedup_table_releases_its_buckets_and_serves_the_next_burst() {
         const BURST: u32 = 4_000;
         let cache = SyncTtlCache::new(u64::from(BURST) * 4, None);
-        let cold_start = std::time::Instant::now();
+        let cold_start = Instant::now();
         for key in 0..BURST {
             cache.insert(key, key);
         }
@@ -1833,7 +1833,7 @@ mod tests {
             "dedup shrink: {grown} -> {shrunk} buckets, {grown_bytes} -> {shrunk_bytes} structural bytes (cold fill took {cold_fill:?})"
         );
 
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         for key in 0..BURST {
             cache.insert(key, key);
         }

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -448,6 +448,7 @@ impl<K: Hash + Eq + Clone, V> SyncTtlGuard<'_, K, V> {
                 .is_some_and(|ttl| self.now.saturating_duration_since(entry.inserted_at) >= ttl)
         }) {
             self.inner.remove_key(key);
+            self.inner.shrink_if_empty();
         }
         self.inner.get_mut(key).map(|entry| {
             entry
@@ -470,6 +471,7 @@ impl<K: Hash + Eq + Clone, V> SyncTtlGuard<'_, K, V> {
 
     pub(crate) fn remove(&mut self, key: &K) {
         self.inner.remove_key(key);
+        self.inner.shrink_if_empty();
     }
 
     pub(crate) fn find_unique_key(&self, matches: impl Fn(&K, &V) -> bool) -> Option<K> {
@@ -573,10 +575,22 @@ impl<K: Hash + Eq + Clone, V: Clone> SyncTtlCache<K, V> {
         for key in expired {
             inner.remove_key(&key);
         }
+        inner.shrink_if_empty();
     }
 
     pub(crate) fn entry_count(&self) -> u64 {
         self.inner.lock().unwrap_or_else(|p| p.into_inner()).len() as u64
+    }
+
+    /// Hash-table buckets currently allocated. Test-only: lets the
+    /// shrink-on-empty test observe the table itself, not just entry counts.
+    #[cfg(test)]
+    pub(crate) fn table_capacity(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .table
+            .capacity()
     }
 }
 
@@ -649,6 +663,21 @@ where
     fn clear(&mut self) {
         self.table.clear();
         self.order.clear();
+    }
+
+    /// Release the slot table's buckets once it holds nothing.
+    ///
+    /// Called only from the synchronous TTL cache (the dispatch-once dedup
+    /// table): hashbrown never shrinks on remove, so a burst that grew the
+    /// table to thousands of buckets kept them with zero entries until the
+    /// next burst. The threshold is empty, not a low-water mark: any
+    /// non-empty table may regrow on the very next insert, paying a realloc
+    /// per dip, while an empty table serves no lookup and frees one
+    /// allocation with no entries to rehash.
+    fn shrink_if_empty(&mut self) {
+        if self.table.is_empty() {
+            self.table.shrink_to(0, |slot| slot.hash);
+        }
     }
 
     /// Borrowed removal: the `order` side is keyed by the entry's own `seq`,
@@ -1764,6 +1793,50 @@ mod tests {
         disabled.insert(1, 1);
         assert_eq!(disabled.get(&1), None);
         assert_eq!(disabled.entry_count(), 0);
+    }
+
+    #[test]
+    fn empty_dedup_table_releases_its_buckets_and_serves_the_next_burst() {
+        const BURST: u32 = 4_000;
+        let cache = SyncTtlCache::new(u64::from(BURST) * 4, None);
+        let cold_start = std::time::Instant::now();
+        for key in 0..BURST {
+            cache.insert(key, key);
+        }
+        let cold_fill = cold_start.elapsed();
+        let grown = cache.table_capacity();
+        assert!(
+            grown >= 4096,
+            "churn must grow the table to production size, got {grown} buckets"
+        );
+        let grown_bytes = cache.memory_stats(|_, _| 0).bytes;
+
+        for key in 0..BURST {
+            cache.with(|guard| guard.remove(&key));
+        }
+        assert_eq!(cache.entry_count(), 0);
+        let shrunk = cache.table_capacity();
+        assert!(
+            shrunk < grown,
+            "empty table must release its buckets: {grown} -> {shrunk}"
+        );
+        let shrunk_bytes = cache.memory_stats(|_, _| 0).bytes;
+        eprintln!(
+            "dedup shrink: {grown} -> {shrunk} buckets, {grown_bytes} -> {shrunk_bytes} structural bytes (cold fill took {cold_fill:?})"
+        );
+
+        let start = std::time::Instant::now();
+        for key in 0..BURST {
+            cache.insert(key, key);
+        }
+        let regrow_fill = start.elapsed();
+        for key in 0..BURST {
+            assert_eq!(cache.get(&key), Some(key));
+        }
+        eprintln!(
+            "dedup regrow: {BURST} inserts in {regrow_fill:?} (cold fill took {cold_fill:?})"
+        );
+        assert_eq!(cache.entry_count(), u64::from(BURST));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Shrink the dispatch-once dedup table when it empties.

The dispatch gate (`dispatched_messages: SyncTtlCache` in `src/portable_cache.rs`)
backs onto a hashbrown `HashTable` that never shrinks on remove. A burst that
grew the table kept thousands of buckets with zero entries until the next
burst, so the long-term memory slope kept the churn peak forever.

Change: `CacheInner::shrink_if_empty` calls `shrink_to(0)` gated on `len == 0`,
wired into the three sync-TTL removal paths (expiry `get`, `remove`, expiry
sweep). The threshold is empty on purpose, not a low-water mark: any non-empty
table can regrow on the next insert and would pay a realloc per dip, while an
empty table serves no lookup and frees one allocation with no entries to
rehash. `insert`/`get` hot paths are untouched; blast radius is the sync TTL
cache only.

Test: `empty_dedup_table_releases_its_buckets_and_serves_the_next_burst`
churns 4,000 entries, drains, asserts the buckets shrank, then re-bursts and
asserts every key reads back.

Measured (u32/u32 slots; production `DispatchKey`/`DispatchClaim` slots are
larger, so real savings are bigger):

- Memory: 7,168 buckets / 401,408 structural bytes retained at 0 entries
  before, 0 buckets / 0 bytes after.
- Regrowth: 4,000-insert burst after shrink 8.9 ms vs 9.5 ms cold fill.
  Regrowth costs nothing beyond a normal fill.
- `client_receive` bench A/B medians at parity within run noise
  (group_receive 49.18 -> 47.43 us, group burst 2.513 -> 2.554 ms,
  worker_hot 2.555 -> 2.274 ms).

Validation: portable_cache 54/54, message 333/333, session 126/126 via
nextest; clippy clean. Pipeline validation was skipped per captain's
direction; review and CI happen here.
