### PR TITLE
test(client): pin non-group cache store lifetime

### DIFF
--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -275,3 +275,17 @@ where
         }
     }
 }
+
+impl<K, V> TypedCache<K, V> {
+    /// Test-only clone of the backing custom store, for pinning the store
+    /// lifetime: `assemble` must leave non-group stores owned solely by their
+    /// live caches, so `Arc::ptr_eq` + `strong_count` catch a future refactor
+    /// that pins another `Arc` elsewhere.
+    #[cfg(test)]
+    pub(crate) fn custom_store_for_tests(&self) -> Option<Arc<dyn CacheStore>> {
+        match &self.inner {
+            Inner::Local(_) => None,
+            Inner::Custom { store, .. } => Some(Arc::clone(store)),
+        }
+    }
+}

--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -277,10 +277,7 @@ where
 }
 
 impl<K, V> TypedCache<K, V> {
-    /// Test-only clone of the backing custom store, for pinning the store
-    /// lifetime: `assemble` must leave non-group stores owned solely by their
-    /// live caches, so `Arc::ptr_eq` + `strong_count` catch a future refactor
-    /// that pins another `Arc` elsewhere.
+    /// Test-only clone of the backing custom store (`None` for the in-process backend).
     #[cfg(test)]
     pub(crate) fn custom_store_for_tests(&self) -> Option<Arc<dyn CacheStore>> {
         match &self.inner {

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -251,6 +251,15 @@ impl DeviceRegistryCache {
         self.cache.run_pending_tasks().await;
     }
 
+    /// Test-only clone of the backing custom store, for pinning the
+    /// `assemble` store lifetime via `Arc::ptr_eq` + `strong_count`.
+    #[cfg(test)]
+    pub(crate) fn custom_store_for_tests(
+        &self,
+    ) -> Option<Arc<dyn wacore::store::cache::CacheStore>> {
+        self.cache.custom_store_for_tests()
+    }
+
     /// Test-only raw write that bypasses topology recording, for fixture
     /// seeding and for proving that memo hits really are hits (a raw change
     /// must be served stale).

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -251,8 +251,7 @@ impl DeviceRegistryCache {
         self.cache.run_pending_tasks().await;
     }
 
-    /// Test-only clone of the backing custom store, for pinning the
-    /// `assemble` store lifetime via `Arc::ptr_eq` + `strong_count`.
+    /// Test-only clone of the backing custom store.
     #[cfg(test)]
     pub(crate) fn custom_store_for_tests(
         &self,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3673,6 +3673,101 @@ async fn runtime_cache_config_honors_disabled_recent_cache() {
 }
 
 #[tokio::test]
+async fn non_group_cache_stores_are_owned_by_live_caches_only() {
+    use crate::cache_config::CacheStores;
+    use std::time::Duration;
+
+    struct StubStore;
+    #[async_trait::async_trait]
+    impl crate::cache_store::CacheStore for StubStore {
+        async fn get(&self, _: &str, _: &str) -> Result<Option<Vec<u8>>> {
+            Ok(None)
+        }
+        async fn set(&self, _: &str, _: &str, _: &[u8], _: Option<Duration>) -> Result<()> {
+            Ok(())
+        }
+        async fn delete(&self, _: &str, _: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn clear(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    let lid_store: Arc<dyn crate::cache_store::CacheStore> = Arc::new(StubStore);
+    let registry_store: Arc<dyn crate::cache_store::CacheStore> = Arc::new(StubStore);
+    let group_store: Arc<dyn crate::cache_store::CacheStore> = Arc::new(StubStore);
+    let config = CacheConfig {
+        cache_stores: CacheStores {
+            group_cache: Some(Arc::clone(&group_store)),
+            device_registry_cache: Some(Arc::clone(&registry_store)),
+            lid_pn_cache: Some(Arc::clone(&lid_store)),
+        },
+        ..CacheConfig::default()
+    };
+    let client = crate::test_utils::create_test_client_with_config(
+        "non_group_store_lifetime",
+        Arc::new(MockHttpClient),
+        config,
+    )
+    .await;
+
+    // Device-registry store: the live cache keeps the same allocation, and the
+    // construction config must not pin a second Arc (count drops to held + cache).
+    let retained_registry = client
+        .device_registry_cache
+        .custom_store_for_tests()
+        .expect("device-registry cache must retain its custom store");
+    assert!(
+        Arc::ptr_eq(&registry_store, &retained_registry),
+        "device-registry cache must reuse the configured store allocation"
+    );
+    drop(retained_registry);
+    assert_eq!(
+        Arc::strong_count(&registry_store),
+        2,
+        "device-registry store must be owned by the test handle plus the live cache only"
+    );
+
+    // LID-PN store: both direction maps share the same allocation, same drop rule.
+    let retained_lid = client.lid_pn_cache.custom_stores_for_tests();
+    assert_eq!(
+        retained_lid.len(),
+        2,
+        "LID-PN cache must back both direction maps with the custom store"
+    );
+    for store in &retained_lid {
+        assert!(
+            Arc::ptr_eq(&lid_store, store),
+            "LID-PN cache must reuse the configured store allocation"
+        );
+    }
+    drop(retained_lid);
+    assert_eq!(
+        Arc::strong_count(&lid_store),
+        3,
+        "LID-PN store must be owned by the test handle plus the two live direction maps only"
+    );
+
+    // Control: the group store stays pinned by the runtime config for lazy init.
+    let retained_group = client
+        .cache_config
+        .group_cache_store
+        .clone()
+        .expect("group-cache store must be retained for lazy init");
+    assert!(
+        Arc::ptr_eq(&group_store, &retained_group),
+        "group cache must reuse the configured store allocation"
+    );
+    drop(retained_group);
+    assert_eq!(
+        Arc::strong_count(&group_store),
+        2,
+        "group store must be owned by the test handle plus the runtime config only"
+    );
+}
+
+#[tokio::test]
 async fn held_group_distribution_lane_survives_capacity_pressure() {
     let config = CacheConfig {
         group_distribution_locks_capacity: 1,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3712,8 +3712,8 @@ async fn non_group_cache_stores_are_owned_by_live_caches_only() {
     )
     .await;
 
-    // Device-registry store: the live cache keeps the same allocation, and the
-    // construction config must not pin a second Arc (count drops to held + cache).
+    // Device-registry store: same allocation, held once by the test plus once
+    // by the live cache.
     let retained_registry = client
         .device_registry_cache
         .custom_store_for_tests()
@@ -3729,7 +3729,8 @@ async fn non_group_cache_stores_are_owned_by_live_caches_only() {
         "device-registry store must be owned by the test handle plus the live cache only"
     );
 
-    // LID-PN store: both direction maps share the same allocation, same drop rule.
+    // LID-PN store: same allocation in both direction maps, held once by the
+    // test plus twice by the cache.
     let retained_lid = client.lid_pn_cache.custom_stores_for_tests();
     assert_eq!(
         retained_lid.len(),

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -173,6 +173,19 @@ impl LidPnCache {
         }
     }
 
+    /// Test-only clones of the backing custom stores (one per direction map),
+    /// for pinning the `assemble` store lifetime via `Arc::ptr_eq`.
+    #[cfg(test)]
+    pub(crate) fn custom_stores_for_tests(&self) -> Vec<Arc<dyn wacore::store::CacheStore>> {
+        [
+            self.lid_to_entry.custom_store_for_tests(),
+            self.pn_to_entry.custom_store_for_tests(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+
     /// Approximate entry counts plus estimated retained bytes for the LID and
     /// PN maps. Bytes are `0` when backed by a custom store (entries live
     /// outside this process).

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -173,8 +173,7 @@ impl LidPnCache {
         }
     }
 
-    /// Test-only clones of the backing custom stores (one per direction map),
-    /// for pinning the `assemble` store lifetime via `Arc::ptr_eq`.
+    /// Test-only clones of the backing custom stores, one per direction map.
     #[cfg(test)]
     pub(crate) fn custom_stores_for_tests(&self) -> Vec<Arc<dyn wacore::store::CacheStore>> {
         [


### PR DESCRIPTION
Locks the store lifetime from #1482: non-group stores (device-registry, LID-PN) drop at the end of assemble, retained only by their live caches, while the group store stays pinned by the runtime config for lazy init.

Adds non_group_cache_stores_are_owned_by_live_caches_only, which holds each store Arc through client construction and asserts the live caches retain the same allocation via Arc::ptr_eq with the expected Arc::strong_count (registry 2, LID-PN 3 across both direction maps, group 2 as control), so a future refactor cannot silently re-pin the stores. No behavior change.

Test-only accessors added on TypedCache, LidPnCache, and DeviceRegistryCache. Verified locally: full whatsapp-rust lib suite green (2051 passed), clippy and fmt clean.