### PR TITLE
fix(voip): treat enc reject as per-device so siblings keep ringing

### DIFF
--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -520,9 +520,10 @@ impl StanzaHandler for CallHandler {
                             client.core.event_bus.dispatch(outcome);
                         }
                     }
-                    // A `busy`/`enc` reject speaks for one device, and a group reject speaks for one
-                    // invited participant. Neither tears down the registered call; authoritative
-                    // timeout/terminate or the group roster owns the corresponding final state.
+                    // A per-device reject (`reject_is_device_busy`) speaks for one device, and a group
+                    // reject speaks for one invited participant. Neither tears down the registered
+                    // call; authoritative timeout/terminate or the group roster owns the
+                    // corresponding final state.
                     #[cfg(feature = "voip-runtime")]
                     if let CallAction::Terminate { .. } = &call.action
                         && let Some(generation) = group_transition_generation
@@ -4310,10 +4311,9 @@ mod tests {
         );
     }
 
-    // An `enc` reject is one device saying it could not decrypt the offer (its registration
-    // changed device-side, observed with registration bytes on the reject), not the callee
-    // declining. Like `busy` it must neither tear the call down nor consume the one-shot rung set,
-    // or the remaining siblings stop ringing and a later genuine answer has nothing to dismiss.
+    // An `enc` reject is per-device like `busy` (see `reject_is_device_busy`): it must neither
+    // tear the call down nor consume the one-shot rung set, or the remaining siblings stop ringing
+    // and a later genuine answer has nothing to dismiss.
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn enc_reject_keeps_the_call_and_the_rung_set() {

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -8,7 +8,7 @@ use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
 #[cfg(feature = "voip-runtime")]
 use wacore::stanza::call::{
-    CAPABILITY_INDEX_MLOW_V1, CapabilityBit, REJECT_REASON_BUSY,
+    CAPABILITY_INDEX_MLOW_V1, CapabilityBit, REJECT_REASON_BUSY, REJECT_REASON_ENC,
     TERMINATE_REASON_ACCEPTED_ELSEWHERE, TERMINATE_REASON_GROUP_CALL_ENDED,
     TERMINATE_REASON_REJECTED_ELSEWHERE, TERMINATE_REASON_TIMEOUT, TerminateParams,
     VideoStateParams, build_call_video_ack, build_terminate, build_video_state, capability_bit,
@@ -520,7 +520,7 @@ impl StanzaHandler for CallHandler {
                             client.core.event_bus.dispatch(outcome);
                         }
                     }
-                    // A `busy` reject speaks for one device, and a group reject speaks for one
+                    // A `busy`/`enc` reject speaks for one device, and a group reject speaks for one
                     // invited participant. Neither tears down the registered call; authoritative
                     // timeout/terminate or the group roster owns the corresponding final state.
                     #[cfg(feature = "voip-runtime")]
@@ -1464,13 +1464,17 @@ async fn send_offer_ack_receipt(client: &Client, call: &IncomingCall) -> anyhow:
 /// Whether a `<reject>` says the DEVICE is unavailable rather than that the callee declined.
 ///
 /// `busy` is a per-device statement (already in a call, or a companion with no voice support); the
-/// callee's other devices go on ringing and may still answer. Any other reason - including none -
-/// is the callee's own decision and ends the call.
+/// callee's other devices go on ringing and may still answer. `enc` is the same shape: the device
+/// could not decrypt the offer (its registration changed device-side, observed with registration
+/// bytes on the reject), so it decided nothing for the callee either. Any other reason - including
+/// none - is the callee's own decision and ends the call.
 #[cfg(feature = "voip-runtime")]
 fn reject_is_device_busy(action: &CallAction) -> bool {
     matches!(
         action,
-        CallAction::Reject { reason, .. } if reason.as_deref() == Some(REJECT_REASON_BUSY)
+        CallAction::Reject { reason, .. }
+            if reason.as_deref() == Some(REJECT_REASON_BUSY)
+                || reason.as_deref() == Some(REJECT_REASON_ENC)
     )
 }
 
@@ -1478,7 +1482,7 @@ fn reject_is_device_busy(action: &CallAction) -> bool {
 async fn dismiss_outgoing_siblings(client: &Client, call: &IncomingCall) {
     let reason = match &call.action {
         CallAction::Accept { .. } => TERMINATE_REASON_ACCEPTED_ELSEWHERE,
-        // A `busy` device has not decided anything for the callee, so its siblings must keep
+        // A `busy`/`enc` device has not decided anything for the callee, so its siblings must keep
         // ringing. Returning BEFORE take_dismiss_targets matters: that take is one-shot, and
         // consuming the rung set here would leave a later genuine accept with nothing to dismiss.
         CallAction::Reject { .. } if reject_is_device_busy(&call.action) => return,
@@ -4302,6 +4306,62 @@ mod tests {
                 .take_dismiss_targets("CALL-ID-0001")
                 .is_some(),
             "the one-shot rung set must survive a busy reject, or a later genuine accept has \
+             nothing to dismiss and the sibling rings until the call times out"
+        );
+    }
+
+    // An `enc` reject is one device saying it could not decrypt the offer (its registration
+    // changed device-side, observed with registration bytes on the reject), not the callee
+    // declining. Like `busy` it must neither tear the call down nor consume the one-shot rung set,
+    // or the remaining siblings stop ringing and a later genuine answer has nothing to dismiss.
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn enc_reject_keeps_the_call_and_the_rung_set() {
+        let client = make_client().await;
+        let peer = Jid::new("222222222222222", Server::Lid);
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let (stale_device, other) = (peer.with_device(75), peer.with_device(2));
+
+        let mut session =
+            wacore::voip::CallSession::new_outgoing("CALL-ID-0001", peer.clone(), creator.clone());
+        session.ring_devices = vec![stale_device.clone(), other.clone()];
+        client.call_registry().insert(session);
+
+        let reject = NodeBuilder::new("call")
+            .attr("from", stale_device.clone())
+            .attr("id", "STANZA-ENC")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("reject")
+                .attr("call-creator", creator.clone())
+                .attr("call-id", "CALL-ID-0001")
+                .attr("count", "0")
+                .attr("reason", "enc")
+                .children([NodeBuilder::new("registration")
+                    .bytes(0x12345678u32.to_be_bytes().to_vec())
+                    .build()])
+                .build()])
+            .build();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&reject), &mut cancelled)
+                .await
+        );
+
+        assert!(
+            client
+                .call_registry()
+                .generation_of("CALL-ID-0001")
+                .is_some(),
+            "a device that failed to decrypt must not end the call for the others"
+        );
+        assert!(
+            client
+                .call_registry()
+                .take_dismiss_targets("CALL-ID-0001")
+                .is_some(),
+            "the one-shot rung set must survive an enc reject, or a later genuine accept has \
              nothing to dismiss and the sibling rings until the call times out"
         );
     }

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -4311,9 +4311,7 @@ mod tests {
         );
     }
 
-    // An `enc` reject is per-device like `busy` (see `reject_is_device_busy`): it must neither
-    // tear the call down nor consume the one-shot rung set, or the remaining siblings stop ringing
-    // and a later genuine answer has nothing to dismiss.
+    // Per-device reject (see `reject_is_device_busy`): keeps the call and rung set.
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn enc_reject_keeps_the_call_and_the_rung_set() {

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4271,24 +4271,32 @@ impl CallHandle {
         Ok(())
     }
 
-    /// Re-ask for video on a live call: re-emit `<video state=11 dec="H264">`
-    /// without touching endpoints or the initiation guard.
+    /// Re-ask for video while a local upgrade is outstanding: re-emit
+    /// `<video state=11 dec="H264">` without touching endpoints.
     ///
-    /// `begin_video(Initiate)` refuses once local video is requested or
-    /// enabled, so an upgrade request the peer never answered cannot be asked
-    /// again through it. This mints a fresh epoch under the reached state and
-    /// sends the identical stanza shape; media, teardown hooks, and the
-    /// previous timeout are the original initiation's and stay untouched,
-    /// except a new timeout is armed for the fresh epoch (the old one goes
-    /// inert on the epoch mismatch). Refuses on audio-only calls, which stay
-    /// on the begin path.
+    /// `begin_video(Initiate)` refuses once local video is requested, so an
+    /// upgrade request the peer never answered cannot be asked again through
+    /// it. This mints a fresh epoch under the reached state and sends the
+    /// identical stanza shape; media and teardown hooks stay with the original
+    /// initiation, and a new timeout is armed for the fresh epoch (the old one
+    /// goes inert on the epoch mismatch). A failed send rolls the pending
+    /// epoch back so the previous timeout stays valid instead of stranding the
+    /// upgrade. Refuses without an outstanding local upgrade.
     pub async fn re_request_video_upgrade(&self) -> Result<(), CallError> {
         self.ensure_current()?;
+        let transition_lock = self
+            .client_registry
+            .video_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        self.ensure_current()?;
         let client = self.upgrade_client()?;
-        let epoch = self
+        let (previous, epoch) = self
             .client_registry
             .re_request_local_video(&self.call_id, self.generation)
-            .ok_or(CallError::Media("no live video to re-request"))?;
+            .ok_or(CallError::Media(
+                "no outstanding video upgrade to re-request",
+            ))?;
         let stanza = build_video_state(&VideoStateParams {
             call_id: &self.call_id,
             to: &self.peer_jid(),
@@ -4298,7 +4306,15 @@ impl CallHandle {
             dec: Some(VIDEO_DEC_REQUEST),
             device_orientation: Some(self.local_video_orientation()),
         });
-        client.send_node(stanza).await?;
+        if let Err(e) = client.send_node(stanza).await {
+            self.client_registry.rollback_re_request(
+                &self.call_id,
+                self.generation,
+                previous,
+                epoch,
+            );
+            return Err(e.into());
+        }
         self.spawn_video_upgrade_timeout(epoch, client);
         Ok(())
     }
@@ -11008,9 +11024,7 @@ mod tests {
         handle.hangup_local().await;
     }
 
-    // A caller-side upgrade the peer never answered must be askable again: the
-    // begin path refuses a second initiation on live video, so the re-request
-    // API re-emits the identical stanza shape under a fresh epoch.
+    // Re-request path: identical stanza shape under a fresh epoch.
     #[tokio::test]
     async fn re_request_video_upgrade_resends_request_shape_on_live_video() {
         let (client, _sent, handle, _relay_keepalive) = sending_handle().await;

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4271,6 +4271,38 @@ impl CallHandle {
         Ok(())
     }
 
+    /// Re-ask for video on a live call: re-emit `<video state=11 dec="H264">`
+    /// without touching endpoints or the initiation guard.
+    ///
+    /// `begin_video(Initiate)` refuses once local video is requested or
+    /// enabled, so an upgrade request the peer never answered cannot be asked
+    /// again through it. This mints a fresh epoch under the reached state and
+    /// sends the identical stanza shape; media, teardown hooks, and the
+    /// previous timeout are the original initiation's and stay untouched,
+    /// except a new timeout is armed for the fresh epoch (the old one goes
+    /// inert on the epoch mismatch). Refuses on audio-only calls, which stay
+    /// on the begin path.
+    pub async fn re_request_video_upgrade(&self) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        let epoch = self
+            .client_registry
+            .re_request_local_video(&self.call_id, self.generation)
+            .ok_or(CallError::Media("no live video to re-request"))?;
+        let stanza = build_video_state(&VideoStateParams {
+            call_id: &self.call_id,
+            to: &self.peer_jid(),
+            id: &client.generate_request_id(),
+            call_creator: &self.call_creator,
+            state: VideoState::UpgradeRequestV2,
+            dec: Some(VIDEO_DEC_REQUEST),
+            device_orientation: Some(self.local_video_orientation()),
+        });
+        client.send_node(stanza).await?;
+        self.spawn_video_upgrade_timeout(epoch, client);
+        Ok(())
+    }
+
     /// Stop our video direction: sends `<video state=6>` (Stopped, no marker), tears the local
     /// video plane down, and releases the source/sink. The peer may keep sending its direction;
     /// audio is untouched. Idempotent.
@@ -10972,6 +11004,59 @@ mod tests {
                 .expect("session")
                 .is_video,
             "start_video must mark the session as video"
+        );
+        handle.hangup_local().await;
+    }
+
+    // A caller-side upgrade the peer never answered must be askable again: the
+    // begin path refuses a second initiation on live video, so the re-request
+    // API re-emits the identical stanza shape under a fresh epoch.
+    #[tokio::test]
+    async fn re_request_video_upgrade_resends_request_shape_on_live_video() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle
+            .re_request_video_upgrade()
+            .await
+            .expect("re-request on live video");
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("re-request must be sent")
+            .expect("waiter");
+        let r = node.as_node_ref();
+        assert!(
+            r.attrs()
+                .optional_string("id")
+                .is_some_and(|id| !id.is_empty()),
+            "the <call> wrapper needs an id so the peer's typed video ack correlates"
+        );
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.tag, "video");
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("11"));
+        assert_eq!(ar.attrs().optional_string("dec").as_deref(), Some("H264"));
+        assert_eq!(
+            ar.attrs().optional_string("device_orientation").as_deref(),
+            Some("0")
+        );
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings").as_deref(),
+            Some("video"),
+            "the re-request must carry the marker attr like the initial request"
+        );
+        handle.hangup_local().await;
+    }
+
+    // Audio-only calls stay on the begin path: with no video state there is
+    // nothing to re-request.
+    #[tokio::test]
+    async fn re_request_video_upgrade_refuses_audio_only_call() {
+        let (_client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        assert!(
+            handle.re_request_video_upgrade().await.is_err(),
+            "audio-only call must refuse the re-request"
         );
         handle.hangup_local().await;
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4284,6 +4284,24 @@ impl CallHandle {
     /// upgrade. Refuses without an outstanding local upgrade.
     pub async fn re_request_video_upgrade(&self) -> Result<(), CallError> {
         self.ensure_current()?;
+        // Group downgrades also reset video negotiation: take their lane first
+        // like `begin_video` does, so a racing downgrade cannot leave a stale
+        // state=11 in flight for a now-audio group.
+        let group_transition_lock = self
+            .client_registry
+            .group_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _group_transition_guard = group_transition_lock.lock().await;
+        self.ensure_current()?;
+        if let Some(group) = self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            && !group_video_upgrade_allowed(&group)
+        {
+            return Err(CallError::Media(
+                "group media mode does not allow a video upgrade",
+            ));
+        }
         let transition_lock = self
             .client_registry
             .video_transition_lock(&self.call_id, self.generation)

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -4324,6 +4324,11 @@ impl CallHandle {
             dec: Some(VIDEO_DEC_REQUEST),
             device_orientation: Some(self.local_video_orientation()),
         });
+        // Arm the timeout before the send: `send_node` awaits, so a caller
+        // cancelling there would otherwise leave the fresh epoch with no live
+        // timeout. On send failure the rollback below restores the previous
+        // epoch, and this timeout then mismatches and no-ops.
+        self.spawn_video_upgrade_timeout(epoch, client.clone());
         if let Err(e) = client.send_node(stanza).await {
             self.client_registry.rollback_re_request(
                 &self.call_id,
@@ -4333,7 +4338,6 @@ impl CallHandle {
             );
             return Err(e.into());
         }
-        self.spawn_video_upgrade_timeout(epoch, client);
         Ok(())
     }
 

--- a/tools/oracle-core/examples/initiator_media_watch.rs
+++ b/tools/oracle-core/examples/initiator_media_watch.rs
@@ -1,0 +1,111 @@
+//! Initiator-side media watch: does the pinned engine emit any transport
+//! bytes (`call_sendto`) or decoded frames (`renderVideoFrame_js`) for an
+//! outgoing video call that has no active peer?
+//!
+//! All identities are fictitious. Execute in release: debug Cranelift
+//! compilation is too slow for meaningful engine deadlines.
+//!
+//! ```sh
+//! cargo run --release -p oracle-core --example initiator_media_watch
+//! ```
+//!
+//! `ENGINE` overrides the pinned module (default `JgwtTQVeWPm`).
+
+use anyhow::{Result, bail};
+use oracle_core::{Catalog, MediaStream, MediaWatch, Runtime, ThreadPolicy, Value};
+use sha2::{Digest, Sha256};
+
+const ENGINE: &str = "JgwtTQVeWPm";
+const ENGINE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+const SELF: &str = "15550002222@c.us";
+const SELF_DEVICE: &str = "15550002222:0@c.us";
+const SELF_LID: &str = "99887766554433:0@lid";
+const PEER_LID: &str = "11223344556677@lid";
+const PEER_DEVICE: &str = "11223344556677:0@lid";
+const CALL_ID: &str = "0011223344556677";
+const TC_TOKEN: [u8; 32] = [0xA5; 32];
+
+fn main() -> Result<()> {
+    let which = std::env::var("ENGINE").unwrap_or_else(|_| ENGINE.into());
+    let catalog = Catalog::discover()?;
+    let entry = catalog.resolve(&which)?;
+    let bytes = std::fs::read(&entry.path)?;
+    let sha = hex::encode(Sha256::digest(&bytes));
+    if which == ENGINE {
+        anyhow::ensure!(sha == ENGINE_SHA);
+    }
+    println!("engine: {which} sha256={sha}");
+
+    let mut r = Runtime::instantiate(&bytes)?;
+    // Transport egress is `call_sendto(fd, buf, len, addr)`: watch the payload.
+    r.watch_media([MediaWatch::new(
+        "env",
+        "call_sendto",
+        MediaStream::Video,
+        1,
+        2,
+    )?])?;
+    r.set_thread_policy(ThreadPolicy::Spawn);
+    r.set_main_thread_registration(true);
+    r.run_ctors()?;
+    r.attach_log_ring(4 << 20)?;
+    let args = [SELF, SELF_DEVICE, SELF_LID].map(|v| Value::Str(v.to_owned()));
+    let init = r.call_embind("initVoipStack", &args);
+    r.refuel();
+    if init.as_ref().ok().and_then(|v| v.as_int()) != Some(0) {
+        bail!("initVoipStack failed: {init:?}");
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let mut started = false;
+    while std::time::Instant::now() < deadline {
+        if r.engine_log()
+            .iter()
+            .any(|l| l.contains("call_event_proc resumed"))
+        {
+            started = true;
+            break;
+        }
+        r.process_queued_calls();
+        r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    if !started {
+        bail!("event thread never announced itself");
+    }
+
+    let outcome = r.call_embind(
+        "startVoipCall",
+        &[
+            Value::Str(PEER_LID.into()),
+            Value::StringList(vec![PEER_DEVICE.into()]),
+            Value::Str(CALL_ID.into()),
+            Value::Bool(true),
+            Value::Str(PEER_LID.into()),
+            Value::Bool(false),
+            Value::Bytes(TC_TOKEN.to_vec()),
+        ],
+    );
+    r.refuel();
+    println!("startVoipCall -> {outcome:?}");
+    r.settle(std::time::Duration::from_secs(8));
+    r.refuel();
+
+    let obs = r.take_media_observations()?;
+    println!("media observations on env::call_sendto: {}", obs.len());
+    for (i, o) in obs.iter().take(8).enumerate() {
+        println!("  [{i}] {o:?}");
+    }
+    println!("signaling stanzas: {}", r.signaling()?.len());
+    for (name, count) in r.stubs_called() {
+        if name.contains("capture")
+            || name.contains("sendto")
+            || name.contains("render")
+            || name.contains("playback")
+        {
+            println!("stub {name}: {count}");
+        }
+    }
+    Ok(())
+}

--- a/tools/oracle-core/examples/initiator_media_watch.rs
+++ b/tools/oracle-core/examples/initiator_media_watch.rs
@@ -88,8 +88,14 @@ fn main() -> Result<()> {
         ],
     );
     r.refuel();
-    println!("startVoipCall -> {outcome:?}");
-    r.settle(std::time::Duration::from_secs(8));
+    // A failed start or an unsettled engine would present as a valid
+    // zero-media result: fail loudly instead of reporting counts.
+    if outcome.as_ref().ok().and_then(|value| value.as_int()) != Some(0) {
+        bail!("startVoipCall failed: {outcome:?}");
+    }
+    if !r.settle(std::time::Duration::from_secs(8)) {
+        bail!("media observation never quiesced; trace may be partial");
+    }
     r.refuel();
 
     let obs = r.take_media_observations()?;

--- a/tools/oracle-core/examples/list_embind.rs
+++ b/tools/oracle-core/examples/list_embind.rs
@@ -1,4 +1,5 @@
 //! List every embind-registered function name and arity.
+use anyhow::bail;
 use oracle_core::{Catalog, Runtime, ThreadPolicy, Value};
 
 fn main() -> anyhow::Result<()> {
@@ -19,6 +20,11 @@ fn main() -> anyhow::Result<()> {
         ],
     );
     r.refuel();
+    // Registrations happen during initialization: a failed init would list
+    // whatever happened to register before that point as the complete set.
+    if init.as_ref().ok().and_then(|v| v.as_int()) != Some(0) {
+        bail!("initVoipStack failed: {init:?}");
+    }
     println!("init: {init:?}");
     let mut names: Vec<String> = r
         .embind()

--- a/tools/oracle-core/examples/list_embind.rs
+++ b/tools/oracle-core/examples/list_embind.rs
@@ -1,0 +1,34 @@
+//! List every embind-registered function name and arity.
+use oracle_core::{Catalog, Runtime, ThreadPolicy, Value};
+
+fn main() -> anyhow::Result<()> {
+    let catalog = Catalog::discover()?;
+    let entry = catalog.resolve("JgwtTQVeWPm")?;
+    let bytes = std::fs::read(&entry.path)?;
+    let mut r = Runtime::instantiate(&bytes)?;
+    r.set_thread_policy(ThreadPolicy::Spawn);
+    r.set_main_thread_registration(true);
+    r.run_ctors()?;
+    r.refuel();
+    let init = r.call_embind(
+        "initVoipStack",
+        &[
+            Value::Str("15550002222@c.us".into()),
+            Value::Str("15550002222:0@c.us".into()),
+            Value::Str("99887766554433:0@lid".into()),
+        ],
+    );
+    r.refuel();
+    println!("init: {init:?}");
+    let mut names: Vec<String> = r
+        .embind()
+        .functions
+        .iter()
+        .map(|f| format!("{}({})", f.name, f.arg_types.len().saturating_sub(1)))
+        .collect();
+    names.sort();
+    for name in names {
+        println!("  {name}");
+    }
+    Ok(())
+}

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -468,9 +468,10 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // Arguments 4 and 5 are the stanza's `e` and `t` timestamps, read with
     // stoull (see `tests/signaling.rs::deliver`): the probe axes ride here,
     // not only on the stanza attributes, because the engine reads the header
-    // inputs. `second_numeric_offset` shifts `t` into the future.
+    // inputs. `second_numeric_offset` shifts `t` into the future, including
+    // under MS_PAIR (offset applied before the millisecond conversion).
     let (e_arg, t_arg) = if ms_pair {
-        (e_all, t_all)
+        (e_all, second_numeric * 1000)
     } else {
         (
             shifted + if probe.expiry { 45 } else { 0 },

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -173,6 +173,28 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             marker_sink: None,
         },
     )?;
+    // The event thread must be up before delivery: an offer into the startup
+    // gap lands on a half-started engine and reads as a refusal.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let mut gated = false;
+    while std::time::Instant::now() < deadline {
+        if r.engine_log()
+            .iter()
+            .any(|l| l.contains("call_event_proc resumed"))
+        {
+            gated = true;
+            break;
+        }
+        r.process_queued_calls();
+        r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    if !gated {
+        println!(
+            "PROBE {}: event thread never announced itself; results suspect",
+            probe.label
+        );
+    };
     if probe.ab_props {
         let set = set_ab_props(&mut r);
         println!("  ab props accepted {set} of {}", AB_PROPS.len());
@@ -223,6 +245,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         Some(offset) => now + offset,
         None => now,
     };
+    // Arguments 4 and 5 are the stanza's `e` and `t` timestamps, read with
+    // stoull (see `tests/signaling.rs::deliver`): the probe axes ride here,
+    // not only on the stanza attributes, because the engine reads the header
+    // inputs. `second_numeric_offset` shifts `t` into the future.
+    let (e_arg, t_arg) = (now + if probe.expiry { 45 } else { 0 }, second_numeric);
+    let t_arg = if probe.t_millis { t_arg * 1000 } else { t_arg };
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
     // Preserve the delivery outcome: a trap here must read as a delivery
     // failure, never as "the engine processed and rejected the offer".
@@ -232,8 +260,8 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             Value::Str(payload),
             Value::Str("web".into()),
             Value::Str("2.3000.0".into()),
-            Value::Str(now.to_string()),
-            Value::Str(second_numeric.to_string()),
+            Value::Str(e_arg.to_string()),
+            Value::Str(t_arg.to_string()),
             Value::Bool(false),
             Value::Bool(true),
             Value::Str(caller.to_string()),
@@ -245,6 +273,13 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         Ok(value) => format!("{value:?}"),
         Err(_) => "trap".to_owned(),
     };
+    // Collect queued main-thread work before reading state: with the main
+    // thread registered, answers wait in the proxy queue and only the host
+    // takes them out.
+    for _ in 0..5 {
+        r.process_queued_calls();
+        r.refuel();
+    }
     let immediate = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
     r.refuel();
     let alive = !immediate.contains("\"\"") && immediate.len() > 20;
@@ -305,7 +340,10 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         &[Value::Bool(probe.accept.0), Value::Bool(probe.accept.1)],
     );
     r.refuel();
-    r.settle(std::time::Duration::from_secs(5));
+    // `settle` drains the proxy queue each tick, but a `false` return means it
+    // never quiesced: reporting a stall then turns harness timing into a
+    // protocol verdict, so quiescence is printed, not discarded.
+    let settled = r.settle(std::time::Duration::from_secs(5));
     r.refuel();
     let emitted = r.signaling()?.len();
     let term_reason = r
@@ -320,7 +358,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .iter()
         .any(|l| l.contains("missed by the user"));
     println!(
-        "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} emitted={emitted} missed={missed} {term_reason}",
+        "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
         probe.label,
     );
     Ok(())
@@ -418,7 +456,7 @@ fn main() -> Result<()> {
             inner_t: false,
         },
         Probe {
-            label: "video+ab+num45",
+            label: "video+ab+future-t",
             ab_props: true,
             video: true,
             accept: (true, true),

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -290,7 +290,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
                 Value::Bytes(Vec::new()),
             ],
         )
-        .ok();
+        .with_context(|| "REPLICATE_LOAD: settings offer delivery trapped")?;
         r.refuel();
         r.settle(std::time::Duration::from_secs(3));
         r.refuel();
@@ -488,7 +488,13 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // DELIVER_VIA=message routes through the generic `handleIncomingSignalingMessage`
     // entry (payload, platform, version, e, t, bool, caller, bytes) instead of
     // the offer-specific one: same bytes, different router.
-    let via_message = std::env::var("DELIVER_VIA").is_ok_and(|v| v == "message");
+    // Unknown values fail loudly: a misspelled selector must not silently
+    // run the wrong delivery path and report its evidence.
+    let via_message = match std::env::var("DELIVER_VIA").as_deref() {
+        Err(_) => false,
+        Ok("message") => true,
+        Ok(other) => bail!("unknown DELIVER_VIA={other:?}: expected message"),
+    };
     // DELIVER_TWICE=1 feeds the same offer again on the same engine: the
     // message-buffer scan decides 14/15/27 by what it finds buffered, so a
     // second delivery meeting the first one's record must behave differently

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -39,43 +39,6 @@ const CALL_KEY: [u8; 32] = [0x5A; 32];
 const SETTINGS: &[u8] =
     br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"false","caller_timeout":"45"}}"#;
 
-/// Neutral A/B values, as `WAWebVoipStackInterfaceWebHelpers` would forward
-/// them. Copied from `outbound_after_settings.rs`; the question is the same:
-/// does configuring the engine at all change what it does?
-const AB_PROPS: &[(&str, &str)] = &[
-    ("aigc_version", "int"),
-    ("app_exit_reason_version", "int"),
-    ("attach_transport_rtx", "bool"),
-    ("audio_level_speaking_threshold", "int"),
-    ("call_admin_version", "int"),
-    ("calling_rust_migration_bitmap", "int"),
-    ("calling_rust_migration_incoming_stanza_bitmap", "int"),
-    ("calling_screen_share_milestone_version", "int"),
-    ("default_endpoint_thread_poll_timeout", "int"),
-    ("enable_av_downgrade", "bool"),
-    ("enable_init_bwe_for_group_call", "bool"),
-    (
-        "enable_new_user_action_stanza_for_raise_hand_sender",
-        "bool",
-    ),
-    ("enable_offer_v2_upgrade", "bool"),
-    ("enable_ring_for_gc_on_offer_expire", "bool"),
-    ("enable_silent_offer", "bool"),
-    ("enable_waiting_room_logging", "bool"),
-    ("enable_webcodec_video_encode", "bool"),
-    ("enable_web_voip_audio_driver_lifetime_fix", "bool"),
-    ("heartbeat_interval_s", "int"),
-    ("ignore_joinable_terminate_on_expired_offer", "bool"),
-    ("lobby_timeout_min", "int"),
-    ("max_group_size_for_long_ringtone", "int"),
-    ("max_num_participants_for_ss", "int"),
-    ("allow_reporting_call_replayer_id", "bool"),
-    ("vid_stream_pause_resume_jb_reset_threshold_ms", "int"),
-    ("voice_ai_conversation_starter_latency_tracking", "bool"),
-    ("voip_stack_incoming_message_ownership_transfer", "bool"),
-    ("log_level", "int"),
-];
-
 /// The vendor's own video child, read back from a `startVoipCall` offer so the
 /// inbound shape carries no invented bytes.
 const VIDEO_ATTRS: &[(&str, &str)] = &[
@@ -116,28 +79,99 @@ fn census_video_offer_at(now: Option<u64>) -> Node {
         .build()
 }
 
-fn set_ab_props(r: &mut Runtime) -> usize {
+/// Pinned A/B values from `wacore::iq::abprops` (the whatspec registry), not
+/// neutral guesses: forcing every boolean true exercises a synthetic flag
+/// combination no WhatsApp client runs. Three wasm keys have no registry entry
+/// (`enable_av_downgrade`, `allow_reporting_call_replayer_id`, `log_level`)
+/// and keep neutral values, marked `unpinned` below.
+#[derive(Clone, Copy)]
+enum ABValue {
+    Bool(bool),
+    Int(i64),
+    UnpinnedBool,
+    UnpinnedInt(i64),
+}
+
+const AB_PROPS: &[(&str, ABValue)] = &[
+    ("aigc_version", ABValue::Int(1)),
+    ("app_exit_reason_version", ABValue::Int(0)),
+    ("attach_transport_rtx", ABValue::Bool(false)),
+    ("audio_level_speaking_threshold", ABValue::Int(30)),
+    ("call_admin_version", ABValue::Int(0)),
+    ("calling_rust_migration_bitmap", ABValue::Int(0)),
+    (
+        "calling_rust_migration_incoming_stanza_bitmap",
+        ABValue::Int(0),
+    ),
+    ("calling_screen_share_milestone_version", ABValue::Int(2)),
+    ("default_endpoint_thread_poll_timeout", ABValue::Int(0)),
+    ("enable_av_downgrade", ABValue::UnpinnedBool),
+    ("enable_init_bwe_for_group_call", ABValue::Bool(false)),
+    (
+        "enable_new_user_action_stanza_for_raise_hand_sender",
+        ABValue::Bool(false),
+    ),
+    ("enable_offer_v2_upgrade", ABValue::Bool(false)),
+    ("enable_ring_for_gc_on_offer_expire", ABValue::Bool(false)),
+    ("enable_silent_offer", ABValue::Bool(false)),
+    ("enable_waiting_room_logging", ABValue::Bool(false)),
+    ("enable_webcodec_video_encode", ABValue::Bool(false)),
+    (
+        "enable_web_voip_audio_driver_lifetime_fix",
+        ABValue::Bool(true),
+    ),
+    ("heartbeat_interval_s", ABValue::Int(10)),
+    (
+        "ignore_joinable_terminate_on_expired_offer",
+        ABValue::Bool(false),
+    ),
+    ("lobby_timeout_min", ABValue::Int(0)),
+    ("max_group_size_for_long_ringtone", ABValue::Int(0)),
+    ("max_num_participants_for_ss", ABValue::Int(8)),
+    ("allow_reporting_call_replayer_id", ABValue::UnpinnedBool),
+    (
+        "vid_stream_pause_resume_jb_reset_threshold_ms",
+        ABValue::Int(0),
+    ),
+    (
+        "voice_ai_conversation_starter_latency_tracking",
+        ABValue::Bool(false),
+    ),
+    (
+        "voip_stack_incoming_message_ownership_transfer",
+        ABValue::Bool(false),
+    ),
+    ("log_level", ABValue::UnpinnedInt(9)),
+];
+
+/// Configure the arm from the pinned table. A trapping setter fails the
+/// probe loudly with the key: silently continuing on a subset would make the
+/// row advertise a configuration it never established.
+fn set_ab_props(r: &mut Runtime) -> Result<usize> {
+    use anyhow::Context;
     let mut set = 0;
-    for (key, kind) in AB_PROPS {
-        let call = match *kind {
-            "bool" => r.call_embind(
+    for (key, value) in AB_PROPS {
+        let call = match *value {
+            ABValue::Bool(v) => r.call_embind(
+                "setABPropBool",
+                &[Value::Str((*key).into()), Value::Bool(v)],
+            ),
+            ABValue::Int(v) => {
+                r.call_embind("setABPropInt", &[Value::Str((*key).into()), Value::Int(v)])
+            }
+            ABValue::UnpinnedBool => r.call_embind(
                 "setABPropBool",
                 &[Value::Str((*key).into()), Value::Bool(true)],
             ),
-            _ => r.call_embind(
-                "setABPropInt",
-                &[
-                    Value::Str((*key).into()),
-                    Value::Int(if *key == "log_level" { 9 } else { 0 }),
-                ],
-            ),
+            ABValue::UnpinnedInt(v) => {
+                r.call_embind("setABPropInt", &[Value::Str((*key).into()), Value::Int(v)])
+            }
         };
         r.refuel();
-        if call.is_ok() {
-            set += 1;
-        }
+        call.with_context(|| format!("setting A/B prop {key}"))?;
+        set += 1;
     }
-    set
+    Ok(set)
 }
 
 struct Probe {
@@ -290,7 +324,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // variant; until then the mode stays out instead of reporting confounded
     // verdicts.
     if probe.ab_props && !minimal {
-        let set = set_ab_props(&mut r);
+        let set = set_ab_props(&mut r)?;
         println!("  ab props accepted {set} of {}", AB_PROPS.len());
     }
     let mut caller = Jid::new("11223344556677", Server::Lid);
@@ -303,18 +337,20 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // offer. The miss path scans the message buffer for a prior accept (→14)
     // or reject (→15) of the call-id; priming decides whether the scan reads
     // buffer writes at all, isolating "scan never matches" from "scan cannot
-    // match".
+    // match". Any other value is a typo that would silently exercise the
+    // reject path under a wrong label, so it fails loudly.
     if let Ok(prime) = std::env::var("PRIME") {
         let action = match prime.as_str() {
             "accept" => NodeBuilder::new("accept")
                 .attr("call-creator", caller.clone())
                 .attr("call-id", CALL_ID)
                 .build(),
-            _ => NodeBuilder::new("reject")
+            "reject" => NodeBuilder::new("reject")
                 .attr("call-creator", caller.clone())
                 .attr("call-id", CALL_ID)
                 .attr("count", "0")
                 .build(),
+            other => anyhow::bail!("unknown PRIME value: {other}"),
         };
         let primer = NodeBuilder::new("call")
             .attr("from", caller.clone())
@@ -341,14 +377,15 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             ],
         );
         r.refuel();
-        println!(
-            "PROBE {}: prime {prime} -> {}",
-            probe.label,
-            match &primed {
-                Ok(value) => format!("{value:?}"),
-                Err(_) => "trap".to_owned(),
-            }
-        );
+        // A trapped primer never reached the buffer: continuing would report
+        // the offer against a setup that did not happen, so the probe stops
+        // inconclusive instead of printing a verdict.
+        if let Err(error) = &primed {
+            println!("PROBE {}: prime {prime} trapped: {error}", probe.label);
+            println!("PROBE {}: INCONCLUSIVE (primer failed)", probe.label);
+            return Ok(());
+        }
+        println!("PROBE {}: prime {prime} delivered", probe.label);
     }
     // MS_PAIR is read here (after priming, before timestamps): millisecond-
     // consistent timestamps on every channel, expiry 45s after offer, derived
@@ -405,11 +442,15 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     }
     if routed {
         // Self LID from init, caller device from the probe: a server-routed
-        // inbound stanza names both ends.
+        // inbound stanza names both ends. Typed JIDs, not strings: the engine
+        // reads the JID wire encoding, and string attrs arrive malformed.
         wrapper = wrapper
-            .attr("recipient", "99887766554433:0@lid")
-            .attr("participant", caller.with_device(caller.device).to_string())
-            .attr("sender_lid", "11223344556677@lid");
+            .attr(
+                "recipient",
+                Jid::new("99887766554433", Server::Lid).with_device(0),
+            )
+            .attr("participant", caller.with_device(caller.device))
+            .attr("sender_lid", Jid::new("11223344556677", Server::Lid));
     }
     let wrapper = wrapper
         .children([
@@ -684,6 +725,10 @@ fn main() -> Result<()> {
     }
     println!("engine: {which}");
 
+    // PROBE=<label> runs a single probe (default: the whole matrix). A
+    // selector that matches nothing fails loudly: an empty run must never
+    // read as completed evidence.
+    let mut matched = false;
     for probe in [
         Probe {
             label: "settings-only",
@@ -874,8 +919,12 @@ fn main() -> Result<()> {
         {
             continue;
         }
+        matched = true;
         println!("=== {}", probe.label);
         run_probe(&bytes, &probe)?;
+    }
+    if !matched {
+        anyhow::bail!("PROBE selector matched no row");
     }
     Ok(())
 }

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -351,6 +351,11 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // The wrapper carries a stanza `id`: the engine files the record under it
     // (an idless record keeps transaction_id -1), and the pinned IR requires
     // it on inbound `<call>`.
+    // ROUTED=1 addresses the stanza like a real server delivery: `recipient`
+    // (this device), `participant` (caller device) and `sender_lid`. The
+    // router may refuse to file an offer it cannot address to itself, and no
+    // probe has ever carried these.
+    let routed = std::env::var("ROUTED").is_ok();
     let mut wrapper = NodeBuilder::new("call")
         .attr("from", caller.clone())
         .attr("id", "1")
@@ -365,6 +370,14 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .attr("t", t_all.to_string());
     if probe.expiry || ms_pair {
         wrapper = wrapper.attr("e", e_all.to_string());
+    }
+    if routed {
+        // Self LID from init, caller device from the probe: a server-routed
+        // inbound stanza names both ends.
+        wrapper = wrapper
+            .attr("recipient", "99887766554433:0@lid")
+            .attr("participant", caller.with_device(caller.device).to_string())
+            .attr("sender_lid", "11223344556677@lid");
     }
     let wrapper = wrapper
         .children([

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -273,12 +273,30 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         Ok(value) => format!("{value:?}"),
         Err(_) => "trap".to_owned(),
     };
-    // Collect queued main-thread work before reading state: with the main
-    // thread registered, answers wait in the proxy queue and only the host
-    // takes them out.
-    for _ in 0..5 {
+    // Collect queued main-thread work to observable quiescence before reading
+    // state: a fixed pass count can sample while activation is still pending,
+    // and processing a callback can enqueue more work. A `false` here marks
+    // the probe suspect, not conclusive.
+    let mut stable = 0;
+    let (mut last_signaling, mut last_log) = (usize::MAX, usize::MAX);
+    let mut quiesced = false;
+    for _ in 0..20 {
         r.process_queued_calls();
         r.refuel();
+        let (signaling, log) = (
+            r.signaling().map(|s| s.len()).unwrap_or(usize::MAX),
+            r.engine_log().len(),
+        );
+        if signaling == last_signaling && log == last_log {
+            stable += 1;
+            if stable >= 3 {
+                quiesced = true;
+                break;
+            }
+        } else {
+            stable = 0;
+            (last_signaling, last_log) = (signaling, log);
+        }
     }
     let immediate = r.call_embind("getCallInfo", &[]);
     r.refuel();
@@ -327,7 +345,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             .iter()
             .any(|l| l.contains("missed by the user"));
         println!(
-            "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
+            "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
             probe.label,
         );
         return Ok(());
@@ -379,7 +397,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .iter()
         .any(|l| l.contains("missed by the user"));
     println!(
-        "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
+        "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
         probe.label,
     );
     Ok(())

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -191,6 +191,18 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             marker_sink: None,
         },
     )?;
+    // LOG_LEVEL=N raises the engine log threshold before delivery: the default
+    // level hides subsystem diagnostics, and the miss decision may explain
+    // itself one level up.
+    if let Ok(level) = std::env::var("LOG_LEVEL")
+        && let Ok(level) = level.parse::<i32>()
+    {
+        match r.set_engine_log_level(level) {
+            Ok(previous) => println!("PROBE {}: log level {previous} -> {level}", probe.label),
+            Err(e) => println!("PROBE {}: set log level failed: {e}", probe.label),
+        }
+        r.refuel();
+    }
     // The event thread must be up before delivery: an offer into the startup
     // gap lands on a half-started engine and reads as a refusal.
     // MINIMAL=1 skips the gate and all seeding: every observation burns the
@@ -230,10 +242,14 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(
             &common::settings_offer(&caller, now, "0102030405060708", SETTINGS),
         )?);
+        if probe.ab_props && !minimal {
+            let set = set_ab_props(&mut r);
+            println!("  ab props accepted {set} of {}", AB_PROPS.len());
+        }
         r.call_embind(
             "handleIncomingSignalingOffer",
             &[
-                Value::Str(payload),
+                Value::Str(payload.clone()),
                 Value::Str("web".into()),
                 Value::Str("2.3000.0".into()),
                 Value::Str(now.to_string()),
@@ -281,8 +297,25 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     }
     let now = r.virtual_unix_time();
     let shifted: u64 = (now as i64 + probe.t_offset).max(0) as u64;
+    // MS_PAIR=1: millisecond-consistent timestamps on every channel (wrapper
+    // `t` and `e`, inner `t`, args 4/5), expiry 45s after offer. Overrides the
+    // per-probe timestamp flags: earlier t-ms probes kept `e` in seconds
+    // (expiry before offer), so they could not test millisecond reading.
+    let ms_pair = std::env::var("MS_PAIR").is_ok();
+    let t_all: u64 = if ms_pair {
+        now * 1000
+    } else if probe.t_millis {
+        shifted * 1000
+    } else {
+        shifted
+    };
+    let e_all: u64 = if ms_pair {
+        now * 1000 + 45000
+    } else {
+        shifted + if probe.expiry { 45 } else { 0 }
+    };
     let offer = if probe.video {
-        census_video_offer_at(probe.inner_t.then_some(shifted))
+        census_video_offer_at(probe.inner_t.then_some(t_all))
     } else {
         match common::settings_offer(&caller, shifted, CALL_ID, SETTINGS)
             .content
@@ -297,8 +330,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         }
     };
     // The settings sibling rides inside <call>, next to <offer>, on the wire.
+    // The wrapper carries a stanza `id`: the engine files the record under it
+    // (an idless record keeps transaction_id -1), and the pinned IR requires
+    // it on inbound `<call>`.
     let mut wrapper = NodeBuilder::new("call")
         .attr("from", caller.clone())
+        .attr("id", "1")
         .attr("call-id", CALL_ID)
         .attr(
             "call-creator",
@@ -307,16 +344,9 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
                 None => caller.clone(),
             },
         )
-        .attr(
-            "t",
-            if probe.t_millis {
-                (shifted * 1000).to_string()
-            } else {
-                shifted.to_string()
-            },
-        );
-    if probe.expiry {
-        wrapper = wrapper.attr("e", (shifted + 45).to_string());
+        .attr("t", t_all.to_string());
+    if probe.expiry || ms_pair {
+        wrapper = wrapper.attr("e", e_all.to_string());
     }
     let wrapper = wrapper
         .children([
@@ -335,8 +365,18 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // stoull (see `tests/signaling.rs::deliver`): the probe axes ride here,
     // not only on the stanza attributes, because the engine reads the header
     // inputs. `second_numeric_offset` shifts `t` into the future.
-    let (e_arg, t_arg) = (shifted + if probe.expiry { 45 } else { 0 }, second_numeric);
-    let t_arg = if probe.t_millis { t_arg * 1000 } else { t_arg };
+    let (e_arg, t_arg) = if ms_pair {
+        (e_all, t_all)
+    } else {
+        (
+            shifted + if probe.expiry { 45 } else { 0 },
+            if probe.t_millis {
+                second_numeric * 1000
+            } else {
+                second_numeric
+            },
+        )
+    };
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
     // Preserve the delivery outcome: a trap here must read as a delivery
     // failure, never as "the engine processed and rejected the offer".
@@ -344,41 +384,53 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // entry (payload, platform, version, e, t, bool, caller, bytes) instead of
     // the offer-specific one: same bytes, different router.
     let via_message = std::env::var("DELIVER_VIA").is_ok_and(|v| v == "message");
-    let delivered = if via_message {
-        r.call_embind(
-            "handleIncomingSignalingMessage",
-            &[
-                Value::Str(payload),
-                Value::Str("web".into()),
-                Value::Str("2.3000.0".into()),
-                Value::Str(e_arg.to_string()),
-                Value::Str(t_arg.to_string()),
-                Value::Bool(false),
-                Value::Str(caller.to_string()),
-                Value::Bytes(Vec::new()),
-            ],
-        )
-    } else {
-        r.call_embind(
-            "handleIncomingSignalingOffer",
-            &[
-                Value::Str(payload),
-                Value::Str("web".into()),
-                Value::Str("2.3000.0".into()),
-                Value::Str(e_arg.to_string()),
-                Value::Str(t_arg.to_string()),
-                Value::Bool(false),
-                Value::Bool(true),
-                Value::Str(caller.to_string()),
-                Value::Bytes(Vec::new()),
-            ],
-        )
-    };
-    r.refuel();
-    let delivered = match &delivered {
-        Ok(value) => format!("{value:?}"),
-        Err(_) => "trap".to_owned(),
-    };
+    // DELIVER_TWICE=1 feeds the same offer again on the same engine: the
+    // message-buffer scan decides 14/15/27 by what it finds buffered, so a
+    // second delivery meeting the first one's record must behave differently
+    // if buffer state is the gate.
+    let twice = std::env::var("DELIVER_TWICE").is_ok();
+    let rounds = if twice { 2 } else { 1 };
+    let mut delivered = String::new();
+    for round in 0..rounds {
+        let outcome = if via_message {
+            r.call_embind(
+                "handleIncomingSignalingMessage",
+                &[
+                    Value::Str(payload.clone()),
+                    Value::Str("web".into()),
+                    Value::Str("2.3000.0".into()),
+                    Value::Str(e_arg.to_string()),
+                    Value::Str(t_arg.to_string()),
+                    Value::Bool(false),
+                    Value::Str(caller.to_string()),
+                    Value::Bytes(Vec::new()),
+                ],
+            )
+        } else {
+            r.call_embind(
+                "handleIncomingSignalingOffer",
+                &[
+                    Value::Str(payload.clone()),
+                    Value::Str("web".into()),
+                    Value::Str("2.3000.0".into()),
+                    Value::Str(e_arg.to_string()),
+                    Value::Str(t_arg.to_string()),
+                    Value::Bool(false),
+                    Value::Bool(true),
+                    Value::Str(caller.to_string()),
+                    Value::Bytes(Vec::new()),
+                ],
+            )
+        };
+        r.refuel();
+        delivered = match &outcome {
+            Ok(value) => format!("{value:?}"),
+            Err(_) => "trap".to_owned(),
+        };
+        if twice {
+            println!("PROBE {}: delivery round {round}: {delivered}", probe.label);
+        }
+    }
     // Collect queued main-thread work to observable quiescence before reading
     // state: a fixed pass count can sample while activation is still pending,
     // and processing a callback can enqueue more work. Each pass yields briefly

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -18,7 +18,7 @@
 
 mod common;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base64::Engine as _;
 use oracle_core::{Runtime, Value};
 use sha2::{Digest, Sha256};
@@ -528,10 +528,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             )
         };
         r.refuel();
-        delivered = match &outcome {
-            Ok(value) => format!("{value:?}"),
-            Err(_) => "trap".to_owned(),
-        };
+        // A trapped delivery is a host failure, not a protocol observation:
+        // bail instead of carrying a dead row through state inspection and
+        // accept into an ordinary-looking verdict.
+        let value = outcome
+            .with_context(|| format!("PROBE {}: delivery round {round} trapped", probe.label))?;
+        delivered = format!("{value:?}");
         if twice {
             println!("PROBE {}: delivery round {round}: {delivered}", probe.label);
         }

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -300,20 +300,20 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     }
     let immediate = r.call_embind("getCallInfo", &[]);
     r.refuel();
-    // A trapped state query is a host failure, not a dead call: propagate it
-    // instead of letting the length heuristic below read it as torn down.
-    let alive = match &immediate {
+    // A trapped state query is a host failure, not a dead call: it is a
+    // distinct `unknown` outcome, never folded into dead.
+    let alive: Option<bool> = match &immediate {
         Err(e) => {
             println!("PROBE {}: getCallInfo trapped: {e}", probe.label);
-            false
+            None
         }
-        Ok(Value::Str(s)) => !s.is_empty(),
+        Ok(Value::Str(s)) => Some(!s.is_empty()),
         Ok(other) => {
             println!(
                 "PROBE {}: unexpected getCallInfo shape: {other:?}",
                 probe.label
             );
-            true
+            Some(true)
         }
     };
     // Was it already torn down before accept, or still pending? Snapshot the
@@ -330,13 +330,13 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     if std::env::var("SKIP_ACCEPT").is_ok() {
         r.settle(std::time::Duration::from_secs(3));
         r.refuel();
-        let alive_later = match r.call_embind("getCallInfo", &[]) {
+        let alive_later: Option<bool> = match r.call_embind("getCallInfo", &[]) {
             Err(e) => {
                 println!("PROBE {}: late getCallInfo trapped: {e}", probe.label);
-                false
+                None
             }
-            Ok(Value::Str(s)) => !s.is_empty(),
-            Ok(_) => true,
+            Ok(Value::Str(s)) => Some(!s.is_empty()),
+            Ok(_) => Some(true),
         };
         r.refuel();
         let emitted = r.signaling()?.len();
@@ -345,7 +345,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             .iter()
             .any(|l| l.contains("missed by the user"));
         println!(
-            "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
+            "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive:?} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later:?} emitted={emitted} missed={missed}",
             probe.label,
         );
         return Ok(());
@@ -397,7 +397,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .iter()
         .any(|l| l.contains("missed by the user"));
     println!(
-        "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
+        "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive:?} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
         probe.label,
     );
     Ok(())

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -280,9 +280,24 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         r.process_queued_calls();
         r.refuel();
     }
-    let immediate = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
+    let immediate = r.call_embind("getCallInfo", &[]);
     r.refuel();
-    let alive = !immediate.contains("\"\"") && immediate.len() > 20;
+    // A trapped state query is a host failure, not a dead call: propagate it
+    // instead of letting the length heuristic below read it as torn down.
+    let alive = match &immediate {
+        Err(e) => {
+            println!("PROBE {}: getCallInfo trapped: {e}", probe.label);
+            false
+        }
+        Ok(Value::Str(s)) => !s.is_empty(),
+        Ok(other) => {
+            println!(
+                "PROBE {}: unexpected getCallInfo shape: {other:?}",
+                probe.label
+            );
+            true
+        }
+    };
     // Was it already torn down before accept, or still pending? Snapshot the
     // teardown markers now: if `missed by the user` is logged pre-accept, the
     // call was born torn down (timestamp/parse issue); if absent, accept raced
@@ -297,9 +312,15 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     if std::env::var("SKIP_ACCEPT").is_ok() {
         r.settle(std::time::Duration::from_secs(3));
         r.refuel();
-        let later = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
+        let alive_later = match r.call_embind("getCallInfo", &[]) {
+            Err(e) => {
+                println!("PROBE {}: late getCallInfo trapped: {e}", probe.label);
+                false
+            }
+            Ok(Value::Str(s)) => !s.is_empty(),
+            Ok(_) => true,
+        };
         r.refuel();
-        let alive_later = !later.contains("\"\"") && later.len() > 20;
         let emitted = r.signaling()?.len();
         let missed = r
             .engine_log()

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -315,10 +315,59 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     }
     let now = r.virtual_unix_time();
     let shifted: u64 = (now as i64 + probe.t_offset).max(0) as u64;
-    // MS_PAIR=1: millisecond-consistent timestamps on every channel (wrapper
-    // `t` and `e`, inner `t`, args 4/5), expiry 45s after offer. Overrides the
-    // per-probe timestamp flags: earlier t-ms probes kept `e` in seconds
-    // (expiry before offer), so they could not test millisecond reading.
+    // PRIME=accept|reject: deliver that stanza for the same call id BEFORE the
+    // offer. The miss path scans the message buffer for a prior accept (→14)
+    // or reject (→15) of the call-id; priming decides whether the scan reads
+    // buffer writes at all, isolating "scan never matches" from "scan cannot
+    // match".
+    if let Ok(prime) = std::env::var("PRIME") {
+        let action = match prime.as_str() {
+            "accept" => NodeBuilder::new("accept")
+                .attr("call-creator", caller.clone())
+                .attr("call-id", CALL_ID)
+                .build(),
+            _ => NodeBuilder::new("reject")
+                .attr("call-creator", caller.clone())
+                .attr("call-id", CALL_ID)
+                .attr("count", "0")
+                .build(),
+        };
+        let primer = NodeBuilder::new("call")
+            .attr("from", caller.clone())
+            .attr("id", "0")
+            .attr("call-id", CALL_ID)
+            .attr("call-creator", caller.clone())
+            .attr("t", now.to_string())
+            .children([action])
+            .build();
+        let primer_payload =
+            base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&primer)?);
+        let primed = r.call_embind(
+            "handleIncomingSignalingOffer",
+            &[
+                Value::Str(primer_payload),
+                Value::Str("web".into()),
+                Value::Str("2.3000.0".into()),
+                Value::Str(now.to_string()),
+                Value::Str(now.to_string()),
+                Value::Bool(false),
+                Value::Bool(true),
+                Value::Str(caller.to_string()),
+                Value::Bytes(Vec::new()),
+            ],
+        );
+        r.refuel();
+        println!(
+            "PROBE {}: prime {prime} -> {}",
+            probe.label,
+            match &primed {
+                Ok(value) => format!("{value:?}"),
+                Err(_) => "trap".to_owned(),
+            }
+        );
+    }
+    // MS_PAIR is read here (after priming, before timestamps): millisecond-
+    // consistent timestamps on every channel, expiry 45s after offer.
     let ms_pair = std::env::var("MS_PAIR").is_ok();
     let t_all: u64 = if ms_pair {
         now * 1000

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -18,7 +18,7 @@
 
 mod common;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use base64::Engine as _;
 use oracle_core::{Runtime, Value};
 use sha2::{Digest, Sha256};
@@ -259,8 +259,8 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
         if !gated {
-            println!(
-                "PROBE {}: event thread never announced itself; results suspect",
+            bail!(
+                "PROBE {}: event thread never announced itself; delivering into the startup gap reads as refusal",
                 probe.label
             );
         }
@@ -686,10 +686,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         }
         return Ok(());
     }
-    let accepted = r.call_embind(
-        "acceptCall",
-        &[Value::Bool(probe.accept.0), Value::Bool(probe.accept.1)],
-    );
+    let accepted = r
+        .call_embind(
+            "acceptCall",
+            &[Value::Bool(probe.accept.0), Value::Bool(probe.accept.1)],
+        )
+        .with_context(|| format!("PROBE {}: acceptCall trapped", probe.label))?;
     r.refuel();
     // `settle` drains the proxy queue each tick, but a `false` return means it
     // never quiesced: reporting a stall then turns harness timing into a

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -292,13 +292,21 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         )
         .with_context(|| "REPLICATE_LOAD: settings offer delivery trapped")?;
         r.refuel();
-        r.settle(std::time::Duration::from_secs(3));
+        if !r.settle(std::time::Duration::from_secs(3)) {
+            bail!(
+                "REPLICATE_LOAD: offer settle never quiesced; replica sequence is work in flight"
+            );
+        }
         r.refuel();
         let rejected = r
             .call_embind("rejectCall", &[])
             .with_context(|| "REPLICATE_LOAD: rejectCall trapped")?;
         r.refuel();
-        r.settle(std::time::Duration::from_secs(3));
+        if !r.settle(std::time::Duration::from_secs(3)) {
+            bail!(
+                "REPLICATE_LOAD: post-reject settle never quiesced; second start would race teardown"
+            );
+        }
         r.refuel();
         let second = r.call_embind(
             "startVoipCall",

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -160,6 +160,18 @@ struct Probe {
     second_numeric_offset: Option<u64>,
     /// Stamp `t` on the inner `<offer>` as well as the `<call>` wrapper.
     inner_t: bool,
+    /// Shift the offer timestamp by this many seconds (wheels the wrapper `t`
+    /// and the `t` arg together). Diagnostic: if `call_offer_elapsed_t`
+    /// follows the shift, the engine reads our timestamp and the miss comes
+    /// from elsewhere; if it stays at the clock epoch, the engine never
+    /// finds it.
+    t_offset: i64,
+    /// Device suffix on the caller JID handed to the engine (untested axis:
+    /// every harness passes bare user form).
+    caller_device: Option<u16>,
+    /// Call-creator device suffix (`None` = bare user form, as the repo
+    /// suite sends; the matrix defaultресс is device 1).
+    creator_device: Option<u16>,
 }
 
 fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
@@ -168,43 +180,111 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         common::Startup {
             identity: SELF,
             attempts: 8,
-            register_main: true,
+            // NO_MAIN_THREAD=1: skip main-thread registration. With it on, a
+            // synchronous `handleIncomingSignalingOffer` can spin on work
+            // queued for the blocking main thread (see `state.rs`), and the
+            // scheduler's timeout escape may then surface partial processing
+            // as a verdict. Registration off trades away outbound-signaling
+            // collection (nothing to collect here) for a clean inbound path.
+            register_main: std::env::var("NO_MAIN_THREAD").is_err(),
             log_bytes: 4 << 20,
             marker_sink: None,
         },
     )?;
     // The event thread must be up before delivery: an offer into the startup
     // gap lands on a half-started engine and reads as a refusal.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
-    let mut gated = false;
-    while std::time::Instant::now() < deadline {
-        if r.engine_log()
-            .iter()
-            .any(|l| l.contains("call_event_proc resumed"))
-        {
-            gated = true;
-            break;
+    // MINIMAL=1 skips the gate and all seeding: every observation burns the
+    // monotonic clock the guest advances per read, so the earliest possible
+    // feed discriminates clock-burn from unreadiness.
+    let minimal = std::env::var("MINIMAL").is_ok();
+    if !minimal {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let mut gated = false;
+        while std::time::Instant::now() < deadline {
+            if r.engine_log()
+                .iter()
+                .any(|l| l.contains("call_event_proc resumed"))
+            {
+                gated = true;
+                break;
+            }
+            r.process_queued_calls();
+            r.refuel();
+            std::thread::sleep(std::time::Duration::from_millis(20));
         }
-        r.process_queued_calls();
-        r.refuel();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        if !gated {
+            println!(
+                "PROBE {}: event thread never announced itself; results suspect",
+                probe.label
+            );
+        }
     }
-    if !gated {
-        println!(
-            "PROBE {}: event thread never announced itself; results suspect",
-            probe.label
+    // REPLICATE_LOAD=1: exact `load_settings` sequence from
+    // `outbound_after_settings.rs` (settings offer, settle, rejectCall to
+    // clear, second start). That flow reports the second start failing with
+    // "already initialized", i.e. a surviving context; if it does not
+    // replicate here, the observation is harness-conditional.
+    if std::env::var("REPLICATE_LOAD").is_ok() {
+        let caller = Jid::new("11223344556677", Server::Lid);
+        let now = r.virtual_unix_time();
+        let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(
+            &common::settings_offer(&caller, now, "0102030405060708", SETTINGS),
+        )?);
+        r.call_embind(
+            "handleIncomingSignalingOffer",
+            &[
+                Value::Str(payload),
+                Value::Str("web".into()),
+                Value::Str("2.3000.0".into()),
+                Value::Str(now.to_string()),
+                Value::Str(now.to_string()),
+                Value::Bool(false),
+                Value::Bool(true),
+                Value::Str(caller.to_string()),
+                Value::Bytes(Vec::new()),
+            ],
+        )
+        .ok();
+        r.refuel();
+        r.settle(std::time::Duration::from_secs(3));
+        r.refuel();
+        let rejected = r.call_embind("rejectCall", &[]);
+        r.refuel();
+        r.settle(std::time::Duration::from_secs(3));
+        r.refuel();
+        let second = r.call_embind(
+            "startVoipCall",
+            &[
+                Value::Str("11223344556677@lid".into()),
+                Value::StringList(vec!["11223344556677:0@lid".into()]),
+                Value::Str("0011223344556677".into()),
+                Value::Bool(false),
+                Value::Str("11223344556677@lid".into()),
+                Value::Bool(false),
+                Value::Bytes(Vec::new()),
+            ],
         );
-    };
-    if probe.ab_props {
+        r.refuel();
+        println!("REPLICA: rejectCall -> {rejected:?}, second start -> {second:?}");
+        for line in r.engine_log().iter().rev().take(8).rev() {
+            println!("    log: {}", line.trim());
+        }
+        return Ok(());
+    }
+    if probe.ab_props && !minimal {
         let set = set_ab_props(&mut r);
         println!("  ab props accepted {set} of {}", AB_PROPS.len());
     }
-    let caller = Jid::new("11223344556677", Server::Lid);
+    let mut caller = Jid::new("11223344556677", Server::Lid);
+    if let Some(device) = probe.caller_device {
+        caller = caller.with_device(device);
+    }
     let now = r.virtual_unix_time();
+    let shifted: u64 = (now as i64 + probe.t_offset).max(0) as u64;
     let offer = if probe.video {
-        census_video_offer_at(probe.inner_t.then_some(now))
+        census_video_offer_at(probe.inner_t.then_some(shifted))
     } else {
-        match common::settings_offer(&caller, now, CALL_ID, SETTINGS)
+        match common::settings_offer(&caller, shifted, CALL_ID, SETTINGS)
             .content
             .clone()
         {
@@ -220,17 +300,23 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     let mut wrapper = NodeBuilder::new("call")
         .attr("from", caller.clone())
         .attr("call-id", CALL_ID)
-        .attr("call-creator", caller.with_device(1))
+        .attr(
+            "call-creator",
+            match probe.creator_device {
+                Some(device) => caller.with_device(device),
+                None => caller.clone(),
+            },
+        )
         .attr(
             "t",
             if probe.t_millis {
-                (now * 1000).to_string()
+                (shifted * 1000).to_string()
             } else {
-                now.to_string()
+                shifted.to_string()
             },
         );
     if probe.expiry {
-        wrapper = wrapper.attr("e", (now + 45).to_string());
+        wrapper = wrapper.attr("e", (shifted + 45).to_string());
     }
     let wrapper = wrapper
         .children([
@@ -242,32 +328,52 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         ])
         .build();
     let second_numeric = match probe.second_numeric_offset {
-        Some(offset) => now + offset,
-        None => now,
+        Some(offset) => shifted + offset,
+        None => shifted,
     };
     // Arguments 4 and 5 are the stanza's `e` and `t` timestamps, read with
     // stoull (see `tests/signaling.rs::deliver`): the probe axes ride here,
     // not only on the stanza attributes, because the engine reads the header
     // inputs. `second_numeric_offset` shifts `t` into the future.
-    let (e_arg, t_arg) = (now + if probe.expiry { 45 } else { 0 }, second_numeric);
+    let (e_arg, t_arg) = (shifted + if probe.expiry { 45 } else { 0 }, second_numeric);
     let t_arg = if probe.t_millis { t_arg * 1000 } else { t_arg };
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
     // Preserve the delivery outcome: a trap here must read as a delivery
     // failure, never as "the engine processed and rejected the offer".
-    let delivered = r.call_embind(
-        "handleIncomingSignalingOffer",
-        &[
-            Value::Str(payload),
-            Value::Str("web".into()),
-            Value::Str("2.3000.0".into()),
-            Value::Str(e_arg.to_string()),
-            Value::Str(t_arg.to_string()),
-            Value::Bool(false),
-            Value::Bool(true),
-            Value::Str(caller.to_string()),
-            Value::Bytes(Vec::new()),
-        ],
-    );
+    // DELIVER_VIA=message routes through the generic `handleIncomingSignalingMessage`
+    // entry (payload, platform, version, e, t, bool, caller, bytes) instead of
+    // the offer-specific one: same bytes, different router.
+    let via_message = std::env::var("DELIVER_VIA").is_ok_and(|v| v == "message");
+    let delivered = if via_message {
+        r.call_embind(
+            "handleIncomingSignalingMessage",
+            &[
+                Value::Str(payload),
+                Value::Str("web".into()),
+                Value::Str("2.3000.0".into()),
+                Value::Str(e_arg.to_string()),
+                Value::Str(t_arg.to_string()),
+                Value::Bool(false),
+                Value::Str(caller.to_string()),
+                Value::Bytes(Vec::new()),
+            ],
+        )
+    } else {
+        r.call_embind(
+            "handleIncomingSignalingOffer",
+            &[
+                Value::Str(payload),
+                Value::Str("web".into()),
+                Value::Str("2.3000.0".into()),
+                Value::Str(e_arg.to_string()),
+                Value::Str(t_arg.to_string()),
+                Value::Bool(false),
+                Value::Bool(true),
+                Value::Str(caller.to_string()),
+                Value::Bytes(Vec::new()),
+            ],
+        )
+    };
     r.refuel();
     let delivered = match &delivered {
         Ok(value) => format!("{value:?}"),
@@ -299,6 +405,45 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             stable = 0;
             (last_signaling, last_log) = (signaling, log);
         }
+    }
+    // Did the inbound blob land in the applied settings store? The offer
+    // carries caller_timeout=45; an empty read-back means the expiry path
+    // computes against an unapplied (zero) window and every offer is
+    // instantly stale no matter what timestamps ride it.
+    let applied_timeout = match r.call_embind(
+        "getVoipParam",
+        &[Value::Str("options.caller_timeout".into())],
+    ) {
+        Ok(Value::Str(s)) if s.is_empty() => "empty".to_owned(),
+        Ok(Value::Str(s)) => s,
+        other => format!("{other:?}"),
+    };
+    r.refuel();
+    println!(
+        "PROBE {}: applied caller_timeout={applied_timeout}",
+        probe.label
+    );
+    if std::env::var("LOG_SPAN").is_ok() {
+        let lines = r.engine_log();
+        if let Some(start) = lines.iter().position(|l| l.contains("!Offer from:")) {
+            for line in lines.iter().skip(start).take(60) {
+                println!("    span: {}", line.trim());
+            }
+        } else {
+            println!("    span: no !Offer line; last 10 lines:");
+            for line in lines.iter().rev().take(10).rev() {
+                println!("    span: {}", line.trim());
+            }
+        }
+        for line in r
+            .logs()
+            .iter()
+            .filter(|l| l.contains("host stat:"))
+            .take(10)
+        {
+            println!("    {line}");
+        }
+        return Ok(());
     }
     let immediate = r.call_embind("getCallInfo", &[]);
     r.refuel();
@@ -398,8 +543,17 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .engine_log()
         .iter()
         .any(|l| l.contains("missed by the user"));
+    // Report the elapsed stat the engine logged: it discriminates "reads our
+    // timestamp" (follows the shift) from "never finds it" (stays at epoch).
+    let elapsed = r
+        .engine_log()
+        .iter()
+        .rev()
+        .find(|l| l.contains("call_offer_elapsed_t"))
+        .map(|l| l.trim().to_owned())
+        .unwrap_or_default();
     println!(
-        "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive:?} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason}",
+        "PROBE {}: delivered={delivered} quiesced={quiesced} alive={alive:?} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} settled={settled} emitted={emitted} missed={missed} {term_reason} | {elapsed}",
         probe.label,
     );
     Ok(())
@@ -425,6 +579,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "settings-only+ab",
@@ -435,6 +592,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab",
@@ -445,6 +605,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab,accept-ff",
@@ -455,6 +618,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab+expiry",
@@ -465,6 +631,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "settings-only+expiry",
@@ -475,6 +644,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "settings-only+t-ms",
@@ -485,6 +657,9 @@ fn main() -> Result<()> {
             t_millis: true,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab+t-ms",
@@ -495,6 +670,9 @@ fn main() -> Result<()> {
             t_millis: true,
             second_numeric_offset: None,
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab+future-t",
@@ -505,6 +683,9 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: Some(45),
             inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
         },
         Probe {
             label: "video+ab+inner-t",
@@ -515,8 +696,69 @@ fn main() -> Result<()> {
             t_millis: false,
             second_numeric_offset: None,
             inner_t: true,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: Some(1),
+        },
+        Probe {
+            label: "video+ab+t+100k",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+            t_offset: 100000,
+            caller_device: None,
+            creator_device: Some(1),
+        },
+        Probe {
+            label: "video+ab+t-100k",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+            t_offset: -100000,
+            caller_device: None,
+            creator_device: Some(1),
+        },
+        Probe {
+            label: "video+ab+caller-dev0",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+            t_offset: 0,
+            caller_device: Some(0),
+            creator_device: Some(1),
+        },
+        Probe {
+            label: "video+ab+creator-bare",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+            t_offset: 0,
+            caller_device: None,
+            creator_device: None,
         },
     ] {
+        // PROBE=<label> runs a single probe (default: the whole matrix).
+        if let Ok(only) = std::env::var("PROBE")
+            && only != probe.label
+        {
+            continue;
+        }
         println!("=== {}", probe.label);
         run_probe(&bytes, &probe)?;
     }

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -275,14 +275,16 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     };
     // Collect queued main-thread work to observable quiescence before reading
     // state: a fixed pass count can sample while activation is still pending,
-    // and processing a callback can enqueue more work. A `false` here marks
-    // the probe suspect, not conclusive.
+    // and processing a callback can enqueue more work. Each pass yields briefly
+    // so guest workers are actually scheduled between observations. A `false`
+    // here marks the probe suspect, not conclusive.
     let mut stable = 0;
     let (mut last_signaling, mut last_log) = (usize::MAX, usize::MAX);
     let mut quiesced = false;
     for _ in 0..20 {
         r.process_queued_calls();
         r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(50));
         let (signaling, log) = (
             r.signaling().map(|s| s.len()).unwrap_or(usize::MAX),
             r.engine_log().len(),

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -294,7 +294,9 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         r.refuel();
         r.settle(std::time::Duration::from_secs(3));
         r.refuel();
-        let rejected = r.call_embind("rejectCall", &[]);
+        let rejected = r
+            .call_embind("rejectCall", &[])
+            .with_context(|| "REPLICATE_LOAD: rejectCall trapped")?;
         r.refuel();
         r.settle(std::time::Duration::from_secs(3));
         r.refuel();
@@ -640,7 +642,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // does, then read state: if the call is alive here, the premature accept
     // is what kills it, and the fix is sequencing (wait for active).
     if std::env::var("SKIP_ACCEPT").is_ok() {
-        r.settle(std::time::Duration::from_secs(3));
+        if !r.settle(std::time::Duration::from_secs(3)) {
+            bail!(
+                "PROBE {}: SKIP_ACCEPT settle never quiesced; state below is work in flight, not evidence",
+                probe.label
+            );
+        }
         r.refuel();
         let alive_later: Option<bool> = match r.call_embind("getCallInfo", &[]) {
             Err(e) => {

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -752,10 +752,13 @@ fn main() -> Result<()> {
     let catalog = oracle_core::Catalog::discover()?;
     let entry = catalog.resolve(&which)?;
     let bytes = std::fs::read(&entry.path)?;
+    let sha = hex::encode(Sha256::digest(&bytes));
     if which == ENGINE {
-        assert_eq!(hex::encode(Sha256::digest(&bytes)), ENGINE_SHA);
+        assert_eq!(sha, ENGINE_SHA);
     }
-    println!("engine: {which}");
+    // An override never runs silently: its hash prints every run, so a stale
+    // or modified capture cannot masquerade as the pinned engine's evidence.
+    println!("engine: {which} sha256={sha}");
 
     // PROBE=<label> runs a single probe (default: the whole matrix). A
     // selector that matches nothing fails loudly: an empty run must never

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -617,7 +617,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
                 "PROBE {}: unexpected getCallInfo shape: {other:?}",
                 probe.label
             );
-            Some(true)
+            None
         }
     };
     // Was it already torn down before accept, or still pending? Snapshot the
@@ -640,7 +640,13 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
                 None
             }
             Ok(Value::Str(s)) => Some(!s.is_empty()),
-            Ok(_) => Some(true),
+            Ok(other) => {
+                println!(
+                    "PROBE {}: unexpected late getCallInfo shape: {other:?}",
+                    probe.label
+                );
+                None
+            }
         };
         r.refuel();
         let emitted = r.signaling()?.len();

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -308,18 +308,20 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             );
         }
         r.refuel();
-        let second = r.call_embind(
-            "startVoipCall",
-            &[
-                Value::Str("11223344556677@lid".into()),
-                Value::StringList(vec!["11223344556677:0@lid".into()]),
-                Value::Str("0011223344556677".into()),
-                Value::Bool(false),
-                Value::Str("11223344556677@lid".into()),
-                Value::Bool(false),
-                Value::Bytes(Vec::new()),
-            ],
-        );
+        let second = r
+            .call_embind(
+                "startVoipCall",
+                &[
+                    Value::Str("11223344556677@lid".into()),
+                    Value::StringList(vec!["11223344556677:0@lid".into()]),
+                    Value::Str("0011223344556677".into()),
+                    Value::Bool(false),
+                    Value::Str("11223344556677@lid".into()),
+                    Value::Bool(false),
+                    Value::Bytes(Vec::new()),
+                ],
+            )
+            .with_context(|| "REPLICATE_LOAD: second startVoipCall trapped")?;
         r.refuel();
         println!("REPLICA: rejectCall -> {rejected:?}, second start -> {second:?}");
         for line in r.engine_log().iter().rev().take(8).rev() {
@@ -581,6 +583,18 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             (last_signaling, last_log) = (signaling, log);
         }
     }
+    // The scheduler's lock watchdog taints the run: handling stops partway,
+    // which would otherwise read as a protocol observation. Bail on exactly
+    // that complaint, like the signaling tests and the both-sides driver.
+    if r.engine_log()
+        .iter()
+        .any(|l| l.contains("check_locking_order"))
+    {
+        bail!(
+            "PROBE {}: lock-order inversion handling the offer; row tainted",
+            probe.label
+        );
+    }
     // Did the inbound blob land in the applied settings store? The offer
     // carries caller_timeout=45; an empty read-back means the expiry path
     // computes against an unapplied (zero) window and every offer is
@@ -688,18 +702,20 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
     // object exists even when `getCallInfo` reads empty, separating
     // state (missed) from existence.
     if std::env::var("CHECK_CONTEXT").is_ok() {
-        let second = r.call_embind(
-            "startVoipCall",
-            &[
-                Value::Str("11223344556677@lid".into()),
-                Value::StringList(vec!["11223344556677:0@lid".into()]),
-                Value::Str("probe-second-start".into()),
-                Value::Bool(true),
-                Value::Str("11223344556677@lid".into()),
-                Value::Bool(false),
-                Value::Bytes(vec![0xA5; 32]),
-            ],
-        );
+        let second = r
+            .call_embind(
+                "startVoipCall",
+                &[
+                    Value::Str("11223344556677@lid".into()),
+                    Value::StringList(vec!["11223344556677:0@lid".into()]),
+                    Value::Str("probe-second-start".into()),
+                    Value::Bool(true),
+                    Value::Str("11223344556677@lid".into()),
+                    Value::Bool(false),
+                    Value::Bytes(vec![0xA5; 32]),
+                ],
+            )
+            .with_context(|| "REPLICATE_LOAD: second startVoipCall trapped")?;
         r.refuel();
         println!("PROBE {}: second start -> {second:?}", probe.label,);
         for line in r.engine_log().iter().rev().take(6).rev() {

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -224,7 +224,9 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         None => now,
     };
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
-    r.call_embind(
+    // Preserve the delivery outcome: a trap here must read as a delivery
+    // failure, never as "the engine processed and rejected the offer".
+    let delivered = r.call_embind(
         "handleIncomingSignalingOffer",
         &[
             Value::Str(payload),
@@ -237,9 +239,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             Value::Str(caller.to_string()),
             Value::Bytes(Vec::new()),
         ],
-    )
-    .ok();
+    );
     r.refuel();
+    let delivered = match &delivered {
+        Ok(value) => format!("{value:?}"),
+        Err(_) => "trap".to_owned(),
+    };
     let immediate = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
     r.refuel();
     let alive = !immediate.contains("\"\"") && immediate.len() > 20;
@@ -266,7 +271,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             .iter()
             .any(|l| l.contains("missed by the user"));
         println!(
-            "PROBE {}: alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
+            "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
             probe.label,
         );
         return Ok(());
@@ -315,7 +320,7 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         .iter()
         .any(|l| l.contains("missed by the user"));
     println!(
-        "PROBE {}: alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} emitted={emitted} missed={missed} {term_reason}",
+        "PROBE {}: delivered={delivered} alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} emitted={emitted} missed={missed} {term_reason}",
         probe.label,
     );
     Ok(())

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -242,10 +242,6 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(
             &common::settings_offer(&caller, now, "0102030405060708", SETTINGS),
         )?);
-        if probe.ab_props && !minimal {
-            let set = set_ab_props(&mut r);
-            println!("  ab props accepted {set} of {}", AB_PROPS.len());
-        }
         r.call_embind(
             "handleIncomingSignalingOffer",
             &[
@@ -286,6 +282,28 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
             println!("    log: {}", line.trim());
         }
         return Ok(());
+    }
+    // COMBINED=1: originate an outbound call first, then feed the inbound
+    // offer for a different call id. The miss path bails when the message
+    // buffer is absent, and origination may be what allocates it: if the
+    // inbound call activates here, buffer/global init is the gate.
+    if std::env::var("COMBINED").is_ok() {
+        let started = r.call_embind(
+            "startVoipCall",
+            &[
+                Value::Str("11223344556677@lid".into()),
+                Value::StringList(vec!["11223344556677:0@lid".into()]),
+                Value::Str("outbound-seed".into()),
+                Value::Bool(false),
+                Value::Str("11223344556677@lid".into()),
+                Value::Bool(false),
+                Value::Bytes(vec![0xA5; 32]),
+            ],
+        );
+        r.refuel();
+        r.settle(std::time::Duration::from_secs(5));
+        r.refuel();
+        println!("PROBE {}: seed start -> {started:?}", probe.label);
     }
     if probe.ab_props && !minimal {
         let set = set_ab_props(&mut r);

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -1,0 +1,440 @@
+//! Which seeded state, if any, lets the pinned engine keep an inbound video
+//! offer alive long enough to accept it?
+//!
+//! Each probe feeds one inbound offer to a fresh engine, reads `getCallInfo`
+//! immediately (empty means the call never existed, not even transiently),
+//! attempts `acceptCall`, and reports what the engine emitted. Probes vary
+//! three axes: the A/B properties `setABPropsOnWasm` forwards (`AB_PROPS`,
+//! neutral values, copied from `outbound_after_settings.rs`), the offer shape
+//! (settings-only vs video with a clear call key), and the accept arguments.
+//!
+//! All identities are fictitious. Execute in release.
+//!
+//! ```sh
+//! cargo run --release -p oracle-core --example video_answerer_matrix
+//! ```
+//!
+//! `ENGINE` overrides the pinned module (default `JgwtTQVeWPm`).
+
+mod common;
+
+use anyhow::Result;
+use base64::Engine as _;
+use oracle_core::{Runtime, Value};
+use sha2::{Digest, Sha256};
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::jid::Server;
+use wacore_binary::{Jid, Node, marshal};
+
+const ENGINE: &str = "JgwtTQVeWPm";
+const ENGINE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+const SELF: [&str; 3] = [
+    "15550002222@c.us",
+    "15550002222:0@c.us",
+    "99887766554433:0@lid",
+];
+const CALL_ID: &str = "0011223344556677";
+const CALL_KEY: [u8; 32] = [0x5A; 32];
+const SETTINGS: &[u8] =
+    br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"false","caller_timeout":"45"}}"#;
+
+/// Neutral A/B values, as `WAWebVoipStackInterfaceWebHelpers` would forward
+/// them. Copied from `outbound_after_settings.rs`; the question is the same:
+/// does configuring the engine at all change what it does?
+const AB_PROPS: &[(&str, &str)] = &[
+    ("aigc_version", "int"),
+    ("app_exit_reason_version", "int"),
+    ("attach_transport_rtx", "bool"),
+    ("audio_level_speaking_threshold", "int"),
+    ("call_admin_version", "int"),
+    ("calling_rust_migration_bitmap", "int"),
+    ("calling_rust_migration_incoming_stanza_bitmap", "int"),
+    ("calling_screen_share_milestone_version", "int"),
+    ("default_endpoint_thread_poll_timeout", "int"),
+    ("enable_av_downgrade", "bool"),
+    ("enable_init_bwe_for_group_call", "bool"),
+    (
+        "enable_new_user_action_stanza_for_raise_hand_sender",
+        "bool",
+    ),
+    ("enable_offer_v2_upgrade", "bool"),
+    ("enable_ring_for_gc_on_offer_expire", "bool"),
+    ("enable_silent_offer", "bool"),
+    ("enable_waiting_room_logging", "bool"),
+    ("enable_webcodec_video_encode", "bool"),
+    ("enable_web_voip_audio_driver_lifetime_fix", "bool"),
+    ("heartbeat_interval_s", "int"),
+    ("ignore_joinable_terminate_on_expired_offer", "bool"),
+    ("lobby_timeout_min", "int"),
+    ("max_group_size_for_long_ringtone", "int"),
+    ("max_num_participants_for_ss", "int"),
+    ("allow_reporting_call_replayer_id", "bool"),
+    ("vid_stream_pause_resume_jb_reset_threshold_ms", "int"),
+    ("voice_ai_conversation_starter_latency_tracking", "bool"),
+    ("voip_stack_incoming_message_ownership_transfer", "bool"),
+    ("log_level", "int"),
+];
+
+/// The vendor's own video child, read back from a `startVoipCall` offer so the
+/// inbound shape carries no invented bytes.
+const VIDEO_ATTRS: &[(&str, &str)] = &[
+    ("enc", "h.264"),
+    ("dec", "H264"),
+    ("device_orientation", "0"),
+    ("screen_width", "0"),
+    ("screen_height", "0"),
+];
+
+fn video_child() -> Node {
+    let mut builder = NodeBuilder::new("video");
+    for (name, value) in VIDEO_ATTRS {
+        builder = builder.attr(name, (*value).to_owned());
+    }
+    builder.build()
+}
+
+fn census_video_offer_at(now: Option<u64>) -> Node {
+    let mut offer = NodeBuilder::new("offer");
+    if let Some(now) = now {
+        offer = offer.attr("t", now.to_string());
+    }
+    offer
+        .children([
+            NodeBuilder::new("audio")
+                .attr("enc", "opus")
+                .attr("rate", "16000")
+                .build(),
+            video_child(),
+            NodeBuilder::new("net").attr("medium", "3").build(),
+            NodeBuilder::new("enc")
+                .attr("count", "0")
+                .bytes(CALL_KEY.to_vec())
+                .build(),
+            NodeBuilder::new("encopt").attr("keygen", "2").build(),
+        ])
+        .build()
+}
+
+fn set_ab_props(r: &mut Runtime) -> usize {
+    let mut set = 0;
+    for (key, kind) in AB_PROPS {
+        let call = match *kind {
+            "bool" => r.call_embind(
+                "setABPropBool",
+                &[Value::Str((*key).into()), Value::Bool(true)],
+            ),
+            _ => r.call_embind(
+                "setABPropInt",
+                &[
+                    Value::Str((*key).into()),
+                    Value::Int(if *key == "log_level" { 9 } else { 0 }),
+                ],
+            ),
+        };
+        r.refuel();
+        if call.is_ok() {
+            set += 1;
+        }
+    }
+    set
+}
+
+struct Probe {
+    label: &'static str,
+    ab_props: bool,
+    video: bool,
+    accept: (bool, bool),
+    /// Expiry (`e`) on the `<call>` wrapper: the pinned IR lists it as a known
+    /// inbound attr, and the engine tears the offer down as expired before
+    /// accept, so a missing expiry is a suspect.
+    expiry: bool,
+    /// Send `t` in milliseconds rather than seconds: if the engine reads the
+    /// offer timestamp in ms, a seconds `t` sits 1000x in the past and the
+    /// offer arrives already expired.
+    t_millis: bool,
+    /// Second numeric argument to `handleIncomingSignalingOffer` as an offset
+    /// from now (`None` repeats now, as every harness does). If that slot is
+    /// an expiry rather than a second timestamp, `now` expires the offer on
+    /// arrival, which fits the born-torn-down verdict exactly.
+    second_numeric_offset: Option<u64>,
+    /// Stamp `t` on the inner `<offer>` as well as the `<call>` wrapper.
+    inner_t: bool,
+}
+
+fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
+    let mut r = common::engine(
+        bytes,
+        common::Startup {
+            identity: SELF,
+            attempts: 8,
+            register_main: true,
+            log_bytes: 4 << 20,
+            marker_sink: None,
+        },
+    )?;
+    if probe.ab_props {
+        let set = set_ab_props(&mut r);
+        println!("  ab props accepted {set} of {}", AB_PROPS.len());
+    }
+    let caller = Jid::new("11223344556677", Server::Lid);
+    let now = r.virtual_unix_time();
+    let offer = if probe.video {
+        census_video_offer_at(probe.inner_t.then_some(now))
+    } else {
+        match common::settings_offer(&caller, now, CALL_ID, SETTINGS)
+            .content
+            .clone()
+        {
+            Some(wacore_binary::node::NodeContent::Nodes(children)) => children
+                .iter()
+                .find(|c| c.tag == "offer")
+                .cloned()
+                .expect("settings carrier holds an <offer>"),
+            _ => anyhow::bail!("settings carrier has no children"),
+        }
+    };
+    // The settings sibling rides inside <call>, next to <offer>, on the wire.
+    let mut wrapper = NodeBuilder::new("call")
+        .attr("from", caller.clone())
+        .attr("call-id", CALL_ID)
+        .attr("call-creator", caller.with_device(1))
+        .attr(
+            "t",
+            if probe.t_millis {
+                (now * 1000).to_string()
+            } else {
+                now.to_string()
+            },
+        );
+    if probe.expiry {
+        wrapper = wrapper.attr("e", (now + 45).to_string());
+    }
+    let wrapper = wrapper
+        .children([
+            offer,
+            NodeBuilder::new("voip_settings")
+                .attr("uncompressed", "1")
+                .bytes(SETTINGS.to_vec())
+                .build(),
+        ])
+        .build();
+    let second_numeric = match probe.second_numeric_offset {
+        Some(offset) => now + offset,
+        None => now,
+    };
+    let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
+    r.call_embind(
+        "handleIncomingSignalingOffer",
+        &[
+            Value::Str(payload),
+            Value::Str("web".into()),
+            Value::Str("2.3000.0".into()),
+            Value::Str(now.to_string()),
+            Value::Str(second_numeric.to_string()),
+            Value::Bool(false),
+            Value::Bool(true),
+            Value::Str(caller.to_string()),
+            Value::Bytes(Vec::new()),
+        ],
+    )
+    .ok();
+    r.refuel();
+    let immediate = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
+    r.refuel();
+    let alive = !immediate.contains("\"\"") && immediate.len() > 20;
+    // Was it already torn down before accept, or still pending? Snapshot the
+    // teardown markers now: if `missed by the user` is logged pre-accept, the
+    // call was born torn down (timestamp/parse issue); if absent, accept raced
+    // an activation that never completes (missing-state issue).
+    let torn_down_pre_accept = r
+        .engine_log()
+        .iter()
+        .any(|l| l.contains("missed by the user") || l.contains("call_term_reason"));
+    // SKIP_ACCEPT=1: do not race activation. Feed, settle like `load_settings`
+    // does, then read state: if the call is alive here, the premature accept
+    // is what kills it, and the fix is sequencing (wait for active).
+    if std::env::var("SKIP_ACCEPT").is_ok() {
+        r.settle(std::time::Duration::from_secs(3));
+        r.refuel();
+        let later = format!("{:?}", r.call_embind("getCallInfo", &[]).ok());
+        r.refuel();
+        let alive_later = !later.contains("\"\"") && later.len() > 20;
+        let emitted = r.signaling()?.len();
+        let missed = r
+            .engine_log()
+            .iter()
+            .any(|l| l.contains("missed by the user"));
+        println!(
+            "PROBE {}: alive={alive} preaccept_torn_down={torn_down_pre_accept} no-accept: alive_later={alive_later} emitted={emitted} missed={missed}",
+            probe.label,
+        );
+        return Ok(());
+    }
+    // CHECK_CONTEXT=1: replicate the `load_settings` observation. A second
+    // `startVoipCall` reporting already-initialized proves a call context
+    // object exists even when `getCallInfo` reads empty, separating
+    // state (missed) from existence.
+    if std::env::var("CHECK_CONTEXT").is_ok() {
+        let second = r.call_embind(
+            "startVoipCall",
+            &[
+                Value::Str("11223344556677@lid".into()),
+                Value::StringList(vec!["11223344556677:0@lid".into()]),
+                Value::Str("probe-second-start".into()),
+                Value::Bool(true),
+                Value::Str("11223344556677@lid".into()),
+                Value::Bool(false),
+                Value::Bytes(vec![0xA5; 32]),
+            ],
+        );
+        r.refuel();
+        println!("PROBE {}: second start -> {second:?}", probe.label,);
+        for line in r.engine_log().iter().rev().take(6).rev() {
+            println!("    log: {}", line.trim());
+        }
+        return Ok(());
+    }
+    let accepted = r.call_embind(
+        "acceptCall",
+        &[Value::Bool(probe.accept.0), Value::Bool(probe.accept.1)],
+    );
+    r.refuel();
+    r.settle(std::time::Duration::from_secs(5));
+    r.refuel();
+    let emitted = r.signaling()?.len();
+    let term_reason = r
+        .engine_log()
+        .iter()
+        .rev()
+        .find(|l| l.contains("call_term_reason"))
+        .map(|l| l.trim().to_owned())
+        .unwrap_or_default();
+    let missed = r
+        .engine_log()
+        .iter()
+        .any(|l| l.contains("missed by the user"));
+    println!(
+        "PROBE {}: alive={alive} preaccept_torn_down={torn_down_pre_accept} accept={accepted:?} emitted={emitted} missed={missed} {term_reason}",
+        probe.label,
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let which = std::env::var("ENGINE").unwrap_or_else(|_| ENGINE.into());
+    let catalog = oracle_core::Catalog::discover()?;
+    let entry = catalog.resolve(&which)?;
+    let bytes = std::fs::read(&entry.path)?;
+    if which == ENGINE {
+        assert_eq!(hex::encode(Sha256::digest(&bytes)), ENGINE_SHA);
+    }
+    println!("engine: {which}");
+
+    for probe in [
+        Probe {
+            label: "settings-only",
+            ab_props: false,
+            video: false,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "settings-only+ab",
+            ab_props: true,
+            video: false,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab,accept-ff",
+            ab_props: true,
+            video: true,
+            accept: (false, false),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab+expiry",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: true,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "settings-only+expiry",
+            ab_props: false,
+            video: false,
+            accept: (true, true),
+            expiry: true,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "settings-only+t-ms",
+            ab_props: false,
+            video: false,
+            accept: (true, true),
+            expiry: false,
+            t_millis: true,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab+t-ms",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: true,
+            second_numeric_offset: None,
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab+num45",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: Some(45),
+            inner_t: false,
+        },
+        Probe {
+            label: "video+ab+inner-t",
+            ab_props: true,
+            video: true,
+            accept: (true, true),
+            expiry: false,
+            t_millis: false,
+            second_numeric_offset: None,
+            inner_t: true,
+        },
+    ] {
+        println!("=== {}", probe.label);
+        run_probe(&bytes, &probe)?;
+    }
+    Ok(())
+}

--- a/tools/oracle-core/examples/video_answerer_matrix.rs
+++ b/tools/oracle-core/examples/video_answerer_matrix.rs
@@ -170,7 +170,7 @@ struct Probe {
     /// every harness passes bare user form).
     caller_device: Option<u16>,
     /// Call-creator device suffix (`None` = bare user form, as the repo
-    /// suite sends; the matrix defaultресс is device 1).
+    /// suite sends; the matrix default is device 1).
     creator_device: Option<u16>,
 }
 
@@ -283,28 +283,12 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         }
         return Ok(());
     }
-    // COMBINED=1: originate an outbound call first, then feed the inbound
-    // offer for a different call id. The miss path bails when the message
-    // buffer is absent, and origination may be what allocates it: if the
-    // inbound call activates here, buffer/global init is the gate.
-    if std::env::var("COMBINED").is_ok() {
-        let started = r.call_embind(
-            "startVoipCall",
-            &[
-                Value::Str("11223344556677@lid".into()),
-                Value::StringList(vec!["11223344556677:0@lid".into()]),
-                Value::Str("outbound-seed".into()),
-                Value::Bool(false),
-                Value::Str("11223344556677@lid".into()),
-                Value::Bool(false),
-                Value::Bytes(vec![0xA5; 32]),
-            ],
-        );
-        r.refuel();
-        r.settle(std::time::Duration::from_secs(5));
-        r.refuel();
-        println!("PROBE {}: seed start -> {started:?}", probe.label);
-    }
+    // COMBINED mode removed: originating first leaves the outbound context
+    // live during the inbound feed, so a failure reads as glare against an
+    // active call rather than answering whether origination allocates the
+    // missing message buffer. Clearing it first (endCall) would be the honest
+    // variant; until then the mode stays out instead of reporting confounded
+    // verdicts.
     if probe.ab_props && !minimal {
         let set = set_ab_props(&mut r);
         println!("  ab props accepted {set} of {}", AB_PROPS.len());
@@ -367,17 +351,16 @@ fn run_probe(bytes: &[u8], probe: &Probe) -> Result<()> {
         );
     }
     // MS_PAIR is read here (after priming, before timestamps): millisecond-
-    // consistent timestamps on every channel, expiry 45s after offer.
+    // consistent timestamps on every channel, expiry 45s after offer, derived
+    // from the shifted clock so past/future rows actually move.
     let ms_pair = std::env::var("MS_PAIR").is_ok();
-    let t_all: u64 = if ms_pair {
-        now * 1000
-    } else if probe.t_millis {
+    let t_all: u64 = if ms_pair || probe.t_millis {
         shifted * 1000
     } else {
         shifted
     };
     let e_all: u64 = if ms_pair {
-        now * 1000 + 45000
+        shifted * 1000 + 45000
     } else {
         shifted + if probe.expiry { 45 } else { 0 }
     };

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -278,6 +278,8 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
 /// what the engine emitted plus whether the offer parsed. Returns the emitted
 /// stanzas and whether the run quiesced throughout: without quiescence a
 /// missing accept is inconclusive host scheduling, not a protocol stall.
+/// The third element reports whether activation was ever unobservable
+/// (trapped or misshapen state queries), which is likewise inconclusive.
 ///
 /// `identity` is the device under test: the raw probe runs the engine as the
 /// peer (the offer's true recipient), the census probe as self.
@@ -287,7 +289,7 @@ fn side_b_answerer(
     caller: Jid,
     body: Vec<Node>,
     label: &str,
-) -> Result<(Vec<Node>, bool)> {
+) -> Result<(Vec<Node>, bool, bool)> {
     let mut r = start(bytes, identity)?;
     await_event_thread(&mut r, label)?;
     let now = r.virtual_unix_time();
@@ -342,13 +344,25 @@ fn side_b_answerer(
     // so a never-activating offer still terminates the run with a verdict.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
     let mut activated = false;
+    // A trapped or misshapen state query is not an empty state: it means
+    // activation was never successfully observed, which the final verdict
+    // must carry as unknown rather than a clean stall.
+    let mut activation_unknown = false;
     while std::time::Instant::now() < deadline {
         match r.call_embind("getCallInfo", &[]) {
             Ok(Value::Str(s)) if !s.is_empty() => {
                 activated = true;
                 break;
             }
-            _ => {}
+            Ok(Value::Str(_)) => {}
+            Ok(other) => {
+                println!("side B [{label}]: unexpected getCallInfo shape: {other:?}");
+                activation_unknown = true;
+            }
+            Err(e) => {
+                println!("side B [{label}]: getCallInfo trapped: {e}");
+                activation_unknown = true;
+            }
         }
         r.process_queued_calls();
         r.refuel();
@@ -371,7 +385,7 @@ fn side_b_answerer(
     for line in r.engine_log().iter().rev().take(12).rev() {
         println!("    log: {}", line.trim());
     }
-    Ok((emitted, quiesced && settled))
+    Ok((emitted, quiesced && settled, activation_unknown))
 }
 
 fn voip_settings_sibling() -> Node {
@@ -447,7 +461,7 @@ fn main() -> Result<()> {
     // delivered to an engine running as the peer — the offer's true recipient —
     // with Side A as the incoming caller.
     let peer_caller = Jid::new("99887766554433", Server::Lid);
-    let (emitted_raw, raw_quiet) = side_b_answerer(
+    let (emitted_raw, raw_quiet, _raw_unknown) = side_b_answerer(
         &bytes,
         [
             "11223344556677@c.us",
@@ -466,7 +480,7 @@ fn main() -> Result<()> {
     // Side B, probe 2: census shape with the vendor's own <video> child,
     // delivered to an engine running as self with the peer as caller.
     let census_caller = Jid::new("11223344556677", Server::Lid);
-    let (emitted, quiet) = side_b_answerer(
+    let (emitted, quiet, activation_unknown) = side_b_answerer(
         &bytes,
         [SELF, SELF_DEVICE, SELF_LID],
         census_caller.clone(),
@@ -510,11 +524,11 @@ fn main() -> Result<()> {
                 Some(d) => println!("VERDICT answerer: DIVERGENCE: {d}"),
             }
         }
-        None if quiet => {
+        None if quiet && !activation_unknown => {
             println!("VERDICT answerer: STALL, no <accept> emitted; nothing to compare")
         }
         None => println!(
-            "VERDICT answerer: INCONCLUSIVE, no <accept> emitted without quiescence; not a protocol stall"
+            "VERDICT answerer: INCONCLUSIVE, no <accept> emitted without clean activation observation; not a protocol stall"
         ),
     }
 

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -75,10 +75,6 @@ fn start(bytes: &[u8], identity: [&str; 3]) -> Result<Runtime> {
 }
 
 /// Wait for the event thread before delivering anything: an offer into the
-/// startup gap lands on a half-started engine and reads as a refusal. Warns
-/// and continues on timeout so a slow host degrades the verdict instead of
-/// hanging the run.
-/// Wait for the event thread before delivering anything: an offer into the
 /// startup gap lands on a half-started engine and reads as a refusal. A
 /// missing startup marker is a startup failure, not protocol evidence, so a
 /// blown deadline fails loudly instead of letting later verdicts blame the

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -81,14 +81,27 @@ fn start(bytes: &[u8]) -> Result<Runtime> {
 }
 
 /// Decode one recorded stanza, skipping the stream-flag leading byte.
-fn decode(call: &SignalingCall) -> Option<Node> {
-    call.stanza
+///
+/// Loud on failure: a corrupt or truncated capture must surface as a decode
+/// error, never as "the engine emitted nothing" (which would misreport a
+/// broken host path as a signaling stall).
+fn decode(call: &SignalingCall) -> Result<Node> {
+    let body = call
+        .stanza
         .get(1..)
-        .map(marshal::unmarshal_ref)
-        .transpose()
-        .ok()
-        .flatten()
-        .map(|node| node.to_owned())
+        .context("signaling stanza shorter than the stream flag")?;
+    Ok(marshal::unmarshal_ref(body)
+        .with_context(|| format!("undecodable signaling stanza ({} bytes)", body.len()))?
+        .to_owned())
+}
+
+/// Truncate at a character boundary: engine Debug output may hold multi-byte
+/// characters, and byte-index slicing panics mid-character.
+fn clip(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
 }
 
 fn children_of(node: &Node) -> Vec<Node> {
@@ -105,55 +118,54 @@ fn child_tags(node: &Node) -> Vec<String> {
         .collect()
 }
 
-/// Field-level diff of the vendor offer against our video-offer builder.
-/// Returns the first divergence, or `None` when the deterministic fields agree.
-/// Random per-call bytes (`<enc>` ciphertext, `<privacy>`) are excluded: the
-/// engine mints fresh keys every run, so byte equality there is unachievable.
-fn diff_offer(vendor: &Node, rust: &Node) -> Option<String> {
-    let v_tags = child_tags(vendor);
-    let r_tags = child_tags(rust);
-    if v_tags != r_tags {
-        return Some(format!("child order {v_tags:?} vs {r_tags:?}"));
-    }
-    let attr = |node: &Node, tag: &str, name: &str| {
-        children_of(node)
+/// Field-level diff of two same-level stanzas: child order, every child's
+/// attributes, and every child's bytes.
+///
+/// Two exclusions, both stage mismatches rather than drift. `<enc>` carries
+/// fresh ciphertext per run, so its bytes can never agree. And the engine
+/// emits the pre-fanout skeleton (bare `count`), while our builder emits the
+/// post-fanout per-device form (`v`/`type` added by the JS fan-out the engine
+/// never performs) — so only `count` participates for `<enc>`. Per-call
+/// `<privacy>` is deterministic inside this harness (both sides are handed the
+/// same token), so it compares in full.
+fn diff_children(vendor: &Node, rust: &Node) -> Option<String> {
+    // Attribute order is not a wire fact (XML attributes are unordered), so
+    // the signature sorts attributes by name; only the set of pairs matters.
+    fn signature(node: &Node) -> String {
+        let mut attrs: Vec<(String, String)> = node
+            .attrs
             .iter()
-            .find(|c| c.tag == tag)
-            .and_then(|n| {
-                n.attrs()
-                    .optional_string(name)
-                    .as_deref()
-                    .map(str::to_owned)
-            })
-    };
-    for name in [
-        "enc",
-        "dec",
-        "device_orientation",
-        "screen_width",
-        "screen_height",
-    ] {
-        if attr(vendor, "video", name) != attr(rust, "video", name) {
-            return Some(format!(
-                "video attr {name}: {:?} vs {:?}",
-                attr(vendor, "video", name),
-                attr(rust, "video", name)
-            ));
+            .filter(|(k, _)| node.tag != "enc" || k.as_ref() as &str == "count")
+            .map(|(k, v)| (k.to_string(), format!("{v:?}")))
+            .collect();
+        attrs.sort();
+        match &node.content {
+            Some(NodeContent::Bytes(_)) if node.tag == "enc" => {
+                format!("{} {attrs:?}", node.tag)
+            }
+            _ => format!("{} {attrs:?} {:?}", node.tag, node.content),
         }
     }
-    let cap = |node: &Node| {
-        children_of(node)
-            .iter()
-            .find(|c| c.tag == "capability")
-            .and_then(|n| match &n.content {
-                Some(NodeContent::Bytes(bytes)) => Some(bytes.clone()),
-                _ => None,
-            })
-    };
-    if cap(vendor) != cap(rust) {
-        return Some("capability bytes differ".to_owned());
+    let (v_children, r_children) = (children_of(vendor), children_of(rust));
+    if child_tags(vendor) != child_tags(rust) {
+        return Some(format!(
+            "child order {:?} vs {:?}",
+            child_tags(vendor),
+            child_tags(rust)
+        ));
     }
-    None
+    v_children
+        .iter()
+        .zip(r_children.iter())
+        .enumerate()
+        .find_map(|(i, (v, r))| {
+            (signature(v) != signature(r)).then(|| {
+                format!(
+                    "child {i} <{}> differs:\n  vendor {v:?}\n  rust   {r:?}",
+                    v.tag
+                )
+            })
+        })
 }
 
 /// Side A: place a video call, return the emitted `<offer>` node.
@@ -176,15 +188,17 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
     r.refuel();
     let ret = outcome.as_ref().ok().and_then(|v| v.as_int());
     let stanzas = r.signaling()?;
-    let total: usize = stanzas.iter().map(|s| s.stanza.len()).sum();
-    let offer = stanzas
+    let decoded: Vec<(usize, Node)> = stanzas
         .iter()
-        .filter_map(decode)
-        .find(|n| n.tag == "offer")
+        .map(|call| decode(call).map(|node| (call.stanza.len(), node)))
+        .collect::<Result<_>>()?;
+    let (offer_len, offer) = decoded
+        .into_iter()
+        .find(|(_, n)| n.tag == "offer")
         .context("side A emitted no <offer>")?;
     let info = r.call_embind("getCallInfo", &[]).ok();
     r.refuel();
-    println!("side A: startVoipCall -> {ret:?}, offer {total} bytes");
+    println!("side A: startVoipCall -> {ret:?}, offer {offer_len} bytes");
     println!("side A: offer children {:?}", child_tags(&offer));
     Ok((offer, format!("{info:?}")))
 }
@@ -230,13 +244,13 @@ fn side_b_answerer(bytes: &[u8], body: Vec<Node>, label: &str) -> Result<Vec<Nod
     let immediate_state = format!("{immediate:?}");
     println!(
         "side B [{label}]: immediate getCallInfo: {}",
-        &immediate_state[..immediate_state.len().min(400)]
+        clip(&immediate_state, 400)
     );
     let accepted = r.call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)]);
     r.refuel();
     r.settle(std::time::Duration::from_secs(5));
     r.refuel();
-    let emitted: Vec<Node> = r.signaling()?.iter().filter_map(decode).collect();
+    let emitted: Vec<Node> = r.signaling()?.iter().map(decode).collect::<Result<_>>()?;
     println!(
         "side B [{label}]: offer parsed={parsed}, acceptCall -> {accepted:?}, emitted={}",
         emitted.len()
@@ -285,7 +299,8 @@ fn main() -> Result<()> {
         .cloned()
         .context("side A offer has no <video> child")?;
 
-    // Initiator differential: vendor offer vs our builder on deterministic fields.
+    // Initiator differential: vendor offer vs our builder, every deterministic
+    // field (`<enc>` bytes excluded: fresh ciphertext per run).
     let peer = Jid::new("11223344556677", Server::Lid);
     let creator = Jid::new("99887766554433", Server::Lid);
     let rust_offer = build_offer(&OfferParams {
@@ -310,8 +325,8 @@ fn main() -> Result<()> {
         .find(|c| c.tag == "offer")
         .cloned()
         .context("rust offer wrapper holds no <offer>")?;
-    match diff_offer(&offer, &rust_inner) {
-        None => println!("VERDICT initiator: MATCH on deterministic fields"),
+    match diff_children(&offer, &rust_inner) {
+        None => println!("VERDICT initiator: MATCH on all compared fields"),
         Some(d) => println!("VERDICT initiator: DIVERGENCE: {d}"),
     }
 
@@ -359,15 +374,14 @@ fn main() -> Result<()> {
                 .find(|c| c.tag == "accept")
                 .cloned()
                 .context("rust accept wrapper holds no <accept>")?;
-            println!(
-                "VERDICT answerer: vendor accept children {:?} vs rust {:?}",
-                child_tags(vendor_accept),
-                child_tags(&rust_accept)
-            );
+            match diff_children(vendor_accept, &rust_accept) {
+                None => println!("VERDICT answerer: MATCH on all compared fields"),
+                Some(d) => println!("VERDICT answerer: DIVERGENCE: {d}"),
+            }
         }
         None => println!("VERDICT answerer: STALL, no <accept> emitted; nothing to compare"),
     }
 
-    println!("side A call state: {}", &a_state[..a_state.len().min(300)]);
+    println!("side A call state: {}", clip(&a_state, 300));
     Ok(())
 }

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -466,7 +466,7 @@ fn main() -> Result<()> {
     // delivered to an engine running as the peer — the offer's true recipient —
     // with Side A as the incoming caller.
     let peer_caller = Jid::new("99887766554433", Server::Lid);
-    let (emitted_raw, raw_quiet, _raw_unknown) = side_b_answerer(
+    let (emitted_raw, raw_quiet, raw_unknown) = side_b_answerer(
         &bytes,
         [
             "11223344556677@c.us",
@@ -478,7 +478,7 @@ fn main() -> Result<()> {
         "raw vendor offer",
     )?;
     println!(
-        "VERDICT answerer/raw: emitted {} stanza(s), quiesced={raw_quiet}",
+        "VERDICT answerer/raw: emitted {} stanza(s), quiesced={raw_quiet}, activation_unknown={raw_unknown}",
         emitted_raw.len()
     );
 

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -360,7 +360,11 @@ fn side_b_answerer(
         std::thread::sleep(std::time::Duration::from_millis(20));
     }
     println!("side B [{label}]: activated={activated}");
-    let accepted = r.call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)]);
+    // A trapped accept is a host failure, not answerer behavior: bail
+    // inconclusive instead of reporting a stall on signaling that never ran.
+    let accepted = r
+        .call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)])
+        .context("side B acceptCall trapped")?;
     r.refuel();
     let settled = r.settle(std::time::Duration::from_secs(5));
     r.refuel();

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -346,8 +346,13 @@ fn side_b_answerer(
     let mut activated = false;
     // A trapped or misshapen state query is not an empty state: it means
     // activation was never successfully observed, which the final verdict
-    // must carry as unknown rather than a clean stall.
-    let mut activation_unknown = false;
+    // must carry as unknown rather than a clean stall. An unparsed offer is
+    // the same: with no parse, a later quiet drain cannot make the missing
+    // accept a protocol verdict.
+    let mut activation_unknown = !parsed;
+    if !parsed {
+        println!("side B [{label}]: offer never parsed; answerer behavior unobservable");
+    }
     while std::time::Instant::now() < deadline {
         match r.call_embind("getCallInfo", &[]) {
             Ok(Value::Str(s)) if !s.is_empty() => {

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -155,8 +155,8 @@ fn child_tags(node: &Node) -> Vec<String> {
 /// same token), so it compares in full.
 fn diff_children(vendor: &Node, rust: &Node) -> Option<String> {
     // Attribute order is not a wire fact (XML attributes are unordered), so
-    // the signature sorts attributes by name; only the set of pairs matters.
-    fn signature(node: &Node) -> String {
+    // signatures sort attributes by name; only the set of pairs matters.
+    fn attr_set(node: &Node) -> Vec<(String, String)> {
         let mut attrs: Vec<(String, String)> = node
             .attrs
             .iter()
@@ -164,12 +164,28 @@ fn diff_children(vendor: &Node, rust: &Node) -> Option<String> {
             .map(|(k, v)| (k.to_string(), format!("{v:?}")))
             .collect();
         attrs.sort();
+        attrs
+    }
+    fn signature(node: &Node) -> String {
         match &node.content {
             Some(NodeContent::Bytes(_)) if node.tag == "enc" => {
-                format!("{} {attrs:?}", node.tag)
+                format!("{} {:?}", node.tag, attr_set(node))
             }
-            _ => format!("{} {attrs:?} {:?}", node.tag, node.content),
+            _ => format!("{} {:?} {:?}", node.tag, attr_set(node), node.content),
         }
+    }
+    // The action nodes themselves carry `call-id`/`call-creator`: an identifier
+    // drift must fail here, not hide behind matching children. (`<enc>`
+    // bytes/`v`/`type` stay excluded per the stage rule above.)
+    if vendor.tag != rust.tag {
+        return Some(format!("action tag {} vs {}", vendor.tag, rust.tag));
+    }
+    if attr_set(vendor) != attr_set(rust) {
+        return Some(format!(
+            "action attrs {:?} vs {:?}",
+            attr_set(vendor),
+            attr_set(rust)
+        ));
     }
     let (v_children, r_children) = (children_of(vendor), children_of(rust));
     if child_tags(vendor) != child_tags(rust) {
@@ -283,6 +299,23 @@ fn side_b_answerer(
         "side B [{label}]: immediate getCallInfo: {}",
         clip(&immediate_state, 400)
     );
+    // Do not race activation: poll for a live call before accepting, bounded
+    // so a never-activating offer still terminates the run with a verdict.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut activated = false;
+    while std::time::Instant::now() < deadline {
+        match r.call_embind("getCallInfo", &[]) {
+            Ok(Value::Str(s)) if !s.is_empty() => {
+                activated = true;
+                break;
+            }
+            _ => {}
+        }
+        r.process_queued_calls();
+        r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    println!("side B [{label}]: activated={activated}");
     let accepted = r.call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)]);
     r.refuel();
     let settled = r.settle(std::time::Duration::from_secs(5));

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -335,9 +335,18 @@ fn side_b_answerer(
     let quiesced = drain(&mut r);
     println!("side B [{label}]: quiesced={quiesced}");
     let parsed = r.engine_log().iter().any(|l| l.contains("!Offer from:"));
+    // The scheduler's lock watchdog taints the run: handling stops after the
+    // offer marker but before status 0, which would otherwise read as a clean
+    // stall. Bail on exactly that complaint, like the signaling tests.
+    if r.engine_log()
+        .iter()
+        .any(|l| l.contains("check_locking_order"))
+    {
+        bail!("side B [{label}]: lock-order inversion handling the offer; run tainted");
+    }
     // State immediately after delivery, before accept: is the call EVER active,
     // even transiently, or is it born torn down?
-    let immediate = r.call_embind("getCallInfo", &[]).ok();
+    let immediate = r.call_embind("getCallInfo", &[]);
     r.refuel();
     let immediate_state = format!("{immediate:?}");
     println!(
@@ -356,6 +365,10 @@ fn side_b_answerer(
     let mut activation_unknown = !parsed;
     if !parsed {
         println!("side B [{label}]: offer never parsed; answerer behavior unobservable");
+    }
+    if let Err(e) = &immediate {
+        println!("side B [{label}]: initial getCallInfo trapped: {e}");
+        activation_unknown = true;
     }
     while std::time::Instant::now() < deadline {
         match r.call_embind("getCallInfo", &[]) {

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -275,7 +275,9 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
 }
 
 /// Side B: deliver one inbound `<call>` body, attempt `acceptCall`, and report
-/// what the engine emitted plus whether the offer parsed.
+/// what the engine emitted plus whether the offer parsed. Returns the emitted
+/// stanzas and whether the run quiesced throughout: without quiescence a
+/// missing accept is inconclusive host scheduling, not a protocol stall.
 ///
 /// `identity` is the device under test: the raw probe runs the engine as the
 /// peer (the offer's true recipient), the census probe as self.
@@ -285,7 +287,7 @@ fn side_b_answerer(
     caller: Jid,
     body: Vec<Node>,
     label: &str,
-) -> Result<Vec<Node>> {
+) -> Result<(Vec<Node>, bool)> {
     let mut r = start(bytes, identity)?;
     await_event_thread(&mut r, label)?;
     let now = r.virtual_unix_time();
@@ -369,7 +371,7 @@ fn side_b_answerer(
     for line in r.engine_log().iter().rev().take(12).rev() {
         println!("    log: {}", line.trim());
     }
-    Ok(emitted)
+    Ok((emitted, quiesced && settled))
 }
 
 fn voip_settings_sibling() -> Node {
@@ -445,7 +447,7 @@ fn main() -> Result<()> {
     // delivered to an engine running as the peer — the offer's true recipient —
     // with Side A as the incoming caller.
     let peer_caller = Jid::new("99887766554433", Server::Lid);
-    let emitted_raw = side_b_answerer(
+    let (emitted_raw, raw_quiet) = side_b_answerer(
         &bytes,
         [
             "11223344556677@c.us",
@@ -457,14 +459,14 @@ fn main() -> Result<()> {
         "raw vendor offer",
     )?;
     println!(
-        "VERDICT answerer/raw: emitted {} stanza(s)",
+        "VERDICT answerer/raw: emitted {} stanza(s), quiesced={raw_quiet}",
         emitted_raw.len()
     );
 
     // Side B, probe 2: census shape with the vendor's own <video> child,
     // delivered to an engine running as self with the peer as caller.
     let census_caller = Jid::new("11223344556677", Server::Lid);
-    let emitted = side_b_answerer(
+    let (emitted, quiet) = side_b_answerer(
         &bytes,
         [SELF, SELF_DEVICE, SELF_LID],
         census_caller.clone(),
@@ -508,7 +510,12 @@ fn main() -> Result<()> {
                 Some(d) => println!("VERDICT answerer: DIVERGENCE: {d}"),
             }
         }
-        None => println!("VERDICT answerer: STALL, no <accept> emitted; nothing to compare"),
+        None if quiet => {
+            println!("VERDICT answerer: STALL, no <accept> emitted; nothing to compare")
+        }
+        None => println!(
+            "VERDICT answerer: INCONCLUSIVE, no <accept> emitted without quiescence; not a protocol stall"
+        ),
     }
 
     println!("side A call state: {}", clip(&a_state, 300));

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -99,7 +99,9 @@ fn await_event_thread(r: &mut Runtime, label: &str) {
 /// only the host takes them out. A fixed pass count can sample state while
 /// activation is still pending (processing a callback can enqueue more work),
 /// so quiescence — signaling count and log length unchanged across passes — is
-/// awaited and reported. Returns whether it was reached.
+/// awaited and reported. Each pass yields briefly so guest workers are actually
+/// scheduled between observations; back-to-back passes with no worker progress
+/// would declare a false quiescence. Returns whether it was reached.
 fn drain(r: &mut Runtime) -> bool {
     const PASSES: usize = 20;
     const STABLE: usize = 3;
@@ -108,6 +110,7 @@ fn drain(r: &mut Runtime) -> bool {
     for _ in 0..PASSES {
         r.process_queued_calls();
         r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(50));
         let (signaling, log) = (
             r.signaling().map(|s| s.len()).unwrap_or(usize::MAX),
             r.engine_log().len(),
@@ -288,7 +291,9 @@ fn side_b_answerer(
         .children(body)
         .build();
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
-    r.call_embind(
+    // Preserve the delivery outcome: a trap here must read as a delivery
+    // failure, never as a signaling stall.
+    let delivered = r.call_embind(
         "handleIncomingSignalingOffer",
         &[
             Value::Str(payload),
@@ -301,9 +306,15 @@ fn side_b_answerer(
             Value::Str(caller.to_string()),
             Value::Bytes(Vec::new()),
         ],
-    )
-    .ok();
+    );
     r.refuel();
+    println!(
+        "side B [{label}]: delivered={}",
+        match &delivered {
+            Ok(value) => format!("{value:?}"),
+            Err(_) => "trap".to_owned(),
+        }
+    );
     // No settle here: the virtual clock advances per observation, and settling
     // ages the call past `caller_timeout`, tearing it down as missed before
     // anything can accept it (see `signaling_census`). Drain to observable

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -57,27 +57,52 @@ fn load_engine() -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn start(bytes: &[u8]) -> Result<Runtime> {
+fn start(bytes: &[u8], identity: [&str; 3]) -> Result<Runtime> {
     for _ in 0..8 {
         let mut r = Runtime::instantiate(bytes)?;
         r.set_thread_policy(ThreadPolicy::Spawn);
         r.set_main_thread_registration(true);
         r.run_ctors()?;
         r.attach_log_ring(4 << 20)?;
-        let init = r.call_embind(
-            "initVoipStack",
-            &[
-                Value::Str(SELF.into()),
-                Value::Str(SELF_DEVICE.into()),
-                Value::Str(SELF_LID.into()),
-            ],
-        );
+        let args = identity.map(|value| Value::Str(value.to_owned()));
+        let init = r.call_embind("initVoipStack", &args);
         r.refuel();
         if init.as_ref().ok().and_then(|v| v.as_int()) == Some(0) {
             return Ok(r);
         }
     }
     bail!("initVoipStack never returned 0")
+}
+
+/// Wait for the event thread before delivering anything: an offer into the
+/// startup gap lands on a half-started engine and reads as a refusal. Warns
+/// and continues on timeout so a slow host degrades the verdict instead of
+/// hanging the run.
+fn await_event_thread(r: &mut Runtime, label: &str) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        if r.engine_log()
+            .iter()
+            .any(|l| l.contains("call_event_proc resumed"))
+        {
+            return;
+        }
+        r.process_queued_calls();
+        r.refuel();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    println!("{label}: event thread never announced itself; results suspect");
+}
+
+/// Drain main-thread work the engine queued: with the main thread registered,
+/// answers wait in the proxy queue and only the host takes them out. Reading
+/// state without draining reports "the engine did nothing" about a run in
+/// which it queued the answer and nobody collected it.
+fn drain(r: &mut Runtime) {
+    for _ in 0..5 {
+        r.process_queued_calls();
+        r.refuel();
+    }
 }
 
 /// Decode one recorded stanza, skipping the stream-flag leading byte.
@@ -170,7 +195,8 @@ fn diff_children(vendor: &Node, rust: &Node) -> Option<String> {
 
 /// Side A: place a video call, return the emitted `<offer>` node.
 fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
-    let mut r = start(bytes)?;
+    let mut r = start(bytes, [SELF, SELF_DEVICE, SELF_LID])?;
+    await_event_thread(&mut r, "side A");
     let outcome = r.call_embind(
         "startVoipCall",
         &[
@@ -205,9 +231,18 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
 
 /// Side B: deliver one inbound `<call>` body, attempt `acceptCall`, and report
 /// what the engine emitted plus whether the offer parsed.
-fn side_b_answerer(bytes: &[u8], body: Vec<Node>, label: &str) -> Result<Vec<Node>> {
-    let mut r = start(bytes)?;
-    let caller = Jid::new("11223344556677", Server::Lid);
+///
+/// `identity` is the device under test: the raw probe runs the engine as the
+/// peer (the offer's true recipient), the census probe as self.
+fn side_b_answerer(
+    bytes: &[u8],
+    identity: [&str; 3],
+    caller: Jid,
+    body: Vec<Node>,
+    label: &str,
+) -> Result<Vec<Node>> {
+    let mut r = start(bytes, identity)?;
+    await_event_thread(&mut r, label);
     let now = r.virtual_unix_time();
     let wrapper = NodeBuilder::new("call")
         .attr("from", caller.clone())
@@ -235,7 +270,9 @@ fn side_b_answerer(bytes: &[u8], body: Vec<Node>, label: &str) -> Result<Vec<Nod
     r.refuel();
     // No settle here: the virtual clock advances per observation, and settling
     // ages the call past `caller_timeout`, tearing it down as missed before
-    // anything can accept it (see `signaling_census`).
+    // anything can accept it (see `signaling_census`). Drain first so queued
+    // main-thread work is collected before state is read.
+    drain(&mut r);
     let parsed = r.engine_log().iter().any(|l| l.contains("!Offer from:"));
     // State immediately after delivery, before accept: is the call EVER active,
     // even transiently, or is it born torn down?
@@ -248,11 +285,11 @@ fn side_b_answerer(bytes: &[u8], body: Vec<Node>, label: &str) -> Result<Vec<Nod
     );
     let accepted = r.call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)]);
     r.refuel();
-    r.settle(std::time::Duration::from_secs(5));
+    let settled = r.settle(std::time::Duration::from_secs(5));
     r.refuel();
     let emitted: Vec<Node> = r.signaling()?.iter().map(decode).collect::<Result<_>>()?;
     println!(
-        "side B [{label}]: offer parsed={parsed}, acceptCall -> {accepted:?}, emitted={}",
+        "side B [{label}]: offer parsed={parsed}, acceptCall -> {accepted:?}, settled={settled}, emitted={}",
         emitted.len()
     );
     for line in r.engine_log().iter().rev().take(12).rev() {
@@ -330,9 +367,18 @@ fn main() -> Result<()> {
         Some(d) => println!("VERDICT initiator: DIVERGENCE: {d}"),
     }
 
-    // Side B, probe 1: the vendor's own offer bytes (real ciphertext, no key).
+    // Side B, probe 1: the vendor's own offer bytes (real ciphertext, no key),
+    // delivered to an engine running as the peer — the offer's true recipient —
+    // with Side A as the incoming caller.
+    let peer_caller = Jid::new("99887766554433", Server::Lid);
     let emitted_raw = side_b_answerer(
         &bytes,
+        [
+            "11223344556677@c.us",
+            "11223344556677:0@c.us",
+            "11223344556677:0@lid",
+        ],
+        peer_caller,
         vec![offer.clone(), voip_settings_sibling()],
         "raw vendor offer",
     )?;
@@ -341,9 +387,12 @@ fn main() -> Result<()> {
         emitted_raw.len()
     );
 
-    // Side B, probe 2: census shape with the vendor's own <video> child.
+    // Side B, probe 2: census shape with the vendor's own <video> child,
+    // delivered to an engine running as self with the peer as caller.
     let emitted = side_b_answerer(
         &bytes,
+        [SELF, SELF_DEVICE, SELF_LID],
+        Jid::new("11223344556677", Server::Lid),
         vec![census_video_offer(&video), voip_settings_sibling()],
         "census video offer",
     )?;

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -1,0 +1,364 @@
+//! A complete video call through the pinned engine, both sides in one run.
+//!
+//! Side A (initiator) places a video call with `startVoipCall` and the emitted
+//! `<offer>` is captured. Side B (answerer) is fed an offer through
+//! `handleIncomingSignalingOffer`, then `acceptCall` is attempted and whatever
+//! the engine emits is captured. Each emitted stanza is diffed field by field
+//! against the matching whatsapp-rust builder; the run ends with a VERDICTS
+//! block naming the first divergence, or the stall point with engine-log
+//! evidence when a side emits nothing.
+//!
+//! All identities are fictitious. Execute in release: debug Cranelift
+//! compilation is too slow for meaningful engine deadlines.
+//!
+//! ```sh
+//! cargo run --release -p oracle-core --example video_call_both_sides
+//! ```
+//!
+//! `ENGINE` overrides the pinned module (default `JgwtTQVeWPm`).
+
+use anyhow::{Context, Result, bail};
+use base64::Engine as _;
+use oracle_core::{Catalog, Runtime, SignalingCall, ThreadPolicy, Value};
+use sha2::{Digest, Sha256};
+use wacore::stanza::call::{
+    AcceptParams, CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, build_accept, build_offer,
+};
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::jid::Server;
+use wacore_binary::node::NodeContent;
+use wacore_binary::{Jid, Node, marshal};
+
+const ENGINE: &str = "JgwtTQVeWPm";
+const ENGINE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+const SELF: &str = "15550002222@c.us";
+const SELF_DEVICE: &str = "15550002222:0@c.us";
+const SELF_LID: &str = "99887766554433:0@lid";
+const PEER_LID: &str = "11223344556677@lid";
+const PEER_DEVICE: &str = "11223344556677:0@lid";
+const CALL_ID: &str = "0011223344556677";
+const TC_TOKEN: [u8; 32] = [0xA5; 32];
+/// The 32-byte call key the JS layer leaves in `<enc>` for the engine, in the
+/// clear: on the wire the child holds a Signal ciphertext that
+/// `WAWebVoipValidateAndDecryptEnc` replaces before the engine sees it.
+const CALL_KEY: [u8; 32] = [0x5A; 32];
+const SETTINGS: &[u8] =
+    br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"false","caller_timeout":"45"}}"#;
+
+fn load_engine() -> Result<Vec<u8>> {
+    let which = std::env::var("ENGINE").unwrap_or_else(|_| ENGINE.into());
+    let catalog = Catalog::discover()?;
+    let entry = catalog.resolve(&which)?;
+    let bytes = std::fs::read(&entry.path)?;
+    if which == ENGINE {
+        assert_eq!(hex::encode(Sha256::digest(&bytes)), ENGINE_SHA);
+    }
+    Ok(bytes)
+}
+
+fn start(bytes: &[u8]) -> Result<Runtime> {
+    for _ in 0..8 {
+        let mut r = Runtime::instantiate(bytes)?;
+        r.set_thread_policy(ThreadPolicy::Spawn);
+        r.set_main_thread_registration(true);
+        r.run_ctors()?;
+        r.attach_log_ring(4 << 20)?;
+        let init = r.call_embind(
+            "initVoipStack",
+            &[
+                Value::Str(SELF.into()),
+                Value::Str(SELF_DEVICE.into()),
+                Value::Str(SELF_LID.into()),
+            ],
+        );
+        r.refuel();
+        if init.as_ref().ok().and_then(|v| v.as_int()) == Some(0) {
+            return Ok(r);
+        }
+    }
+    bail!("initVoipStack never returned 0")
+}
+
+/// Decode one recorded stanza, skipping the stream-flag leading byte.
+fn decode(call: &SignalingCall) -> Option<Node> {
+    call.stanza
+        .get(1..)
+        .map(marshal::unmarshal_ref)
+        .transpose()
+        .ok()
+        .flatten()
+        .map(|node| node.to_owned())
+}
+
+fn children_of(node: &Node) -> Vec<Node> {
+    match &node.content {
+        Some(NodeContent::Nodes(children)) => children.clone(),
+        _ => vec![],
+    }
+}
+
+fn child_tags(node: &Node) -> Vec<String> {
+    children_of(node)
+        .iter()
+        .map(|c| c.tag.to_string())
+        .collect()
+}
+
+/// Field-level diff of the vendor offer against our video-offer builder.
+/// Returns the first divergence, or `None` when the deterministic fields agree.
+/// Random per-call bytes (`<enc>` ciphertext, `<privacy>`) are excluded: the
+/// engine mints fresh keys every run, so byte equality there is unachievable.
+fn diff_offer(vendor: &Node, rust: &Node) -> Option<String> {
+    let v_tags = child_tags(vendor);
+    let r_tags = child_tags(rust);
+    if v_tags != r_tags {
+        return Some(format!("child order {v_tags:?} vs {r_tags:?}"));
+    }
+    let attr = |node: &Node, tag: &str, name: &str| {
+        children_of(node)
+            .iter()
+            .find(|c| c.tag == tag)
+            .and_then(|n| {
+                n.attrs()
+                    .optional_string(name)
+                    .as_deref()
+                    .map(str::to_owned)
+            })
+    };
+    for name in [
+        "enc",
+        "dec",
+        "device_orientation",
+        "screen_width",
+        "screen_height",
+    ] {
+        if attr(vendor, "video", name) != attr(rust, "video", name) {
+            return Some(format!(
+                "video attr {name}: {:?} vs {:?}",
+                attr(vendor, "video", name),
+                attr(rust, "video", name)
+            ));
+        }
+    }
+    let cap = |node: &Node| {
+        children_of(node)
+            .iter()
+            .find(|c| c.tag == "capability")
+            .and_then(|n| match &n.content {
+                Some(NodeContent::Bytes(bytes)) => Some(bytes.clone()),
+                _ => None,
+            })
+    };
+    if cap(vendor) != cap(rust) {
+        return Some("capability bytes differ".to_owned());
+    }
+    None
+}
+
+/// Side A: place a video call, return the emitted `<offer>` node.
+fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
+    let mut r = start(bytes)?;
+    let outcome = r.call_embind(
+        "startVoipCall",
+        &[
+            Value::Str(PEER_LID.into()),
+            Value::StringList(vec![PEER_DEVICE.into()]),
+            Value::Str(CALL_ID.into()),
+            Value::Bool(true),
+            Value::Str(PEER_LID.into()),
+            Value::Bool(false),
+            Value::Bytes(TC_TOKEN.to_vec()),
+        ],
+    );
+    r.refuel();
+    r.settle(std::time::Duration::from_secs(8));
+    r.refuel();
+    let ret = outcome.as_ref().ok().and_then(|v| v.as_int());
+    let stanzas = r.signaling()?;
+    let total: usize = stanzas.iter().map(|s| s.stanza.len()).sum();
+    let offer = stanzas
+        .iter()
+        .filter_map(decode)
+        .find(|n| n.tag == "offer")
+        .context("side A emitted no <offer>")?;
+    let info = r.call_embind("getCallInfo", &[]).ok();
+    r.refuel();
+    println!("side A: startVoipCall -> {ret:?}, offer {total} bytes");
+    println!("side A: offer children {:?}", child_tags(&offer));
+    Ok((offer, format!("{info:?}")))
+}
+
+/// Side B: deliver one inbound `<call>` body, attempt `acceptCall`, and report
+/// what the engine emitted plus whether the offer parsed.
+fn side_b_answerer(bytes: &[u8], body: Vec<Node>, label: &str) -> Result<Vec<Node>> {
+    let mut r = start(bytes)?;
+    let caller = Jid::new("11223344556677", Server::Lid);
+    let now = r.virtual_unix_time();
+    let wrapper = NodeBuilder::new("call")
+        .attr("from", caller.clone())
+        .attr("call-id", CALL_ID)
+        .attr("call-creator", caller.with_device(1))
+        .attr("t", now.to_string())
+        .children(body)
+        .build();
+    let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
+    r.call_embind(
+        "handleIncomingSignalingOffer",
+        &[
+            Value::Str(payload),
+            Value::Str("web".into()),
+            Value::Str("2.3000.0".into()),
+            Value::Str(now.to_string()),
+            Value::Str(now.to_string()),
+            Value::Bool(false),
+            Value::Bool(true),
+            Value::Str(caller.to_string()),
+            Value::Bytes(Vec::new()),
+        ],
+    )
+    .ok();
+    r.refuel();
+    // No settle here: the virtual clock advances per observation, and settling
+    // ages the call past `caller_timeout`, tearing it down as missed before
+    // anything can accept it (see `signaling_census`).
+    let parsed = r.engine_log().iter().any(|l| l.contains("!Offer from:"));
+    // State immediately after delivery, before accept: is the call EVER active,
+    // even transiently, or is it born torn down?
+    let immediate = r.call_embind("getCallInfo", &[]).ok();
+    r.refuel();
+    let immediate_state = format!("{immediate:?}");
+    println!(
+        "side B [{label}]: immediate getCallInfo: {}",
+        &immediate_state[..immediate_state.len().min(400)]
+    );
+    let accepted = r.call_embind("acceptCall", &[Value::Bool(true), Value::Bool(true)]);
+    r.refuel();
+    r.settle(std::time::Duration::from_secs(5));
+    r.refuel();
+    let emitted: Vec<Node> = r.signaling()?.iter().filter_map(decode).collect();
+    println!(
+        "side B [{label}]: offer parsed={parsed}, acceptCall -> {accepted:?}, emitted={}",
+        emitted.len()
+    );
+    for line in r.engine_log().iter().rev().take(12).rev() {
+        println!("    log: {}", line.trim());
+    }
+    Ok(emitted)
+}
+
+fn voip_settings_sibling() -> Node {
+    NodeBuilder::new("voip_settings")
+        .attr("uncompressed", "1")
+        .bytes(SETTINGS.to_vec())
+        .build()
+}
+
+/// The census-shaped inbound video offer: clear call key, the vendor's own
+/// `<video>` child, and the settings sibling the parser requires.
+fn census_video_offer(video: &Node) -> Node {
+    NodeBuilder::new("offer")
+        .children([
+            NodeBuilder::new("audio")
+                .attr("enc", "opus")
+                .attr("rate", "16000")
+                .build(),
+            video.clone(),
+            NodeBuilder::new("net").attr("medium", "3").build(),
+            NodeBuilder::new("enc")
+                .attr("count", "0")
+                .bytes(CALL_KEY.to_vec())
+                .build(),
+            NodeBuilder::new("encopt").attr("keygen", "2").build(),
+        ])
+        .build()
+}
+
+fn main() -> Result<()> {
+    let bytes = load_engine()?;
+
+    // Side A: initiator.
+    let (offer, a_state) = side_a_initiator(&bytes)?;
+    let video = children_of(&offer)
+        .iter()
+        .find(|c| c.tag == "video")
+        .cloned()
+        .context("side A offer has no <video> child")?;
+
+    // Initiator differential: vendor offer vs our builder on deterministic fields.
+    let peer = Jid::new("11223344556677", Server::Lid);
+    let creator = Jid::new("99887766554433", Server::Lid);
+    let rust_offer = build_offer(&OfferParams {
+        call_id: CALL_ID,
+        to: &peer,
+        call_creator: &creator,
+        device_keys: &[OfferDeviceKey {
+            device_jid: peer.clone().with_device(0),
+            ciphertext: vec![0x42; 32],
+            enc_type: "pkmsg".to_string(),
+        }],
+        privacy_token: Some(&[0xa5; 32]),
+        capability: Some(&CAPABILITY_VIDEO_OFFER),
+        device_identity: None,
+        id: Some("1"),
+        multi_device: false,
+        video: true,
+        audio_rates: &["8000", "16000"],
+    });
+    let rust_inner = children_of(&rust_offer)
+        .iter()
+        .find(|c| c.tag == "offer")
+        .cloned()
+        .context("rust offer wrapper holds no <offer>")?;
+    match diff_offer(&offer, &rust_inner) {
+        None => println!("VERDICT initiator: MATCH on deterministic fields"),
+        Some(d) => println!("VERDICT initiator: DIVERGENCE: {d}"),
+    }
+
+    // Side B, probe 1: the vendor's own offer bytes (real ciphertext, no key).
+    let emitted_raw = side_b_answerer(
+        &bytes,
+        vec![offer.clone(), voip_settings_sibling()],
+        "raw vendor offer",
+    )?;
+    println!(
+        "VERDICT answerer/raw: emitted {} stanza(s)",
+        emitted_raw.len()
+    );
+
+    // Side B, probe 2: census shape with the vendor's own <video> child.
+    let emitted = side_b_answerer(
+        &bytes,
+        vec![census_video_offer(&video), voip_settings_sibling()],
+        "census video offer",
+    )?;
+
+    // Answerer differential, if the engine emitted an accept.
+    match emitted.iter().find(|n| n.tag == "accept") {
+        Some(vendor_accept) => {
+            let rust_accept = build_accept(&AcceptParams {
+                call_id: CALL_ID,
+                to: &peer,
+                id: "2",
+                call_creator: &creator,
+                audio_rates: &["8000", "16000"],
+                relay_te: None,
+                rte: None,
+                voip_settings: None,
+                capability: Some(&CAPABILITY_VIDEO_OFFER),
+                video: true,
+                peer_abtest_bucket: None,
+                peer_abtest_bucket_id_list: None,
+            });
+            println!(
+                "VERDICT answerer: vendor accept children {:?} vs rust {:?}",
+                child_tags(vendor_accept),
+                child_tags(&rust_accept)
+            );
+        }
+        None => println!("VERDICT answerer: STALL, no <accept> emitted; nothing to compare"),
+    }
+
+    println!("side A call state: {}", &a_state[..a_state.len().min(300)]);
+    Ok(())
+}

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -78,20 +78,25 @@ fn start(bytes: &[u8], identity: [&str; 3]) -> Result<Runtime> {
 /// startup gap lands on a half-started engine and reads as a refusal. Warns
 /// and continues on timeout so a slow host degrades the verdict instead of
 /// hanging the run.
-fn await_event_thread(r: &mut Runtime, label: &str) {
+/// Wait for the event thread before delivering anything: an offer into the
+/// startup gap lands on a half-started engine and reads as a refusal. A
+/// missing startup marker is a startup failure, not protocol evidence, so a
+/// blown deadline fails loudly instead of letting later verdicts blame the
+/// signaling.
+fn await_event_thread(r: &mut Runtime, label: &str) -> Result<()> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
     while std::time::Instant::now() < deadline {
         if r.engine_log()
             .iter()
             .any(|l| l.contains("call_event_proc resumed"))
         {
-            return;
+            return Ok(());
         }
         r.process_queued_calls();
         r.refuel();
         std::thread::sleep(std::time::Duration::from_millis(20));
     }
-    println!("{label}: event thread never announced itself; results suspect");
+    bail!("{label}: event thread never announced itself")
 }
 
 /// Drain main-thread work the engine queued, until observable quiescence or a
@@ -232,10 +237,12 @@ fn diff_children(vendor: &Node, rust: &Node) -> Option<String> {
         })
 }
 
-/// Side A: place a video call, return the emitted `<offer>` node.
+/// Side A: place a video call, return the emitted `<offer>` node. A trapped
+/// or nonzero start is a host failure, not an empty offer: fail loudly
+/// instead of judging the signaling that never ran.
 fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
     let mut r = start(bytes, [SELF, SELF_DEVICE, SELF_LID])?;
-    await_event_thread(&mut r, "side A");
+    await_event_thread(&mut r, "side A")?;
     let outcome = r.call_embind(
         "startVoipCall",
         &[
@@ -251,7 +258,10 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
     r.refuel();
     r.settle(std::time::Duration::from_secs(8));
     r.refuel();
-    let ret = outcome.as_ref().ok().and_then(|v| v.as_int());
+    match &outcome {
+        Ok(value) if value.as_int() == Some(0) => {}
+        other => bail!("side A startVoipCall failed: {other:?}"),
+    }
     let stanzas = r.signaling()?;
     let decoded: Vec<(usize, Node)> = stanzas
         .iter()
@@ -263,7 +273,7 @@ fn side_a_initiator(bytes: &[u8]) -> Result<(Node, String)> {
         .context("side A emitted no <offer>")?;
     let info = r.call_embind("getCallInfo", &[]).ok();
     r.refuel();
-    println!("side A: startVoipCall -> {ret:?}, offer {offer_len} bytes");
+    println!("side A: startVoipCall -> 0, offer {offer_len} bytes");
     println!("side A: offer children {:?}", child_tags(&offer));
     Ok((offer, format!("{info:?}")))
 }
@@ -281,10 +291,11 @@ fn side_b_answerer(
     label: &str,
 ) -> Result<Vec<Node>> {
     let mut r = start(bytes, identity)?;
-    await_event_thread(&mut r, label);
+    await_event_thread(&mut r, label)?;
     let now = r.virtual_unix_time();
     let wrapper = NodeBuilder::new("call")
         .attr("from", caller.clone())
+        .attr("id", "1")
         .attr("call-id", CALL_ID)
         .attr("call-creator", caller.with_device(1))
         .attr("t", now.to_string())

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -298,30 +298,27 @@ fn side_b_answerer(
         .children(body)
         .build();
     let payload = base64::engine::general_purpose::STANDARD.encode(marshal::marshal(&wrapper)?);
-    // Preserve the delivery outcome: a trap here must read as a delivery
-    // failure, never as a signaling stall.
-    let delivered = r.call_embind(
-        "handleIncomingSignalingOffer",
-        &[
-            Value::Str(payload),
-            Value::Str("web".into()),
-            Value::Str("2.3000.0".into()),
-            Value::Str(now.to_string()),
-            Value::Str(now.to_string()),
-            Value::Bool(false),
-            Value::Bool(true),
-            Value::Str(caller.to_string()),
-            Value::Bytes(Vec::new()),
-        ],
-    );
+    // A trapped delivery is a host failure, not answerer behavior: bail
+    // inconclusive instead of draining, accepting, and reporting a stall on
+    // an offer that never arrived.
+    let delivered = r
+        .call_embind(
+            "handleIncomingSignalingOffer",
+            &[
+                Value::Str(payload),
+                Value::Str("web".into()),
+                Value::Str("2.3000.0".into()),
+                Value::Str(now.to_string()),
+                Value::Str(now.to_string()),
+                Value::Bool(false),
+                Value::Bool(true),
+                Value::Str(caller.to_string()),
+                Value::Bytes(Vec::new()),
+            ],
+        )
+        .with_context(|| format!("side B [{label}]: offer delivery trapped"))?;
     r.refuel();
-    println!(
-        "side B [{label}]: delivered={}",
-        match &delivered {
-            Ok(value) => format!("{value:?}"),
-            Err(_) => "trap".to_owned(),
-        }
-    );
+    println!("side B [{label}]: delivered={delivered:?}");
     // No settle here: the virtual clock advances per observation, and settling
     // ages the call past `caller_timeout`, tearing it down as missed before
     // anything can accept it (see `signaling_census`). Drain to observable

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -46,15 +46,19 @@ const CALL_KEY: [u8; 32] = [0x5A; 32];
 const SETTINGS: &[u8] =
     br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"false","caller_timeout":"45"}}"#;
 
-fn load_engine() -> Result<Vec<u8>> {
+fn load_engine() -> Result<(Vec<u8>, String)> {
     let which = std::env::var("ENGINE").unwrap_or_else(|_| ENGINE.into());
     let catalog = Catalog::discover()?;
     let entry = catalog.resolve(&which)?;
     let bytes = std::fs::read(&entry.path)?;
+    let sha = hex::encode(Sha256::digest(&bytes));
     if which == ENGINE {
-        assert_eq!(hex::encode(Sha256::digest(&bytes)), ENGINE_SHA);
+        assert_eq!(sha, ENGINE_SHA);
     }
-    Ok(bytes)
+    // An override never runs silently: its hash prints every run, so a stale
+    // or modified capture cannot masquerade as the pinned engine's evidence.
+    println!("engine: {which} sha256={sha}");
+    Ok((bytes, which))
 }
 
 fn start(bytes: &[u8], identity: [&str; 3]) -> Result<Runtime> {
@@ -421,7 +425,7 @@ fn census_video_offer(video: &Node) -> Node {
 }
 
 fn main() -> Result<()> {
-    let bytes = load_engine()?;
+    let (bytes, _engine) = load_engine()?;
 
     // Side A: initiator.
     let (offer, a_state) = side_a_initiator(&bytes)?;

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -444,10 +444,11 @@ fn main() -> Result<()> {
 
     // Side B, probe 2: census shape with the vendor's own <video> child,
     // delivered to an engine running as self with the peer as caller.
+    let census_caller = Jid::new("11223344556677", Server::Lid);
     let emitted = side_b_answerer(
         &bytes,
         [SELF, SELF_DEVICE, SELF_LID],
-        Jid::new("11223344556677", Server::Lid),
+        census_caller.clone(),
         vec![census_video_offer(&video), voip_settings_sibling()],
         "census video offer",
     )?;
@@ -457,19 +458,22 @@ fn main() -> Result<()> {
     // `<call>` wrapper, so descend into the wrapper first, as the offer
     // comparison does; comparing wrapper children would report the protocol
     // fields against `["accept"]`.
+    //
+    // The expectation mirrors the production answer path (`answer_with_ids`):
+    // creator and target are the incoming caller, the audio set is exactly the
+    // offered rate (a conforming accept can select only what was offered), and
+    // a from-start video accept carries no capability child.
     match emitted.iter().find(|n| n.tag == "accept") {
         Some(vendor_accept) => {
             let rust_wrapper = build_accept(&AcceptParams {
                 call_id: CALL_ID,
-                to: &peer,
+                to: &census_caller.clone().with_device(1),
                 id: "2",
-                call_creator: &creator,
-                audio_rates: &["8000", "16000"],
+                call_creator: &census_caller.clone().with_device(1),
+                audio_rates: &["16000"],
                 relay_te: None,
                 rte: None,
                 voip_settings: None,
-                // Production from-start video accepts carry no capability
-                // child (see `answer_with_ids`); audio answers advertise one.
                 capability: None,
                 video: true,
                 peer_abtest_bucket: None,

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -333,10 +333,14 @@ fn main() -> Result<()> {
         "census video offer",
     )?;
 
-    // Answerer differential, if the engine emitted an accept.
+    // Answerer differential, if the engine emitted an accept. The vendor value
+    // is the inner `<accept>` node while `build_accept` returns the outer
+    // `<call>` wrapper, so descend into the wrapper first, as the offer
+    // comparison does; comparing wrapper children would report the protocol
+    // fields against `["accept"]`.
     match emitted.iter().find(|n| n.tag == "accept") {
         Some(vendor_accept) => {
-            let rust_accept = build_accept(&AcceptParams {
+            let rust_wrapper = build_accept(&AcceptParams {
                 call_id: CALL_ID,
                 to: &peer,
                 id: "2",
@@ -350,6 +354,11 @@ fn main() -> Result<()> {
                 peer_abtest_bucket: None,
                 peer_abtest_bucket_id_list: None,
             });
+            let rust_accept = children_of(&rust_wrapper)
+                .iter()
+                .find(|c| c.tag == "accept")
+                .cloned()
+                .context("rust accept wrapper holds no <accept>")?;
             println!(
                 "VERDICT answerer: vendor accept children {:?} vs rust {:?}",
                 child_tags(vendor_accept),

--- a/tools/oracle-core/examples/video_call_both_sides.rs
+++ b/tools/oracle-core/examples/video_call_both_sides.rs
@@ -94,15 +94,35 @@ fn await_event_thread(r: &mut Runtime, label: &str) {
     println!("{label}: event thread never announced itself; results suspect");
 }
 
-/// Drain main-thread work the engine queued: with the main thread registered,
-/// answers wait in the proxy queue and only the host takes them out. Reading
-/// state without draining reports "the engine did nothing" about a run in
-/// which it queued the answer and nobody collected it.
-fn drain(r: &mut Runtime) {
-    for _ in 0..5 {
+/// Drain main-thread work the engine queued, until observable quiescence or a
+/// bound: with the main thread registered, answers wait in the proxy queue and
+/// only the host takes them out. A fixed pass count can sample state while
+/// activation is still pending (processing a callback can enqueue more work),
+/// so quiescence — signaling count and log length unchanged across passes — is
+/// awaited and reported. Returns whether it was reached.
+fn drain(r: &mut Runtime) -> bool {
+    const PASSES: usize = 20;
+    const STABLE: usize = 3;
+    let mut stable = 0;
+    let (mut last_signaling, mut last_log) = (usize::MAX, usize::MAX);
+    for _ in 0..PASSES {
         r.process_queued_calls();
         r.refuel();
+        let (signaling, log) = (
+            r.signaling().map(|s| s.len()).unwrap_or(usize::MAX),
+            r.engine_log().len(),
+        );
+        if signaling == last_signaling && log == last_log {
+            stable += 1;
+            if stable >= STABLE {
+                return true;
+            }
+        } else {
+            stable = 0;
+            (last_signaling, last_log) = (signaling, log);
+        }
     }
+    false
 }
 
 /// Decode one recorded stanza, skipping the stream-flag leading byte.
@@ -286,9 +306,11 @@ fn side_b_answerer(
     r.refuel();
     // No settle here: the virtual clock advances per observation, and settling
     // ages the call past `caller_timeout`, tearing it down as missed before
-    // anything can accept it (see `signaling_census`). Drain first so queued
-    // main-thread work is collected before state is read.
-    drain(&mut r);
+    // anything can accept it (see `signaling_census`). Drain to observable
+    // quiescence first so queued main-thread work is collected before state
+    // is read; a `false` here marks the verdict suspect, not conclusive.
+    let quiesced = drain(&mut r);
+    println!("side B [{label}]: quiesced={quiesced}");
     let parsed = r.engine_log().iter().any(|l| l.contains("!Offer from:"));
     // State immediately after delivery, before accept: is the call EVER active,
     // even transiently, or is it born torn down?
@@ -446,7 +468,9 @@ fn main() -> Result<()> {
                 relay_te: None,
                 rte: None,
                 voip_settings: None,
-                capability: Some(&CAPABILITY_VIDEO_OFFER),
+                // Production from-start video accepts carry no capability
+                // child (see `answer_with_ids`); audio answers advertise one.
+                capability: None,
                 video: true,
                 peer_abtest_bucket: None,
                 peer_abtest_bucket_id_list: None,

--- a/tools/oracle-core/src/emscripten.rs
+++ b/tools/oracle-core/src/emscripten.rs
@@ -165,6 +165,64 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
     // reported as one under the single-threaded policies so those pools stay
     // empty, and as a small fixed number when threads really run — fixed rather
     // than the host's actual count, so a run does not depend on the machine.
+
+    // Where the engine keeps file-backed application settings. In a browser
+    // this is JS glue answering with the persistent directory; the recording
+    // stub answers null, the engine reports "Failed to get voip storage dir",
+    // settings stay unapplied, and no inbound call can activate. Answer with
+    // the memfs root — the one directory this host guarantees — allocated
+    // through the guest's own malloc so the pointer stays valid for code that
+    // will later free it.
+    linker.func_wrap(
+        "env",
+        "get_persistent_directory_path_js",
+        |mut caller: Caller<'_, HostState>| -> Result<i32, wasmtime::Error> {
+            crate::state::sync_memory(&mut caller);
+            let state = caller.data();
+            state
+                .shared
+                .record("env", "get_persistent_directory_path_js", Vec::new());
+            let malloc = match caller.get_export("malloc") {
+                Some(wasmtime::Extern::Func(func)) => func,
+                _ => return Err(wasmtime::Error::msg("guest has no malloc export")),
+            };
+            let mut results = [Val::I32(0)];
+            malloc
+                .call(&mut caller, &[Val::I32(2)], &mut results)
+                .map_err(|error| wasmtime::Error::msg(format!("guest malloc failed: {error}")))?;
+            let ptr = match results[0] {
+                Val::I32(ptr) if ptr != 0 => ptr as u32,
+                _ => return Err(wasmtime::Error::msg("guest malloc returned null")),
+            };
+            caller.data().write(ptr, b"/\0").map_err(|error| {
+                wasmtime::Error::msg(format!("writing persistent dir: {error}"))
+            })?;
+            Ok(ptr as i32)
+        },
+    )?;
+
+    // What the engine stats under the persistent directory. The recording stub
+    // answers zero (success with a zeroed buffer), which would bless a file
+    // the guest never verified; instead report the path it asked about and
+    // refuse, so the wanted filenames stay visible and missing files read as
+    // missing. `-1` is the musl failure return; errno plumbing stays with the
+    // stub contract until a caller needs more.
+    linker.func_wrap(
+        "env",
+        "__syscall_stat64",
+        |mut caller: Caller<'_, HostState>, path: i32, _buf: i32| -> Result<i32, wasmtime::Error> {
+            crate::state::sync_memory(&mut caller);
+            let state = caller.data();
+            let name = state
+                .read_cstr(path as u32)
+                .unwrap_or_else(|_| "<unreadable>".to_owned());
+            state
+                .shared
+                .record("env", "__syscall_stat64", vec![i64::from(path)]);
+            state.log(format!("host stat: {name} -> ENOENT"));
+            Ok(-1)
+        },
+    )?;
     linker.func_wrap(
         "env",
         "emscripten_num_logical_cores",

--- a/tools/oracle-core/src/emscripten.rs
+++ b/tools/oracle-core/src/emscripten.rs
@@ -194,6 +194,9 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
                 Val::I32(ptr) if ptr != 0 => ptr as u32,
                 _ => return Err(wasmtime::Error::msg("guest malloc returned null")),
             };
+            // The nested guest call can grow memory, invalidating the cached
+            // view the single pre-call sync took: resynchronize before writing.
+            crate::state::sync_memory(&mut caller);
             caller.data().write(ptr, b"/\0").map_err(|error| {
                 wasmtime::Error::msg(format!("writing persistent dir: {error}"))
             })?;
@@ -204,9 +207,9 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
     // What the engine stats under the persistent directory. The recording stub
     // answers zero (success with a zeroed buffer), which would bless a file
     // the guest never verified; instead report the path it asked about and
-    // refuse, so the wanted filenames stay visible and missing files read as
-    // missing. `-1` is the musl failure return; errno plumbing stays with the
-    // stub contract until a caller needs more.
+    // refuse with the musl ABI's negative errno (ENOENT is 2), so a missing
+    // file reads as missing and guest code that distinguishes failures keeps
+    // its intended fallback.
     linker.func_wrap(
         "env",
         "__syscall_stat64",
@@ -220,7 +223,7 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
                 .shared
                 .record("env", "__syscall_stat64", vec![i64::from(path)]);
             state.log(format!("host stat: {name} -> ENOENT"));
-            Ok(-1)
+            Ok(-2)
         },
     )?;
     linker.func_wrap(

--- a/tools/oracle-core/src/emscripten.rs
+++ b/tools/oracle-core/src/emscripten.rs
@@ -15,6 +15,7 @@ use wasmtime::error::Context as _;
 use wasmtime::{Caller, Func, Linker, Module, Ref, Store, Val, ValType};
 
 use crate::IntoWasmtime as _;
+use crate::exports;
 use crate::state::{HostState, ThreadPolicy};
 
 /// Fixed wall-clock origin: 2021-01-01T00:00:00Z in milliseconds. Arbitrary but
@@ -182,10 +183,8 @@ pub fn define(store: &mut Store<HostState>, linker: &mut Linker<HostState>) -> R
             state
                 .shared
                 .record("env", "get_persistent_directory_path_js", Vec::new());
-            let malloc = match caller.get_export("malloc") {
-                Some(wasmtime::Extern::Func(func)) => func,
-                _ => return Err(wasmtime::Error::msg("guest has no malloc export")),
-            };
+            let malloc = exports::func(&mut caller, &["malloc", "_malloc"])
+                .map_err(|error| wasmtime::Error::msg(format!("guest allocator: {error}")))?;
             let mut results = [Val::I32(0)];
             malloc
                 .call(&mut caller, &[Val::I32(2)], &mut results)

--- a/tools/oracle-core/tests/video_offer.rs
+++ b/tools/oracle-core/tests/video_offer.rs
@@ -75,12 +75,15 @@ fn video_offer_matches_the_vendor_engine() -> Result<()> {
 
     let mut stubs = runtime.stubs_called();
     stubs.sort();
+    // `get_persistent_directory_path_js` and `__syscall_stat64` are
+    // implemented, not stubbed (the engine reads file-backed application
+    // settings through them), so neither appears here. A changed
+    // stub-dependent path must fail here, not bless new geometry.
     assert_eq!(
         stubs,
         [
             ("env::call_start_video_capture_js_sync".to_owned(), 1),
             ("env::emscripten_check_blocking_allowed".to_owned(), 1),
-            ("env::get_persistent_directory_path_js".to_owned(), 1),
             ("env::on_call_event_js_sync".to_owned(), 3),
             (
                 "env::query_browser_audio_processing_status_js_sync".to_owned(),

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -394,9 +394,9 @@ fn parse_action(node: &NodeRef<'_>, action_tag: CallActionTag) -> Result<CallAct
             }
         }
         CallActionTag::Reject => {
-            // `reason` distinguishes a device that CANNOT take the call (`busy`, or `enc` when the
-            // device could not decrypt the offer) from the callee actually declining; dropping it
-            // made both look identical and ended calls the peer's other devices were still answering.
+            // `reason` distinguishes a device that CANNOT take the call (`busy`, `enc`) from the
+            // callee actually declining; dropping it made both look identical and ended calls the
+            // peer's other devices were still answering.
             let reason = attrs.optional_string("reason").map(|c| c.into_owned());
             attrs.finish().map_err(|e| anyhow!("<reject> attrs: {e}"))?;
             CallAction::Reject {
@@ -657,9 +657,7 @@ pub const TERMINATE_REASON_GROUP_CALL_ENDED: &str = "group_call_ended";
 /// decision: the peer's remaining devices go on ringing and may still answer.
 pub const REJECT_REASON_BUSY: &str = "busy";
 
-/// `<reject reason>` wire token for a device that could not decrypt the offer (its registration
-/// changed device-side, so the offered sender key no longer opens). Like `busy` it speaks for ONE
-/// DEVICE only: the peer's remaining devices go on ringing and may still answer.
+/// Like `busy`, but the device could not decrypt the offer (stale registration). Per-device.
 pub const REJECT_REASON_ENC: &str = "enc";
 
 /// Relay latency wire encoding: `0x2000000 + rtt_ms`.

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -394,9 +394,9 @@ fn parse_action(node: &NodeRef<'_>, action_tag: CallActionTag) -> Result<CallAct
             }
         }
         CallActionTag::Reject => {
-            // `reason` distinguishes a device that CANNOT take the call (`busy`) from the callee
-            // actually declining; dropping it made both look identical and ended calls the peer's
-            // other devices were still answering.
+            // `reason` distinguishes a device that CANNOT take the call (`busy`, or `enc` when the
+            // device could not decrypt the offer) from the callee actually declining; dropping it
+            // made both look identical and ended calls the peer's other devices were still answering.
             let reason = attrs.optional_string("reason").map(|c| c.into_owned());
             attrs.finish().map_err(|e| anyhow!("<reject> attrs: {e}"))?;
             CallAction::Reject {
@@ -656,6 +656,11 @@ pub const TERMINATE_REASON_GROUP_CALL_ENDED: &str = "group_call_ended";
 /// companion that does not do voice at all. It is a statement about ONE DEVICE, not the callee's
 /// decision: the peer's remaining devices go on ringing and may still answer.
 pub const REJECT_REASON_BUSY: &str = "busy";
+
+/// `<reject reason>` wire token for a device that could not decrypt the offer (its registration
+/// changed device-side, so the offered sender key no longer opens). Like `busy` it speaks for ONE
+/// DEVICE only: the peer's remaining devices go on ringing and may still answer.
+pub const REJECT_REASON_ENC: &str = "enc";
 
 /// Relay latency wire encoding: `0x2000000 + rtt_ms`.
 pub fn encode_latency(rtt_ms: u32) -> String {

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -2016,7 +2016,7 @@ mod tests {
                 .attr("call-creator", fake_caller_lid())
                 .attr("call-id", "CID")
                 .attr("count", "0")
-                .attr("reason", REJECT_REASON_ENC)
+                .attr("reason", "enc")
                 .children([NodeBuilder::new("registration")
                     .bytes(0x12345678u32.to_be_bytes().to_vec())
                     .build()])

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -2005,6 +2005,33 @@ mod tests {
         }
     }
 
+    /// A `<reject>` from a device that could not decrypt the offer carries `reason="enc"`. The
+    /// pinned whatspec IR models `reason` as an opaque string (`WAWebHandleVoipCall` dispatcher,
+    /// `WAWebHandleVoipCallReceipt` parser; no reject-reason wire enum in the catalog), so the
+    /// parser must preserve it verbatim for the handler's per-device dispatch.
+    #[test]
+    fn reject_preserves_an_enc_reason() {
+        let node = base_call_builder()
+            .children([NodeBuilder::new("reject")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CID")
+                .attr("count", "0")
+                .attr("reason", REJECT_REASON_ENC)
+                .children([NodeBuilder::new("registration")
+                    .bytes(0x12345678u32.to_be_bytes().to_vec())
+                    .build()])
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::Reject { reason, .. } => {
+                assert_eq!(reason.as_deref(), Some(REJECT_REASON_ENC));
+            }
+            other => panic!("expected Reject, got {other:?}"),
+        }
+    }
+
     /// The failure case for the above: an explicit decline carries no `reason`, and must not be
     /// confused with a busy device.
     #[test]

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -180,9 +180,9 @@ pub enum CallAction {
         call_id: String,
         call_creator: Jid,
         /// Why the device rejected. `busy` means THAT DEVICE cannot take the call (already in one,
-        /// or a companion that does not do voice), `enc` means THAT DEVICE could not decrypt the
-        /// offer (its registration changed device-side) - neither is the callee declining, and the
-        /// peer's other devices keep ringing. Absent means an explicit decline by the user.
+        /// or a companion that does not do voice); `enc` means THAT DEVICE could not decrypt the
+        /// offer. Neither is the callee declining, and the peer's other devices keep ringing.
+        /// Absent means an explicit decline by the user.
         reason: Option<String>,
     },
     #[wire = "terminate"]

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -180,8 +180,9 @@ pub enum CallAction {
         call_id: String,
         call_creator: Jid,
         /// Why the device rejected. `busy` means THAT DEVICE cannot take the call (already in one,
-        /// or a companion that does not do voice) - it is not the callee declining, and the peer's
-        /// other devices keep ringing. Absent means an explicit decline by the user.
+        /// or a companion that does not do voice), `enc` means THAT DEVICE could not decrypt the
+        /// offer (its registration changed device-side) - neither is the callee declining, and the
+        /// peer's other devices keep ringing. Absent means an explicit decline by the user.
         reason: Option<String>,
     },
     #[wire = "terminate"]

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -542,8 +542,8 @@ pub struct AnnexBAuSplitter {
     /// The buffered bytes already hold a VCL NAL.
     buf_has_vcl: bool,
     /// Start of a trailing all-SEI run after the last VCL NAL, if any: when
-    /// a new picture confirms the boundary, the run rides with it instead of
-    /// the previous AU.
+    /// a group opener or a new picture confirms the boundary, the run rides
+    /// with it instead of the previous AU.
     pending_sei_start: Option<usize>,
 }
 
@@ -576,7 +576,11 @@ impl AnnexBAuSplitter {
             };
             let Some(&nal_byte) = self.buf.get(sc.end) else {
                 // Start code at the buffer edge: wait for the NAL type byte.
+                // This break skips the loop-end check, so enforce the cap here.
                 self.scan_pos = sc.begin;
+                if self.buf.len() > H264_MAX_AU_BYTES {
+                    self.drop_runaway();
+                }
                 break;
             };
             let unit_type = nal_byte & 0x1f;
@@ -610,17 +614,17 @@ impl AnnexBAuSplitter {
                 break;
             }
             let new_picture = picture.unwrap_or(1) == 0;
-            // An SEI run preceding a new picture describes it: cut before the
-            // run so it rides with its picture, not the previous AU. Other
-            // non-VCL runs (SPS/PPS) keep the existing boundary.
-            let sei_handoff = self.pending_sei_start.filter(|&start| {
-                start > 0 && is_vcl && self.buf_has_vcl && new_picture && !self.seen_aud
-            });
-            let cuts_here = sc.begin > 0
-                && (unit_type == NAL_TYPE_AUD
-                    || (!self.seen_aud
-                        && ((unit_type == NAL_TYPE_SPS && self.buf_has_vcl)
-                            || (is_vcl && self.buf_has_vcl && new_picture))));
+            // Every AUD-less cut below. An SEI run preceding a group opener
+            // or a new picture describes what follows: cut before the run so
+            // it rides with its picture, not the previous AU. Other non-VCL
+            // runs (PPS) keep the existing boundary.
+            let audless_cut = !self.seen_aud
+                && ((unit_type == NAL_TYPE_SPS && self.buf_has_vcl)
+                    || (is_vcl && self.buf_has_vcl && new_picture));
+            let sei_handoff = self
+                .pending_sei_start
+                .filter(|&start| start > 0 && audless_cut);
+            let cuts_here = sc.begin > 0 && (unit_type == NAL_TYPE_AUD || audless_cut);
             if cuts_here {
                 let at = sei_handoff.unwrap_or(sc.begin);
                 let rest = self.buf.split_off(at);
@@ -1504,6 +1508,49 @@ mod tests {
         assert!(au_is_keyframe(&got));
     }
 
+    /// An SEI preceding a group opener rides with the group: VCL, SEI, SPS,
+    /// PPS, IDR frames as [VCL] + [SEI, SPS, PPS, IDR], so the metadata keeps
+    /// the timestamp of the picture it describes.
+    #[test]
+    fn au_splitter_sei_rides_with_group_opener() {
+        let vcl = |first: &[u8]| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first);
+            n.extend((0..30).map(|i| (i % 251) as u8));
+            n
+        };
+        let idr = vec![0x65, 0x80, 0x01, 0x02];
+        let (first, sei, sps, pps) = (
+            vcl(&[0x80]),
+            vec![0x06, 0x05, 0x11, 0x22],
+            nal(7, 4),
+            nal(8, 4),
+        );
+        let stream = au_from_nals(&[
+            first.clone(),
+            sei.clone(),
+            sps.clone(),
+            pps.clone(),
+            idr.clone(),
+        ]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au_from_nals(&[first])]);
+        let rest = s.finish().expect("trailing AU");
+        assert_eq!(
+            rest,
+            au_from_nals(&[sei, sps.clone(), pps.clone(), idr.clone()])
+        );
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&rest, &mut payloads);
+        assert_eq!(
+            depacketize_all(payloads.iter()),
+            Some(au_from_nals(&[sps, pps, idr.clone()]))
+        );
+        assert!(au_is_keyframe(&rest));
+    }
+
     /// An SEI preceding a new picture rides with it: VCL, SEI, VCL frames as
     /// [VCL] + [SEI, VCL], so the metadata keeps its picture's timestamp.
     /// Pre-VCL now, the default packetizer drops the SEI instead of sending
@@ -1530,6 +1577,26 @@ mod tests {
         assert_eq!(
             depacketize_all(payloads.iter()),
             Some(au_from_nals(&[second]))
+        );
+    }
+
+    /// Every push ends exactly on a start code here, so only the
+    /// wait-for-type-byte exit runs: it must enforce the cap like every
+    /// other exit, or the buffer grows without bound and `finish` returns it.
+    #[test]
+    fn au_splitter_trailing_start_code_is_capped() {
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        let mut chunk = vec![0xabu8; 64 * 1024];
+        chunk.extend_from_slice(&START_CODE);
+        for _ in 0..80 {
+            s.push(&chunk, &mut out);
+        }
+        assert!(out.is_empty());
+        assert!(
+            s.buf.len() <= H264_MAX_AU_BYTES,
+            "trailing-start-code stream must be capped, got {}",
+            s.buf.len()
         );
     }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -16,6 +16,7 @@ const H264_FUA_FRAG_SIZE: usize = H264_SINGLE_NAL_MAX - 2;
 pub const H264_MAX_AU_BYTES: usize = 4 * 1024 * 1024;
 
 const NAL_TYPE_IDR: u8 = 5;
+const NAL_TYPE_SEI: u8 = 6;
 const NAL_TYPE_SPS: u8 = 7;
 const NAL_TYPE_PPS: u8 = 8;
 const NAL_TYPE_AUD: u8 = 9;
@@ -243,12 +244,26 @@ impl core::ops::Index<usize> for PacketizedAu {
 /// Packetize one Annex-B access unit into WhatsApp RTP payloads (no RTP headers): each
 /// media NAL goes out as a single-NAL payload when it fits, or a run of FU-A
 /// fragments otherwise. Encoder-only AUDs are omitted because WhatsApp's H.264
-/// decoder requires SPS/PPS to lead an IDR frame. `out` is cleared and refilled
+/// decoder requires SPS/PPS to lead an IDR frame, and SEI units are omitted
+/// for the same reason: supplemental metadata no decoder needs for rendering
+/// that would otherwise take NALU index 0 from SPS. `out` is cleared and refilled
 /// so the send path can reuse one buffer per AU.
 pub fn packetize_au(au: &[u8], out: &mut PacketizedAu) {
+    packetize_au_inner(au, out, false);
+}
+
+/// [`packetize_au`] preserving SEI units, for the explicit opt-in case of a
+/// peer that needs the metadata. The default strips; callers keep SEI only
+/// deliberately, never by accident.
+pub fn packetize_au_keep_sei(au: &[u8], out: &mut PacketizedAu) {
+    packetize_au_inner(au, out, true);
+}
+
+fn packetize_au_inner(au: &[u8], out: &mut PacketizedAu, keep_sei: bool) {
     out.clear();
     for nal in split_annexb(au) {
-        if nal_unit_type(nal) == NAL_TYPE_AUD {
+        let unit_type = nal_unit_type(nal);
+        if unit_type == NAL_TYPE_AUD || (!keep_sei && unit_type == NAL_TYPE_SEI) {
             continue;
         }
         if nal.len() <= H264_SINGLE_NAL_MAX {
@@ -1049,21 +1064,36 @@ mod tests {
         assert_eq!(types[0], 7, "AUD dropped, SPS opens, got {types:?}");
     }
 
-    /// Documents current passthrough, not approved shape: an SEI-first input
-    /// stays SEI-first on the wire — the packetizer preserves supplier order
-    /// and only AUD is filtered. If a live encoder emits SEI-first groups,
-    /// the peer decoder drops the IDR; fixing that belongs at the source (or
-    /// in packetize policy, which is a product decision), not in this test.
+    /// SEI NALs are supplemental metadata no decoder needs for rendering, and
+    /// a leading SEI breaks the decoder keyframe gate (SPS must open at index
+    /// 0). The packetizer strips them exactly like encoder-only AUDs; a peer
+    /// that needs SEI passthrough uses `packetize_au_keep_sei` explicitly.
     #[test]
-    fn outbound_sei_first_input_stays_sei_first() {
-        let au = au_from_nals(&[nal(6, 12), nal(7, 24), nal(8, 8), nal(5, 100)]);
+    fn outbound_sei_first_input_goes_out_sps_first() {
+        let sps = nal(7, 24);
+        let au = au_from_nals(&[nal(6, 12), sps.clone(), nal(8, 8), nal(5, 100)]);
         let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         let got = depacketize_all(payloads.iter()).expect("reassembled AU");
-        let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
-        assert_eq!(
-            types[0], 6,
-            "SEI currently passes through first, got {types:?}"
+        let nals: Vec<_> = split_annexb(&got).collect();
+        let types: Vec<u8> = nals.iter().map(|n| nal_unit_type(n)).collect();
+        assert_eq!(types[0], 7, "SEI stripped, SPS opens, got {types:?}");
+        assert_eq!(nals[0], sps.as_slice(), "SPS bytes intact");
+        assert!(
+            !types.iter().any(|t| *t == 6),
+            "no SEI may reach the wire, got {types:?}"
         );
+    }
+
+    /// Explicit opt-in for the strip default above: keeps SEI for a peer that
+    /// needs the metadata, verified byte-identical apart from the kept unit.
+    #[test]
+    fn keep_sei_variant_preserves_sei() {
+        let au = au_from_nals(&[nal(6, 12), nal(7, 24), nal(8, 8), nal(5, 100)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au_keep_sei(&au, &mut payloads);
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
+        assert_eq!(types[0], 6, "keep variant preserves SEI, got {types:?}");
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -632,8 +632,9 @@ impl AnnexBAuSplitter {
                     // The current NAL was fully evaluated above: resume past
                     // it, or it cuts itself away from its SEI run on rescan.
                     // `nal_end` is in old-buffer offsets; the new buffer
-                    // starts at `at`.
-                    self.scan_pos = nal_end - at;
+                    // starts at `at`. Keep the usual three-byte overlap so a
+                    // start code split across pushes is still found.
+                    self.scan_pos = (nal_end - at).saturating_sub(3);
                 } else {
                     self.scan_pos = 0;
                 }
@@ -1530,6 +1531,37 @@ mod tests {
             depacketize_all(payloads.iter()),
             Some(au_from_nals(&[second]))
         );
+    }
+
+    /// A start code split across pushes after a handoff is still found: the
+    /// resume keeps the usual three-byte overlap instead of skipping to the
+    /// end and merging the next picture into the current AU.
+    #[test]
+    fn au_splitter_handoff_keeps_start_code_overlap() {
+        let vcl = |first: &[u8]| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first);
+            n.extend((0..30).map(|i| (i % 251) as u8));
+            n
+        };
+        let (a, b, c) = (vcl(&[0x80]), vcl(&[0x80]), vcl(&[0x80]));
+        let sei = vec![0x06, 0x05, 0x11, 0x22];
+        let mut part1 = au_from_nals(&[a.clone(), sei.clone()]);
+        part1.extend_from_slice(&START_CODE);
+        part1.extend_from_slice(&b);
+        // Trailing start-code prefix; part2 completes it into c's start code.
+        part1.extend_from_slice(&[0x00, 0x00]);
+        let mut part2 = vec![0x00, 0x01];
+        part2.extend_from_slice(&c);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&part1, &mut out);
+        let first_au = au_from_nals(&[a]);
+        let second_au = au_from_nals(&[sei, b]);
+        assert_eq!(out, vec![first_au.clone()]);
+        s.push(&part2, &mut out);
+        assert_eq!(out, vec![first_au, second_au]);
+        assert_eq!(s.finish(), Some(au_from_nals(&[c])));
     }
 
     /// A picture following a handed-off SEI still closes its own AU: the

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -460,14 +460,20 @@ impl H264Depacketizer {
 }
 
 /// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
-/// units, cutting at AUD NALs (type 9). Feed arbitrary chunks; complete AUs
-/// come back as they close. Requires the producer to emit AUDs (ffmpeg:
-/// `-bsf:v h264_metadata=aud=insert`).
+/// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at SPS NALs
+/// (type 7): every IDR group opens with SPS, so a parameter set with bytes
+/// before it starts the next group. Feed arbitrary chunks; complete AUs come
+/// back as they close. PPS alone never cuts — it belongs with the SPS that
+/// precedes it, not the slices that follow. Once an AUD is observed, AUDs own
+/// the framing and SPS no longer cuts, so AUD-bearing streams behave exactly
+/// as before.
 #[derive(Default)]
 pub struct AnnexBAuSplitter {
     buf: Vec<u8>,
     /// Scan resume point: everything before it was already searched for an AUD.
     scan_pos: usize,
+    /// An AUD has been observed: SPS cutting stays off from here on.
+    seen_aud: bool,
 }
 
 impl AnnexBAuSplitter {
@@ -490,7 +496,15 @@ impl AnnexBAuSplitter {
                 self.scan_pos = sc.begin;
                 break;
             };
+            if nal_byte & 0x1f == NAL_TYPE_AUD {
+                self.seen_aud = true;
+            }
             if nal_byte & 0x1f == NAL_TYPE_AUD && sc.begin > 0 {
+                let rest = self.buf.split_off(sc.begin);
+                let au = std::mem::replace(&mut self.buf, rest);
+                out.push(au);
+                self.scan_pos = 0;
+            } else if !self.seen_aud && nal_byte & 0x1f == NAL_TYPE_SPS && sc.begin > 0 {
                 let rest = self.buf.split_off(sc.begin);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);
@@ -928,6 +942,34 @@ mod tests {
         assert!(payloads.is_empty(), "packetize_au must clear stale output");
         let mut d = H264Depacketizer::default();
         assert_eq!(d.push(0, 0, &[], true), None);
+    }
+
+    /// An AUD-less encoder still frames: every IDR group opens with SPS (the
+    /// decoder keyframe gate requires it), so SPS starts a new access unit
+    /// when bytes precede it. Without this, an AUD-less stream accumulates to
+    /// the 4 MiB cap and is cleared — the call sends nothing, the peer PLIs
+    /// forever, and forced IDRs die in the same buffer.
+    #[test]
+    fn au_splitter_cuts_on_sps_without_aud() {
+        let group = |id: u8| {
+            let mut au = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+            au[6] = id;
+            au
+        };
+        let delta = au_from_nals(&[nal(1, 40)]);
+        let mut stream = group(1);
+        stream.extend_from_slice(&delta);
+        stream.extend_from_slice(&group(2));
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        // Like the AUD cut, the boundary lands when the NEXT group's opener
+        // arrives: the delta rides with the group it follows, exactly as with
+        // a trailing AUD.
+        let mut first = group(1);
+        first.extend_from_slice(&delta);
+        assert_eq!(out, vec![first]);
+        assert_eq!(s.finish(), Some(group(2)));
     }
 
     #[test]

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -535,7 +535,9 @@ pub struct AnnexBAuSplitter {
     buf: Vec<u8>,
     /// Scan resume point: everything before it was already searched for an AUD.
     scan_pos: usize,
-    /// An AUD has been observed: SPS/IDR/VCL cutting stays off from here on.
+    /// An AUD has been observed: SPS/IDR/VCL cutting stays off while the
+    /// buffered content survives it. A runaway reset drops the content, so it
+    /// drops this too and AUD-less framing can recover.
     seen_aud: bool,
     /// The buffered bytes already hold an IDR slice.
     buf_has_idr: bool,
@@ -545,10 +547,13 @@ pub struct AnnexBAuSplitter {
 
 impl AnnexBAuSplitter {
     /// Drop a runaway buffer: without AUDs the cap is the only bound, so
-    /// every early exit enforces it, not just the loop end.
+    /// every early exit enforces it, not just the loop end. The flags
+    /// describe cleared content, so they reset with it — including `seen_aud`,
+    /// or AUD-less input after the reset could never frame again.
     fn drop_runaway(&mut self) {
         self.buf.clear();
         self.scan_pos = 0;
+        self.seen_aud = false;
         self.buf_has_idr = false;
         self.buf_has_vcl = false;
     }
@@ -562,7 +567,7 @@ impl AnnexBAuSplitter {
                 // here too — keep only the last few bytes so a start code split across chunks still
                 // reassembles.
                 if self.buf.len() > H264_MAX_AU_BYTES {
-                    self.buf.clear();
+                    self.drop_runaway();
                 }
                 self.scan_pos = self.buf.len().saturating_sub(3);
                 break;
@@ -1432,5 +1437,29 @@ mod tests {
         s.push(&stream, &mut out);
         assert!(out.is_empty(), "partitions B/C ride with their partition A");
         assert_eq!(s.finish(), Some(stream));
+    }
+
+    /// A runaway reset restores AUD-less framing: after the cap drops a
+    /// stream that once carried AUDs, SPS groups frame again instead of
+    /// accumulating to the cap forever.
+    #[test]
+    fn au_splitter_runaway_reset_restores_audless_framing() {
+        let aud_au = au_from_nals(&[nal(9, 2), nal(7, 4), nal(5, 60)]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&aud_au, &mut out);
+        assert!(s.seen_aud);
+        let chunk = au_from_nals(&[nal(1, 64 * 1024)]);
+        for _ in 0..80 {
+            s.push(&chunk, &mut out);
+        }
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        s.push(&group, &mut out);
+        s.push(&group, &mut out);
+        // The chunk residue cut at the first post-reset SPS is itself an AU;
+        // the point is the second group boundary lands again.
+        assert_eq!(out.len(), 2, "AUD-less groups must frame after the reset");
+        assert_eq!(out[1], group, "the cut lands on the second group's SPS");
+        assert_eq!(s.finish(), Some(group));
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -984,4 +984,86 @@ mod tests {
         let f = VideoFrame::new(au_from_nals(&[nal(1, 30)]));
         assert!(!f.keyframe);
     }
+
+    /// Decoder keyframe gate (WhatsApp decoder): every IDR group must open
+    /// with SPS at NALU index 0 plus PPS, SPS bytes constant all call, no
+    /// SEI/AUD at index 0. Round-trips three IDR groups with one constant SPS
+    /// through the real send path (`packetize_au`, including an FU-A-split
+    /// IDR) into the depacketizer and pins the emitted order.
+    #[test]
+    fn outbound_idr_groups_open_sps_pps_idr_with_constant_sps() {
+        let sps = nal(7, 24);
+        let pps = nal(8, 8);
+        // Two IDR groups sharing one SPS, with a delta frame between: the
+        // stream shape a live call repeats.
+        let groups = [
+            au_from_nals(&[sps.clone(), pps.clone(), nal(5, 2000)]),
+            au_from_nals(&[nal(1, 60)]),
+            au_from_nals(&[sps.clone(), pps.clone(), nal(5, 900)]),
+        ];
+        for au in &groups {
+            let mut payloads = PacketizedAu::default();
+            packetize_au(au, &mut payloads);
+            let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+            let nals: Vec<_> = split_annexb(&got).collect();
+            let types: Vec<u8> = nals.iter().map(|n| nal_unit_type(n)).collect();
+            if au_has_idr(au) {
+                assert!(
+                    types.len() >= 3,
+                    "an IDR group must keep SPS, PPS and IDR, got {types:?}"
+                );
+                assert_eq!(
+                    types[0], 7,
+                    "SPS must open the IDR group at NALU index 0, got {types:?}"
+                );
+                assert_eq!(types[1], 8, "PPS must follow SPS at index 1, got {types:?}");
+                assert!(
+                    types.iter().any(|t| *t == 5),
+                    "the IDR slice must survive, got {types:?}"
+                );
+                assert!(
+                    !types.iter().any(|t| *t == 9),
+                    "no AUD may reach the wire, got {types:?}"
+                );
+                assert_eq!(
+                    nals[0],
+                    sps.as_slice(),
+                    "SPS bytes must stay constant across the call"
+                );
+            } else {
+                assert_eq!(types, [1], "delta frames pass through untouched");
+            }
+        }
+    }
+
+    /// Encoder-only AUDs never reach the wire: the packetizer drops them so a
+    /// supplier-side AUD cannot take NALU index 0 from SPS.
+    #[test]
+    fn outbound_aud_first_input_still_opens_sps() {
+        let sps = nal(7, 24);
+        let au = au_from_nals(&[nal(9, 2), sps.clone(), nal(8, 8), nal(5, 100)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
+        assert_eq!(types[0], 7, "AUD dropped, SPS opens, got {types:?}");
+    }
+
+    /// Documents current passthrough, not approved shape: an SEI-first input
+    /// stays SEI-first on the wire — the packetizer preserves supplier order
+    /// and only AUD is filtered. If a live encoder emits SEI-first groups,
+    /// the peer decoder drops the IDR; fixing that belongs at the source (or
+    /// in packetize policy, which is a product decision), not in this test.
+    #[test]
+    fn outbound_sei_first_input_stays_sei_first() {
+        let au = au_from_nals(&[nal(6, 12), nal(7, 24), nal(8, 8), nal(5, 100)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
+        assert_eq!(
+            types[0], 6,
+            "SEI currently passes through first, got {types:?}"
+        );
+    }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -1033,11 +1033,11 @@ mod tests {
                 );
                 assert_eq!(types[1], 8, "PPS must follow SPS at index 1, got {types:?}");
                 assert!(
-                    types.iter().any(|t| *t == 5),
+                    types.contains(&5),
                     "the IDR slice must survive, got {types:?}"
                 );
                 assert!(
-                    !types.iter().any(|t| *t == 9),
+                    !types.contains(&9),
                     "no AUD may reach the wire, got {types:?}"
                 );
                 assert_eq!(
@@ -1080,7 +1080,7 @@ mod tests {
         assert_eq!(types[0], 7, "SEI stripped, SPS opens, got {types:?}");
         assert_eq!(nals[0], sps.as_slice(), "SPS bytes intact");
         assert!(
-            !types.iter().any(|t| *t == 6),
+            !types.contains(&6),
             "no SEI may reach the wire, got {types:?}"
         );
     }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -648,16 +648,13 @@ impl AnnexBAuSplitter {
             // Record this NAL for the next boundary decision: the flag update
             // runs after the cut check above, so a group opener never closes
             // the group its own parameter sets belong to. A VCL NAL ends any
-            // SEI run; any other non-VCL NAL breaks it.
+            // SEI run; other prefix NALs leave a pending run in place, since
+            // they describe the same following picture.
             if is_vcl {
                 self.buf_has_vcl = true;
                 self.pending_sei_start = None;
-            } else if unit_type == NAL_TYPE_SEI {
-                if self.pending_sei_start.is_none() {
-                    self.pending_sei_start = Some(sc.begin);
-                }
-            } else {
-                self.pending_sei_start = None;
+            } else if unit_type == NAL_TYPE_SEI && self.pending_sei_start.is_none() {
+                self.pending_sei_start = Some(sc.begin);
             }
             if self.buf.len() > H264_MAX_AU_BYTES {
                 // Runaway buffer means the stream has no AUDs; dropping is
@@ -1506,6 +1503,26 @@ mod tests {
         let got = depacketize_all(payloads.iter()).expect("AU must reassemble");
         assert_eq!(got, au);
         assert!(au_is_keyframe(&got));
+    }
+
+    /// Prefix NALs between an SEI run and its picture do not break the run:
+    /// VCL, SEI, PPS, VCL frames as [VCL] + [SEI, PPS, VCL].
+    #[test]
+    fn au_splitter_sei_run_survives_prefix_nals() {
+        let vcl = |first: &[u8]| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first);
+            n.extend((0..30).map(|i| (i % 251) as u8));
+            n
+        };
+        let (first, second) = (vcl(&[0x80]), vcl(&[0x80]));
+        let (sei, pps) = (vec![0x06, 0x05, 0x11, 0x22], nal(8, 4));
+        let stream = au_from_nals(&[first.clone(), sei.clone(), pps.clone(), second.clone()]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au_from_nals(&[first])]);
+        assert_eq!(s.finish(), Some(au_from_nals(&[sei, pps, second])));
     }
 
     /// An SEI preceding a group opener rides with the group: VCL, SEI, SPS,

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -71,7 +71,8 @@ pub fn nal_unit_type(nal: &[u8]) -> u8 {
 
 /// `first_mb_in_slice` of a VCL NAL: the first Exp-Golomb code of the slice
 /// header, 0 on a picture's first slice and nonzero after it. Returns `None`
-/// when the NAL is too short to read. Emulation-prevention bytes are removed
+/// when the NAL is too short to read or carries no decodable code.
+/// Emulation-prevention bytes are removed
 /// before reading, so `00 00 03` never parses as leading zeros.
 fn first_mb_in_slice(nal: &[u8]) -> Option<u32> {
     const MAX_BYTES: usize = 8;
@@ -521,8 +522,9 @@ impl H264Depacketizer {
 
 /// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
 /// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at picture
-/// boundaries: SPS opens a group, an IDR following a complete group closes
-/// the previous one, and any VCL slice starting a new picture (`first_mb_in_slice`
+/// boundaries: SPS opens a group once a picture is buffered (leading
+/// parameter sets stay with their slices), an IDR following a complete group
+/// closes the previous one, and any VCL slice starting a new picture (`first_mb_in_slice`
 /// zero) with a VCL NAL already buffered splits delta frames apart. Feed
 /// arbitrary chunks; complete AUs come back as they close. PPS alone never
 /// cuts — it belongs with the SPS that precedes it, not the slices that
@@ -542,6 +544,15 @@ pub struct AnnexBAuSplitter {
 }
 
 impl AnnexBAuSplitter {
+    /// Drop a runaway buffer: without AUDs the cap is the only bound, so
+    /// every early exit enforces it, not just the loop end.
+    fn drop_runaway(&mut self) {
+        self.buf.clear();
+        self.scan_pos = 0;
+        self.buf_has_idr = false;
+        self.buf_has_vcl = false;
+    }
+
     pub fn push(&mut self, data: &[u8], out: &mut Vec<Vec<u8>>) {
         self.buf.extend_from_slice(data);
         loop {
@@ -566,30 +577,36 @@ impl AnnexBAuSplitter {
                 self.seen_aud = true;
             }
             let is_vcl = matches!(unit_type, 1..=5);
-            // An IDR closes the previous group only when the buffer already
-            // holds one: the IDR's own parameter sets still arrive after it
-            // here (SPS-first ordering), so cutting on every IDR would orphan
-            // them. A VCL slice starting a new picture splits only when a
-            // previous VCL NAL is buffered, so parameter sets never separate
-            // from their slices. Evaluated before recording this NAL below.
-            // The picture check reads this NAL alone (up to the next start
-            // code), never bytes of a following NAL. When the NAL runs to the
-            // buffer end and its picture bit is unreadable, the header may
-            // simply not have arrived yet: rewind and wait for more bytes
-            // rather than advancing past a boundary forever.
+            // Only slice-carrying NALs (1, 2, 5) start with
+            // `first_mb_in_slice`: data partitions (3, 4) start with
+            // `slice_id`, where 0 would misread as a new picture and split
+            // the partition away from its group.
             let nal_end = find_start_code(&self.buf, sc.end)
                 .map(|next| next.begin)
                 .unwrap_or(self.buf.len());
-            let picture = first_mb_in_slice(&self.buf[sc.end..nal_end]);
+            let picture = if matches!(unit_type, 1 | 2 | 5) {
+                first_mb_in_slice(&self.buf[sc.end..nal_end])
+            } else {
+                // Readable stand-in: non-slice NALs never picture-split and
+                // skip the wait-for-header path below.
+                Some(1)
+            };
             if is_vcl && picture.is_none() && nal_end == self.buf.len() {
+                // The header may simply not have arrived yet: rewind and wait
+                // for more bytes rather than advancing past a boundary
+                // forever. A corrupt header never becomes readable, so enforce
+                // the cap here too — this break skips the loop-end check.
                 self.scan_pos = sc.begin;
+                if self.buf.len() > H264_MAX_AU_BYTES {
+                    self.drop_runaway();
+                }
                 break;
             }
             let new_picture = picture.unwrap_or(1) == 0;
             let cuts_here = sc.begin > 0
                 && (unit_type == NAL_TYPE_AUD
                     || (!self.seen_aud
-                        && (unit_type == NAL_TYPE_SPS
+                        && ((unit_type == NAL_TYPE_SPS && self.buf_has_vcl)
                             || (unit_type == NAL_TYPE_IDR && self.buf_has_idr)
                             || (is_vcl && self.buf_has_vcl && new_picture))));
             if cuts_here {
@@ -614,10 +631,7 @@ impl AnnexBAuSplitter {
             if self.buf.len() > H264_MAX_AU_BYTES {
                 // Runaway buffer means the stream has no AUDs; dropping is
                 // safer than emitting a cut mid-NAL.
-                self.buf.clear();
-                self.scan_pos = 0;
-                self.buf_has_idr = false;
-                self.buf_has_vcl = false;
+                self.drop_runaway();
             }
         }
     }
@@ -1346,5 +1360,77 @@ mod tests {
         s.push(&stream[cut..], &mut out);
         assert_eq!(out, vec![au1]);
         assert_eq!(s.finish(), Some(au2));
+    }
+
+    /// A VCL NAL whose slice header never becomes readable must not grow the
+    /// buffer without bound: the wait path enforces the cap like the loop
+    /// end, and framing recovers on later well-formed input.
+    #[test]
+    fn au_splitter_corrupt_slice_header_is_capped() {
+        // 32 leading zero bits: no decodable Exp-Golomb code, permanently None.
+        let corrupt = vec![0x41, 0x00, 0x00, 0x00, 0x00, 0x40];
+        assert_eq!(first_mb_in_slice(&corrupt), None);
+        let mut first = START_CODE.to_vec();
+        first.extend_from_slice(&corrupt);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&first, &mut out);
+        assert!(out.is_empty());
+        let chunk = vec![0xabu8; 64 * 1024];
+        for _ in 0..80 {
+            s.push(&chunk, &mut out);
+        }
+        assert!(out.is_empty());
+        assert!(
+            s.buf.len() <= H264_MAX_AU_BYTES,
+            "corrupt-header stream must be capped, got {}",
+            s.buf.len()
+        );
+        // Framing recovers: the next group's SPS still cuts an AU boundary.
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        s.push(&group, &mut out);
+        s.push(&group, &mut out);
+        assert_eq!(out.len(), 1, "emissions must resume after the cap drop");
+        assert!(
+            out[0].ends_with(&group),
+            "the cut lands on the second group's SPS"
+        );
+    }
+
+    /// Repeated SPS before the first slice stay with their group: SPS only
+    /// opens a group once a picture is buffered, so a parameter-set-only AU
+    /// is never emitted to be dropped downstream.
+    #[test]
+    fn au_splitter_leading_sps_without_vcl_stays_together() {
+        let mut first = au_from_nals(&[nal(7, 4)]);
+        first.extend_from_slice(&au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]));
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&first, &mut out);
+        assert!(
+            out.is_empty(),
+            "leading SPS must not split before any picture"
+        );
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        s.push(&group, &mut out);
+        assert_eq!(out, vec![first]);
+        assert_eq!(s.finish(), Some(group));
+    }
+
+    /// Data partitions (types 3/4) carry slice_id, not first_mb_in_slice: a
+    /// partition with id 0 must not split away from its partition A.
+    #[test]
+    fn au_splitter_data_partitions_stay_with_partition_a() {
+        // 0x80 is ue(0): first_mb 0 on partition A, slice_id 0 on partition B.
+        let mut part_a = vec![0x42, 0x80];
+        part_a.extend((0..28).map(|i| (i % 251) as u8));
+        let mut part_b = vec![0x43, 0x80];
+        part_b.extend((0..28).map(|i| (i % 251) as u8));
+        let stream = au_from_nals(&[part_a, part_b]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert!(out.is_empty(), "partitions B/C ride with their partition A");
+        assert_eq!(s.finish(), Some(stream));
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -69,6 +69,59 @@ pub fn nal_unit_type(nal: &[u8]) -> u8 {
     nal.first().map(|b| b & 0x1f).unwrap_or(0)
 }
 
+/// `first_mb_in_slice` of a VCL NAL: the first Exp-Golomb code of the slice
+/// header, 0 on a picture's first slice and nonzero after it. Returns `None`
+/// when the NAL is too short to read. Emulation-prevention bytes are removed
+/// before reading, so `00 00 03` never parses as leading zeros.
+fn first_mb_in_slice(nal: &[u8]) -> Option<u32> {
+    const MAX_BYTES: usize = 8;
+    let mut raw = [0u8; MAX_BYTES];
+    let mut len = 0;
+    let mut zeros = 0u8;
+    for &byte in nal.iter().skip(1) {
+        if zeros >= 2 && byte == 0x03 {
+            zeros = 0;
+            continue;
+        }
+        zeros = if byte == 0x00 { zeros + 1 } else { 0 };
+        if len == MAX_BYTES {
+            break;
+        }
+        raw[len] = byte;
+        len += 1;
+    }
+    let total_bits = len * 8;
+    let mut consumed = 0usize;
+    let bit_at = |pos: usize| -> u8 {
+        let byte = raw[pos / 8];
+        (byte >> (7 - pos % 8)) & 1
+    };
+    let mut leading = 0u32;
+    loop {
+        if consumed >= total_bits {
+            return None;
+        }
+        if bit_at(consumed) != 0 {
+            break;
+        }
+        consumed += 1;
+        leading += 1;
+        if leading > 31 {
+            return None;
+        }
+    }
+    consumed += 1;
+    if consumed + leading as usize > total_bits {
+        return None;
+    }
+    let mut value = 0u32;
+    for _ in 0..leading {
+        value = (value << 1) | u32::from(bit_at(consumed));
+        consumed += 1;
+    }
+    Some((1u32 << leading).wrapping_sub(1).wrapping_add(value))
+}
+
 /// Iterate the NAL units of an Annex-B buffer (start codes stripped, empty NALs skipped).
 pub fn split_annexb(data: &[u8]) -> impl Iterator<Item = &[u8]> {
     SplitAnnexB { data, pos: 0 }
@@ -467,24 +520,25 @@ impl H264Depacketizer {
 }
 
 /// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
-/// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at SPS NALs
-/// (type 7) and at IDRs that complete an earlier group: every IDR group opens
-/// with SPS, so a parameter set with bytes before it starts the next group,
-/// and an IDR arriving when the buffer already holds one closes the previous
-/// group instead of batching a GOP under one timestamp. Feed arbitrary
-/// chunks; complete AUs come back as they close. PPS alone never cuts — it
-/// belongs with the SPS that precedes it, not the slices that follow. Once an
-/// AUD is observed, AUDs own the framing and SPS/IDR no longer cut, so
-/// AUD-bearing streams behave exactly as before.
+/// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at picture
+/// boundaries: SPS opens a group, an IDR following a complete group closes
+/// the previous one, and any VCL slice starting a new picture (`first_mb_in_slice`
+/// zero) with a VCL NAL already buffered splits delta frames apart. Feed
+/// arbitrary chunks; complete AUs come back as they close. PPS alone never
+/// cuts — it belongs with the SPS that precedes it, not the slices that
+/// follow. Once an AUD is observed, AUDs own the framing and nothing else
+/// cuts, so AUD-bearing streams behave exactly as before.
 #[derive(Default)]
 pub struct AnnexBAuSplitter {
     buf: Vec<u8>,
     /// Scan resume point: everything before it was already searched for an AUD.
     scan_pos: usize,
-    /// An AUD has been observed: SPS/IDR cutting stays off from here on.
+    /// An AUD has been observed: SPS/IDR/VCL cutting stays off from here on.
     seen_aud: bool,
     /// The buffered bytes already hold an IDR slice.
     buf_has_idr: bool,
+    /// The buffered bytes already hold a VCL NAL.
+    buf_has_vcl: bool,
 }
 
 impl AnnexBAuSplitter {
@@ -511,26 +565,43 @@ impl AnnexBAuSplitter {
             if unit_type == NAL_TYPE_AUD {
                 self.seen_aud = true;
             }
+            let is_vcl = matches!(unit_type, 1..=5);
             // An IDR closes the previous group only when the buffer already
             // holds one: the IDR's own parameter sets still arrive after it
             // here (SPS-first ordering), so cutting on every IDR would orphan
-            // them. Evaluated before recording this NAL below.
+            // them. A VCL slice starting a new picture splits only when a
+            // previous VCL NAL is buffered, so parameter sets never separate
+            // from their slices. Evaluated before recording this NAL below.
+            // The picture check reads this NAL alone (up to the next start
+            // code), never bytes of a following NAL.
+            let nal_end = find_start_code(&self.buf, sc.end)
+                .map(|next| next.begin)
+                .unwrap_or(self.buf.len());
+            let new_picture = first_mb_in_slice(&self.buf[sc.end..nal_end]).unwrap_or(1) == 0;
             let cuts_here = sc.begin > 0
                 && (unit_type == NAL_TYPE_AUD
                     || (!self.seen_aud
                         && (unit_type == NAL_TYPE_SPS
-                            || (unit_type == NAL_TYPE_IDR && self.buf_has_idr))));
+                            || (unit_type == NAL_TYPE_IDR && self.buf_has_idr)
+                            || (is_vcl && self.buf_has_vcl && new_picture))));
             if cuts_here {
                 let rest = self.buf.split_off(sc.begin);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);
                 self.scan_pos = 0;
                 self.buf_has_idr = false;
+                self.buf_has_vcl = false;
             } else {
                 self.scan_pos = sc.end;
             }
+            // Record this NAL for the next boundary decision: the flag update
+            // runs after the cut check above, so an IDR never closes the group
+            // its own parameter sets belong to.
             if unit_type == NAL_TYPE_IDR {
                 self.buf_has_idr = true;
+            }
+            if is_vcl {
+                self.buf_has_vcl = true;
             }
             if self.buf.len() > H264_MAX_AU_BYTES {
                 // Runaway buffer means the stream has no AUDs; dropping is
@@ -538,6 +609,7 @@ impl AnnexBAuSplitter {
                 self.buf.clear();
                 self.scan_pos = 0;
                 self.buf_has_idr = false;
+                self.buf_has_vcl = false;
             }
         }
     }
@@ -1190,5 +1262,54 @@ mod tests {
         let got = depacketize_all(payloads.iter()).expect("reassembled AU");
         let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
         assert_eq!(types, [7, 8, 5, 6], "trailing SEI kept, got {types:?}");
+    }
+
+    /// `first_mb_in_slice` reads the first Exp-Golomb code: `1` is macroblock
+    /// 0, longer codes count up, emulation prevention is skipped, and short
+    /// input refuses instead of guessing.
+    #[test]
+    fn first_mb_in_slice_reads_exp_golomb() {
+        // `1` → 0; `010` → 1.
+        assert_eq!(first_mb_in_slice(&[0x41, 0x80]), Some(0));
+        assert_eq!(first_mb_in_slice(&[0x41, 0x40]), Some(1));
+        // `00 00 03 80` parses exactly like `00 00 80`: the prevention byte
+        // is skipped, not read as leading zeros.
+        assert_eq!(
+            first_mb_in_slice(&[0x41, 0x00, 0x00, 0x80]),
+            first_mb_in_slice(&[0x41, 0x00, 0x00, 0x03, 0x80])
+        );
+        assert_eq!(first_mb_in_slice(&[0x41]), None);
+        assert_eq!(first_mb_in_slice(&[]), None);
+    }
+
+    /// Non-IDR pictures split on VCL picture starts, not just on SPS: without
+    /// this, every delta between keyframes batches into the previous group
+    /// under one RTP timestamp and marker.
+    #[test]
+    fn au_splitter_cuts_on_vcl_picture_start() {
+        // Slice headers with first_mb 0, then 16: two pictures of one stream.
+        let pic = |first_mb: &[u8], len: usize| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first_mb);
+            n.extend((0..len.saturating_sub(1 + first_mb.len())).map(|i| (i % 251) as u8));
+            n
+        };
+        let au1 = au_from_nals(&[pic(&[0x80], 30)]);
+        let au2 = au_from_nals(&[pic(&[0x80], 30)]);
+        let mut stream = au1.clone();
+        stream.extend_from_slice(&au2);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au1]);
+        assert_eq!(s.finish(), Some(au2));
+
+        // A second slice of the SAME picture (first_mb nonzero) never cuts.
+        let multi = au_from_nals(&[vec![0x41, 0x80, 0x01], vec![0x41, 0x08, 0x80, 0x02]]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&multi, &mut out);
+        assert!(out.is_empty(), "one picture stays one AU");
+        assert_eq!(s.finish(), Some(multi));
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -541,6 +541,10 @@ pub struct AnnexBAuSplitter {
     seen_aud: bool,
     /// The buffered bytes already hold a VCL NAL.
     buf_has_vcl: bool,
+    /// Start of a trailing all-SEI run after the last VCL NAL, if any: when
+    /// a new picture confirms the boundary, the run rides with it instead of
+    /// the previous AU.
+    pending_sei_start: Option<usize>,
 }
 
 impl AnnexBAuSplitter {
@@ -553,6 +557,7 @@ impl AnnexBAuSplitter {
         self.scan_pos = 0;
         self.seen_aud = false;
         self.buf_has_vcl = false;
+        self.pending_sei_start = None;
     }
 
     pub fn push(&mut self, data: &[u8], out: &mut Vec<Vec<u8>>) {
@@ -605,25 +610,49 @@ impl AnnexBAuSplitter {
                 break;
             }
             let new_picture = picture.unwrap_or(1) == 0;
+            // An SEI run preceding a new picture describes it: cut before the
+            // run so it rides with its picture, not the previous AU. Other
+            // non-VCL runs (SPS/PPS) keep the existing boundary.
+            let sei_handoff = self.pending_sei_start.filter(|&start| {
+                start > 0 && is_vcl && self.buf_has_vcl && new_picture && !self.seen_aud
+            });
             let cuts_here = sc.begin > 0
                 && (unit_type == NAL_TYPE_AUD
                     || (!self.seen_aud
                         && ((unit_type == NAL_TYPE_SPS && self.buf_has_vcl)
                             || (is_vcl && self.buf_has_vcl && new_picture))));
             if cuts_here {
-                let rest = self.buf.split_off(sc.begin);
+                let at = sei_handoff.unwrap_or(sc.begin);
+                let rest = self.buf.split_off(at);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);
-                self.scan_pos = 0;
                 self.buf_has_vcl = false;
+                self.pending_sei_start = None;
+                if sei_handoff.is_some() {
+                    // The current NAL was fully evaluated above: resume past
+                    // it, or it cuts itself away from its SEI run on rescan.
+                    // `nal_end` is in old-buffer offsets; the new buffer
+                    // starts at `at`.
+                    self.scan_pos = nal_end - at;
+                } else {
+                    self.scan_pos = 0;
+                }
             } else {
                 self.scan_pos = sc.end;
             }
             // Record this NAL for the next boundary decision: the flag update
             // runs after the cut check above, so a group opener never closes
-            // the group its own parameter sets belong to.
+            // the group its own parameter sets belong to. A VCL NAL ends any
+            // SEI run; any other non-VCL NAL breaks it.
             if is_vcl {
                 self.buf_has_vcl = true;
+                self.pending_sei_start = None;
+            } else if unit_type == NAL_TYPE_SEI {
+                if self.pending_sei_start.is_none() {
+                    self.pending_sei_start = Some(sc.begin);
+                }
+            } else {
+                self.pending_sei_start = None;
             }
             if self.buf.len() > H264_MAX_AU_BYTES {
                 // Runaway buffer means the stream has no AUDs; dropping is
@@ -640,6 +669,7 @@ impl AnnexBAuSplitter {
         self.scan_pos = 0;
         self.seen_aud = false;
         self.buf_has_vcl = false;
+        self.pending_sei_start = None;
         if self.buf.is_empty() {
             None
         } else {
@@ -1471,6 +1501,35 @@ mod tests {
         let got = depacketize_all(payloads.iter()).expect("AU must reassemble");
         assert_eq!(got, au);
         assert!(au_is_keyframe(&got));
+    }
+
+    /// An SEI preceding a new picture rides with it: VCL, SEI, VCL frames as
+    /// [VCL] + [SEI, VCL], so the metadata keeps its picture's timestamp.
+    /// Pre-VCL now, the default packetizer drops the SEI instead of sending
+    /// it on the previous picture's timestamp.
+    #[test]
+    fn au_splitter_sei_rides_with_following_picture() {
+        let vcl = |first: &[u8]| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first);
+            n.extend((0..30).map(|i| (i % 251) as u8));
+            n
+        };
+        let (first, second) = (vcl(&[0x80]), vcl(&[0x80]));
+        let sei = vec![0x06, 0x05, 0x11, 0x22];
+        let stream = au_from_nals(&[first.clone(), sei.clone(), second.clone()]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au_from_nals(&[first])]);
+        let rest = s.finish().expect("trailing AU");
+        assert_eq!(rest, au_from_nals(&[sei, second.clone()]));
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&rest, &mut payloads);
+        assert_eq!(
+            depacketize_all(payloads.iter()),
+            Some(au_from_nals(&[second]))
+        );
     }
 
     /// `finish` leaves no framing facts behind: a splitter reused for a new

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -496,15 +496,13 @@ impl AnnexBAuSplitter {
                 self.scan_pos = sc.begin;
                 break;
             };
-            if nal_byte & 0x1f == NAL_TYPE_AUD {
+            let unit_type = nal_byte & 0x1f;
+            if unit_type == NAL_TYPE_AUD {
                 self.seen_aud = true;
             }
-            if nal_byte & 0x1f == NAL_TYPE_AUD && sc.begin > 0 {
-                let rest = self.buf.split_off(sc.begin);
-                let au = std::mem::replace(&mut self.buf, rest);
-                out.push(au);
-                self.scan_pos = 0;
-            } else if !self.seen_aud && nal_byte & 0x1f == NAL_TYPE_SPS && sc.begin > 0 {
+            let cuts_here = sc.begin > 0
+                && (unit_type == NAL_TYPE_AUD || (!self.seen_aud && unit_type == NAL_TYPE_SPS));
+            if cuts_here {
                 let rest = self.buf.split_off(sc.begin);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -633,9 +633,13 @@ impl AnnexBAuSplitter {
         }
     }
 
-    /// Flush the trailing AU on end-of-stream.
+    /// Flush the trailing AU on end-of-stream. The splitter is reusable: a
+    /// finished stream leaves no framing facts behind, so the next push
+    /// starts empty rather than inheriting e.g. a stale AUD mode.
     pub fn finish(&mut self) -> Option<Vec<u8>> {
         self.scan_pos = 0;
+        self.seen_aud = false;
+        self.buf_has_vcl = false;
         if self.buf.is_empty() {
             None
         } else {
@@ -1467,6 +1471,25 @@ mod tests {
         let got = depacketize_all(payloads.iter()).expect("AU must reassemble");
         assert_eq!(got, au);
         assert!(au_is_keyframe(&got));
+    }
+
+    /// `finish` leaves no framing facts behind: a splitter reused for a new
+    /// stream neither keeps a stale AUD mode nor splits the new stream's
+    /// leading parameter sets.
+    #[test]
+    fn au_splitter_finish_resets_framing_state() {
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&au_from_nals(&[nal(9, 2), nal(7, 4), nal(5, 60)]), &mut out);
+        assert!(s.seen_aud && s.buf_has_vcl);
+        s.finish();
+        assert!(!s.seen_aud && !s.buf_has_vcl);
+        // AUD-less groups frame on the reused splitter.
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        s.push(&group, &mut out);
+        s.push(&group, &mut out);
+        assert_eq!(out, vec![group.clone()]);
+        assert_eq!(s.finish(), Some(group));
     }
 
     /// A runaway reset restores AUD-less framing: after the cap drops a

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -523,10 +523,10 @@ impl H264Depacketizer {
 /// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
 /// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at picture
 /// boundaries: SPS opens a group once a picture is buffered (leading
-/// parameter sets stay with their slices), an IDR following a complete group
-/// closes the previous one, and any VCL slice starting a new picture (`first_mb_in_slice`
-/// zero) with a VCL NAL already buffered splits delta frames apart. Feed
-/// arbitrary chunks; complete AUs come back as they close. PPS alone never
+/// parameter sets stay with their slices), and any VCL slice starting a new
+/// picture (`first_mb_in_slice` zero) with a VCL NAL already buffered closes
+/// the previous group — IDR and delta slices alike, so multi-slice pictures
+/// stay one AU. Feed arbitrary chunks; complete AUs come back as they close. PPS alone never
 /// cuts — it belongs with the SPS that precedes it, not the slices that
 /// follow. Once an AUD is observed, AUDs own the framing and nothing else
 /// cuts, so AUD-bearing streams behave exactly as before.
@@ -535,12 +535,10 @@ pub struct AnnexBAuSplitter {
     buf: Vec<u8>,
     /// Scan resume point: everything before it was already searched for an AUD.
     scan_pos: usize,
-    /// An AUD has been observed: SPS/IDR/VCL cutting stays off while the
+    /// An AUD has been observed: SPS/VCL cutting stays off while the
     /// buffered content survives it. A runaway reset drops the content, so it
     /// drops this too and AUD-less framing can recover.
     seen_aud: bool,
-    /// The buffered bytes already hold an IDR slice.
-    buf_has_idr: bool,
     /// The buffered bytes already hold a VCL NAL.
     buf_has_vcl: bool,
 }
@@ -554,7 +552,6 @@ impl AnnexBAuSplitter {
         self.buf.clear();
         self.scan_pos = 0;
         self.seen_aud = false;
-        self.buf_has_idr = false;
         self.buf_has_vcl = false;
     }
 
@@ -612,24 +609,19 @@ impl AnnexBAuSplitter {
                 && (unit_type == NAL_TYPE_AUD
                     || (!self.seen_aud
                         && ((unit_type == NAL_TYPE_SPS && self.buf_has_vcl)
-                            || (unit_type == NAL_TYPE_IDR && self.buf_has_idr)
                             || (is_vcl && self.buf_has_vcl && new_picture))));
             if cuts_here {
                 let rest = self.buf.split_off(sc.begin);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);
                 self.scan_pos = 0;
-                self.buf_has_idr = false;
                 self.buf_has_vcl = false;
             } else {
                 self.scan_pos = sc.end;
             }
             // Record this NAL for the next boundary decision: the flag update
-            // runs after the cut check above, so an IDR never closes the group
-            // its own parameter sets belong to.
-            if unit_type == NAL_TYPE_IDR {
-                self.buf_has_idr = true;
-            }
+            // runs after the cut check above, so a group opener never closes
+            // the group its own parameter sets belong to.
             if is_vcl {
                 self.buf_has_vcl = true;
             }
@@ -1092,14 +1084,20 @@ mod tests {
         assert_eq!(s.finish(), Some(group(2)));
     }
 
-    /// An IDR arriving when the buffer already holds one closes the previous
-    /// group instead of batching a GOP under one timestamp: delta frames ride
-    /// with the group they follow, and the trailing IDR starts the next.
+    /// A new IDR picture still closes the previous group instead of batching
+    /// a GOP under one timestamp: delta frames ride with the group they
+    /// follow, and the trailing IDR starts the next.
     #[test]
     fn au_splitter_cuts_on_idr_after_a_complete_group() {
-        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        // IDR slices opening a picture carry first_mb 0; later slices nonzero.
+        let idr = |len: usize| {
+            let mut n = vec![0x65, 0x80];
+            n.extend((0..len.saturating_sub(2)).map(|i| (i % 251) as u8));
+            n
+        };
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), idr(60)]);
         let delta = au_from_nals(&[nal(1, 40)]);
-        let lone_idr = au_from_nals(&[nal(5, 60)]);
+        let lone_idr = au_from_nals(&[idr(60)]);
         let mut stream = group.clone();
         stream.extend_from_slice(&delta);
         stream.extend_from_slice(&lone_idr);
@@ -1437,6 +1435,38 @@ mod tests {
         s.push(&stream, &mut out);
         assert!(out.is_empty(), "partitions B/C ride with their partition A");
         assert_eq!(s.finish(), Some(stream));
+    }
+
+    /// Production local-encoder shape: a multi-slice IDR group (SPS, PPS,
+    /// four IDR slices) frames as one AU and survives packetize/depacketize
+    /// intact, still reading as a keyframe.
+    #[test]
+    fn production_multislice_idr_group_round_trips() {
+        let slice = |first: &[u8]| {
+            let mut n = vec![0x65];
+            n.extend_from_slice(first);
+            n.extend((0..60).map(|i| (i % 251) as u8));
+            n
+        };
+        let stream = au_from_nals(&[
+            nal(7, 4),
+            nal(8, 4),
+            slice(&[0x80]),
+            slice(&[0x08, 0x80]),
+            slice(&[0x08, 0x80]),
+            slice(&[0x08, 0x80]),
+        ]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert!(out.is_empty(), "multi-slice IDR stays one AU");
+        let au = s.finish().expect("trailing AU");
+        assert_eq!(au, stream);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let got = depacketize_all(payloads.iter()).expect("AU must reassemble");
+        assert_eq!(got, au);
+        assert!(au_is_keyframe(&got));
     }
 
     /// A runaway reset restores AUD-less framing: after the cap drops a

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -1532,6 +1532,27 @@ mod tests {
         );
     }
 
+    /// A picture following a handed-off SEI still closes its own AU: the
+    /// handoff retains the buffered VCL state, so VCL3 splits away from
+    /// [SEI, VCL2] instead of merging two pictures under one timestamp.
+    #[test]
+    fn au_splitter_picture_after_sei_handoff_still_cuts() {
+        let vcl = |first: &[u8]| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first);
+            n.extend((0..30).map(|i| (i % 251) as u8));
+            n
+        };
+        let (a, b, c) = (vcl(&[0x80]), vcl(&[0x80]), vcl(&[0x80]));
+        let sei = vec![0x06, 0x05, 0x11, 0x22];
+        let stream = au_from_nals(&[a.clone(), sei.clone(), b.clone(), c.clone()]);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au_from_nals(&[a]), au_from_nals(&[sei, b])]);
+        assert_eq!(s.finish(), Some(au_from_nals(&[c])));
+    }
+
     /// `finish` leaves no framing facts behind: a splitter reused for a new
     /// stream neither keeps a stale AUD mode nor splits the new stream's
     /// leading parameter sets.

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -243,28 +243,35 @@ impl core::ops::Index<usize> for PacketizedAu {
 
 /// Packetize one Annex-B access unit into WhatsApp RTP payloads (no RTP headers): each
 /// media NAL goes out as a single-NAL payload when it fits, or a run of FU-A
-/// fragments otherwise. Encoder-only AUDs are omitted because WhatsApp's H.264
-/// decoder requires SPS/PPS to lead an IDR frame, and SEI units are omitted
-/// for the same reason: supplemental metadata no decoder needs for rendering
-/// that would otherwise take NALU index 0 from SPS. `out` is cleared and refilled
-/// so the send path can reuse one buffer per AU.
+/// fragments otherwise. Encoder-only AUDs are omitted, and SEI units are
+/// omitted until the first VCL NAL: supplemental metadata no decoder needs
+/// for rendering that would otherwise take NALU index 0 from SPS ahead of an
+/// IDR. `out` is cleared and refilled so the send path can reuse one buffer
+/// per AU.
 pub fn packetize_au(au: &[u8], out: &mut PacketizedAu) {
     packetize_au_inner(au, out, false);
 }
 
-/// [`packetize_au`] preserving SEI units, for the explicit opt-in case of a
-/// peer that needs the metadata. The default strips; callers keep SEI only
-/// deliberately, never by accident.
+/// [`packetize_au`] preserving every SEI unit, for the explicit opt-in case of
+/// a peer that needs the metadata. The default strips leading SEI; callers
+/// keep it only deliberately, never by accident.
 pub fn packetize_au_keep_sei(au: &[u8], out: &mut PacketizedAu) {
     packetize_au_inner(au, out, true);
 }
 
 fn packetize_au_inner(au: &[u8], out: &mut PacketizedAu, keep_sei: bool) {
     out.clear();
+    let mut seen_vcl = false;
     for nal in split_annexb(au) {
         let unit_type = nal_unit_type(nal);
-        if unit_type == NAL_TYPE_AUD || (!keep_sei && unit_type == NAL_TYPE_SEI) {
+        if unit_type == NAL_TYPE_AUD {
             continue;
+        }
+        if !keep_sei && !seen_vcl && unit_type == NAL_TYPE_SEI {
+            continue;
+        }
+        if matches!(unit_type, 1..=5) {
+            seen_vcl = true;
         }
         if nal.len() <= H264_SINGLE_NAL_MAX {
             out.data.extend_from_slice(nal);
@@ -461,19 +468,23 @@ impl H264Depacketizer {
 
 /// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
 /// units, cutting at AUD NALs (type 9) or, for AUD-less encoders, at SPS NALs
-/// (type 7): every IDR group opens with SPS, so a parameter set with bytes
-/// before it starts the next group. Feed arbitrary chunks; complete AUs come
-/// back as they close. PPS alone never cuts — it belongs with the SPS that
-/// precedes it, not the slices that follow. Once an AUD is observed, AUDs own
-/// the framing and SPS no longer cuts, so AUD-bearing streams behave exactly
-/// as before.
+/// (type 7) and at IDRs that complete an earlier group: every IDR group opens
+/// with SPS, so a parameter set with bytes before it starts the next group,
+/// and an IDR arriving when the buffer already holds one closes the previous
+/// group instead of batching a GOP under one timestamp. Feed arbitrary
+/// chunks; complete AUs come back as they close. PPS alone never cuts — it
+/// belongs with the SPS that precedes it, not the slices that follow. Once an
+/// AUD is observed, AUDs own the framing and SPS/IDR no longer cut, so
+/// AUD-bearing streams behave exactly as before.
 #[derive(Default)]
 pub struct AnnexBAuSplitter {
     buf: Vec<u8>,
     /// Scan resume point: everything before it was already searched for an AUD.
     scan_pos: usize,
-    /// An AUD has been observed: SPS cutting stays off from here on.
+    /// An AUD has been observed: SPS/IDR cutting stays off from here on.
     seen_aud: bool,
+    /// The buffered bytes already hold an IDR slice.
+    buf_has_idr: bool,
 }
 
 impl AnnexBAuSplitter {
@@ -500,21 +511,33 @@ impl AnnexBAuSplitter {
             if unit_type == NAL_TYPE_AUD {
                 self.seen_aud = true;
             }
+            // An IDR closes the previous group only when the buffer already
+            // holds one: the IDR's own parameter sets still arrive after it
+            // here (SPS-first ordering), so cutting on every IDR would orphan
+            // them. Evaluated before recording this NAL below.
             let cuts_here = sc.begin > 0
-                && (unit_type == NAL_TYPE_AUD || (!self.seen_aud && unit_type == NAL_TYPE_SPS));
+                && (unit_type == NAL_TYPE_AUD
+                    || (!self.seen_aud
+                        && (unit_type == NAL_TYPE_SPS
+                            || (unit_type == NAL_TYPE_IDR && self.buf_has_idr))));
             if cuts_here {
                 let rest = self.buf.split_off(sc.begin);
                 let au = std::mem::replace(&mut self.buf, rest);
                 out.push(au);
                 self.scan_pos = 0;
+                self.buf_has_idr = false;
             } else {
                 self.scan_pos = sc.end;
+            }
+            if unit_type == NAL_TYPE_IDR {
+                self.buf_has_idr = true;
             }
             if self.buf.len() > H264_MAX_AU_BYTES {
                 // Runaway buffer means the stream has no AUDs; dropping is
                 // safer than emitting a cut mid-NAL.
                 self.buf.clear();
                 self.scan_pos = 0;
+                self.buf_has_idr = false;
             }
         }
     }
@@ -970,6 +993,26 @@ mod tests {
         assert_eq!(s.finish(), Some(group(2)));
     }
 
+    /// An IDR arriving when the buffer already holds one closes the previous
+    /// group instead of batching a GOP under one timestamp: delta frames ride
+    /// with the group they follow, and the trailing IDR starts the next.
+    #[test]
+    fn au_splitter_cuts_on_idr_after_a_complete_group() {
+        let group = au_from_nals(&[nal(7, 4), nal(8, 4), nal(5, 60)]);
+        let delta = au_from_nals(&[nal(1, 40)]);
+        let lone_idr = au_from_nals(&[nal(5, 60)]);
+        let mut stream = group.clone();
+        stream.extend_from_slice(&delta);
+        stream.extend_from_slice(&lone_idr);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        let mut first = group;
+        first.extend_from_slice(&delta);
+        assert_eq!(out, vec![first]);
+        assert_eq!(s.finish(), Some(lone_idr));
+    }
+
     #[test]
     fn au_splitter_cuts_on_aud() {
         let au1 = au_from_nals(&[nal(9, 2), nal(7, 4), nal(5, 60)]);
@@ -1135,5 +1178,17 @@ mod tests {
         let got = depacketize_all(payloads.iter()).expect("reassembled AU");
         let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
         assert_eq!(types[0], 6, "keep variant preserves SEI, got {types:?}");
+    }
+
+    /// SEI after the first VCL NAL is metadata, not a gate violation: only
+    /// leading SEI is stripped.
+    #[test]
+    fn outbound_trailing_sei_is_preserved() {
+        let au = au_from_nals(&[nal(7, 24), nal(8, 8), nal(5, 100), nal(6, 12)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        let types: Vec<u8> = split_annexb(&got).map(nal_unit_type).collect();
+        assert_eq!(types, [7, 8, 5, 6], "trailing SEI kept, got {types:?}");
     }
 }

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -573,11 +573,19 @@ impl AnnexBAuSplitter {
             // previous VCL NAL is buffered, so parameter sets never separate
             // from their slices. Evaluated before recording this NAL below.
             // The picture check reads this NAL alone (up to the next start
-            // code), never bytes of a following NAL.
+            // code), never bytes of a following NAL. When the NAL runs to the
+            // buffer end and its picture bit is unreadable, the header may
+            // simply not have arrived yet: rewind and wait for more bytes
+            // rather than advancing past a boundary forever.
             let nal_end = find_start_code(&self.buf, sc.end)
                 .map(|next| next.begin)
                 .unwrap_or(self.buf.len());
-            let new_picture = first_mb_in_slice(&self.buf[sc.end..nal_end]).unwrap_or(1) == 0;
+            let picture = first_mb_in_slice(&self.buf[sc.end..nal_end]);
+            if is_vcl && picture.is_none() && nal_end == self.buf.len() {
+                self.scan_pos = sc.begin;
+                break;
+            }
+            let new_picture = picture.unwrap_or(1) == 0;
             let cuts_here = sc.begin > 0
                 && (unit_type == NAL_TYPE_AUD
                     || (!self.seen_aud
@@ -1311,5 +1319,32 @@ mod tests {
         s.push(&multi, &mut out);
         assert!(out.is_empty(), "one picture stays one AU");
         assert_eq!(s.finish(), Some(multi));
+    }
+
+    /// A VCL NAL split across read chunks still frames: when the slice header
+    /// has not fully arrived the splitter rewinds and rechecks on the next
+    /// push instead of advancing past the boundary forever.
+    #[test]
+    fn au_splitter_rechecks_partial_slice_header() {
+        let pic = |first_mb: &[u8], len: usize| {
+            let mut n = vec![0x41];
+            n.extend_from_slice(first_mb);
+            n.extend((0..len.saturating_sub(1 + first_mb.len())).map(|i| (i % 251) as u8));
+            n
+        };
+        let au1 = au_from_nals(&[pic(&[0x80], 30)]);
+        let au2 = au_from_nals(&[pic(&[0x80], 30)]);
+        let mut stream = au1.clone();
+        stream.extend_from_slice(&au2);
+        // Split mid-slice-header of the second picture: the type byte (0x41)
+        // arrives alone, the header bit with the next chunk.
+        let cut = au1.len() + 3 + 1;
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream[..cut], &mut out);
+        assert!(out.is_empty(), "nothing decidable yet");
+        s.push(&stream[cut..], &mut out);
+        assert_eq!(out, vec![au1]);
+        assert_eq!(s.finish(), Some(au2));
     }
 }

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -2674,6 +2674,28 @@ impl CallRegistry {
         Some(epoch)
     }
 
+    /// Re-issue a local upgrade request on live video and return its epoch.
+    ///
+    /// Unlike [`Self::begin_local_video_request`], which refuses once local
+    /// video is requested or enabled, this is the re-request path: the
+    /// handshake already reached a video state (requested and awaiting the
+    /// peer, or enabled) and the caller needs to ask again, e.g. the peer
+    /// never answered. It mints a fresh epoch and re-arms the pending self
+    /// request without touching the reached state, so a peer answer still
+    /// applies and the previous timeout goes inert (its epoch no longer
+    /// matches). Returns `None` when there is no video to re-request
+    /// (audio-only), which stays on the begin path.
+    pub fn re_request_local_video(&self, call_id: &str, generation: u64) -> Option<u64> {
+        let mut map = self.active_calls();
+        let entry = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)?;
+        if entry.video.self_state.is_inactive_for_call_mode() {
+            return None;
+        }
+        Some(entry.video.next_self_request())
+    }
+
     /// Complete a peer request only when the same request is still pending.
     pub fn complete_peer_video_request(&self, call_id: &str, token: VideoUpgradeToken) -> bool {
         let mut map = self.active_calls();
@@ -5229,6 +5251,32 @@ mod tests {
             Some((VideoState::Disabled, VideoState::Disabled))
         );
         assert!(!reg.snapshot("CID").expect("session").is_video);
+    }
+
+    // A re-request on live video mints a fresh epoch under the reached state:
+    // the previous timeout goes inert on the epoch mismatch instead of
+    // tearing down the newer request.
+    #[test]
+    fn re_request_mints_a_fresh_epoch_without_leaving_requested_state() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        assert!(
+            reg.re_request_local_video("CID", generation).is_none(),
+            "audio-only has nothing to re-request"
+        );
+        let first = reg
+            .begin_local_video_request("CID", generation)
+            .expect("begin");
+        let second = reg
+            .re_request_local_video("CID", generation)
+            .expect("re-request");
+        assert_ne!(first, second);
+        assert!(!reg.end_local_video_request("CID", generation, first));
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::UpgradeRequestV2, VideoState::Disabled))
+        );
+        assert!(reg.end_local_video_request("CID", generation, second));
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -2674,26 +2674,60 @@ impl CallRegistry {
         Some(epoch)
     }
 
-    /// Re-issue a local upgrade request on live video and return its epoch.
+    /// Re-issue a local upgrade request for an OUTSTANDING local upgrade and
+    /// return its previous and fresh epochs.
     ///
     /// Unlike [`Self::begin_local_video_request`], which refuses once local
-    /// video is requested or enabled, this is the re-request path: the
-    /// handshake already reached a video state (requested and awaiting the
-    /// peer, or enabled) and the caller needs to ask again, e.g. the peer
-    /// never answered. It mints a fresh epoch and re-arms the pending self
-    /// request without touching the reached state, so a peer answer still
-    /// applies and the previous timeout goes inert (its epoch no longer
-    /// matches). Returns `None` when there is no video to re-request
-    /// (audio-only), which stays on the begin path.
-    pub fn re_request_local_video(&self, call_id: &str, generation: u64) -> Option<u64> {
+    /// video is requested or enabled, this is the retry path: a local upgrade
+    /// was initiated and the peer has not answered yet. It mints a fresh epoch
+    /// and re-arms the pending self request without touching the reached
+    /// state, so a peer answer still applies and the previous timeout goes
+    /// inert (its epoch no longer matches). Returns `None` unless a local
+    /// upgrade is actually pending: with no outstanding request there is
+    /// nothing to re-ask, and states like fresh-Enabled stay on the begin
+    /// path. Pair with [`Self::rollback_re_request`] when the re-ask never
+    /// reaches the peer.
+    pub fn re_request_local_video(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<(Option<u64>, u64)> {
         let mut map = self.active_calls();
         let entry = map
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)?;
-        if entry.video.self_state.is_inactive_for_call_mode() {
+        if entry.video.self_state.is_inactive_for_call_mode()
+            || entry.video.pending_self_request.is_none()
+        {
             return None;
         }
-        Some(entry.video.next_self_request())
+        let previous = entry.video.pending_self_request;
+        Some((previous, entry.video.next_self_request()))
+    }
+
+    /// Undo a re-request whose stanza never reached the peer: restores the
+    /// previous pending epoch, but only when the fresh one is still current,
+    /// so a concurrent newer request is never clobbered. Returns false when
+    /// there was nothing of ours to restore.
+    pub fn rollback_re_request(
+        &self,
+        call_id: &str,
+        generation: u64,
+        previous: Option<u64>,
+        current: u64,
+    ) -> bool {
+        let mut map = self.active_calls();
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        if entry.video.pending_self_request != Some(current) {
+            return false;
+        }
+        entry.video.pending_self_request = previous;
+        true
     }
 
     /// Complete a peer request only when the same request is still pending.
@@ -5253,9 +5287,9 @@ mod tests {
         assert!(!reg.snapshot("CID").expect("session").is_video);
     }
 
-    // A re-request on live video mints a fresh epoch under the reached state:
-    // the previous timeout goes inert on the epoch mismatch instead of
-    // tearing down the newer request.
+    // A re-request on an outstanding local upgrade mints a fresh epoch under
+    // the reached state: the previous timeout goes inert on the epoch
+    // mismatch instead of tearing down the newer request.
     #[test]
     fn re_request_mints_a_fresh_epoch_without_leaving_requested_state() {
         let reg = CallRegistry::new();
@@ -5267,9 +5301,10 @@ mod tests {
         let first = reg
             .begin_local_video_request("CID", generation)
             .expect("begin");
-        let second = reg
+        let (previous, second) = reg
             .re_request_local_video("CID", generation)
             .expect("re-request");
+        assert_eq!(previous, Some(first));
         assert_ne!(first, second);
         assert!(!reg.end_local_video_request("CID", generation, first));
         assert_eq!(
@@ -5277,6 +5312,21 @@ mod tests {
             Some((VideoState::UpgradeRequestV2, VideoState::Disabled))
         );
         assert!(reg.end_local_video_request("CID", generation, second));
+    }
+
+    #[test]
+    fn rollback_re_request_restores_the_previous_epoch_only() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        let first = reg
+            .begin_local_video_request("CID", generation)
+            .expect("begin");
+        let (previous, second) = reg
+            .re_request_local_video("CID", generation)
+            .expect("re-request");
+        assert!(!reg.rollback_re_request("CID", generation, previous, first));
+        assert!(reg.rollback_re_request("CID", generation, previous, second));
+        assert!(reg.end_local_video_request("CID", generation, first));
     }
 
     #[test]


### PR DESCRIPTION
Treats an outgoing-call `<reject reason="enc">` as per-device, like `busy`.

A reject with reason="enc" means one device could not decrypt the offer (its registration changed device-side), not the callee declining. Previously `dismiss_outgoing_siblings` treated it as user-rejected-elsewhere and terminated the whole sibling set, killing outgoing calls before answer.

Changes:
- `reject_is_device_busy` matches `busy` and `enc`, so both the sibling-dismiss early return and the call-teardown gate keep the remaining siblings ringing.
- New `REJECT_REASON_ENC` wire constant beside `REJECT_REASON_BUSY`; parser/model docs updated with the rationale kept at the decision point.
- Regression tests: `enc_reject_keeps_the_call_and_the_rung_set` (handler: enc reject with registration bytes keeps the call and the one-shot rung set) and `reject_preserves_an_enc_reason` (parser preserves the reason verbatim; the pinned whatspec IR models reason as an opaque string with no wire enum).
- Oracle experiments (tools/oracle-core, unpublished harness): `video_call_both_sides` drives a video call as initiator and answerer against the pinned engine and diffs emitted stanzas against the Rust builders (initiator MATCH on all compared fields); `video_answerer_matrix` sweeps answerer preconditions. Finding so far: the engine parses inbound offers (status 0) but tears them down as missed/27 before any accept path is reachable, identically across seeded state, offer shapes, timestamp placements, and both pinned engines — so the inbound-reject disposition behind this fix is pinned from live traffic (same evidence class as #1107), not the oracle.

Verification: handlers::call and wacore stanza::call suites green; fmt/clippy clean; CI green; all review threads resolved (CodeRabbit, Greptile, Codex findings addressed).