### PR TITLE
feat(voip): add video resume and direction-local upgrade timeout

### DIFF
--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -11920,6 +11920,41 @@ mod tests {
         handle.hangup_local().await;
     }
 
+    // The previously stuck cell end to end: a paused peer keeps the call
+    // video, so the begin path refuses and the re-add must take it. A bare
+    // `Enabled` is what an already-video peer answers.
+    #[tokio::test]
+    async fn resume_video_re_adds_against_a_paused_peer() {
+        let (client, sends, handle, _relay_keepalive) = sending_handle().await;
+        apply_paused_peer(&handle).await;
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let (vsrc, vsink) = video_endpoints();
+        handle
+            .resume_video(vsrc, vsink)
+            .await
+            .expect("a paused peer still holds the call video");
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("re-add must be announced")
+            .expect("waiter");
+        assert_eq!(
+            call_action_of(&node)
+                .as_node_ref()
+                .attrs()
+                .optional_string("state")
+                .as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .video_states(&handle.call_id, handle.generation),
+            Some((VideoState::Enabled, VideoState::Paused))
+        );
+        handle.hangup_local().await;
+    }
+
     // A re-add whose stanza never reaches the peer releases the plane and
     // restores the stopped direction, so a retry stays a resume.
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3417,11 +3417,23 @@ impl VideoShared {
     /// Release the endpoints (downgrade / refused upgrade): the source feed is aborted, the sink is
     /// dropped, and the drive loop's video plane is disabled so it stops emitting/decoding video.
     fn detach_endpoints(&self) {
-        *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        self.detach_source();
+        self.detach_sink();
+    }
+
+    /// Drop the local capture feed and gate outbound video off the wire. Inbound keeps decoding,
+    /// so stopping our camera does not lose the picture we are watching.
+    fn detach_source(&self) {
         let feed = self.feed.lock().unwrap_or_else(|e| e.into_inner()).take();
         if let Some(feed) = feed {
             feed.abort();
         }
+        self.send_control(VideoControl::DisableOutbound);
+    }
+
+    /// Drop the attached sink and disable the whole video plane.
+    fn detach_sink(&self) {
+        *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = None;
         self.send_control(VideoControl::Disable);
     }
 }
@@ -4354,9 +4366,9 @@ impl CallHandle {
         Ok(())
     }
 
-    /// Stop our video direction: sends `<video state=6>` (Stopped, no marker), tears the local
-    /// video plane down, and releases the source/sink. The peer may keep sending its direction;
-    /// audio is untouched. Idempotent.
+    /// Stop our video direction: sends `<video state=6>` (Stopped, no marker) and releases only
+    /// the local capture feed. The sink stays attached and inbound keeps decoding, so the peer's
+    /// picture keeps flowing; audio is untouched. Idempotent.
     pub async fn stop_video(&self) -> Result<(), CallError> {
         self.ensure_current()?;
         let transition_lock = self
@@ -4366,9 +4378,8 @@ impl CallHandle {
         let _transition_guard = transition_lock.lock().await;
         self.ensure_current()?;
         // Tear local media down FIRST, matching `Voip::terminate`: the app asked to stop video, so
-        // a failed signaling send must NOT leave the camera streaming. If the peer misses the
-        // Stopped it keeps sending video, but our plane is disabled so those PT-97 packets drop.
-        self.release_local_video();
+        // a failed signaling send must NOT leave the camera streaming.
+        self.stop_local_source();
         self.client_registry
             .stop_local_video(&self.call_id, self.generation);
         let client = self.upgrade_client()?;
@@ -4456,8 +4467,7 @@ impl CallHandle {
                 .restore_self_video_state(&self.call_id, self.generation, previous);
             return Err(CallError::Media("call no longer active"));
         }
-        // Ungated, unlike the initiator's `EnableAwaitingAccept`: the peer is
-        // already video, so there is no accept to wait for.
+        // The peer is already video, so no accept to wait for.
         self.video.send_control(VideoControl::Enable);
         let stanza = build_video_state(&VideoStateParams {
             call_id: &self.call_id,
@@ -4500,6 +4510,23 @@ impl CallHandle {
             ),
             None => CallError::Media("call no longer active"),
         }
+    }
+
+    fn stop_local_source(&self) {
+        let pending_video = {
+            // This synchronous map is shared with non-async setup paths; its lock covers only one
+            // lookup/take and is never held across an await.
+            let mut pending = self
+                .pending_outgoing_calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            pending
+                .get_mut(&self.call_id)
+                .filter(|entry| entry.generation == self.generation)
+                .and_then(|entry| entry.video.take())
+        };
+        drop(pending_video);
+        self.video.detach_source();
     }
 
     /// Release local codec endpoints without changing the directional signaling state.
@@ -12008,8 +12035,23 @@ mod tests {
         handle.hangup_local().await;
     }
 
+    // A caller stopping its camera must not lose the picture it is
+    // watching: the peer is still sending, so only the local feed goes.
     #[tokio::test]
-    async fn stop_video_sends_stopped_and_releases_endpoints() {
+    async fn stop_video_keeps_the_incoming_sink_attached() {
+        let (_client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        handle.stop_video().await.expect("stop_video");
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_some(),
+            "the remote picture must keep flowing after our camera stops"
+        );
+        handle.hangup_local().await;
+    }
+
+    #[tokio::test]
+    async fn stop_video_sends_stopped_and_keeps_the_remote_sink() {
         let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
         let (vsrc, vsink) = video_endpoints();
         handle.start_video(vsrc, vsink).await.expect("start_video");
@@ -12034,8 +12076,17 @@ mod tests {
             "a downgrade must NOT carry the marker (it re-arms the peer's video)"
         );
         assert!(
-            handle.video.sink_slot.lock().unwrap().is_none(),
-            "stop_video releases the sink"
+            handle.video.sink_slot.lock().unwrap().is_some(),
+            "stopping our camera must not drop the peer's picture"
+        );
+        assert!(
+            handle
+                .video
+                .feed
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_none(),
+            "stopping our camera must stop the local capture feed"
         );
         assert!(
             !client

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3283,7 +3283,12 @@ const VIDEO_DEC_REQUEST: &str = "H264";
 /// `dec` WA Web advertises on an UpgradeAccept.
 const VIDEO_DEC_ACCEPT: &str = "H264,AV1";
 /// WA's native upgrade timer downgrades an unanswered request after five seconds.
-const VIDEO_UPGRADE_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// Published because it is a cross-crate contract: clients arm their own
+/// answer-wait against it (a full second under, so device-close latency
+/// cannot lose the race), and a value they cannot see is one they hardcode
+/// around instead of coordinate with.
+pub const VIDEO_UPGRADE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy)]
 enum VideoUpgradeRole {
@@ -4114,6 +4119,14 @@ impl CallHandle {
             .unwrap_or(0)
     }
 
+    /// Read back this call's video negotiation state as `(self, peer)`, or `None`
+    /// when the call is gone. Diagnostics for clients driving upgrades from
+    /// outside: confirm what the negotiation holds rather than guessing it.
+    pub fn video_states(&self) -> Option<(VideoState, VideoState)> {
+        self.client_registry
+            .video_states(&self.call_id, self.generation)
+    }
+
     /// Announce this side's camera rotation to the peer, as quarter turns in
     /// `0..=3`. See `CallEntry::self_video_orientation` for what the value is
     /// and what it is not.
@@ -4312,9 +4325,9 @@ impl CallHandle {
         let (previous, epoch) = self
             .client_registry
             .re_request_local_video(&self.call_id, self.generation)
-            .ok_or(CallError::Media(
-                "no outstanding video upgrade to re-request",
-            ))?;
+            .ok_or_else(|| {
+                self.unanswerable_upgrade_refusal("no outstanding video upgrade to re-request")
+            })?;
         let stanza = build_video_state(&VideoStateParams {
             call_id: &self.call_id,
             to: &self.peer_jid(),
@@ -4374,6 +4387,121 @@ impl CallHandle {
         Ok(())
     }
 
+    /// Re-add our video direction inside an already-video call: re-attaches
+    /// the endpoints, enables the plane ungated, and announces
+    /// `<video state=1 dec="H264" device_orientation="0">`. Unlike
+    /// [`start_video`](Self::start_video) it opens no upgrade handshake and
+    /// arms no timeout, because the call is already video and the peer
+    /// applies a bare `Enabled` unconditionally -- this is the mute-path
+    /// re-add official clients use instead of a second `11`.
+    ///
+    /// Refuses unless our direction is stopped (or never enabled while the
+    /// peer's is) with no upgrade outstanding in either direction: a fresh
+    /// upgrade belongs on `start_video`, and a pending peer request belongs
+    /// on [`accept_video`](Self::accept_video), which answers it explicitly.
+    pub async fn resume_video<S, K>(&self, source: S, sink: K) -> Result<(), CallError>
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.ensure_current()?;
+        if source.rtp_timestamp_stride() == 0 {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
+        let client = self.upgrade_client()?;
+        // Same lanes as `begin_video`: a group downgrade resets video
+        // negotiation, so eligibility, attachment, and the announce are one
+        // transition relative to it, and one video transition at a time.
+        let group_transition_lock = self
+            .client_registry
+            .group_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _group_transition_guard = group_transition_lock.lock().await;
+        self.ensure_current()?;
+        if let Some(group) = self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            && !group_video_upgrade_allowed(&group)
+        {
+            return Err(CallError::Media(
+                "group media mode does not allow a video upgrade",
+            ));
+        }
+        let transition_lock = self
+            .client_registry
+            .video_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        self.ensure_current()?;
+        let previous = match self
+            .client_registry
+            .resume_local_video(&self.call_id, self.generation)
+        {
+            Some(previous) => previous,
+            None => return Err(self.unresumable_video_refusal()),
+        };
+        let source: Arc<dyn VideoSource> = Arc::new(source);
+        let sink: Arc<dyn VideoSink> = Arc::new(sink);
+        self.video
+            .attach_endpoints(&client, &source, &sink, self.ended.clone());
+        if !self.client_registry.set_video_teardown(
+            &self.call_id,
+            self.generation,
+            video_teardown_hook(&self.video),
+        ) {
+            self.video.detach_endpoints();
+            self.client_registry
+                .restore_self_video_state(&self.call_id, self.generation, previous);
+            return Err(CallError::Media("call no longer active"));
+        }
+        // Ungated, unlike the initiator's `EnableAwaitingAccept`: the peer is
+        // already video, so there is no accept to wait for.
+        self.video.send_control(VideoControl::Enable);
+        let stanza = build_video_state(&VideoStateParams {
+            call_id: &self.call_id,
+            to: &self.peer_jid(),
+            id: &client.generate_request_id(),
+            call_creator: &self.call_creator,
+            state: VideoState::Enabled,
+            dec: Some(VIDEO_DEC_REQUEST),
+            device_orientation: Some(self.local_video_orientation()),
+        });
+        if let Err(e) = client.send_node(stanza).await {
+            self.release_local_video();
+            self.client_registry
+                .restore_self_video_state(&self.call_id, self.generation, previous);
+            return Err(e.into());
+        }
+        Ok(())
+    }
+
+    /// Why a resume just refused: point at the path that owns the current
+    /// state instead of hanging one generic message on every misuse.
+    /// Message-only (the registry owns the rule); a state that raced past
+    /// the refusal keeps the audio-call text.
+    fn unresumable_video_refusal(&self) -> CallError {
+        match self
+            .client_registry
+            .video_states(&self.call_id, self.generation)
+        {
+            Some((VideoState::Enabled, _)) => {
+                CallError::Media("own video direction is already sending")
+            }
+            Some((self_state, _)) if self_state.is_upgrade_request() => {
+                CallError::Media("video upgrade already in progress")
+            }
+            Some((_, peer_state)) if peer_state.is_upgrade_request() => {
+                CallError::Media("answer the peer's upgrade request with accept_video() instead")
+            }
+            Some(_) => CallError::Media(
+                "call has no stopped video direction to resume; use start_video() to upgrade",
+            ),
+            None => CallError::Media("call no longer active"),
+        }
+    }
+
     /// Release local codec endpoints without changing the directional signaling state.
     fn release_local_video(&self) {
         release_video_endpoints(
@@ -4430,7 +4558,9 @@ impl CallHandle {
             VideoUpgradeRole::Initiate => Some(
                 self.client_registry
                     .begin_local_video_request(&self.call_id, self.generation)
-                    .ok_or(CallError::Media("video transition already in progress"))?,
+                    .ok_or_else(|| {
+                        self.unanswerable_upgrade_refusal("video transition already in progress")
+                    })?,
             ),
             VideoUpgradeRole::Accept(request) => {
                 if request.generation() != self.generation
@@ -4548,6 +4678,22 @@ impl CallHandle {
         Ok(())
     }
 
+    /// Why a local upgrade open just refused: an upgrade asked of an
+    /// already-video peer is unanswerable, so say to re-add instead of hanging
+    /// the generic message on it. Message-only (the registry owns the rule);
+    /// a state that raced past the refusal keeps `otherwise`.
+    fn unanswerable_upgrade_refusal(&self, otherwise: &'static str) -> CallError {
+        let peer_active = self
+            .client_registry
+            .video_states(&self.call_id, self.generation)
+            .is_some_and(|(_, peer)| !peer.is_inactive_for_call_mode());
+        CallError::Media(if peer_active {
+            "call already has video; use resume_video() to re-add a stopped direction"
+        } else {
+            otherwise
+        })
+    }
+
     fn spawn_video_upgrade_timeout(&self, epoch: u64, client: Arc<Client>) {
         let runtime = client.runtime.clone();
         let sleeper = runtime.clone();
@@ -4567,6 +4713,34 @@ impl CallHandle {
                     return;
                 };
                 let _transition_guard = transition_lock.lock().await;
+                // The peer stayed video while our request went unanswered: it
+                // ignored the request against its active direction, so there
+                // is no parked peer request to withdraw. Stand only our
+                // direction down with `Stopped`, which the peer applies
+                // without touching its own. The mutual kill below stays for
+                // the initial upgrade, where both directions are down and the
+                // peer may still hold our request.
+                if registry.abort_local_video_request(&call_id, generation, epoch) {
+                    release_video_endpoints(&registry, &pending, &video, &call_id, generation);
+                    let Some(client) = weak_client.upgrade() else {
+                        return;
+                    };
+                    let stanza = build_video_state(&VideoStateParams {
+                        call_id: &call_id,
+                        to: &peer,
+                        id: &client.generate_request_id(),
+                        call_creator: &call_creator,
+                        state: VideoState::Stopped,
+                        dec: None,
+                        device_orientation: None,
+                    });
+                    if let Err(e) = client.send_node(stanza).await {
+                        warn!(
+                            "voip: failed to announce video upgrade abort call_id={call_id}: {e}"
+                        );
+                    }
+                    return;
+                }
                 if !registry.end_local_video_request(&call_id, generation, epoch) {
                     return;
                 }
@@ -11485,6 +11659,317 @@ mod tests {
             registry.video_states("CID-FACADE", generation),
             Some((VideoState::Disabled, VideoState::Disabled))
         );
+        handle.hangup_local().await;
+    }
+
+    async fn apply_paused_peer(handle: &CallHandle) {
+        let transition_lock = handle
+            .client_registry
+            .video_transition_lock(&handle.call_id, handle.generation)
+            .expect("active call");
+        let _guard = transition_lock.lock().await;
+        assert!(matches!(
+            handle.client_registry.apply_peer_video_state(
+                &handle.call_id,
+                handle.generation,
+                VideoState::Paused,
+            ),
+            wacore::voip::PeerVideoTransition::Applied { .. }
+        ));
+    }
+
+    // An upgrade asked of a peer that is already video is unanswerable, so
+    // the begin refuses and names the re-add instead of arming the kill-timer.
+    #[tokio::test]
+    async fn start_video_refuses_when_peer_video_is_up() {
+        let (client, sends, handle, _relay_keepalive) = sending_handle().await;
+        apply_paused_peer(&handle).await;
+        let (vsrc, vsink) = video_endpoints();
+        let err = handle
+            .start_video(vsrc, vsink)
+            .await
+            .expect_err("an upgrade the peer would ignore must be refused");
+        assert!(
+            matches!(err, CallError::Media(msg) if msg.contains("resume_video")),
+            "the refusal must name the re-add, got: {err}"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "refusal sends nothing");
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "refusal attaches nothing"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .video_states(&handle.call_id, handle.generation),
+            Some((VideoState::Disabled, VideoState::Paused)),
+            "the refusal must not disturb the negotiation"
+        );
+        handle.hangup_local().await;
+    }
+
+    // The retry of an unanswerable upgrade is unanswerable too.
+    #[tokio::test]
+    async fn re_request_refuses_when_peer_went_video_mid_handshake() {
+        let (_client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        apply_paused_peer(&handle).await;
+        assert!(
+            handle.re_request_video_upgrade().await.is_err(),
+            "re-asking an active peer must be refused like asking"
+        );
+        handle.hangup_local().await;
+    }
+
+    // The timeout's direction-local half end to end: our upgrade goes
+    // unanswered against a peer that stayed video, so the timer stands our
+    // direction down with `Stopped` instead of killing both with `9`.
+    #[tokio::test(start_paused = true)]
+    async fn unanswered_upgrade_against_an_active_peer_stands_down_locally() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let video = Arc::new(VideoShared::new());
+        let (event_tx, events) = async_channel::unbounded::<CallEvent>();
+        registry.set_video_channels(
+            "CID-FACADE",
+            generation,
+            event_tx,
+            video.ctl_tx.clone(),
+            video_teardown_hook(&video),
+        );
+        let handle = CallHandle {
+            call_id: "CID-FACADE".into(),
+            generation,
+            peer_jid: caller(),
+            call_creator: caller(),
+            client_registry: registry.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
+            client: Arc::downgrade(&client),
+            muted: Arc::new(AtomicBool::new(false)),
+            video: video.clone(),
+            events,
+            ended: Arc::new(EndedFlag::default()),
+            media_stats: Arc::new(wacore::voip::MediaStatsCell::default()),
+        };
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (_frames_tx, frames) = async_channel::unbounded();
+        let source = DropTrackedVideoSource {
+            frames,
+            drops: drops.clone(),
+        };
+        let (sink, _sink_rx) = async_channel::unbounded::<VideoFrame>();
+        handle
+            .start_video(source, sink)
+            .await
+            .expect("request sent");
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        apply_paused_peer(&handle).await;
+
+        let timeout_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        tokio::task::yield_now().await;
+        tokio::time::advance(VIDEO_UPGRADE_TIMEOUT).await;
+        for _ in 0..10 {
+            if drops.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        let timeout_node = timeout_waiter.await.expect("timeout stanza");
+        let timeout_action = call_action_of(&timeout_node);
+        assert_eq!(
+            timeout_action
+                .as_node_ref()
+                .attrs()
+                .optional_string("state")
+                .as_deref(),
+            Some("6"),
+            "an unanswered upgrade against an active peer stands down locally, it does not cancel both"
+        );
+        assert!(
+            registry.snapshot("CID-FACADE").unwrap().is_video,
+            "the peer's direction keeps the call video"
+        );
+        assert_eq!(
+            registry.video_states("CID-FACADE", generation),
+            Some((VideoState::Stopped, VideoState::Paused))
+        );
+        handle.hangup_local().await;
+    }
+
+    async fn apply_upgrade_accept(handle: &CallHandle) {
+        let transition_lock = handle
+            .client_registry
+            .video_transition_lock(&handle.call_id, handle.generation)
+            .expect("active call");
+        let _guard = transition_lock.lock().await;
+        assert!(matches!(
+            handle.client_registry.apply_peer_video_state(
+                &handle.call_id,
+                handle.generation,
+                VideoState::UpgradeAccept,
+            ),
+            wacore::voip::PeerVideoTransition::Applied {
+                enable_plane: true,
+                ..
+            }
+        ));
+    }
+
+    // The mute-path re-add end to end: a stopped direction inside an
+    // already-video call returns ungated with a bare `Enabled` (no handshake,
+    // no marker, no timeout), and both directions read enabled afterwards.
+    #[tokio::test]
+    async fn resume_video_re_adds_a_stopped_direction_ungated() {
+        let (client, sends, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        apply_upgrade_accept(&handle).await;
+        handle.stop_video().await.expect("stop_video");
+        assert_eq!(
+            client
+                .call_registry()
+                .video_states(&handle.call_id, handle.generation),
+            Some((VideoState::Stopped, VideoState::Enabled))
+        );
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let (vsrc, vsink) = video_endpoints();
+        handle
+            .resume_video(vsrc, vsink)
+            .await
+            .expect("resume_video");
+        assert_eq!(sends.load(Ordering::SeqCst), 3);
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("re-add must be announced")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.tag, "video");
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("1"));
+        assert_eq!(ar.attrs().optional_string("dec").as_deref(), Some("H264"));
+        assert_eq!(
+            ar.attrs().optional_string("device_orientation").as_deref(),
+            Some("0")
+        );
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings"),
+            None,
+            "a re-add is not an upgrade request and must not carry the marker"
+        );
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_some(),
+            "resume_video attaches the sink"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .video_states(&handle.call_id, handle.generation),
+            Some((VideoState::Enabled, VideoState::Enabled))
+        );
+        assert!(
+            client
+                .call_registry()
+                .snapshot(&handle.call_id)
+                .expect("session")
+                .is_video
+        );
+        handle.hangup_local().await;
+    }
+
+    // A fresh upgrade is not a re-add.
+    #[tokio::test]
+    async fn resume_video_refuses_an_audio_call() {
+        let (_client, sends, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        let err = handle
+            .resume_video(vsrc, vsink)
+            .await
+            .expect_err("an audio call has no direction to re-add");
+        assert!(
+            matches!(err, CallError::Media(msg) if msg.contains("start_video")),
+            "the refusal must point at the upgrade path, got: {err}"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "refusal sends nothing");
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "refusal attaches nothing"
+        );
+        handle.hangup_local().await;
+    }
+
+    // A pending peer request is answered explicitly, not consumed implicitly.
+    #[tokio::test]
+    async fn resume_video_refuses_a_pending_peer_request() {
+        let (_client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let _token = peer_upgrade_request(&handle).await;
+        let (vsrc, vsink) = video_endpoints();
+        let err = handle
+            .resume_video(vsrc, vsink)
+            .await
+            .expect_err("a peer request belongs on accept_video");
+        assert!(
+            matches!(err, CallError::Media(msg) if msg.contains("accept_video")),
+            "the refusal must point at the accept path, got: {err}"
+        );
+        handle.hangup_local().await;
+    }
+
+    // A re-add whose stanza never reaches the peer releases the plane and
+    // restores the stopped direction, so a retry stays a resume.
+    #[tokio::test]
+    async fn resume_video_send_failure_restores_stopped_and_releases() {
+        let (client, _sent) = make_sending_client_with_failure_after(Some(0)).await;
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let video = Arc::new(VideoShared::new());
+        let (event_tx, events) = async_channel::unbounded::<CallEvent>();
+        registry.set_video_channels(
+            "CID-FACADE",
+            generation,
+            event_tx,
+            video.ctl_tx.clone(),
+            video_teardown_hook(&video),
+        );
+        let handle = CallHandle {
+            call_id: "CID-FACADE".into(),
+            generation,
+            peer_jid: caller(),
+            call_creator: caller(),
+            client_registry: registry.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
+            client: Arc::downgrade(&client),
+            muted: Arc::new(AtomicBool::new(false)),
+            video: video.clone(),
+            events,
+            ended: Arc::new(EndedFlag::default()),
+            media_stats: Arc::new(wacore::voip::MediaStatsCell::default()),
+        };
+        assert!(registry.stop_local_video("CID-FACADE", generation));
+        {
+            let transition_lock = registry
+                .video_transition_lock("CID-FACADE", generation)
+                .expect("active call");
+            let _guard = transition_lock.lock().await;
+            assert!(matches!(
+                registry.apply_peer_video_state("CID-FACADE", generation, VideoState::Enabled,),
+                wacore::voip::PeerVideoTransition::Applied { .. }
+            ));
+        }
+
+        let (source, sink) = video_endpoints();
+        assert!(handle.resume_video(source, sink).await.is_err());
+        assert!(video.sink_slot.lock().unwrap().is_none());
+        assert_eq!(
+            registry.video_states("CID-FACADE", generation),
+            Some((VideoState::Stopped, VideoState::Enabled))
+        );
+        assert!(registry.snapshot("CID-FACADE").unwrap().is_video);
         handle.hangup_local().await;
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3444,6 +3444,31 @@ fn video_teardown_hook(video: &Arc<VideoShared>) -> Box<dyn Fn() + Send + Sync> 
     Box::new(move || video.detach_endpoints())
 }
 
+/// Drop a stale pending upgrade's endpoints and gate local capture off the
+/// wire, keeping the inbound sink: the direction-local abort runs while the
+/// peer is still video, so the remote picture must keep flowing. The terminal
+/// teardown hook stays armed for hangup, which still takes the whole plane.
+fn release_local_video_source(
+    pending_outgoing_calls: &std::sync::Mutex<std::collections::HashMap<String, PendingOutgoing>>,
+    video: &VideoShared,
+    call_id: &str,
+    generation: u64,
+) {
+    let pending_video = {
+        // This synchronous map is shared with non-async setup paths; its lock covers only one
+        // lookup/take and is never held across an await.
+        let mut pending = pending_outgoing_calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pending
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.video.take())
+    };
+    drop(pending_video);
+    video.detach_source();
+}
+
 fn release_video_endpoints(
     registry: &wacore::voip::CallRegistry,
     pending_outgoing_calls: &std::sync::Mutex<std::collections::HashMap<String, PendingOutgoing>>,
@@ -4748,7 +4773,7 @@ impl CallHandle {
                 // the initial upgrade, where both directions are down and the
                 // peer may still hold our request.
                 if registry.abort_local_video_request(&call_id, generation, epoch) {
-                    release_video_endpoints(&registry, &pending, &video, &call_id, generation);
+                    release_local_video_source(&pending, &video, &call_id, generation);
                     let Some(client) = weak_client.upgrade() else {
                         return;
                     };
@@ -10926,6 +10951,16 @@ mod tests {
         drops: Arc<AtomicUsize>,
     }
 
+    struct ChannelVideoSink {
+        playout: async_channel::Sender<VideoFrame>,
+    }
+
+    impl VideoSink for ChannelVideoSink {
+        fn playout(&self) -> async_channel::Sender<VideoFrame> {
+            self.playout.clone()
+        }
+    }
+
     impl VideoSource for DropTrackedVideoSource {
         fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
             self.frames.clone()
@@ -11787,7 +11822,9 @@ mod tests {
             frames,
             drops: drops.clone(),
         };
-        let (sink, _sink_rx) = async_channel::unbounded::<VideoFrame>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<VideoFrame>();
+        let sink = ChannelVideoSink { playout: sink_tx };
+        std::mem::forget(_sink_rx);
         handle
             .start_video(source, sink)
             .await
@@ -11824,6 +11861,10 @@ mod tests {
         assert_eq!(
             registry.video_states("CID-FACADE", generation),
             Some((VideoState::Stopped, VideoState::Paused))
+        );
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_some(),
+            "a direction-local abort must not drop the peer's picture"
         );
         handle.hangup_local().await;
     }

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use state::Voip;
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
 pub use facade::{
     AcceptCall, CallHandle, CallLinkCall, CallTermination, GroupBoundCall, OutgoingCall,
-    OutgoingGroupCall,
+    OutgoingGroupCall, VIDEO_UPGRADE_TIMEOUT,
 };
 pub use video::{TimedVideoFrame, VideoFrame, VideoSink, VideoSource};
 // Surface core types carried by the facade next to the builders and handle that expose them.

--- a/tests/voip_call_fixture.rs
+++ b/tests/voip_call_fixture.rs
@@ -608,3 +608,41 @@ async fn peer_video_metadata_reports_routed_sender_and_supplied_creator_without_
     fixture.shutdown().await?;
     Ok(())
 }
+
+// The upgrade timeout is a cross-crate contract: clients arm their own
+// answer-wait against it, so it is published rather than hardcoded twice.
+#[test]
+fn upgrade_timeout_is_published_for_client_coordination() {
+    assert_eq!(
+        whatsapp_rust::voip::VIDEO_UPGRADE_TIMEOUT,
+        Duration::from_secs(5)
+    );
+}
+
+// Clients verify negotiation read-back through the handle: a video offer
+// starts both directions enabled, an audio offer both disabled.
+#[tokio::test]
+async fn handle_reports_negotiation_states_for_read_back() -> Result<()> {
+    use wacore::types::call::VideoState;
+
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    assert_eq!(
+        handle.video_states(),
+        Some((VideoState::Enabled, VideoState::Enabled)),
+        "a video offer starts both directions enabled"
+    );
+    fixture.shutdown().await?;
+
+    let fixture = CallFixture::new().await?;
+    let starting = start_with_video(&fixture, false);
+    fixture.next_offer().await?.complete()?;
+    let handle = starting.await??;
+    assert_eq!(
+        handle.video_states(),
+        Some((VideoState::Disabled, VideoState::Disabled)),
+        "an audio offer starts both directions disabled"
+    );
+    fixture.shutdown().await?;
+    Ok(())
+}

--- a/tests/voip_call_fixture.rs
+++ b/tests/voip_call_fixture.rs
@@ -646,3 +646,65 @@ async fn handle_reports_negotiation_states_for_read_back() -> Result<()> {
     fixture.shutdown().await?;
     Ok(())
 }
+
+// In an established video call where our direction was stopped, resume_video
+// re-attaches endpoints, emits a bare `Enabled` state stanza without upgrade
+// handshake markers, and returns read-back to (Enabled, Enabled).
+#[tokio::test]
+async fn handle_resumes_local_video_direction_in_video_call() -> Result<()> {
+    use wacore::types::call::VideoState;
+
+    let fixture = CallFixture::new().await?;
+    let handle = dormant(&fixture).await?;
+    assert_eq!(
+        handle.video_states(),
+        Some((VideoState::Enabled, VideoState::Enabled))
+    );
+
+    handle.stop_video().await?;
+    assert_eq!(
+        handle.video_states(),
+        Some((VideoState::Stopped, VideoState::Enabled))
+    );
+
+    let waiter = fixture
+        .client()
+        .wait_for_sent_node(whatsapp_rust::NodeFilter::tag("call"));
+
+    let (_source_tx, source) = async_channel::bounded::<Vec<u8>>(1);
+    let (sink, _sink_rx) = async_channel::bounded::<wacore::voip::VideoFrame>(1);
+    handle.resume_video(source, sink).await?;
+
+    assert_eq!(
+        handle.video_states(),
+        Some((VideoState::Enabled, VideoState::Enabled)),
+        "resumed direction restores both directions enabled"
+    );
+
+    let sent = tokio::time::timeout(Duration::from_secs(2), waiter)
+        .await
+        .expect("must emit call node on resume")
+        .expect("waiter");
+    let video_child = sent
+        .children()
+        .unwrap_or_default()
+        .iter()
+        .find(|c| c.tag == "video")
+        .expect("call node must have video child");
+    assert_eq!(
+        video_child.attrs().optional_string("state").as_deref(),
+        Some("1")
+    );
+    assert_eq!(
+        video_child.attrs().optional_string("dec").as_deref(),
+        Some("H264")
+    );
+    assert_eq!(
+        video_child.attrs().optional_string("voip_settings"),
+        None,
+        "resume must not carry the upgrade handshake marker"
+    );
+
+    fixture.shutdown().await?;
+    Ok(())
+}

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -151,6 +151,9 @@ pub enum VideoControl {
     EnableAwaitingAccept,
     /// Tear the video plane down (downgrade to audio).
     Disable,
+    /// Gate outbound video off the wire while inbound keeps decoding (our camera stopped; the
+    /// peer is still sending). `Enable` later ungates it, like an accepted upgrade.
+    DisableOutbound,
     /// Tear the video plane down while retaining queued legacy AUs for a legacy reattach.
     DisableKeepLegacy,
     /// Require the next outbound access unit to be an IDR frame after changing its source role.
@@ -1681,6 +1684,20 @@ async fn run_call_with_clock_and_wallclock(
                     }
                     Ok(VideoControl::Disable) => {
                         eng.disable_video();
+                        let dropped = purge_unstarted_video(
+                            &mut send_queue,
+                            &mut awaiting_video_keyframe,
+                        );
+                        if dropped.packets != 0 {
+                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            });
+                        }
+                        drain_video_in = true;
+                    }
+                    Ok(VideoControl::DisableOutbound) => {
+                        eng.gate_video_outbound();
                         let dropped = purge_unstarted_video(
                             &mut send_queue,
                             &mut awaiting_video_keyframe,

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -2262,6 +2262,15 @@ impl CallEngine {
         }
     }
 
+    /// Hold OUTBOUND video off the wire while inbound keeps decoding (our camera stopped; the
+    /// peer is still sending). A later [`enable_video`](Self::enable_video) ungates it like an
+    /// accepted upgrade, including the keyframe the peer needs for the fresh stream.
+    pub fn gate_video_outbound(&mut self) {
+        if let Some(v) = self.media.as_mut().and_then(|m| m.video.as_mut()) {
+            v.send_gated = true;
+        }
+    }
+
     /// Deactivate the video plane (downgrade): outbound AUs drop, inbound PT-97 is ignored. The
     /// pipeline (and its SRTP send seq/ROC) is PRESERVED so a later re-upgrade continues the
     /// keystream instead of resetting the packet index. The audio plane is untouched. Idempotent.
@@ -10791,6 +10800,48 @@ mod tests {
             count_transmits(&drain(&mut eng).0),
             1,
             "the next IDR resumes outbound video"
+        );
+    }
+
+    // Gating only the outbound camera must not touch the inbound picture: our Stopped leaves
+    // the peer's stream decodable, so a local mute is not a remote blackout.
+    #[test]
+    fn gating_outbound_keeps_inbound_decoding() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+
+        eng.gate_video_outbound();
+        eng.handle_input(1, Input::VideoFrame(&video_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "a gated camera must not transmit our video"
+        );
+        let mut peer = peer_video_pipe();
+        for p in peer.protect_video(&video_au(120)) {
+            eng.handle_input(1, Input::RelayPacket(&p));
+        }
+        assert!(
+            drain(&mut eng)
+                .0
+                .iter()
+                .any(|o| matches!(o, Output::VideoPlayout(_))),
+            "gating our camera must not lose the peer's picture"
+        );
+
+        // Ungating resumes our camera; the peer's stream never left, so no new SSRC is needed.
+        assert!(eng.enable_video());
+        for p in peer.protect_video(&video_au(120)) {
+            eng.handle_input(2, Input::RelayPacket(&p));
+        }
+        assert!(
+            drain(&mut eng)
+                .0
+                .iter()
+                .any(|o| matches!(o, Output::VideoPlayout(_))),
+            "re-enabling after a local mute must play the peer at once"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -2658,6 +2658,12 @@ impl CallRegistry {
     }
 
     /// Begin a local upgrade and return its timeout epoch.
+    ///
+    /// Refuses when the peer direction is already video: the receiver ignores
+    /// an upgrade request against its active direction, so asking would only
+    /// arm the upgrade timeout, which then cancels both directions. Re-add a
+    /// stopped direction inside an already-video call without the handshake
+    /// instead.
     pub fn begin_local_video_request(&self, call_id: &str, generation: u64) -> Option<u64> {
         let mut map = self.active_calls();
         let entry = map
@@ -2665,6 +2671,7 @@ impl CallRegistry {
             .filter(|entry| entry.generation == generation)?;
         if !entry.video.self_state.is_inactive_for_call_mode()
             || entry.video.pending_peer_request.is_some()
+            || !entry.video.peer_state.is_inactive_for_call_mode()
         {
             return None;
         }
@@ -2685,8 +2692,9 @@ impl CallRegistry {
     /// inert (its epoch no longer matches). Returns `None` unless a local
     /// upgrade is actually pending: with no outstanding request there is
     /// nothing to re-ask, and states like fresh-Enabled stay on the begin
-    /// path. Pair with [`Self::rollback_re_request`] when the re-ask never
-    /// reaches the peer.
+    /// path. Like begin, it refuses once the peer direction is video: the
+    /// retry is as unanswerable as the ask. Pair with
+    /// [`Self::rollback_re_request`] when the re-ask never reaches the peer.
     pub fn re_request_local_video(
         &self,
         call_id: &str,
@@ -2698,6 +2706,7 @@ impl CallRegistry {
             .filter(|entry| entry.generation == generation)?;
         if entry.video.self_state.is_inactive_for_call_mode()
             || entry.video.pending_self_request.is_none()
+            || !entry.video.peer_state.is_inactive_for_call_mode()
         {
             return None;
         }
@@ -2783,6 +2792,38 @@ impl CallRegistry {
         true
     }
 
+    /// Stand our unanswered upgrade down without touching the peer's direction.
+    ///
+    /// The upgrade timeout's direction-local half: our request went to a peer
+    /// that stayed video (it ignores requests against its active direction),
+    /// so there is no parked peer request to withdraw with
+    /// `UpgradeCancelByTimeout` -- only our own pending request to clear. Our
+    /// direction reads `Stopped` afterwards (we are not sending), which keeps
+    /// it re-addable, and the call stays video on the peer's direction. The
+    /// caller announces `Stopped`, which the peer applies without touching
+    /// its own direction. Returns false unless our request is still the
+    /// outstanding one against an active peer; the genuine kill
+    /// ([`Self::end_local_video_request`]) owns every other case.
+    pub fn abort_local_video_request(&self, call_id: &str, generation: u64, epoch: u64) -> bool {
+        let mut map = self.active_calls();
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        if entry.video.pending_self_request != Some(epoch)
+            || !entry.video.self_state.is_upgrade_request()
+            || entry.video.peer_state.is_inactive_for_call_mode()
+        {
+            return false;
+        }
+        entry.video.self_state = VideoState::Stopped;
+        entry.video.pending_self_request = None;
+        entry.session.is_video = entry.video.is_video();
+        true
+    }
+
     /// Clear both directions after a failed handshake or full downgrade.
     pub fn reset_video(&self, call_id: &str, generation: u64) -> bool {
         let mut map = self.active_calls();
@@ -2811,6 +2852,58 @@ impl CallRegistry {
         };
         entry.video.self_state = VideoState::Stopped;
         entry.video.pending_self_request = None;
+        entry.session.is_video = entry.video.is_video();
+        true
+    }
+
+    /// Re-add our direction inside an already-video call and return its
+    /// previous state for rollback.
+    ///
+    /// The mute-path re-add: no handshake epoch is minted and no timeout is
+    /// armed, because the call is already video and the peer applies a bare
+    /// `Enabled` unconditionally. Allowed only with no upgrade outstanding in
+    /// either direction and our direction stopped (or never enabled while the
+    /// peer's is): a fresh upgrade belongs on
+    /// [`Self::begin_local_video_request`], and a pending peer request belongs
+    /// on [`Self::complete_peer_video_request`], which answers it explicitly.
+    pub fn resume_local_video(&self, call_id: &str, generation: u64) -> Option<VideoState> {
+        let mut map = self.active_calls();
+        let entry = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)?;
+        if entry.video.pending_self_request.is_some() || entry.video.pending_peer_request.is_some()
+        {
+            return None;
+        }
+        let resumable = entry.video.self_state == VideoState::Stopped
+            || (entry.video.self_state == VideoState::Disabled
+                && entry.video.peer_state == VideoState::Enabled);
+        if !resumable {
+            return None;
+        }
+        let previous = entry.video.self_state;
+        entry.video.self_state = VideoState::Enabled;
+        entry.session.is_video = entry.video.is_video();
+        Some(previous)
+    }
+
+    /// Return our direction to `state` after a failed resume whose stanza
+    /// never reached the peer, so a retry stays a resume instead of wedging
+    /// on an enabled direction that is not sending.
+    pub fn restore_self_video_state(
+        &self,
+        call_id: &str,
+        generation: u64,
+        state: VideoState,
+    ) -> bool {
+        let mut map = self.active_calls();
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        entry.video.self_state = state;
         entry.session.is_video = entry.video.is_video();
         true
     }
@@ -5287,6 +5380,161 @@ mod tests {
         assert!(!reg.snapshot("CID").expect("session").is_video);
     }
 
+    // An upgrade asked of a peer that is already video is unanswerable: the
+    // receiver ignores it against its active direction, so beginning must
+    // refuse rather than arm a timeout that kills both directions.
+    #[test]
+    fn begin_refuses_an_upgrade_the_peer_cannot_answer() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Paused),
+            PeerVideoTransition::Applied { .. }
+        ));
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::Disabled, VideoState::Paused))
+        );
+        assert!(
+            reg.begin_local_video_request("CID", generation).is_none(),
+            "a paused peer is still video: the 11 would be ignored and the timeout would kill both directions"
+        );
+    }
+
+    // Same hole one step later: the peer went video mid-handshake, so
+    // re-asking is as unanswerable as asking, and the refusal must leave the
+    // outstanding request to the timeout's direction-local path.
+    #[test]
+    fn re_request_refuses_when_the_peer_went_video_mid_handshake() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        let first = reg
+            .begin_local_video_request("CID", generation)
+            .expect("begin on an audio call");
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Paused),
+            PeerVideoTransition::Applied { .. }
+        ));
+        assert!(
+            reg.re_request_local_video("CID", generation).is_none(),
+            "re-asking an active peer is as unanswerable as asking"
+        );
+        assert!(
+            reg.end_local_video_request("CID", generation, first),
+            "the refusal must not disturb the outstanding request"
+        );
+    }
+
+    // The timeout's direction-local half: our request went unanswered against
+    // a peer that stayed video, so only our direction stands down. The peer
+    // keeps its direction, the call stays video, and the genuine kill finds
+    // nothing left to cancel.
+    #[test]
+    fn abort_stands_down_only_our_direction_against_an_active_peer() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        let epoch = reg
+            .begin_local_video_request("CID", generation)
+            .expect("begin on an audio call");
+        assert!(!reg.abort_local_video_request("CID", generation, epoch.wrapping_add(1)));
+        assert!(!reg.abort_local_video_request("CID", generation, epoch));
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Paused),
+            PeerVideoTransition::Applied { .. }
+        ));
+        assert!(reg.abort_local_video_request("CID", generation, epoch));
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::Stopped, VideoState::Paused))
+        );
+        assert!(
+            reg.snapshot("CID").expect("session").is_video,
+            "the peer's direction keeps the call video"
+        );
+        assert!(
+            !reg.end_local_video_request("CID", generation, epoch),
+            "the genuine kill must find no outstanding request"
+        );
+    }
+
+    // The mute-path re-add: a stopped direction inside an already-video call
+    // returns to enabled with no handshake epoch and no pending on either
+    // side. The caller announces bare `Enabled`, which the peer applies
+    // unconditionally.
+    #[test]
+    fn resume_re_adds_a_stopped_direction_without_a_handshake() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        assert!(reg.stop_local_video("CID", generation));
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Enabled),
+            PeerVideoTransition::Applied { .. }
+        ));
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::Stopped, VideoState::Enabled))
+        );
+        assert_eq!(
+            reg.resume_local_video("CID", generation),
+            Some(VideoState::Stopped)
+        );
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::Enabled, VideoState::Enabled))
+        );
+        assert!(reg.snapshot("CID").expect("session").is_video);
+    }
+
+    // Resume is only the re-add: a fresh upgrade belongs on the begin path,
+    // an in-flight upgrade stays on its timeout, and a pending peer request
+    // belongs on the explicit accept.
+    #[test]
+    fn resume_refuses_without_a_resumable_direction() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        assert_eq!(reg.resume_local_video("CID", generation), None);
+
+        let epoch = reg
+            .begin_local_video_request("CID", generation)
+            .expect("begin on an audio call");
+        assert_eq!(reg.resume_local_video("CID", generation), None);
+        assert!(reg.end_local_video_request("CID", generation, epoch));
+
+        let token =
+            match reg.apply_peer_video_state("CID", generation, VideoState::UpgradeRequestV2) {
+                PeerVideoTransition::UpgradeRequested(token) => token,
+                transition => panic!("unexpected transition: {transition:?}"),
+            };
+        assert_eq!(reg.resume_local_video("CID", generation), None);
+        assert!(reg.complete_peer_video_request("CID", token));
+        assert_eq!(reg.resume_local_video("CID", generation), None);
+    }
+
+    // A resume whose stanza never reaches the peer returns the negotiation
+    // to what it held, so a retry stays a resume instead of wedging on an
+    // enabled direction that is not sending.
+    #[test]
+    fn restore_returns_a_failed_resume_to_its_previous_direction() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        assert!(reg.stop_local_video("CID", generation));
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Enabled),
+            PeerVideoTransition::Applied { .. }
+        ));
+        assert_eq!(
+            reg.resume_local_video("CID", generation),
+            Some(VideoState::Stopped)
+        );
+        assert!(reg.restore_self_video_state("CID", generation, VideoState::Stopped));
+        assert_eq!(
+            reg.video_states("CID", generation),
+            Some((VideoState::Stopped, VideoState::Enabled))
+        );
+        assert!(reg.snapshot("CID").expect("session").is_video);
+        assert!(!reg.restore_self_video_state("NOPE", generation, VideoState::Stopped));
+    }
+
     // A re-request on an outstanding local upgrade mints a fresh epoch under
     // the reached state: the previous timeout goes inert on the epoch
     // mismatch instead of tearing down the newer request.
@@ -5356,6 +5604,12 @@ mod tests {
         video_session.is_video = true;
         let generation = reg.insert(video_session);
         assert!(reg.stop_local_video("CID", generation));
+        // The begin below needs an answerable peer: an upgrade asked of an
+        // already-video direction is refused, so the peer stands down first.
+        assert!(matches!(
+            reg.apply_peer_video_state("CID", generation, VideoState::Stopped),
+            PeerVideoTransition::Applied { .. }
+        ));
         let epoch = reg
             .begin_local_video_request("CID", generation)
             .expect("local request");

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -2862,9 +2862,10 @@ impl CallRegistry {
     /// The mute-path re-add: no handshake epoch is minted and no timeout is
     /// armed, because the call is already video and the peer applies a bare
     /// `Enabled` unconditionally. Allowed only with no upgrade outstanding in
-    /// either direction and our direction stopped (or never enabled while the
-    /// peer's is): a fresh upgrade belongs on
-    /// [`Self::begin_local_video_request`], and a pending peer request belongs
+    /// either direction and an inactive self direction while the peer's is
+    /// active: the same rule [`Self::begin_local_video_request`] refuses
+    /// on, so one predicate owns both paths and no negotiation refuses both.
+    /// A fresh upgrade belongs on begin, and a pending peer request belongs
     /// on [`Self::complete_peer_video_request`], which answers it explicitly.
     pub fn resume_local_video(&self, call_id: &str, generation: u64) -> Option<VideoState> {
         let mut map = self.active_calls();
@@ -2876,8 +2877,8 @@ impl CallRegistry {
             return None;
         }
         let resumable = entry.video.self_state == VideoState::Stopped
-            || (entry.video.self_state == VideoState::Disabled
-                && entry.video.peer_state == VideoState::Enabled);
+            || (entry.video.self_state.is_inactive_for_call_mode()
+                && !entry.video.peer_state.is_inactive_for_call_mode());
         if !resumable {
             return None;
         }
@@ -5483,6 +5484,32 @@ mod tests {
             Some((VideoState::Enabled, VideoState::Enabled))
         );
         assert!(reg.snapshot("CID").expect("session").is_video);
+    }
+
+    // The re-add shares the upgrade rule: any inactive self direction with
+    // an active peer is resumable, not just stopped-with-enabled. A paused
+    // (or unknown) peer still holds the call video, and the begin path
+    // refuses it for the same reason, so refusing resume too would leave no
+    // path that enables local video at all.
+    #[test]
+    fn resume_re_adds_against_any_active_peer_direction() {
+        for peer in [VideoState::Paused, VideoState::UnknownPeer] {
+            let reg = CallRegistry::new();
+            let generation = reg.insert(session("CID"));
+            assert!(matches!(
+                reg.apply_peer_video_state("CID", generation, peer),
+                PeerVideoTransition::Applied { .. }
+            ));
+            assert_eq!(
+                reg.resume_local_video("CID", generation),
+                Some(VideoState::Disabled),
+                "{peer:?}: an active peer keeps the call video whatever it sends"
+            );
+            assert_eq!(
+                reg.video_states("CID", generation),
+                Some((VideoState::Enabled, peer))
+            );
+        }
     }
 
     // Resume is only the re-add: a fresh upgrade belongs on the begin path,


### PR DESCRIPTION
Upstream half of the video-call line for bridge PR oxidezap/whatsapp-rust-bridge#115 and the four items requested from client PR oxidezap/client#157 section What would need to change upstream.

1. Re-enable primitive. New CallHandle::resume_video(source, sink): re-attaches endpoints, enables the plane ungated, and announces bare Enabled (state=1, H264, current orientation, no upgrade marker). No handshake epoch, no timeout. Refuses unless our direction is stopped (or never enabled while the peer sends) with nothing outstanding either way, with messages pointing at start_video or accept_video. A failed send releases the plane and restores the previous direction so a retry stays a resume.
2. Unanswerable upgrades no longer arm the kill-timer. begin_local_video_request and re_request_local_video refuse when the peer direction is already video (the receiver ignores the 11). The 5s timeout now stands down direction-locally first: abort_local_video_request reverts our direction to Stopped and announces Stopped (peer applies it without touching its direction). The mutual kill (both Disabled plus UpgradeCancelByTimeout) stays for the genuine initial-upgrade case. One existing registry test (cancelling_a_local_request_is_a_full_native_downgrade) had its setup adjusted: it began against an active peer, which is exactly what is now refused.
3. Published VIDEO_UPGRADE_TIMEOUT (5s) at whatsapp_rust::voip so clients arm their answer-wait against it instead of hardcoding the distance.
4. Read-back: new CallHandle::video_states passthrough for negotiation verification.

Tests are failing-first (new registry/facade/fixture tests; the abort and resume APIs did not exist). Suites: whatsapp-rust lib full native features 2461 passed, wacore lib with voip 2094 passed, wacore default 1657 passed, voip_call_fixture 11 passed, clippy all-targets -D warnings and fmt clean, rustdoc warning-free, no-default plus voip-encoded (bridge profile) check clean. No audio behavior touched.

Bridge pin rev: 61b43bb41 (this branch head).