### PR TITLE
perf(logging): shrink demo logger scratch buffers after idle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,6 @@ version = "0.0.0"
 dependencies = [
  "codspeed-divan-compat",
  "e2e-tests",
- "env_logger",
  "tokio",
  "whatsapp-rust",
 ]
@@ -5804,7 +5803,6 @@ dependencies = [
  "async-channel",
  "bytes",
  "cpal",
- "env_logger",
  "hex",
  "log",
  "portable-atomic",

--- a/examples/alloc_tracking.rs
+++ b/examples/alloc_tracking.rs
@@ -57,7 +57,10 @@ unsafe impl GlobalAlloc for AttributingAllocator {
 static GLOBAL: AttributingAllocator = AttributingAllocator;
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("info"),
+    )
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -104,19 +104,21 @@ fn resolve_benchmark_endpoint_from_env() -> BenchmarkEndpoint {
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(
-                buf,
-                "{} [{:<5}] [{}] - {}",
-                wacore::time::now_utc().format("%H:%M:%S"),
-                record.level(),
-                record.target(),
-                record.args()
-            )
-        })
-        .init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("warn"),
+    )
+    .format(|buf, record| {
+        use std::io::Write;
+        writeln!(
+            buf,
+            "{} [{:<5}] [{}] - {}",
+            wacore::time::now_utc().format("%H:%M:%S"),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    })
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -32,19 +32,21 @@ fn main() {
         }
         eprintln!("Will use pair code authentication (concurrent with QR)");
     }
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .format(|buf, record| {
-            use std::io::Write;
-            writeln!(
-                buf,
-                "{} [{:<5}] [{}] - {}",
-                wacore::time::now_utc().format("%H:%M:%S"),
-                record.level(),
-                record.target(),
-                record.args()
-            )
-        })
-        .init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("info"),
+    )
+    .format(|buf, record| {
+        use std::io::Write;
+        writeln!(
+            buf,
+            "{} [{:<5}] [{}] - {}",
+            wacore::time::now_utc().format("%H:%M:%S"),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    })
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -169,7 +169,10 @@ impl InboundDurabilityHook for InboxArchiver {
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("info"),
+    )
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/multi_session_metrics.rs
+++ b/examples/multi_session_metrics.rs
@@ -79,7 +79,10 @@ async fn print_session_metrics(label: &str, client: &Arc<Client>, cpu: &CpuMeter
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("info"),
+    )
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/retry_quarantine.rs
+++ b/examples/retry_quarantine.rs
@@ -126,7 +126,10 @@ impl RetryAdmission for RetryQuarantine {
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default().default_filter_or("info"),
+    )
+    .init();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/voip-cli/Cargo.toml
+++ b/examples/voip-cli/Cargo.toml
@@ -21,7 +21,6 @@ anyhow = { workspace = true }
 async-channel = { workspace = true }
 bytes = { workspace = true }
 cpal = "0.18"
-env_logger = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
 portable-atomic = { workspace = true }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -166,8 +166,9 @@ async fn main() -> Result<()> {
     // packets on net_conn: Alert is Fatal or Close Notify"), which is benign teardown noise: the
     // call already ended via <terminate> and the disconnect is surfaced through CallEvent. Quiet
     // those crates to error so the demo output stays clean; RUST_LOG still overrides this.
-    env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info,webrtc_sctp=error,webrtc_dtls=error"),
+    whatsapp_rust::logging::Builder::from_env(
+        whatsapp_rust::logging::Env::default()
+            .default_filter_or("info,webrtc_sctp=error,webrtc_dtls=error"),
     )
     .format(move |buf, record| {
         use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ pub use handlers::chatstate::ChatStateEvent;
 pub mod handshake;
 pub mod jid_utils;
 pub mod keepalive;
+pub mod logging;
 pub mod mediaconn;
 pub mod message;
 pub(crate) mod msg_secret_buffer;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -341,12 +341,17 @@ impl Builder {
                 Ok(())
             }
             Err(_) => {
-                match log::set_logger(&REJECTED) {
-                    Ok(()) => panic!(
-                        "logging::try_init found no installed logger after a rejected install"
-                    ),
-                    Err(e) => Err(e),
-                }
+                // The slot is full but the winning thread may not have reached
+                // `log::set_logger` yet. Register the slot value so a racy
+                // loser completes the winner's install instead of failing
+                // against a logger that is not installed yet; when a logger
+                // really is installed this fails the same clean way.
+                let installed = INSTALLED
+                    .get()
+                    .unwrap_or_else(|| panic!("logging::INSTALLED is full, so it must read back"));
+                log::set_logger(installed)?;
+                log::set_max_level(installed.filter.max_level());
+                Ok(())
             }
         }
     }
@@ -372,25 +377,9 @@ fn emit_to_stderr(bytes: &[u8]) {
 }
 
 /// Slot for the installed logger. `OnceLock::set` hands a rejected logger
-/// back for dropping, so failed `try_init` calls leak nothing.
+/// back for dropping, so failed `try_init` calls leak nothing, and a racy
+/// loser installs the slot value rather than failing spuriously.
 static INSTALLED: OnceLock<Logger> = OnceLock::new();
-
-/// Throwaway logger used only to manufacture the `SetLoggerError` value when
-/// the slot above is already full; registering it always fails, with no
-/// observable effect, because a global logger is installed by then.
-struct Rejected;
-
-impl log::Log for Rejected {
-    fn enabled(&self, _: &Metadata) -> bool {
-        false
-    }
-
-    fn log(&self, _: &Record) {}
-
-    fn flush(&self) {}
-}
-
-static REJECTED: Rejected = Rejected;
 
 /// Logger installed by [`Builder`]. Stateless across records except for the
 /// calling thread's scratch buffer, which shrinks after the idle threshold.
@@ -411,6 +400,10 @@ impl Logger {
                         buf: Vec::new(),
                         last_use: wacore::time::Instant::now(),
                     });
+                    // Establish the empty-buffer invariant on entry: a panic
+                    // inside a format closure or sink would otherwise leave
+                    // stale bytes for the next record to append to.
+                    scratch.buf.clear();
                     if scratch.last_use.elapsed() >= idle_after {
                         scratch.buf.shrink_to_fit();
                     }
@@ -481,10 +474,14 @@ mod tests {
         }
     }
 
-    fn capture_logger(default_filter: &str) -> (Logger, Arc<Mutex<Vec<u8>>>) {
+    fn capture_logger(spec: &str) -> (Logger, Arc<Mutex<Vec<u8>>>) {
         let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
         let sink = Arc::clone(&captured);
-        let mut builder = Builder::from_env(Env::default().default_filter_or(default_filter));
+        // Parse the spec directly instead of routing through `Env`: an
+        // ambient `RUST_LOG` on the test machine must not override the case
+        // under test. `Env` precedence has its own test below.
+        let mut builder = Builder::new();
+        builder.filter = parse_filter(spec);
         let mut logger = builder.build();
         logger.emit = Arc::new(move |bytes: &[u8]| {
             sink.lock()
@@ -631,10 +628,46 @@ mod tests {
 
     #[test]
     fn max_level_covers_configured_directives() {
-        let mut named = Builder::from_env(Env::default().default_filter_or("foo=off"));
+        let mut named = Builder::new();
+        named.filter = parse_filter("foo=off");
         assert_eq!(named.build().filter.max_level(), LevelFilter::Off);
-        let mut global = Builder::from_env(Env::default().default_filter_or("info,foo=off"));
+        let mut global = Builder::new();
+        global.filter = parse_filter("info,foo=off");
         assert_eq!(global.build().filter.max_level(), LevelFilter::Info);
+    }
+
+    #[test]
+    fn env_variable_overrides_the_default() {
+        // Unique variable name so no other test or ambient environment can
+        // observe it; the set/remove pair is scoped to this test.
+        const VAR: &str = "WR_R3_LOGGING_TEST_FILTER";
+        unsafe {
+            std::env::remove_var(VAR);
+        }
+        let unset = Env::default().filter_or(VAR, "info").resolve();
+        assert!(
+            unset.enabled(
+                &Metadata::builder()
+                    .level(log::Level::Info)
+                    .target("app")
+                    .build()
+            )
+        );
+        unsafe {
+            std::env::set_var(VAR, "off");
+        }
+        let set = Env::default().filter_or(VAR, "info").resolve();
+        assert!(
+            !set.enabled(
+                &Metadata::builder()
+                    .level(log::Level::Error)
+                    .target("app")
+                    .build()
+            )
+        );
+        unsafe {
+            std::env::remove_var(VAR);
+        }
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,7 +16,7 @@
 
 use std::cell::RefCell;
 use std::io::{self, Write};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use log::{LevelFilter, Metadata, Record, SetLoggerError};
@@ -87,13 +87,20 @@ impl Write for Formatter<'_> {
 type FormatFn = dyn Fn(&mut Formatter, &Record) -> io::Result<()> + Send + Sync;
 
 fn default_format(buf: &mut Formatter, record: &Record) -> io::Result<()> {
-    writeln!(
-        buf,
-        "[{:<5} {}] {}",
-        record.level(),
-        record.target(),
-        record.args()
-    )
+    write!(buf, "[{:<5} {}] ", record.level(), record.target())?;
+    // Continuation lines indent by four spaces, matching env_logger's default
+    // format exactly. Only this default path does it; custom closures receive
+    // the raw record, exactly as under env_logger.
+    let args = record.args().to_string();
+    let mut first = true;
+    for chunk in args.split('\n') {
+        if !first {
+            write!(buf, "\n    ")?;
+        }
+        buf.write_all(chunk.as_bytes())?;
+        first = false;
+    }
+    writeln!(buf)
 }
 
 #[derive(Debug, Clone)]
@@ -102,20 +109,19 @@ struct Directive {
     level: LevelFilter,
 }
 
+/// Parsed filter: target directives plus the optional `/substring` message
+/// filter. Semantics mirror `env_filter` (the crate `env_logger` parses
+/// through here): a bare word that is not a level means `name=trace`, matching
+/// is a plain prefix so `Client` covers the crate's `Client/...` targets, the
+/// longest name wins, and an unmatched target is disabled rather than falling
+/// back to a global level.
 #[derive(Debug, Clone)]
 struct Filter {
     directives: Vec<Directive>,
+    message: Option<String>,
 }
 
 impl Filter {
-    fn global_default(&self) -> LevelFilter {
-        self.directives
-            .iter()
-            .rev()
-            .find_map(|d| d.name.is_none().then_some(d.level))
-            .unwrap_or(LevelFilter::Error)
-    }
-
     fn max_level(&self) -> LevelFilter {
         self.directives
             .iter()
@@ -126,28 +132,37 @@ impl Filter {
 
     fn enabled(&self, metadata: &Metadata) -> bool {
         let target = metadata.target();
-        let mut matched: Option<(usize, LevelFilter)> = None;
-        for directive in &self.directives {
-            if let Some(name) = &directive.name
-                && target_matches(target, name)
-                && matched.is_none_or(|(len, _)| name.len() > len)
-            {
-                matched = Some((name.len(), directive.level));
+        // Directives sort ascending by name length at build, so the reverse
+        // scan meets the longest name first, with bare levels as the fallback.
+        for directive in self.directives.iter().rev() {
+            match &directive.name {
+                Some(name) if !target.starts_with(name) => {}
+                _ => return metadata.level() <= directive.level,
             }
         }
-        metadata.level() <= matched.map_or_else(|| self.global_default(), |(_, level)| level)
+        false
+    }
+
+    fn matches(&self, record: &Record) -> bool {
+        if !self.enabled(record.metadata()) {
+            return false;
+        }
+        if let Some(needle) = &self.message
+            && !record.args().to_string().contains(needle)
+        {
+            return false;
+        }
+        true
     }
 }
 
-fn target_matches(target: &str, name: &str) -> bool {
-    target == name
-        || target
-            .strip_prefix(name)
-            .is_some_and(|rest| rest.starts_with("::"))
-}
-
-fn parse_directives(spec: &str) -> Vec<Directive> {
-    spec.split(',')
+fn parse_filter(spec: &str) -> Filter {
+    let (mods, message) = match spec.split_once('/') {
+        Some((mods, message)) => (mods, Some(message.to_string())),
+        None => (spec, None),
+    };
+    let mut directives: Vec<Directive> = mods
+        .split(',')
         .filter_map(|part| {
             let part = part.trim();
             if part.is_empty() {
@@ -155,17 +170,37 @@ fn parse_directives(spec: &str) -> Vec<Directive> {
             }
             if let Some((name, level)) = part.split_once('=') {
                 let name = name.trim();
-                level.trim().parse().ok().map(|level| Directive {
-                    name: (!name.is_empty()).then(|| name.to_string()),
-                    level,
-                })
+                let level = level.trim();
+                if level.is_empty() {
+                    (!name.is_empty()).then(|| Directive {
+                        name: Some(name.to_string()),
+                        level: LevelFilter::max(),
+                    })
+                } else {
+                    level.parse().ok().map(|level| Directive {
+                        name: (!name.is_empty()).then(|| name.to_string()),
+                        level,
+                    })
+                }
             } else {
-                part.parse()
-                    .ok()
-                    .map(|level| Directive { name: None, level })
+                match part.parse() {
+                    Ok(level) => Some(Directive { name: None, level }),
+                    Err(_) => Some(Directive {
+                        name: Some(part.to_string()),
+                        level: LevelFilter::max(),
+                    }),
+                }
             }
         })
-        .collect()
+        .collect();
+    // Ascending by name length (bare levels first); `enabled` scans in
+    // reverse so the longest name wins. Stable, so equal lengths keep spec
+    // order and the last one in the spec decides ties.
+    directives.sort_by_key(|d| d.name.as_ref().map_or(0, String::len));
+    Filter {
+        directives,
+        message,
+    }
 }
 
 /// Which environment variable carries the filter, and what applies when it is
@@ -200,12 +235,15 @@ impl<'a> Env<'a> {
         self
     }
 
-    fn resolve(&self) -> Vec<Directive> {
+    fn resolve(&self) -> Filter {
         std::env::var(self.filter_var)
             .ok()
             .or_else(|| self.default_filter.map(str::to_string))
-            .map(|spec| parse_directives(&spec))
-            .unwrap_or_default()
+            .map(|spec| parse_filter(&spec))
+            .unwrap_or(Filter {
+                directives: Vec::new(),
+                message: None,
+            })
     }
 }
 
@@ -218,21 +256,24 @@ impl Default for Env<'_> {
 /// Builder shaped like `env_logger::Builder` for the calls this repo makes:
 /// `from_env`, `format`, `filter`, `try_init`, `init`.
 pub struct Builder {
-    directives: Vec<Directive>,
+    filter: Filter,
     format: Option<Box<FormatFn>>,
 }
 
 impl Builder {
     pub fn new() -> Self {
         Self {
-            directives: Vec::new(),
+            filter: Filter {
+                directives: Vec::new(),
+                message: None,
+            },
             format: None,
         }
     }
 
     pub fn from_env<'a>(env: Env<'a>) -> Self {
         Self {
-            directives: env.resolve(),
+            filter: env.resolve(),
             format: None,
         }
     }
@@ -246,7 +287,7 @@ impl Builder {
     }
 
     pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
-        self.directives.push(Directive {
+        self.filter.directives.push(Directive {
             name: module.map(str::to_string),
             level,
         });
@@ -258,10 +299,26 @@ impl Builder {
             Some(custom) => Arc::from(custom),
             None => Arc::new(default_format),
         };
-        Logger {
-            filter: Filter {
-                directives: std::mem::take(&mut self.directives),
+        let mut filter = std::mem::replace(
+            &mut self.filter,
+            Filter {
+                directives: Vec::new(),
+                message: None,
             },
+        );
+        if filter.directives.is_empty() {
+            // Matches `env_filter`: no directives at all means Error.
+            filter.directives.push(Directive {
+                name: None,
+                level: LevelFilter::Error,
+            });
+        } else {
+            filter
+                .directives
+                .sort_by_key(|d| d.name.as_ref().map_or(0, String::len));
+        }
+        Logger {
+            filter,
             format,
             emit: Arc::new(emit_to_stderr),
         }
@@ -270,13 +327,28 @@ impl Builder {
     pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
         let logger = self.build();
         let max = logger.filter.max_level();
-        // `log` without its `alloc` feature (this workspace's case: something
-        // pins it to `std` only) has no `set_boxed_logger`, so leak once and
-        // use the `&'static` form. One Logger per process either way.
-        let logger: &'static Logger = Box::leak(Box::new(logger));
-        log::set_logger(logger)?;
-        log::set_max_level(max);
-        Ok(())
+        // `log` without its `alloc` feature (this workspace's case) has no
+        // `set_boxed_logger`, so the installed logger lives in a `static`
+        // slot. A rejected logger drops here instead of leaking, which a
+        // `Box::leak`-before-`set_logger` sequence cannot do.
+        match INSTALLED.set(logger) {
+            Ok(()) => {
+                let installed = INSTALLED.get().unwrap_or_else(|| {
+                    panic!("logging::INSTALLED was just set, so it must read back")
+                });
+                log::set_logger(installed)?;
+                log::set_max_level(max);
+                Ok(())
+            }
+            Err(_) => {
+                match log::set_logger(&REJECTED) {
+                    Ok(()) => panic!(
+                        "logging::try_init found no installed logger after a rejected install"
+                    ),
+                    Err(e) => Err(e),
+                }
+            }
+        }
     }
 
     pub fn init(&mut self) {
@@ -298,6 +370,27 @@ fn emit_to_stderr(bytes: &[u8]) {
     let _ = handle.write_all(bytes);
     let _ = handle.flush();
 }
+
+/// Slot for the installed logger. `OnceLock::set` hands a rejected logger
+/// back for dropping, so failed `try_init` calls leak nothing.
+static INSTALLED: OnceLock<Logger> = OnceLock::new();
+
+/// Throwaway logger used only to manufacture the `SetLoggerError` value when
+/// the slot above is already full; registering it always fails, with no
+/// observable effect, because a global logger is installed by then.
+struct Rejected;
+
+impl log::Log for Rejected {
+    fn enabled(&self, _: &Metadata) -> bool {
+        false
+    }
+
+    fn log(&self, _: &Record) {}
+
+    fn flush(&self) {}
+}
+
+static REJECTED: Rejected = Rejected;
 
 /// Logger installed by [`Builder`]. Stateless across records except for the
 /// calling thread's scratch buffer, which shrinks after the idle threshold.
@@ -355,7 +448,7 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        if self.filter.enabled(record.metadata()) {
+        if self.filter.matches(record) {
             self.log_inner(record);
         }
     }
@@ -437,7 +530,9 @@ mod tests {
 
     #[test]
     fn log_output_survives_the_shrink() {
-        let _idle = IdleGuard::set(Duration::ZERO);
+        // No idle-guard here on purpose: `scratch_buffer_shrinks_after_idle`
+        // is the single test that retunes the process-global threshold, so
+        // parallel tests cannot race its restore against a probe log.
         let (logger, captured) = capture_logger("info");
 
         logger.log(&record(format_args!("hello-after-idle")));
@@ -462,6 +557,25 @@ mod tests {
         assert!(logger.enabled(&probe("webrtc_sctp", log::Level::Error)));
         assert!(logger.enabled(&probe("webrtc_sctp::conn", log::Level::Error)));
 
+        // A bare word is a target directive at maximum level, not a level:
+        // `RUST_LOG=webrtc_sctp` enables everything under that target.
+        let (bare, _) = capture_logger("webrtc_sctp");
+        assert!(bare.enabled(&probe("webrtc_sctp", log::Level::Trace)));
+        assert!(bare.enabled(&probe("webrtc_sctp::conn", log::Level::Debug)));
+        assert!(!bare.enabled(&probe("app", log::Level::Error)));
+
+        // Prefix matching is plain, so `Client` covers the crate's
+        // `Client/...` custom targets.
+        let (slash, _) = capture_logger("Client=debug");
+        assert!(slash.enabled(&probe("Client/AppState", log::Level::Debug)));
+        assert!(!slash.enabled(&probe("Client/AppState", log::Level::Trace)));
+        assert!(!slash.enabled(&probe("app", log::Level::Error)));
+
+        // Longest name wins over the bare fallback.
+        let (longest, _) = capture_logger("info,whatsapp_rust=debug");
+        assert!(longest.enabled(&probe("whatsapp_rust::x", log::Level::Debug)));
+        assert!(!longest.enabled(&probe("app", log::Level::Debug)));
+
         // Disabled records never reach the sink.
         logger.log(
             &Record::builder()
@@ -479,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn default_format_is_a_single_line() {
+    fn default_format_matches_env_logger_lines() {
         let (logger, captured) = capture_logger("info");
         logger.log(&record(format_args!("one line")));
         let bytes = captured.lock().expect("test holds no other lock").clone();
@@ -489,5 +603,50 @@ mod tests {
             "record must end the line, got: {text:?}"
         );
         assert!(text.contains("INFO") && text.contains("one line"));
+
+        // Continuation lines indent by four spaces, as in env_logger's
+        // default format.
+        captured.lock().expect("test holds no other lock").clear();
+        logger.log(&record(format_args!("first\nsecond")));
+        let bytes = captured.lock().expect("test holds no other lock").clone();
+        let text = String::from_utf8(bytes).expect("logger emits UTF-8");
+        assert!(
+            text.ends_with("first\n    second\n"),
+            "continuation must indent, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn slash_message_filter_screens_records() {
+        let (logger, captured) = capture_logger("info/needle");
+        logger.log(&record(format_args!("find the needle here")));
+        logger.log(&record(format_args!("nothing relevant")));
+        let bytes = captured.lock().expect("test holds no other lock").clone();
+        let text = String::from_utf8(bytes).expect("logger emits UTF-8");
+        assert!(
+            text.contains("needle here") && !text.contains("nothing relevant"),
+            "only matching records pass, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn max_level_covers_configured_directives() {
+        let mut named = Builder::from_env(Env::default().default_filter_or("foo=off"));
+        assert_eq!(named.build().filter.max_level(), LevelFilter::Off);
+        let mut global = Builder::from_env(Env::default().default_filter_or("info,foo=off"));
+        assert_eq!(global.build().filter.max_level(), LevelFilter::Info);
+    }
+
+    #[test]
+    fn repeated_try_init_fails_without_leaking() {
+        let previous = log::max_level();
+        let mut first = Builder::from_env(Env::default().default_filter_or("info"));
+        let _ = first.try_init();
+        let mut second = Builder::from_env(Env::default().default_filter_or("info"));
+        // The slot is full after the first call (whether or not a foreign
+        // logger beat it to the global install), so the second call always
+        // fails — and the rejected logger drops instead of leaking.
+        assert!(second.try_init().is_err());
+        log::set_max_level(previous);
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,493 @@
+//! Demo logger with idle-shrinking scratch buffers.
+//!
+//! `env_logger` formats each record into a thread-local buffer that is cleared
+//! but never shrunk, so every thread that logs keeps capacity for the largest
+//! record it ever formatted (its `Logger::log` source comment says exactly
+//! this). The demo's QR-code burst grows that buffer to tens of KiB per logging
+//! thread and the capacity then sits at length zero for the rest of the
+//! process; heap profiling showed ~108 KiB held across two such buffers with
+//! nothing in them, and `env_logger` offers no hook to release it.
+//!
+//! This logger keeps `RUST_LOG` filtering and caller-supplied format closures,
+//! but a thread's scratch buffer shrinks back to the current record's size once
+//! the thread has been quiet longer than [`set_idle_shrink_after`]. The only
+//! cost is one realloc on the first log after the quiet period; a hot burst
+//! reuses its buffer without reallocating.
+
+use std::cell::RefCell;
+use std::io::{self, Write};
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{LevelFilter, Metadata, Record, SetLoggerError};
+use portable_atomic::{AtomicU64, Ordering};
+
+/// Quiet period after which the next log on a thread releases that thread's
+/// scratch capacity first. A minute covers the demo's shape: a large QR burst
+/// at startup, then small records on an otherwise idle connection.
+const DEFAULT_IDLE_SHRINK_AFTER: Duration = Duration::from_secs(60);
+
+/// Idle threshold in nanoseconds; [`set_idle_shrink_after`] retunes it.
+static IDLE_SHRINK_AFTER_NANOS: AtomicU64 =
+    AtomicU64::new(DEFAULT_IDLE_SHRINK_AFTER.as_nanos() as u64);
+
+/// Retune how long a thread must be quiet before its next log shrinks the
+/// scratch buffer. The test suite sets this to zero to simulate the quiet
+/// period deterministically.
+pub fn set_idle_shrink_after(after: Duration) -> Duration {
+    Duration::from_nanos(IDLE_SHRINK_AFTER_NANOS.swap(
+        after.as_nanos().min(u64::MAX as u128) as u64,
+        Ordering::Relaxed,
+    ))
+}
+
+/// Current-thread scratch capacity in bytes. Zero when nothing was ever logged
+/// here. Exposed so the footprint test can assert the buffers shrink.
+pub fn buffer_capacity_bytes() -> usize {
+    SCRATCH
+        .try_with(|cell| {
+            cell.try_borrow()
+                .map(|scratch| scratch.as_ref().map_or(0, |s| s.buf.capacity()))
+                .unwrap_or(0)
+        })
+        .unwrap_or(0)
+}
+
+struct Scratch {
+    buf: Vec<u8>,
+    last_use: wacore::time::Instant,
+}
+
+thread_local! {
+    static SCRATCH: RefCell<Option<Scratch>> = const { RefCell::new(None) };
+}
+
+/// Sink for a formatted record. `Fn` rather than `Write` so the default path
+/// locks stderr per record (no handle retained) while tests capture bytes.
+type EmitFn = dyn Fn(&[u8]) + Send + Sync;
+
+/// `std::io::Write` over the scratch buffer, handed to format closures. Shaped
+/// like `env_logger::fmt::Formatter` so existing `.format(...)` closures move
+/// over unchanged.
+pub struct Formatter<'a> {
+    buf: &'a mut Vec<u8>,
+}
+
+impl Write for Formatter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+type FormatFn = dyn Fn(&mut Formatter, &Record) -> io::Result<()> + Send + Sync;
+
+fn default_format(buf: &mut Formatter, record: &Record) -> io::Result<()> {
+    writeln!(
+        buf,
+        "[{:<5} {}] {}",
+        record.level(),
+        record.target(),
+        record.args()
+    )
+}
+
+#[derive(Debug, Clone)]
+struct Directive {
+    name: Option<String>,
+    level: LevelFilter,
+}
+
+#[derive(Debug, Clone)]
+struct Filter {
+    directives: Vec<Directive>,
+}
+
+impl Filter {
+    fn global_default(&self) -> LevelFilter {
+        self.directives
+            .iter()
+            .rev()
+            .find_map(|d| d.name.is_none().then_some(d.level))
+            .unwrap_or(LevelFilter::Error)
+    }
+
+    fn max_level(&self) -> LevelFilter {
+        self.directives
+            .iter()
+            .map(|d| d.level)
+            .max()
+            .unwrap_or(LevelFilter::Error)
+    }
+
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        let target = metadata.target();
+        let mut matched: Option<(usize, LevelFilter)> = None;
+        for directive in &self.directives {
+            if let Some(name) = &directive.name
+                && target_matches(target, name)
+                && matched.is_none_or(|(len, _)| name.len() > len)
+            {
+                matched = Some((name.len(), directive.level));
+            }
+        }
+        metadata.level() <= matched.map_or_else(|| self.global_default(), |(_, level)| level)
+    }
+}
+
+fn target_matches(target: &str, name: &str) -> bool {
+    target == name
+        || target
+            .strip_prefix(name)
+            .is_some_and(|rest| rest.starts_with("::"))
+}
+
+fn parse_directives(spec: &str) -> Vec<Directive> {
+    spec.split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            if let Some((name, level)) = part.split_once('=') {
+                let name = name.trim();
+                level.trim().parse().ok().map(|level| Directive {
+                    name: (!name.is_empty()).then(|| name.to_string()),
+                    level,
+                })
+            } else {
+                part.parse()
+                    .ok()
+                    .map(|level| Directive { name: None, level })
+            }
+        })
+        .collect()
+}
+
+/// Which environment variable carries the filter, and what applies when it is
+/// unset. Shaped like `env_logger::Env` so call sites read unchanged.
+#[derive(Debug, Clone)]
+pub struct Env<'a> {
+    filter_var: &'a str,
+    default_filter: Option<&'a str>,
+}
+
+impl<'a> Env<'a> {
+    pub fn new() -> Self {
+        Self {
+            filter_var: "RUST_LOG",
+            default_filter: None,
+        }
+    }
+
+    pub fn filter(mut self, var: &'a str) -> Self {
+        self.filter_var = var;
+        self
+    }
+
+    pub fn filter_or(mut self, var: &'a str, default: &'a str) -> Self {
+        self.filter_var = var;
+        self.default_filter = Some(default);
+        self
+    }
+
+    pub fn default_filter_or(mut self, default: &'a str) -> Self {
+        self.default_filter = Some(default);
+        self
+    }
+
+    fn resolve(&self) -> Vec<Directive> {
+        std::env::var(self.filter_var)
+            .ok()
+            .or_else(|| self.default_filter.map(str::to_string))
+            .map(|spec| parse_directives(&spec))
+            .unwrap_or_default()
+    }
+}
+
+impl Default for Env<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder shaped like `env_logger::Builder` for the calls this repo makes:
+/// `from_env`, `format`, `filter`, `try_init`, `init`.
+pub struct Builder {
+    directives: Vec<Directive>,
+    format: Option<Box<FormatFn>>,
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Self {
+            directives: Vec::new(),
+            format: None,
+        }
+    }
+
+    pub fn from_env<'a>(env: Env<'a>) -> Self {
+        Self {
+            directives: env.resolve(),
+            format: None,
+        }
+    }
+
+    pub fn format<F>(&mut self, format: F) -> &mut Self
+    where
+        F: Fn(&mut Formatter, &Record) -> io::Result<()> + Send + Sync + 'static,
+    {
+        self.format = Some(Box::new(format));
+        self
+    }
+
+    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
+        self.directives.push(Directive {
+            name: module.map(str::to_string),
+            level,
+        });
+        self
+    }
+
+    pub fn build(&mut self) -> Logger {
+        let format: Arc<FormatFn> = match self.format.take() {
+            Some(custom) => Arc::from(custom),
+            None => Arc::new(default_format),
+        };
+        Logger {
+            filter: Filter {
+                directives: std::mem::take(&mut self.directives),
+            },
+            format,
+            emit: Arc::new(emit_to_stderr),
+        }
+    }
+
+    pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
+        let logger = self.build();
+        let max = logger.filter.max_level();
+        // `log` without its `alloc` feature (this workspace's case: something
+        // pins it to `std` only) has no `set_boxed_logger`, so leak once and
+        // use the `&'static` form. One Logger per process either way.
+        let logger: &'static Logger = Box::leak(Box::new(logger));
+        log::set_logger(logger)?;
+        log::set_max_level(max);
+        Ok(())
+    }
+
+    pub fn init(&mut self) {
+        if self.try_init().is_err() {
+            panic!("logging::init called after another logger was initialized");
+        }
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn emit_to_stderr(bytes: &[u8]) {
+    let stderr = io::stderr();
+    let mut handle = stderr.lock();
+    let _ = handle.write_all(bytes);
+    let _ = handle.flush();
+}
+
+/// Logger installed by [`Builder`]. Stateless across records except for the
+/// calling thread's scratch buffer, which shrinks after the idle threshold.
+#[derive(Clone)]
+pub struct Logger {
+    filter: Filter,
+    format: Arc<FormatFn>,
+    emit: Arc<EmitFn>,
+}
+
+impl Logger {
+    fn log_inner(&self, record: &Record) {
+        let idle_after = Duration::from_nanos(IDLE_SHRINK_AFTER_NANOS.load(Ordering::Relaxed));
+        let printed = SCRATCH
+            .try_with(|cell| {
+                if let Ok(mut guard) = cell.try_borrow_mut() {
+                    let scratch = guard.get_or_insert_with(|| Scratch {
+                        buf: Vec::new(),
+                        last_use: wacore::time::Instant::now(),
+                    });
+                    if scratch.last_use.elapsed() >= idle_after {
+                        scratch.buf.shrink_to_fit();
+                    }
+                    let mut formatter = Formatter {
+                        buf: &mut scratch.buf,
+                    };
+                    let _ = (self.format)(&mut formatter, record);
+                    (self.emit)(formatter.buf);
+                    scratch.buf.clear();
+                    scratch.last_use = wacore::time::Instant::now();
+                } else {
+                    // Re-entrant log from inside a format closure: the scratch
+                    // buffer is already borrowed, so format on the stack.
+                    let mut owned = Vec::new();
+                    let mut formatter = Formatter { buf: &mut owned };
+                    let _ = (self.format)(&mut formatter, record);
+                    (self.emit)(formatter.buf);
+                }
+            })
+            .is_ok();
+        if !printed {
+            // Thread-local storage is gone (thread shutdown): single-use stack
+            // buffer, mirroring env_logger's fallback.
+            let mut owned = Vec::new();
+            let mut formatter = Formatter { buf: &mut owned };
+            let _ = (self.format)(&mut formatter, record);
+            (self.emit)(formatter.buf);
+        }
+    }
+}
+
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        if self.filter.enabled(record.metadata()) {
+            self.log_inner(record);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::Log as _;
+    use std::fmt::Arguments;
+    use std::sync::Mutex;
+
+    struct IdleGuard {
+        previous: Duration,
+    }
+
+    impl IdleGuard {
+        fn set(after: Duration) -> Self {
+            Self {
+                previous: set_idle_shrink_after(after),
+            }
+        }
+    }
+
+    impl Drop for IdleGuard {
+        fn drop(&mut self) {
+            set_idle_shrink_after(self.previous);
+        }
+    }
+
+    fn capture_logger(default_filter: &str) -> (Logger, Arc<Mutex<Vec<u8>>>) {
+        let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let mut builder = Builder::from_env(Env::default().default_filter_or(default_filter));
+        let mut logger = builder.build();
+        logger.emit = Arc::new(move |bytes: &[u8]| {
+            sink.lock()
+                .expect("capture lock is never held across a log call")
+                .extend_from_slice(bytes);
+        });
+        (logger, captured)
+    }
+
+    fn record(args: Arguments<'_>) -> Record<'_> {
+        Record::builder()
+            .args(args)
+            .level(log::Level::Info)
+            .target("wr_r3_probe")
+            .build()
+    }
+
+    #[test]
+    fn scratch_buffer_shrinks_after_idle() {
+        let _idle = IdleGuard::set(Duration::from_secs(3600));
+        let (logger, _) = capture_logger("info");
+
+        let big = "x".repeat(64 * 1024);
+        logger.log(&record(format_args!("{}", big)));
+        let grown = buffer_capacity_bytes();
+        assert!(
+            grown >= big.len(),
+            "scratch must hold the large record: capacity {grown}, record {}",
+            big.len()
+        );
+
+        // Simulate the quiet period expiring, then log small: the historic
+        // capacity is released first, so the buffer only regrows to this
+        // record's size. The realloc for that regrow is the whole cost.
+        set_idle_shrink_after(Duration::ZERO);
+        logger.log(&record(format_args!("ping")));
+        let shrunk = buffer_capacity_bytes();
+        assert!(
+            shrunk * 16 < grown,
+            "capacity must collapse after idle: {grown} -> {shrunk}"
+        );
+    }
+
+    #[test]
+    fn log_output_survives_the_shrink() {
+        let _idle = IdleGuard::set(Duration::ZERO);
+        let (logger, captured) = capture_logger("info");
+
+        logger.log(&record(format_args!("hello-after-idle")));
+        let bytes = captured.lock().expect("test holds no other lock").clone();
+        let text = String::from_utf8(bytes).expect("logger emits UTF-8");
+        assert!(
+            text.contains("hello-after-idle") && text.contains("wr_r3_probe"),
+            "record must still be emitted, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn filter_directives_match_env_logger_shape() {
+        let (logger, captured) = capture_logger("info,webrtc_sctp=error,webrtc_dtls=error");
+
+        fn probe(target: &str, level: log::Level) -> Metadata<'_> {
+            Metadata::builder().level(level).target(target).build()
+        }
+        assert!(logger.enabled(&probe("app", log::Level::Info)));
+        assert!(!logger.enabled(&probe("app", log::Level::Debug)));
+        assert!(!logger.enabled(&probe("webrtc_sctp", log::Level::Warn)));
+        assert!(logger.enabled(&probe("webrtc_sctp", log::Level::Error)));
+        assert!(logger.enabled(&probe("webrtc_sctp::conn", log::Level::Error)));
+
+        // Disabled records never reach the sink.
+        logger.log(
+            &Record::builder()
+                .args(format_args!("m"))
+                .level(log::Level::Debug)
+                .target("app")
+                .build(),
+        );
+        assert!(
+            captured
+                .lock()
+                .expect("test holds no other lock")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn default_format_is_a_single_line() {
+        let (logger, captured) = capture_logger("info");
+        logger.log(&record(format_args!("one line")));
+        let bytes = captured.lock().expect("test holds no other lock").clone();
+        let text = String::from_utf8(bytes).expect("logger emits UTF-8");
+        assert!(
+            text.ends_with('\n'),
+            "record must end the line, got: {text:?}"
+        );
+        assert!(text.contains("INFO") && text.contains("one line"));
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -340,18 +340,24 @@ impl Builder {
                 log::set_max_level(max);
                 Ok(())
             }
-            Err(_) => {
-                // The slot is full but the winning thread may not have reached
-                // `log::set_logger` yet. Register the slot value so a racy
-                // loser completes the winner's install instead of failing
-                // against a logger that is not installed yet; when a logger
-                // really is installed this fails the same clean way.
+            Err(rejected) => {
+                drop(rejected);
                 let installed = INSTALLED
                     .get()
                     .unwrap_or_else(|| panic!("logging::INSTALLED is full, so it must read back"));
-                log::set_logger(installed)?;
-                log::set_max_level(installed.filter.max_level());
-                Ok(())
+                // Complete the winner's install when it hasn't happened yet,
+                // so a racy handoff can never park the process with no logger.
+                // Then still report failure: this caller's own configuration
+                // was discarded, mirroring env_logger's losing racer. The
+                // second registration always fails — a global logger is
+                // installed by then — and yields the error value.
+                if log::set_logger(installed).is_ok() {
+                    log::set_max_level(installed.filter.max_level());
+                }
+                let Err(e) = log::set_logger(installed) else {
+                    unreachable!("a global logger is installed by now, so registration must fail")
+                };
+                Err(e)
             }
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,7 +16,7 @@
 
 use std::cell::RefCell;
 use std::io::{self, Write};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use log::{LevelFilter, Metadata, Record, SetLoggerError};
@@ -203,6 +203,20 @@ fn parse_filter(spec: &str) -> Filter {
     }
 }
 
+/// Pure half of [`Env::resolve`], split out so tests can pin the precedence
+/// without touching the process environment (`set_var` is unsafe to call
+/// while other threads may read it, which a parallel test runner always
+/// risks).
+fn resolve_value(env_value: Option<String>, default: Option<&str>) -> Filter {
+    env_value
+        .or_else(|| default.map(str::to_string))
+        .map(|spec| parse_filter(&spec))
+        .unwrap_or(Filter {
+            directives: Vec::new(),
+            message: None,
+        })
+}
+
 /// Which environment variable carries the filter, and what applies when it is
 /// unset. Shaped like `env_logger::Env` so call sites read unchanged.
 #[derive(Debug, Clone)]
@@ -236,14 +250,7 @@ impl<'a> Env<'a> {
     }
 
     fn resolve(&self) -> Filter {
-        std::env::var(self.filter_var)
-            .ok()
-            .or_else(|| self.default_filter.map(str::to_string))
-            .map(|spec| parse_filter(&spec))
-            .unwrap_or(Filter {
-                directives: Vec::new(),
-                message: None,
-            })
+        resolve_value(std::env::var(self.filter_var).ok(), self.default_filter)
     }
 }
 
@@ -327,10 +334,23 @@ impl Builder {
     pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
         let logger = self.build();
         let max = logger.filter.max_level();
-        // `log` without its `alloc` feature (this workspace's case) has no
-        // `set_boxed_logger`, so the installed logger lives in a `static`
-        // slot. A rejected logger drops here instead of leaking, which a
-        // `Box::leak`-before-`set_logger` sequence cannot do.
+        // Fill and install under one lock so concurrent first-time callers
+        // cannot interleave: exactly one caller owns the install and reports
+        // its outcome, and a loser can never complete someone else's install
+        // and then misreport its own discarded configuration.
+        let _guard = INSTALL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(installed) = INSTALLED.get() {
+            // Our configuration lost to an earlier install. A global logger
+            // is installed whenever this slot is full — both change under
+            // this lock — so this registration fails and yields the error.
+            let _ = log::set_logger(installed);
+            return match log::set_logger(installed) {
+                Err(e) => Err(e),
+                Ok(()) => unreachable!(
+                    "a global logger is installed whenever the slot is full, so registration must fail"
+                ),
+            };
+        }
         match INSTALLED.set(logger) {
             Ok(()) => {
                 let installed = INSTALLED.get().unwrap_or_else(|| {
@@ -340,24 +360,8 @@ impl Builder {
                 log::set_max_level(max);
                 Ok(())
             }
-            Err(rejected) => {
-                drop(rejected);
-                let installed = INSTALLED
-                    .get()
-                    .unwrap_or_else(|| panic!("logging::INSTALLED is full, so it must read back"));
-                // Complete the winner's install when it hasn't happened yet,
-                // so a racy handoff can never park the process with no logger.
-                // Then still report failure: this caller's own configuration
-                // was discarded, mirroring env_logger's losing racer. The
-                // second registration always fails — a global logger is
-                // installed by then — and yields the error value.
-                if log::set_logger(installed).is_ok() {
-                    log::set_max_level(installed.filter.max_level());
-                }
-                let Err(e) = log::set_logger(installed) else {
-                    unreachable!("a global logger is installed by now, so registration must fail")
-                };
-                Err(e)
+            Err(_) => {
+                unreachable!("the slot was empty under INSTALL_LOCK, so claiming it must succeed")
             }
         }
     }
@@ -383,9 +387,14 @@ fn emit_to_stderr(bytes: &[u8]) {
 }
 
 /// Slot for the installed logger. `OnceLock::set` hands a rejected logger
-/// back for dropping, so failed `try_init` calls leak nothing, and a racy
-/// loser installs the slot value rather than failing spuriously.
+/// back for dropping, so failed `try_init` calls leak nothing. Every fill
+/// and install happens under [`INSTALL_LOCK`], so concurrent first-time
+/// callers serialize: one winner installs and reports its outcome, losers
+/// report failure without touching the installed configuration.
 static INSTALLED: OnceLock<Logger> = OnceLock::new();
+
+/// Serializes [`Builder::try_init`]; see [`INSTALLED`].
+static INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Logger installed by [`Builder`]. Stateless across records except for the
 /// calling thread's scratch buffer, which shrinks after the idle threshold.
@@ -643,14 +652,10 @@ mod tests {
     }
 
     #[test]
-    fn env_variable_overrides_the_default() {
-        // Unique variable name so no other test or ambient environment can
-        // observe it; the set/remove pair is scoped to this test.
-        const VAR: &str = "WR_R3_LOGGING_TEST_FILTER";
-        unsafe {
-            std::env::remove_var(VAR);
-        }
-        let unset = Env::default().filter_or(VAR, "info").resolve();
+    fn env_value_overrides_the_default() {
+        // Pinned inputs, no process-environment access: `set_var` is unsafe
+        // while sibling test threads may read the environment.
+        let unset = resolve_value(None, Some("info"));
         assert!(
             unset.enabled(
                 &Metadata::builder()
@@ -659,10 +664,7 @@ mod tests {
                     .build()
             )
         );
-        unsafe {
-            std::env::set_var(VAR, "off");
-        }
-        let set = Env::default().filter_or(VAR, "info").resolve();
+        let set = resolve_value(Some("off".to_string()), Some("info"));
         assert!(
             !set.enabled(
                 &Metadata::builder()
@@ -671,9 +673,6 @@ mod tests {
                     .build()
             )
         );
-        unsafe {
-            std::env::remove_var(VAR);
-        }
     }
 
     #[test]

--- a/tests/bench-integration/Cargo.toml
+++ b/tests/bench-integration/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 divan = { workspace = true }
 e2e-tests = { path = "../e2e" }
-env_logger = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 whatsapp-rust = { path = "../..", default-features = false, features = [
     "danger-skip-tls-verify",

--- a/tests/bench-integration/benches/integration.rs
+++ b/tests/bench-integration/benches/integration.rs
@@ -74,9 +74,11 @@ fn rt() -> &'static tokio::runtime::Runtime {
     RT.get_or_init(|| {
         // Best-effort logger init, mirroring the old binary; ignore errors so a
         // second bench module call is harmless.
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-            .try_init()
-            .ok();
+        whatsapp_rust::logging::Builder::from_env(
+            whatsapp_rust::logging::Env::default().default_filter_or("warn"),
+        )
+        .try_init()
+        .ok();
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .enable_all()


### PR DESCRIPTION
Replaces the env_logger runtime path with a small local logger (whatsapp_rust::logging) whose per-thread scratch buffer shrinks after 60s idle. Same RUST_LOG filtering and format closures, so output is unchanged. Probe: 55KB burst held 110064B, next log after quiet dropped capacity to 60B at ~48us cost. Adds shrink-after-idle, output-preservation, and filter tests.