### PR TITLE
fix(voip): aggregate video parameter sets into STAP-A

### DIFF
--- a/tools/oracle-core/tests/video_our_bytes_to_j.rs
+++ b/tools/oracle-core/tests/video_our_bytes_to_j.rs
@@ -19,7 +19,7 @@ mod common;
 use anyhow::Result;
 use oracle_core::{Runtime, abi, derive::function_body_sha256};
 use sha2::{Digest, Sha256};
-use wacore::voip::h264::{PacketizedAu, au_has_idr, packetize_au};
+use wacore::voip::h264::{PacketizedAu, au_has_idr, nal_unit_type, packetize_au};
 use wacore::voip::rtp::{
     VIDEO_MEDIA_FRAME_INFO_DELTA, VIDEO_MEDIA_FRAME_INFO_IDR, VIDEO_TS_STRIDE_15FPS,
     VideoRtpStream, encode_rtp_header,
@@ -79,7 +79,18 @@ fn our_idr_stream_through_j_parser_and_constructor() -> Result<()> {
     let info = VIDEO_MEDIA_FRAME_INFO_IDR;
     let mut payloads = PacketizedAu::default();
     packetize_au(&au, &mut payloads);
-    assert!(payloads.len() > 1);
+    // Pin the wire shape, not just the count: STAP-A(SPS, PPS) opens, then
+    // FU-A fragments carry the IDR slice.
+    assert_eq!(payloads.len(), 5);
+    let stap = &payloads[0];
+    assert_eq!(nal_unit_type(stap), 24);
+    let (first_len, rest) = stap[1..].split_at(2);
+    let first_len = u16::from_be_bytes([first_len[0], first_len[1]]) as usize;
+    assert_eq!(nal_unit_type(&rest[..first_len]), 7, "SPS opens the STAP-A");
+    let (second_len, rest) = rest[first_len..].split_at(2);
+    let second_len = u16::from_be_bytes([second_len[0], second_len[1]]) as usize;
+    assert_eq!(nal_unit_type(&rest[..second_len]), 8, "PPS follows SPS");
+    assert_eq!(rest.len(), second_len, "STAP-A holds exactly SPS then PPS");
     let mut stream = VideoRtpStream::new(0x4996_ed22, VIDEO_TS_STRIDE_15FPS).unwrap();
     let last = payloads.len() - 1;
     let wires: Vec<Vec<u8>> = payloads

--- a/tools/oracle-core/tests/video_our_bytes_to_j.rs
+++ b/tools/oracle-core/tests/video_our_bytes_to_j.rs
@@ -1,0 +1,164 @@
+//! Our video RTP stream through the captured J engine's receive chain.
+//!
+//! The byte-diff the Android hunt can run without a live call: one IDR access
+//! unit packetized by the real `wacore` send path (STAP-A aggregated
+//! parameter sets, FU-A fragmented IDR, PT 97, shared-timestamp markers, the
+//! captured 12-byte video extension) is fed packet by packet through J's RTP
+//! parser (function 4873, slot 3954) and packet-frame constructor (function
+//! 6003, slot 4331). Every parse must succeed and the marker packet's frame
+//! must carry presence plus the keyframe bit with the original payload.
+//!
+//! Function/slot/body pins mirror `incoming_orientation_probe.rs`.
+//!
+//! ```sh
+//! cargo test --release -p oracle-core --test video_our_bytes_to_j -- --nocapture
+//! ```
+
+mod common;
+
+use anyhow::Result;
+use oracle_core::{Runtime, abi, derive::function_body_sha256};
+use sha2::{Digest, Sha256};
+use wacore::voip::h264::{PacketizedAu, au_has_idr, packetize_au};
+use wacore::voip::rtp::{
+    VIDEO_MEDIA_FRAME_INFO_DELTA, VIDEO_MEDIA_FRAME_INFO_IDR, VIDEO_TS_STRIDE_15FPS,
+    VideoRtpStream, encode_rtp_header,
+};
+use wasmtime::Val;
+
+const CAPTURE: &str = "JgwtTQVeWPm";
+const CAPTURE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+/// AUD, SPS(23), PPS(4), IDR slice(3000): the x264 shape, small enough to log.
+fn fixture_au() -> Vec<u8> {
+    let mut au = vec![0, 0, 0, 1, 0x09, 0xf0];
+    au.extend_from_slice(&[0, 0, 0, 1, 0x67]);
+    au.extend((0..22).map(|i| (i % 251) as u8));
+    au.extend_from_slice(&[0, 0, 0, 1, 0x68, 0xce, 0x06, 0xe2]);
+    au.extend_from_slice(&[0, 0, 0, 1, 0x65]);
+    au.extend((0..2999).map(|i| (i % 251) as u8));
+    au
+}
+
+#[test]
+fn our_idr_stream_through_j_parser_and_constructor() -> Result<()> {
+    let Some(bytes) = common::capture(CAPTURE)? else {
+        eprintln!("skipping: {CAPTURE} unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
+    assert_eq!(hex::encode(Sha256::digest(&bytes)), CAPTURE_SHA);
+    for (index, slot, anchor, hash) in [
+        (
+            4873u32,
+            3954u32,
+            "EXT_HDR: payload offset",
+            "198c51630bcec7240cbb6472423831f89d6c1ad3676d477032030e624ea07c3b",
+        ),
+        (
+            6003u32,
+            4331u32,
+            "Unsupported codec for jbuf",
+            "415de384a70490b5b0b75c37aee0ff2abc447c1a2fb4cdb96bec5588ffb5d045",
+        ),
+    ] {
+        assert!(
+            abi::find_string_refs(&bytes, anchor)?
+                .iter()
+                .any(|entry| entry.referenced_by.contains(&index))
+        );
+        assert!(abi::table_slots_of(&bytes, index)?.contains(&slot));
+        assert_eq!(function_body_sha256(&bytes, index)?, hash);
+    }
+    let _serial = common::threaded_guard();
+    let mut runtime = Runtime::instantiate(&bytes)?;
+    runtime.run_ctors()?;
+
+    // The exact send path: Annex-B AU -> RTP payloads -> RTP headers.
+    let au = fixture_au();
+    assert!(au_has_idr(&au));
+    let info = VIDEO_MEDIA_FRAME_INFO_IDR;
+    let mut payloads = PacketizedAu::default();
+    packetize_au(&au, &mut payloads);
+    assert!(payloads.len() > 1);
+    let mut stream = VideoRtpStream::new(0x4996_ed22, VIDEO_TS_STRIDE_15FPS).unwrap();
+    let last = payloads.len() - 1;
+    let wires: Vec<Vec<u8>> = payloads
+        .iter()
+        .enumerate()
+        .map(|(i, payload)| {
+            let header = stream.next_video_packet(i == last, info);
+            let mut wire = encode_rtp_header(&header);
+            wire.extend_from_slice(payload);
+            wire
+        })
+        .collect();
+    eprintln!(
+        "fixture AU {} bytes -> {} RTP packets (first payload type {:#x})",
+        au.len(),
+        wires.len(),
+        wires[0][28]
+    );
+    let _ = VIDEO_MEDIA_FRAME_INFO_DELTA;
+
+    let n = wires.len();
+    let packet_area = runtime.write_bytes(&vec![0; n * 2048])?;
+    let extensions = runtime.write_bytes(&[0; 136])?;
+    let frames = runtime.write_bytes(&vec![0; n * 336])?;
+    let stream_j = runtime.write_bytes(&[0; 13000])?;
+    let context = runtime.write_bytes(&[0; 16])?;
+    let status = runtime.write_bytes(&[0; 8])?;
+    let clock = runtime.write_bytes(&[0; 8])?;
+
+    let mut keyframe_seen = false;
+    for (i, wire) in wires.iter().enumerate() {
+        let marker = i + 1 == n;
+        let packet = packet_area + (i as u32) * 2048;
+        runtime.write_bytes_at(packet, wire)?;
+        runtime.write_bytes_at(extensions, &[0; 136])?;
+        runtime.shared().clear_trace();
+        runtime.refuel();
+        let parsed = runtime.call_table(
+            3954,
+            &[
+                Val::I32(packet as i32),
+                Val::I64(wire.len() as i64),
+                Val::I32(extensions as i32),
+            ],
+        )?;
+        assert_eq!(parsed[0].i32(), Some(0), "J parser rejects our packet {i}");
+        let frame = frames + (i as u32) * 336;
+        runtime.call_table(
+            4331,
+            &[
+                Val::I32(frame as i32),
+                Val::I32(stream_j as i32),
+                Val::I32(context as i32),
+                Val::I32((packet + 28) as i32),
+                Val::I32((wire.len() - 28) as i32),
+                Val::I32(status as i32),
+                Val::I32(packet as i32),
+                Val::I32(extensions as i32),
+                Val::I32(97),
+                Val::I32(clock as i32),
+            ],
+        )?;
+        let meta = runtime.read_u32_at(frame + 52)?;
+        eprintln!(
+            "pkt{i}: wire={}B marker={marker} frame_meta={meta:#x}",
+            wire.len()
+        );
+        if marker {
+            assert_eq!(
+                meta & 0x808,
+                0x808,
+                "marker packet frame must carry presence+keyframe"
+            );
+            keyframe_seen = true;
+        }
+        assert!(runtime.shared().hot_calls().is_empty());
+        assert!(runtime.stubs_called().is_empty());
+    }
+    assert!(keyframe_seen);
+    eprintln!("J accepted all {} packets of our IDR stream", n);
+    Ok(())
+}

--- a/tools/oracle-core/tests/video_our_bytes_to_j.rs
+++ b/tools/oracle-core/tests/video_our_bytes_to_j.rs
@@ -91,6 +91,21 @@ fn our_idr_stream_through_j_parser_and_constructor() -> Result<()> {
     let second_len = u16::from_be_bytes([second_len[0], second_len[1]]) as usize;
     assert_eq!(nal_unit_type(&rest[..second_len]), 8, "PPS follows SPS");
     assert_eq!(rest.len(), second_len, "STAP-A holds exactly SPS then PPS");
+    for (i, payload) in payloads.iter().enumerate().skip(1) {
+        assert_eq!(nal_unit_type(payload), 28, "IDR rides FU-A, packet {i}");
+        let fu = payload[1];
+        assert_eq!(fu & 0x1f, 5, "FU-A carries the IDR slice, packet {i}");
+        assert_eq!(
+            fu & 0x80 != 0,
+            i == 1,
+            "S bit only on the first fragment, packet {i}"
+        );
+        assert_eq!(
+            fu & 0x40 != 0,
+            i == payloads.len() - 1,
+            "E bit only on the last fragment, packet {i}"
+        );
+    }
     let mut stream = VideoRtpStream::new(0x4996_ed22, VIDEO_TS_STRIDE_15FPS).unwrap();
     let last = payloads.len() - 1;
     let wires: Vec<Vec<u8>> = payloads

--- a/tools/oracle-core/tests/video_sender_static.rs
+++ b/tools/oracle-core/tests/video_sender_static.rs
@@ -9,7 +9,7 @@
 
 mod common;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use oracle_core::abi;
 use sha2::{Digest, Sha256};
 
@@ -53,14 +53,27 @@ fn transport_egress_chain() -> Result<()> {
         .context("call_sendto import")?;
     assert_eq!(abi::find_callers(&bytes, sendto)?, vec![10078]);
     assert_eq!(abi::table_slots_of(&bytes, 10078)?, vec![7472]);
-    // Two paths feed the egress slot: keep both pinned for the follow-up.
-    for (func, slot) in [(10089u32, 7490u32), (12912u32, 9306u32)] {
+    // Two paths feed the egress slot: pin each link so the chain reads
+    // caller -> sender slot -> sender func -> egress slot -> egress func ->
+    // call_sendto, with no unnamed hop in between.
+    let egress_users: Vec<u32> = abi::find_constant_users(&bytes, 7472)?
+        .into_iter()
+        .map(|(f, _)| f)
+        .collect();
+    for (caller, slot, func) in [(10025u32, 7490u32, 10089u32), (12900u32, 9306u32, 12912u32)] {
         assert_eq!(abi::table_slots_of(&bytes, func)?, vec![slot]);
         let users: Vec<u32> = abi::find_constant_users(&bytes, slot as i32)?
             .into_iter()
             .map(|(f, _)| f)
             .collect();
-        assert!(!users.is_empty(), "slot {slot} must have a user");
+        assert!(
+            users.contains(&caller),
+            "slot {slot} must be dispatched by func {caller}, got {users:?}"
+        );
+        assert!(
+            egress_users.contains(&func),
+            "func {func} must dispatch egress slot 7472, got {egress_users:?}"
+        );
     }
     // Capture-start import and its table slot (invoked indirectly).
     let cap = *import_index

--- a/tools/oracle-core/tests/video_sender_static.rs
+++ b/tools/oracle-core/tests/video_sender_static.rs
@@ -9,7 +9,7 @@
 
 mod common;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use oracle_core::abi;
 use sha2::{Digest, Sha256};
 
@@ -18,7 +18,10 @@ const CAPTURE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b6
 
 #[test]
 fn transport_egress_chain() -> Result<()> {
-    let bytes = common::capture(CAPTURE)?.with_context(|| format!("missing {CAPTURE}"))?;
+    let Some(bytes) = common::capture(CAPTURE)? else {
+        eprintln!("skipping: {CAPTURE} unavailable (set WA_WASM_DIR)");
+        return Ok(());
+    };
     assert_eq!(hex::encode(Sha256::digest(&bytes)), CAPTURE_SHA);
 
     // Import indices of the transport and capture host functions.

--- a/tools/oracle-core/tests/video_sender_static.rs
+++ b/tools/oracle-core/tests/video_sender_static.rs
@@ -1,0 +1,69 @@
+//! Static map of the J engine's transport-egress and capture imports.
+//!
+//! Fast (no instantiation): pins the function indices of the relay-send and
+//! capture imports plus the table-slot chain from the video/audio senders
+//! down to `env::call_sendto`. The follow-up established-call harness (relay
+//! emulation) starts from slot 7472 instead of re-deriving it.
+//!
+//! `cargo test -p oracle-core --test video_sender_static -- --nocapture`
+
+mod common;
+
+use anyhow::{Context, Result};
+use oracle_core::abi;
+use sha2::{Digest, Sha256};
+
+const CAPTURE: &str = "JgwtTQVeWPm";
+const CAPTURE_SHA: &str = "97259423aea19cc30c1771478e035105cb0d0e64ab4b0297741b62d01deac8db";
+
+#[test]
+fn transport_egress_chain() -> Result<()> {
+    let bytes = common::capture(CAPTURE)?.with_context(|| format!("missing {CAPTURE}"))?;
+    assert_eq!(hex::encode(Sha256::digest(&bytes)), CAPTURE_SHA);
+
+    // Import indices of the transport and capture host functions.
+    let mut import_index = std::collections::HashMap::new();
+    {
+        use wasmparser::{Parser, Payload};
+        for payload in Parser::new(0).parse_all(&bytes) {
+            let payload = payload.map_err(anyhow::Error::msg)?;
+            if let Payload::ImportSection(reader) = payload {
+                let mut func_index = 0u32;
+                for import in reader.into_imports() {
+                    let import = import.map_err(anyhow::Error::msg)?;
+                    if matches!(
+                        import.ty,
+                        wasmparser::TypeRef::Func(_) | wasmparser::TypeRef::FuncExact(_)
+                    ) {
+                        import_index
+                            .insert(format!("{}::{}", import.module, import.name), func_index);
+                        func_index += 1;
+                    }
+                }
+            }
+        }
+    }
+    // NOTE: non-function imports do not advance the function index space, so
+    // count only Func imports (as above).
+    let sendto = *import_index
+        .get("env::call_sendto")
+        .context("call_sendto import")?;
+    assert_eq!(abi::find_callers(&bytes, sendto)?, vec![10078]);
+    assert_eq!(abi::table_slots_of(&bytes, 10078)?, vec![7472]);
+    // Two paths feed the egress slot: keep both pinned for the follow-up.
+    for (func, slot) in [(10089u32, 7490u32), (12912u32, 9306u32)] {
+        assert_eq!(abi::table_slots_of(&bytes, func)?, vec![slot]);
+        let users: Vec<u32> = abi::find_constant_users(&bytes, slot as i32)?
+            .into_iter()
+            .map(|(f, _)| f)
+            .collect();
+        assert!(!users.is_empty(), "slot {slot} must have a user");
+    }
+    // Capture-start import and its table slot (invoked indirectly).
+    let cap = *import_index
+        .get("env::call_start_video_capture_js_sync")
+        .context("capture import")?;
+    assert_eq!(abi::table_slots_of(&bytes, cap)?, vec![9351]);
+    eprintln!("egress chain pinned: call_sendto={sendto} -> 10078 @7472, capture={cap} @9351");
+    Ok(())
+}

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -3699,6 +3699,64 @@ mod tests {
         assert_eq!(sent, (0..40u16).collect::<Vec<_>>());
     }
 
+    /// The STAP-A-first keyframe shape the packetizer now emits must queue as
+    /// one atomic keyframe batch: the keyframe bit is read from the RTP
+    /// extension (identical on every fragment), never from the payload type.
+    #[test]
+    fn stap_a_first_keyframe_au_batches_atomically_as_keyframe() {
+        fn video_packet(seq: u16, marker: bool, payload: &[u8]) -> Bytes {
+            let mut packet = vec![0x90, ((marker as u8) << 7) | RTP_PAYLOAD_TYPE_H264];
+            packet.extend_from_slice(&seq.to_be_bytes());
+            packet.extend_from_slice(&0u32.to_be_bytes());
+            packet.extend_from_slice(&0x1122_3344u32.to_be_bytes());
+            packet.extend_from_slice(&[0xde, 0xbe, 0x00, 0x03]);
+            packet.extend_from_slice(&[
+                0x30,
+                VIDEO_MEDIA_FRAME_INFO_IDR,
+                0x51,
+                0,
+                0,
+                0x61,
+                0,
+                0,
+                0x91,
+                0,
+                0,
+                0,
+            ]);
+            packet.extend_from_slice(payload);
+            Bytes::from(packet)
+        }
+
+        let stap = [0x78, 0, 2, 0x67, 0x42, 0, 2, 0x68, 0xce];
+        let packets = [
+            video_packet(0, false, &stap),
+            video_packet(1, false, &[0x7c, 0x85, 0x01]),
+            video_packet(2, true, &[0x7c, 0x45, 0x02]),
+        ];
+        let mut queue = VecDeque::new();
+        let mut pending = Vec::new();
+        let mut awaiting_keyframe = SendKeyframeGate::default();
+        for packet in &packets {
+            let dropped = queue_transmit(
+                &mut queue,
+                &mut pending,
+                &mut awaiting_keyframe,
+                packet.clone(),
+            );
+            assert_eq!(dropped.packets, 0);
+        }
+        assert!(pending.is_empty());
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].kind, SendBatchKind::Video);
+        assert!(queue[0].video_keyframe, "STAP-A-first AU is a keyframe");
+        assert_eq!(queue[0].packets.len(), 3);
+        let sent: Vec<u16> = std::iter::from_fn(|| pop_next_packet(&mut queue))
+            .map(|(packet, _)| parse_rtp_header(&packet).unwrap().sequence_number)
+            .collect();
+        assert_eq!(sent, vec![0, 1, 2]);
+    }
+
     #[test]
     fn epoch_transition_cancels_media_already_removed_from_the_send_queue() {
         struct DropProbe(Arc<AtomicBool>);

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -316,6 +316,17 @@ pub fn packetize_au_keep_sei(au: &[u8], out: &mut PacketizedAu) {
 fn packetize_au_inner(au: &[u8], out: &mut PacketizedAu, keep_sei: bool) {
     out.clear();
     let mut seen_vcl = false;
+    // Open STAP-A aggregation, if any: byte offset of its indicator in
+    // `out.data`, plus the F bit (OR) and NRI (max) accumulated over its
+    // members. Small non-VCL NALs (parameter sets) pack into one payload; the
+    // indicator is backpatched at flush once every member is known.
+    let mut stap: Option<(usize, u8, u8)> = None;
+    let flush_stap = |out: &mut PacketizedAu, stap: &mut Option<(usize, u8, u8)>| {
+        if let Some((start, f, nri)) = stap.take() {
+            out.data[start] = f | nri | NAL_TYPE_STAP_A;
+            out.finish_payload();
+        }
+    };
     for nal in split_annexb(au) {
         let unit_type = nal_unit_type(nal);
         if unit_type == NAL_TYPE_AUD {
@@ -325,32 +336,71 @@ fn packetize_au_inner(au: &[u8], out: &mut PacketizedAu, keep_sei: bool) {
             continue;
         }
         if matches!(unit_type, 1..=5) {
+            flush_stap(out, &mut stap);
             seen_vcl = true;
-        }
-        if nal.len() <= H264_SINGLE_NAL_MAX {
-            out.data.extend_from_slice(nal);
-            out.finish_payload();
+            if nal.len() <= H264_SINGLE_NAL_MAX {
+                out.data.extend_from_slice(nal);
+                out.finish_payload();
+                continue;
+            }
+            fragment_nal(nal, out);
             continue;
         }
-        let indicator = (nal[0] & 0xe0) | NAL_TYPE_FU_A;
-        let orig_type = nal[0] & 0x1f;
-        let body = &nal[1..];
-        let n_frags = body.len().div_ceil(H264_FUA_FRAG_SIZE);
-        for (i, chunk) in body.chunks(H264_FUA_FRAG_SIZE).enumerate() {
-            let mut fu_header = orig_type;
-            if i == 0 {
-                fu_header |= 0x80; // S
+        // Non-VCL NAL: aggregate while the run fits, otherwise start a new
+        // STAP-A. A lone oversized unit keeps the old single/FU-A fallback.
+        let stap_cost = 2 + nal.len();
+        let fits = match stap {
+            Some((start, _, _)) => out.data.len() - start + stap_cost <= H264_SINGLE_NAL_MAX,
+            None => stap_cost < H264_SINGLE_NAL_MAX,
+        };
+        if !fits {
+            flush_stap(out, &mut stap);
+            if nal.len() <= H264_SINGLE_NAL_MAX {
+                out.data.extend_from_slice(nal);
+                out.finish_payload();
+                continue;
             }
-            if i == n_frags - 1 {
-                fu_header |= 0x40; // E
-            }
-            out.data.push(indicator);
-            out.data.push(fu_header);
-            out.data.extend_from_slice(chunk);
-            out.finish_payload();
+            fragment_nal(nal, out);
+            continue;
         }
+        match stap.as_mut() {
+            Some((_, f, nri)) => {
+                *f |= nal[0] & 0x80;
+                *nri = (*nri).max(nal[0] & 0x60);
+            }
+            None => {
+                let start = out.data.len();
+                out.data.push(0);
+                stap = Some((start, nal[0] & 0x80, nal[0] & 0x60));
+            }
+        }
+        out.data
+            .extend_from_slice(&(nal.len() as u16).to_be_bytes());
+        out.data.extend_from_slice(nal);
     }
+    flush_stap(out, &mut stap);
     out.release_outlier_capacity();
+}
+
+/// Fragment one oversized NAL into an FU-A run (RFC 6184 section 5.8).
+fn fragment_nal(nal: &[u8], out: &mut PacketizedAu) {
+    let indicator = (nal[0] & 0xe0) | NAL_TYPE_FU_A;
+    let orig_type = nal[0] & 0x1f;
+    let body = &nal[1..];
+    let n_frags = body.len().div_ceil(H264_FUA_FRAG_SIZE);
+    for (i, chunk) in body.chunks(H264_FUA_FRAG_SIZE).enumerate() {
+        let mut fu_header = orig_type;
+        if i == 0 {
+            fu_header |= 0x80; // S
+        }
+        if i == n_frags - 1 {
+            fu_header |= 0x40; // E
+        }
+        out.data.push(indicator);
+        out.data.push(fu_header);
+        out.data.extend_from_slice(chunk);
+        out.finish_payload();
+    }
 }
 
 /// Access units completed but not yet returned can briefly exceed one when a
@@ -815,14 +865,125 @@ mod tests {
 
         packetize_au(&au, &mut payloads);
 
+        // Parameter sets ride aggregated (see
+        // `parameter_sets_aggregate_into_stap_a`); the reassembled AU is
+        // unchanged: AUD dropped, SPS opens, SEI absent.
         assert_eq!(
             payloads.iter().map(nal_unit_type).collect::<Vec<_>>(),
-            [NAL_TYPE_SPS, NAL_TYPE_PPS, NAL_TYPE_IDR]
+            [NAL_TYPE_STAP_A, NAL_TYPE_IDR]
         );
         assert_eq!(
             depacketize_all(payloads.iter()),
             Some(au_from_nals(&[sps, pps, idr]))
         );
+    }
+
+    /// Parameter sets travel aggregated: consecutive small non-VCL NALs
+    /// (SPS/PPS) pack into one STAP-A payload instead of riding as separate
+    /// single-NAL packets. The captured vendor receiver parses an aggregated
+    /// SPS/PPS reliably while a lone single-NAL parameter set takes a fragile
+    /// path, and the Android decoder keeps an STAP-A SPS rewriting path for
+    /// exactly this shape. VCL slices are never aggregated.
+    #[test]
+    fn parameter_sets_aggregate_into_stap_a() {
+        let sps = nal(7, 20);
+        let pps = nal(8, 8);
+        let idr = nal(5, 100);
+        let au = au_from_nals(&[nal(9, 2), sps.clone(), pps.clone(), idr.clone()]);
+        let mut payloads = PacketizedAu::default();
+
+        packetize_au(&au, &mut payloads);
+
+        assert_eq!(payloads.len(), 2, "STAP-A(SPS,PPS) plus the IDR slice");
+        let stap = &payloads[0];
+        assert_eq!(nal_unit_type(stap), NAL_TYPE_STAP_A);
+        let mut rest = &stap[1..];
+        for want in [&sps, &pps] {
+            let len = u16::from_be_bytes([rest[0], rest[1]]) as usize;
+            assert_eq!(&rest[2..2 + len], want.as_slice());
+            rest = &rest[2 + len..];
+        }
+        assert!(rest.is_empty(), "STAP-A holds exactly SPS then PPS");
+        assert_eq!(nal_unit_type(&payloads[1]), NAL_TYPE_IDR);
+        assert_eq!(
+            depacketize_all(payloads.iter()),
+            Some(au_from_nals(&[sps, pps, idr]))
+        );
+    }
+
+    /// Slices are never aggregated, however small: STAP-A carries parameter
+    /// sets and small metadata only, so two small slices stay two packets.
+    #[test]
+    fn small_slices_are_never_aggregated() {
+        let au = au_from_nals(&[nal(1, 40), nal(1, 50)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        assert_eq!(
+            payloads.iter().map(nal_unit_type).collect::<Vec<_>>(),
+            [1, 1]
+        );
+        assert_eq!(depacketize_all(payloads.iter()), Some(au));
+    }
+
+    /// Production WebCodecs IDR shape (local debug log: avc1.42c01f, NALs
+    /// [7, 8, 5, 5, 5, 5]): parameter sets aggregate once, every slice keeps
+    /// its own packet, NAL order survives the round trip.
+    #[test]
+    fn production_multislice_idr_keeps_slice_packets() {
+        let sps = nal(7, 18);
+        let pps = nal(8, 4);
+        let slices = [nal(5, 900), nal(5, 1200), nal(5, 800), nal(5, 950)];
+        let mut nals = vec![sps.clone(), pps.clone()];
+        nals.extend(slices.clone());
+        let au = au_from_nals(&nals);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let types: Vec<u8> = payloads.iter().map(nal_unit_type).collect();
+        assert_eq!(types[0], NAL_TYPE_STAP_A, "params aggregate, got {types:?}");
+        assert!(
+            types[1..]
+                .iter()
+                .all(|t| *t == NAL_TYPE_FU_A || *t == NAL_TYPE_IDR),
+            "slices never join the STAP-A, got {types:?}"
+        );
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        assert_eq!(
+            split_annexb(&got).map(nal_unit_type).collect::<Vec<_>>(),
+            [7, 8, 5, 5, 5, 5]
+        );
+    }
+
+    /// Production parameter-set bytes from the failing call's local IDR
+    /// (SPS 18, PPS 4): aggregation carries them byte-identical and the
+    /// reassembled AU opens with the same SPS.
+    #[test]
+    fn production_parameter_sets_round_trip_byte_identical() {
+        let sps = hex::decode("6742c01f8c6805005ba6a0202020f08846a0").unwrap();
+        let pps = hex::decode("68ce3c80").unwrap();
+        assert_eq!(nal_unit_type(&sps), NAL_TYPE_SPS);
+        assert_eq!(nal_unit_type(&pps), NAL_TYPE_PPS);
+        let au = au_from_nals(&[sps.clone(), pps.clone(), nal(5, 60)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        assert_eq!(nal_unit_type(&payloads[0]), NAL_TYPE_STAP_A);
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        let nals: Vec<_> = split_annexb(&got).collect();
+        assert_eq!(nals[0], sps.as_slice(), "SPS bytes intact");
+        assert_eq!(nals[1], pps.as_slice(), "PPS bytes intact");
+    }
+
+    /// Peer's small keyframe shape (remote debug log: NALs [7, 8, 5], a few
+    /// hundred bytes): one STAP-A plus the slice, decoded back intact.
+    #[test]
+    fn small_peer_keyframe_round_trips() {
+        let au = au_from_nals(&[nal(7, 14), nal(8, 4), nal(5, 200)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        assert_eq!(
+            payloads.iter().map(nal_unit_type).collect::<Vec<_>>(),
+            [NAL_TYPE_STAP_A, NAL_TYPE_IDR]
+        );
+        assert_eq!(depacketize_all(payloads.iter()), Some(au));
     }
 
     #[test]

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -355,13 +355,17 @@ fn packetize_au_inner(au: &[u8], out: &mut PacketizedAu, keep_sei: bool) {
         };
         if !fits {
             flush_stap(out, &mut stap);
-            if nal.len() <= H264_SINGLE_NAL_MAX {
-                out.data.extend_from_slice(nal);
-                out.finish_payload();
+            // Reconsider for a fresh aggregate: only a unit too big for even
+            // an empty STAP-A keeps the standalone fallback.
+            if stap_cost >= H264_SINGLE_NAL_MAX {
+                if nal.len() <= H264_SINGLE_NAL_MAX {
+                    out.data.extend_from_slice(nal);
+                    out.finish_payload();
+                } else {
+                    fragment_nal(nal, out);
+                }
                 continue;
             }
-            fragment_nal(nal, out);
-            continue;
         }
         match stap.as_mut() {
             Some((_, f, nri)) => {
@@ -908,6 +912,29 @@ mod tests {
         assert_eq!(
             depacketize_all(payloads.iter()),
             Some(au_from_nals(&[sps, pps, idr]))
+        );
+    }
+
+    /// Overflow starts a new aggregate instead of stranding the triggering
+    /// NAL: a run whose members cannot share one STAP-A still aggregates in
+    /// pairs, so parameter sets stay packed even after a large prefix unit.
+    #[test]
+    fn stap_a_overflow_opens_a_new_aggregate() {
+        let sps = nal(7, 400);
+        let pps = nal(8, 400);
+        let au = au_from_nals(&[sps.clone(), pps.clone(), nal(5, 60)]);
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au, &mut payloads);
+        let types: Vec<u8> = payloads.iter().map(nal_unit_type).collect();
+        assert_eq!(
+            types,
+            [NAL_TYPE_STAP_A, NAL_TYPE_STAP_A, NAL_TYPE_IDR],
+            "each parameter set aggregates, got {types:?}"
+        );
+        let got = depacketize_all(payloads.iter()).expect("reassembled AU");
+        assert_eq!(
+            split_annexb(&got).map(nal_unit_type).collect::<Vec<_>>(),
+            [7, 8, 5]
         );
     }
 

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -2511,6 +2511,54 @@ mod tests {
         assert_eq!(body, expect.as_slice(), "video send must key on self LID");
     }
 
+    /// Lock the wire shape Android renders: an IDR AU leaves protect_video as
+    /// STAP-A(SPS, PPS) plus slice packets, with PT 97, the keyframe bit on
+    /// every fragment, and the marker on the last packet only. Production
+    /// preview confirmed Android decodes from the first such IDR with no PLI
+    /// storm, after never rendering the old single-NAL parameter sets.
+    #[test]
+    fn protected_idr_opens_with_stap_a_parameter_sets() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let self_lid = "111111111111111:0@lid";
+        let peer_lid = "222222222222222:0@lid";
+        let mut pipe = VideoPipeline::new(&video_params(&call_key, self_lid, peer_lid)).unwrap();
+        let sps = [0x67, 0x42, 0xc0, 0x1f, 0x08, 0x80];
+        let pps = [0x68, 0xce, 0x06, 0xe2];
+        let mut au = vec![0, 0, 0, 1];
+        au.extend_from_slice(&sps);
+        au.extend_from_slice(&[0, 0, 0, 1]);
+        au.extend_from_slice(&pps);
+        au.extend_from_slice(&[0, 0, 0, 1, 0x65, 0x01, 0x02, 0x03]);
+        let packets = pipe.protect_video(&au);
+        assert_eq!(packets.len(), 2, "STAP-A plus the IDR slice");
+
+        let keys = derive_e2e_keys(&call_key, self_lid).unwrap();
+        let first = &packets[0][..packets[0].len() - WARP_MI_TAG_LEN];
+        let header = parse_rtp_header(first).unwrap();
+        assert_eq!(header.payload_type, crate::voip::rtp::RTP_PAYLOAD_TYPE_H264);
+        assert!(!header.marker, "only the last packet of the AU marks");
+        assert_eq!(
+            header.video_extension.unwrap().media_frame_info,
+            VIDEO_MEDIA_FRAME_INFO_IDR
+        );
+        let header_len = rtp_header_byte_length(first).unwrap();
+        let mut stap = vec![0x78]; // STAP-A, NRI 3: the unit tests pin the const mapping.
+        stap.extend_from_slice(&(sps.len() as u16).to_be_bytes());
+        stap.extend_from_slice(&sps);
+        stap.extend_from_slice(&(pps.len() as u16).to_be_bytes());
+        stap.extend_from_slice(&pps);
+        let expect = crypt_payload(&keys, header.ssrc, 0, 0, &stap);
+        assert_eq!(&first[header_len..], expect.as_slice());
+
+        let last = &packets[1][..packets[1].len() - WARP_MI_TAG_LEN];
+        let header = parse_rtp_header(last).unwrap();
+        assert!(header.marker, "the AU closes with the marker");
+        assert_eq!(
+            header.video_extension.unwrap().media_frame_info,
+            VIDEO_MEDIA_FRAME_INFO_IDR
+        );
+    }
+
     #[test]
     fn upright_video_frame_info_is_constant_across_every_au_fragment() {
         let call_key: Vec<u8> = (0u8..32).collect();

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -2552,11 +2552,15 @@ mod tests {
 
         let last = &packets[1][..packets[1].len() - WARP_MI_TAG_LEN];
         let header = parse_rtp_header(last).unwrap();
+        assert_eq!(header.payload_type, crate::voip::rtp::RTP_PAYLOAD_TYPE_H264);
         assert!(header.marker, "the AU closes with the marker");
         assert_eq!(
             header.video_extension.unwrap().media_frame_info,
             VIDEO_MEDIA_FRAME_INFO_IDR
         );
+        let header_len = rtp_header_byte_length(last).unwrap();
+        let expect = crypt_payload(&keys, header.ssrc, 1, 0, &[0x65, 0x01, 0x02, 0x03]);
+        assert_eq!(&last[header_len..], expect.as_slice());
     }
 
     #[test]


### PR DESCRIPTION
One-variable candidate for Android never rendering our video. Our sender emitted SPS and PPS as separate single-NAL RTP packets and never produced STAP-A. This change packs consecutive small non-VCL NALs into one STAP-A payload, opening a fresh aggregate on rollover instead of stranding the triggering NAL. Slices still go out as single-NAL or FU-A exactly as before.

Why this variable. A production caller-side call logged 276 video packets with zero local drops, 13 encoder IDRs, and about 20 inbound PLIs naming our video SSRC, yet Android rendered zero frames over 10.7 seconds. Android locks the stream and keeps asking, so packets arrive but no keyframe ever becomes decodable. That reads like lost parameter sets, not lost slices.

Oracle evidence. Driving the pinned J engine (JgwtTQVeWPm) shows its packet-frame constructor accepts STAP-A SPS+PPS every run with correct keyframe metadata, while a lone single-NAL SPS takes a fragile path that faults on first sight. The new test video_our_bytes_to_j feeds our real packetizer output through J's parser and constructor and passes, with the STAP-A shape and the FU-A fragment layout both pinned.

What I verified. Failing-first test parameter_sets_aggregate_into_stap_a failed before the change with three payloads and passes now with STAP-A plus slice, and a second failing-first test covers rollover opening a fresh aggregate. wacore lib is green at 2386 tests, whatsapp-rust voip at 226, workspace clippy clean, and the oracle video suites pass. New regression fixtures replay production NAL descriptors from the browser logs, including the exact SPS and PPS bytes of the failing call, and a session test locks the protected wire shape: STAP-A parameter sets open the IDR with PT 97, keyframe bit throughout, marker on close. Our depacketizer, J, and Android WebRTC code all parse STAP-A, so no receiver loses anything.

Preview result. The client preview carrying this change rendered on the captain's phone from the first IDR: 3873 video packets with zero drops, no PLI storm, both sides decoding to a normal hangup, against byte-identical encoder output and handshake to the failing calls. That closes the loop on this variable.

Honest limits. I could not capture the vendor sender egress, because that needs an established relay-backed call in the harness, so the byte diff covers our bytes against the vendor receive path, not vendor send against ours. Runner-ups stay documented: first video seq/ts starting at zero, and caller-side post-accept video state.
