### PR TITLE
feat(storage): make bundled sqlite opt-out via sqlite-storage-bundled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ test-support = ["voip-runtime", "tokio-runtime", "dep:wacore-noise", "wacore-noi
 danger-skip-tls-verify = ["whatsapp-rust-tokio-transport?/danger-skip-tls-verify"]
 default = [
     "sqlite-storage",
+    "sqlite-storage-bundled",
     "tokio-transport",
     "tokio-runtime",
     "ureq-client",
@@ -216,6 +217,7 @@ tokio-transport = ["dep:whatsapp-rust-tokio-transport"]
 tokio-runtime = ["dep:tokio"]
 signal = ["tokio-runtime", "tokio/signal"]
 sqlite-storage = ["whatsapp-rust-sqlite-storage"]
+sqlite-storage-bundled = ["sqlite-storage", "whatsapp-rust-sqlite-storage/bundled-sqlite"]
 tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
 # The portable half of the VoIP runtime: call signaling, the facade, and the orchestration around
 # `wacore`'s sans-IO engine. It owns no socket and names no clock, so it builds wherever `wacore`
@@ -298,7 +300,7 @@ wacore-binary = { workspace = true }
 wacore-noise = { path = "./wacore/noise", version = "0.7.0", optional = true }
 waproto = { workspace = true }
 zeroize = { workspace = true }
-whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true }
+whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true, default-features = false }
 whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.7.0", optional = true }
 whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.7.0", optional = true }
 


### PR DESCRIPTION
## Summary

When consuming `whatsapp-rust` with the `sqlite-storage` backend enabled in applications that also link another SQLite engine (such as `libsql-ffi`, `sqlcipher`, or custom SQLite builds), the linker encounters duplicate symbol collisions for SQLite symbols (`sqlite3_*`).

### Root Cause
In `Cargo.toml`, `whatsapp-rust-sqlite-storage` was declared as an optional dependency without `default-features = false`:
```toml
whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true }
```
Because `whatsapp-rust-sqlite-storage` defines `default = ["bundled-sqlite"]` (which activates `libsqlite3-sys/bundled`), enabling the `sqlite-storage` feature on `whatsapp-rust` transitively pulled in `whatsapp-rust-sqlite-storage`'s default features. This forced `libsqlite3-sys/bundled` into the build graph and compiled a private `sqlite3.c` amalgamation into the binary, giving downstream consumers no mechanism to opt out without forking.

### Solution (Design A: Backward-Compatible Opt-Out)
1. Updated the dependency declaration in root `Cargo.toml` to specify `default-features = false`:
   ```toml
   whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true, default-features = false }
   ```
2. Defined the `sqlite-storage-bundled` feature:
   ```toml
   sqlite-storage = ["whatsapp-rust-sqlite-storage"]
   sqlite-storage-bundled = ["sqlite-storage", "whatsapp-rust-sqlite-storage/bundled-sqlite"]
   ```
3. Added `"sqlite-storage-bundled"` to `default` alongside `"sqlite-storage"`.

This preserves 100% backward compatibility for existing default builds while allowing consumers building with `default-features = false` to enable `sqlite-storage` without `sqlite-storage-bundled`, preventing symbol collisions with other statically linked SQLite engines.

### Verification
- `cargo check -p whatsapp-rust`: Verified default features check passed.
- `cargo check -p whatsapp-rust --no-default-features --features sqlite-storage`: Verified unbundled build check passed without bundling libsqlite3.
- `cargo test -p whatsapp-rust-sqlite-storage --lib`: 113 tests passed.
- `cargo fmt --all --check`: Clean formatting.
- `cargo clippy -p whatsapp-rust --features sqlite-storage,sqlite-storage-bundled`: Passed with 0 warnings.

Closes #1497