### PR TITLE
perf(cache): share table growth across cache instantiations

### DIFF
--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -168,8 +168,7 @@ where
     #[inline(never)]
     fn insert_new(&mut self, key: K, value: V) {
         let hash = self.hash_of(&key);
-        self.table
-            .insert_unique(hash, PlainSlot { value, key, hash }, |slot| slot.hash);
+        insert_slot(&mut self.table, hash, PlainSlot { value, key, hash });
     }
 
     /// Replace-or-insert shared by `insert` and `insert_and_return` so the
@@ -225,6 +224,39 @@ where
             Storage::Managed(inner) => inner.structural_bytes(),
         }
     }
+}
+
+/// The hash a table slot was inserted with, read back when its table grows so
+/// growth never re-hashes a key. Both slot kinds carry it; the shared
+/// [`insert_slot`] tail reads it through this trait so the two `insert_unique`
+/// call sites compile from one definition instead of one per insert path.
+trait StoredHash {
+    fn stored_hash(&self) -> u64;
+}
+
+impl<K, V> StoredHash for Slot<K, V> {
+    #[inline]
+    fn stored_hash(&self) -> u64 {
+        self.hash
+    }
+}
+
+impl<K, V> StoredHash for PlainSlot<K, V> {
+    #[inline]
+    fn stored_hash(&self) -> u64 {
+        self.hash
+    }
+}
+
+/// Growth tail shared by [`PlainInner::insert_new`] and
+/// [`CacheInner::insert_new`]: grow the table when needed and insert the slot.
+/// Out of line so each `<K, V>` table carries its hashbrown growth chain once,
+/// not once per insert entry point (`insert`, `upsert_with_by_ref`,
+/// `insert_and_return`); a new cache instantiates one copy for its slot type
+/// however many paths insert into it.
+#[inline(never)]
+fn insert_slot<T: StoredHash>(table: &mut HashTable<T>, hash: u64, slot: T) {
+    table.insert_unique(hash, slot, |existing| existing.stored_hash());
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -759,6 +791,13 @@ where
     /// Insert a brand-new entry (the caller has already confirmed the key is
     /// absent), evicting the oldest entries first if at capacity. Assigns and
     /// records the FIFO sequence.
+    ///
+    /// Stays out of line like [`PlainInner::insert_new`]: under fat LTO this
+    /// would otherwise inline into every managed insert path (`insert`,
+    /// `upsert_with_by_ref`, `insert_and_return`, plus the synchronous
+    /// [`SyncTtlGuard::insert`](SyncTtlGuard::insert)), stamping the eviction
+    /// prologue and the hashbrown growth call per caller instead of per table.
+    #[inline(never)]
     fn insert_new(
         &mut self,
         key: K,
@@ -777,7 +816,8 @@ where
         if self.track_order {
             self.order.insert(seq, hash);
         }
-        self.table.insert_unique(
+        insert_slot(
+            &mut self.table,
             hash,
             Slot {
                 value,
@@ -788,7 +828,6 @@ where
                 key,
                 hash,
             },
-            |slot| slot.hash,
         );
     }
 


### PR DESCRIPTION
Shares the hash-table growth tail across cache instantiations so each new generic cache pays it once per table instead of once per insert entry point.

`PlainInner::insert_new` (the LID/unbounded path from #1481) and `CacheInner::insert_new` (the generic path) both called `HashTable::insert_unique` with their own stored-hash closure, and the managed path had no outline marker, so under fat LTO it stamped its eviction prologue plus the growth call into every insert caller (`insert`, `upsert_with_by_ref`, `insert_and_return`, `SyncTtlGuard::insert`). Both now route through one `#[inline(never)] insert_slot<T: StoredHash>` tail, and managed `insert_new` stays out of line like the plain one. No eviction, removal, expiry, or timing changes; same hash, same slot fields, same rehash reader.

Measured with `cargo run -p whatsapp-xtask -- ci measure-binary-size` (demo binary, nightly-2026-06-16):

- bin .text 9,045,814 -> 9,044,854 (-960 B); `.text whatsapp_rust` -1,114 B
- reserve_rehash: 25 -> 25 symbols, 36,332 B unchanged. The remaining chains are one per (slot size, drop glue) and cannot merge without layout surgery; the toolchain already folds every same-layout chain transitively. All 25 now hang off the shared tail (old per-inner closure chains: zero remaining)
- Managed `insert_new`: 0 -> 19 outline bodies; evict probe closures 28 -> 13 symbols (-10.1 KiB); RawTable insert specializations 18 -> 9 (-6.7 KiB); llvm-lines whatsapp-rust +148 lines / +74 copies (the shared tail's own instantiations)

Validation: 148 cache-filtered nextest tests green (all `lid_pn_cache` and `portable_cache` suites), `cargo fmt --check` clean, `cargo clippy -p whatsapp-rust --lib -- -D warnings` clean.
