### PR TITLE
perf(message): key the dispatch gate by a hashed identity

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -493,9 +493,11 @@ impl Client {
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count_async().await,
             dispatched_messages: self.dispatched_messages.entry_count(),
             dispatched_message_contents: self.dispatched_messages.memory_stats(
-                |key: &crate::message::DispatchKey, claim: &crate::message::DispatchClaim| {
+                // The identity is a 64-bit digest stored in the slot itself,
+                // so only the claim's payloads retain anything beside it.
+                |_key: &crate::message::DispatchKey, claim: &crate::message::DispatchClaim| {
                     use wacore::stats::HeapSize;
-                    key.heap_bytes() + claim.heap_bytes()
+                    claim.heap_bytes()
                 },
             ),
             pdo_pending_requests: self.pdo_pending_requests.entry_count_async().await,

--- a/src/message.rs
+++ b/src/message.rs
@@ -218,12 +218,40 @@ pub(crate) enum MessageDispatch {
     RecoveredCommitted,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct DispatchKey {
-    chat: Jid,
-    id: wacore_binary::MessageId,
-    participant: Option<Jid>,
-    from_me: bool,
+/// A message identity — chat, id, author and direction — reduced to a keyed
+/// 64-bit digest.
+///
+/// The gate keys one claim per identity for a whole TTL, so what the identity
+/// costs is paid by every dispatched message twice over: once in the table
+/// slot it is stored in, once in the growth allocation that doubles that
+/// table. Spelled out it was a `Jid`, a `MessageId` and an optional second
+/// `Jid` — 96 bytes of the 208-byte slot, and a pair of `CompactString` copies
+/// on every lookup.
+///
+/// Hashing it is sound because a collision cannot suppress anything on its
+/// own: two identities landing on one claim still compare their payload
+/// digests, and a message is only suppressed when one of those 128-bit digests
+/// matches too. Aiming a message at another claim's slot means finding a
+/// collision under [`DISPATCH_IDENTITY`], whose SipHash key is drawn once per
+/// process and never leaves it, so the id and JIDs a peer chooses buy it
+/// nothing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct DispatchKey(std::num::NonZeroU64);
+
+/// The gate's identity key, drawn per process: a fixed hash would let a peer
+/// compute which claim its id lands on.
+static DISPATCH_IDENTITY: std::sync::LazyLock<std::hash::RandomState> =
+    std::sync::LazyLock::new(std::hash::RandomState::new);
+
+impl DispatchKey {
+    /// Hashes an identity through the process key. Zero folds onto one so
+    /// `Option<DispatchKey>` rides in 8 bytes: one extra colliding pair in
+    /// 2^64, below the collision rate the identity already tolerates.
+    fn new(identity: impl std::hash::Hash) -> Self {
+        use std::hash::BuildHasher;
+        let digest = DISPATCH_IDENTITY.hash_one(identity);
+        Self(std::num::NonZeroU64::new(digest).unwrap_or(std::num::NonZeroU64::MIN))
+    }
 }
 
 const MAX_DISPATCH_PAYLOADS: usize = 8;
@@ -249,11 +277,15 @@ struct DispatchPayload {
     publication: Arc<AtomicU8>,
 }
 
-/// Boxed: an alternate identity is evidence a *minority* of claims carry (only
-/// a stanza that spelled both namespaces has one), while the claim itself is
-/// retained for every message id the client dispatches. Inline it cost every
-/// claim a `Jid` whether or not one existed.
-type DispatchAlias = Option<Box<Jid>>;
+/// The identity this claim's message carries under the alternate PN/LID
+/// spelling, when its stanza spelled both out.
+///
+/// The alternate *identity* rather than the alternate `Jid`: every use is a
+/// comparison against some other message's identity, so substituting the
+/// spelling once at admission answers them all without a scan re-deriving it,
+/// and `Option<DispatchKey>` rides in 8 bytes with no allocation for the
+/// minority of claims that have one.
+type DispatchAlias = Option<DispatchKey>;
 
 #[derive(Clone, Default)]
 pub(crate) struct DispatchClaim {
@@ -394,14 +426,6 @@ std::thread_local! {
         const { std::cell::RefCell::new(Vec::new()) };
 }
 
-impl wacore::stats::HeapSize for DispatchKey {
-    fn heap_bytes(&self) -> usize {
-        self.chat.heap_bytes()
-            + self.id.heap_bytes()
-            + self.participant.as_ref().map_or(0, |p| p.heap_bytes())
-    }
-}
-
 /// One publication token allocation: the value plus the strong and weak
 /// counts. Allocator rounding above that is not counted, the same floor the
 /// table accounting in `hash_table_bytes` uses.
@@ -409,8 +433,8 @@ const TOKEN_ALLOC_BYTES: usize = 2 * size_of::<usize>() + size_of::<AtomicU8>();
 
 impl wacore::stats::HeapSize for DispatchClaim {
     /// Heap retained beside the table slot: spilled payloads at their
-    /// allocated capacity, one token allocation per payload, and the boxed
-    /// alias. The inline SmallVec slot lives in the slot itself and is
+    /// allocated capacity and one token allocation per payload. The inline
+    /// SmallVec slot and the alias identity live in the slot itself and are
     /// charged with the table.
     fn heap_bytes(&self) -> usize {
         let mut bytes = 0;
@@ -418,9 +442,6 @@ impl wacore::stats::HeapSize for DispatchClaim {
             bytes += self.payloads.capacity() * size_of::<DispatchPayload>();
         }
         bytes += self.payloads.len() * TOKEN_ALLOC_BYTES;
-        if let Some(alias) = &self.alias {
-            bytes += size_of::<Jid>() + alias.heap_bytes();
-        }
         bytes
     }
 }

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -34,57 +34,29 @@ impl Client {
             if let Some(claim) = cache.get(&key) {
                 claim.prune();
                 if !pdo && claim.alias.is_none() {
-                    claim.alias = Self::dispatch_alias(info, &key).map(Box::new);
+                    claim.alias = Self::dispatch_alias(info);
                 }
                 return update(claim);
             }
             let mut alias = None;
             let recovery_key = if pdo {
-                // Only PDO misses scan. Two primaries naming this alternate
-                // are ambiguous, so neither may suppress the recovered event.
-                cache.find_unique_key(|primary, claim| {
-                    if !claim.has_deliveries()
-                        || primary.id != key.id
-                        || primary.from_me != key.from_me
-                    {
-                        return false;
-                    }
-                    match (&primary.participant, &key.participant, &claim.alias) {
-                        (Some(_), Some(participant), Some(alias)) => {
-                            primary.chat == key.chat && participant == &**alias
-                        }
-                        (None, None, Some(alias)) => key.chat == **alias,
-                        _ => false,
-                    }
-                })
+                // Only PDO misses scan. A claim's alias is the identity its
+                // message carries under the alternate spelling, so naming this
+                // recovery is the whole match. Two claims naming it are
+                // ambiguous, so neither may suppress the recovered event.
+                cache.find_unique_key(|_, claim| claim.has_deliveries() && claim.alias == Some(key))
             } else {
-                alias = Self::dispatch_alias(info, &key);
-                alias.as_ref().and_then(|alternate| {
-                    let alternate_key = DispatchKey {
-                        chat: if key.participant.is_some() {
-                            key.chat.clone()
-                        } else {
-                            alternate.clone()
-                        },
-                        id: key.id.clone(),
-                        participant: key.participant.as_ref().map(|_| alternate.clone()),
-                        from_me: key.from_me,
-                    };
-                    let claim = cache.get(&alternate_key)?;
+                alias = Self::dispatch_alias(info);
+                alias.and_then(|alternate| {
+                    let claim = cache.get(&alternate)?;
                     claim.prune();
-                    let primary = key.participant.as_ref().unwrap_or(&key.chat);
-                    if !claim.has_recovery()
-                        || claim
-                            .alias
-                            .as_ref()
-                            .is_some_and(|bound| &**bound != primary)
-                    {
+                    if !claim.has_recovery() || claim.alias.is_some_and(|bound| bound != key) {
                         return None;
                     }
                     // Bind only the direct evidence in this stanza. A later
                     // conflicting primary cannot reuse the PDO claim.
-                    claim.alias.get_or_insert_with(|| Box::new(primary.clone()));
-                    Some(alternate_key)
+                    claim.alias.get_or_insert(key);
+                    Some(alternate)
                 })
             };
             if let Some(claim) = recovery_key.as_ref().and_then(|key| cache.get(key)) {
@@ -92,9 +64,7 @@ impl Client {
                 return update(claim);
             }
             let mut claim = DispatchClaim {
-                alias: alias
-                    .or_else(|| Self::dispatch_alias(info, &key))
-                    .map(Box::new),
+                alias: alias.or_else(|| Self::dispatch_alias(info)),
                 ..Default::default()
             };
             let result = update(&mut claim);
@@ -206,36 +176,50 @@ impl Client {
     /// this primary key or followed through another claim.
     pub(crate) fn dispatch_key(info: &Arc<MessageInfo>) -> DispatchKey {
         let source = &info.source;
-        let has_participant = source.chat.is_group()
-            || source.chat.is_broadcast_list()
-            || source.chat.is_status_broadcast();
-        DispatchKey {
-            chat: source.chat.clone(),
-            id: info.id.clone(),
-            participant: has_participant.then(|| source.sender.to_non_ad()),
-            from_me: source.is_from_me,
-        }
+        let participant = Self::dispatch_participant(info);
+        DispatchKey::new((&source.chat, &info.id, &participant, source.is_from_me))
     }
 
-    fn dispatch_alias(info: &Arc<MessageInfo>, key: &DispatchKey) -> Option<Jid> {
+    /// The author an identity carries outside DMs, device dropped.
+    fn dispatch_participant(info: &Arc<MessageInfo>) -> Option<Jid> {
+        let chat = &info.source.chat;
+        (chat.is_group() || chat.is_broadcast_list() || chat.is_status_broadcast())
+            .then(|| info.source.sender.to_non_ad())
+    }
+
+    /// The identity this same message carries under the alternate PN/LID
+    /// spelling, when the stanza spelled both out.
+    ///
+    /// Substituting the spelling here rather than retaining the alternate
+    /// `Jid` is what lets every later comparison be one identity equality: the
+    /// PDO scan asks whether a claim names the recovery it is holding, and the
+    /// ordinary path asks whether the claim it found names this stanza. Both
+    /// asked the same question of a `Jid` before, spelled out field by field.
+    fn dispatch_alias(info: &Arc<MessageInfo>) -> Option<DispatchKey> {
         let source = &info.source;
-        let (primary, alternate) = if let Some(participant) = &key.participant {
+        let participant = Self::dispatch_participant(info);
+        let (primary, alternate) = if let Some(participant) = &participant {
             (participant, source.sender_alt.as_ref()?)
         } else if source.is_from_me {
-            (&key.chat, source.recipient_alt.as_ref()?)
+            (&source.chat, source.recipient_alt.as_ref()?)
         } else {
             let alternate = source.sender_alt.as_ref()?;
-            if source.sender.to_non_ad() != key.chat {
+            if source.sender.to_non_ad() != source.chat {
                 return None;
             }
-            (&key.chat, alternate)
+            (&source.chat, alternate)
         };
         if !(primary.server.is_pn_family() && alternate.server.is_lid_family()
             || primary.server.is_lid_family() && alternate.server.is_pn_family())
         {
             return None;
         }
-        Some(alternate.to_non_ad())
+        let alternate = alternate.to_non_ad();
+        Some(if participant.is_some() {
+            DispatchKey::new((&source.chat, &info.id, &Some(alternate), source.is_from_me))
+        } else {
+            DispatchKey::new((&alternate, &info.id, &None::<Jid>, source.is_from_me))
+        })
     }
 
     /// Dispatches a successfully parsed message to the event bus and sends a delivery receipt.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15122,7 +15122,9 @@ mod pdo_alias_tests {
     /// cache holds them inline in a single table, so the claim's size is what
     /// the client's resident memory — and every doubling of that table — scales
     /// with. The `client_receive` memory rows read that growth allocation
-    /// directly, which is why this is pinned rather than left to drift.
+    /// directly, which is why this is pinned rather than left to drift. The
+    /// slot it rides in is pinned beside the cache, in
+    /// `dispatch_gate_slot_stays_below_the_spelled_out_identity`.
     #[test]
     fn pdo_alias_claim_stays_small() {
         let size = size_of::<DispatchClaim>();
@@ -15230,6 +15232,47 @@ mod pdo_alias_tests {
             },
             ..Default::default()
         })
+    }
+
+    /// What one client actually pays for the gate, end to end: the table it
+    /// keeps a claim in for the whole TTL, plus everything the claims retain
+    /// beside it. This is the quantity the `client_receive` memory rows read,
+    /// and the bound is the 128-byte slot of the identity-only gate this grew
+    /// out of — payload-aware dedup must not cost more resident memory than
+    /// the marker it replaced. Measured: 256 B/identity here, against 436 B
+    /// when the identity was spelled out in the key.
+    #[tokio::test]
+    async fn pdo_alias_gate_retains_no_more_than_the_identity_only_marker() {
+        const IDENTITIES: u32 = 1000;
+        let (client, _) = client().await;
+        for index in 0..IDENTITIES {
+            let info = Arc::new(MessageInfo {
+                id: format!("MSGID{index:08}").into(),
+                source: MessageSource {
+                    chat: LID.parse().unwrap(),
+                    sender: LID.parse().unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            let mut publication = PublicationGuard::default();
+            assert!(!client.admit_message_dispatch(
+                &info,
+                false,
+                Some([index as u8; size_of::<DispatchFingerprint>()]),
+                false,
+                &mut publication
+            ));
+            publication.complete();
+        }
+        let retained = client.memory_report().await.dispatched_message_contents;
+        assert_eq!(retained.entries, u64::from(IDENTITIES));
+        let per_identity = retained.bytes / retained.entries;
+        assert!(
+            per_identity <= 288,
+            "the dispatch gate retains {per_identity} B per identity, more than the \
+             identity-only marker it replaced"
+        );
     }
 
     fn response(info: &MessageInfo) -> wa::message::PeerDataOperationRequestResponseMessage {

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -3167,4 +3167,21 @@ mod tests {
             128
         );
     }
+
+    /// The dispatch gate inserts one slot per message the client delivers and
+    /// keeps it for the whole TTL, so this slot is what the `client_receive`
+    /// memory rows read: a burst reports the peak of the growth allocation
+    /// that doubles this table, which scales with the slot. The bound is the
+    /// slot of the `SenderMessageId -> ()` marker this gate replaced: keying
+    /// by a digest instead of the spelled-out identity took it from 208 bytes
+    /// to under that, and it must not drift back.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn dispatch_gate_slot_stays_below_the_spelled_out_identity() {
+        let slot = size_of::<Slot<crate::message::DispatchKey, crate::message::DispatchClaim>>();
+        assert!(
+            slot <= size_of::<Slot<wacore::types::message::SenderMessageId, ()>>(),
+            "a dispatch-gate slot grew to {slot} bytes; the gate keeps one per delivered message"
+        );
+    }
 }


### PR DESCRIPTION
Cherry-picks the CodSpeed perf commit f286618 from https://github.com/oxidezap/whatsapp-rust/pull/1492 onto current main.

That PR branched at 823158d and main has moved on, with the base dedup already merged as d0a6ae9 plus cache work in 1480 and 1481. Rebasing the whole branch would replay merged work. I ported only the perf change.

Conflict resolution. src/portable_cache.rs had two pin tests at the same spot. I kept both, the flattened slot check from main and the new dispatch gate slot check.

Verification. cargo fmt check passes. cargo clippy -p whatsapp-rust --lib --tests with -D warnings passes. nextest message suite 334 passed. portable_cache 54 passed. pdo_alias 28 passed. The three pin tests pass, including the new 1000-identity retention test. report_coverage 13 passed.

Numbers. The 208 to 104 byte slot claim was measured on the old layout. On current main the spelled out marker is 128 bytes after the flatten work, and the pin test holds the digest keyed slot at or below that. I did not rerun the CodSpeed simulation bench here, so treat the 1.4 percent dm_receive delta as carried over from the bot report, not remeasured.
