### PR TITLE
ci: let autofix.ci apply rustfmt fixes on pull requests

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,27 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Same pinned toolchain as the Format Check job in main.yml, so the
+      # fixer and the gate never disagree on formatting.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-16
+          components: rustfmt
+      # rustfmt only: it is deterministic and never changes semantics. Clippy
+      # stays a manual gate — `clippy --fix` can rewrite logic, and the
+      # generated-artifacts and bartender-pin checks in main.yml must stay
+      # human-reviewed, never auto-committed.
+      - run: cargo fmt --all
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a


### PR DESCRIPTION
Routine formatting failures currently bounce pull requests back to the author. This adds the autofix.ci workflow from https://autofix.ci/setup so rustfmt fixes commit themselves onto the PR branch instead.

What it does:
- New workflow .github/workflows/autofix.yml runs cargo fmt on pull requests and pushes to main, then hands the diff to autofix.ci, which commits any formatting fixes back to the PR.
- Uses the same pinned toolchain as the Format Check job in main.yml (nightly-2026-06-16), so the fixer and the gate agree.
- Runner permissions stay at contents: read, and the fixer action is pinned to a commit hash, per the setup guide.

What it deliberately leaves out:
- No clippy autofix. clippy suggestions can change program behavior, and the full lint needs protoc, ALSA headers and a workspace build. Clippy stays a manual gate.
- No auto-regeneration of whatspec files or bartender image pins. Those checks stay human-reviewed.

One manual step remains after merge: someone with admin access installs the autofix.ci GitHub App on this repo (step 1 of the setup guide). Until then the workflow runs but cannot commit fixes.

Verified: the new file parses as valid YAML with the expected triggers, permissions and steps, and the change touches only that one new file.